### PR TITLE
doc: development prereq and librechat model default

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -2,22 +2,10 @@
 
 You can use Aura within LibreChat and OpenWebUI because Aura supports an OpenAI-compatible HTTP API.
 
+
 ## Pre-requisites
 
-You must have the environment variable MEZMO_API_KEY populated with a valid Mezmo API Key.
-
-- Sign-in to https://app.mezmo.com/
-- Click the "settings" icon in the left panel
-- Click "Organization"
-- Click "API Keys"
-- Under the "Service Keys" section
-  - Click "Generate Service Key"
-  - Copy the key
-- When running the commands in `Starting LibreChat and OpenWebUI` section, be sure to have MEZMO_API_KEY environment variable defined
-  - You can supply it when you run the docker up command by preceding the command with the variable:
-    - `MEZMO_API_KEY=your_key_from_mezmo docker compose up -d`
-  - Alternatively, you can export the environment variable so it's available for the current terminal session like so:
-    - `export MEZMO_API_KEY=your_key_from_mezmo`
+- You have Aura web-server running on docker's host on port 8080.  See [running the web server](../README.md#web-api-server) for help on this.
 
 ## Starting LibreChat and OpenWebUI
 

--- a/development/configs/librechat.yaml
+++ b/development/configs/librechat.yaml
@@ -8,13 +8,13 @@ endpoints:
   custom:
     # Aura Server - OpenAI-compatible endpoint
     - name: "Aura"
-      apiKey: "${MEZMO_API_KEY}"  # Use environment variable
+      apiKey: "not_used"
       baseURL: "http://host.docker.internal:8080/v1"
       models:
         default:
-          - "claude-3-5-sonnet-20241022"  # Your default model from config.toml
           - "gpt-4o"
           - "gpt-4o-mini"
+          - "claude-3-5-sonnet-20241022"
         fetch: false  # Don't try to fetch models from /v1/models
       titleConvo: true
       titleModel: "aura"

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -59,9 +59,6 @@ services:
       # Allow registration
       - ALLOW_REGISTRATION=true
 
-      # Mezmo API Key (for aura endpoint)
-      - MEZMO_API_KEY=${MEZMO_API_KEY}
-
     volumes:
       - ./configs/librechat.yaml:/app/librechat.yaml:ro
       - aura-librechat-data:/app/client/public/images


### PR DESCRIPTION
Add to the development/README so that the user  knows they need aura web-server running
Changed the order of models in the librechat.yaml
since we are guiding the user toward OpenAI first.

Ref: LOG-22815