### PR TITLE
doc: add quickstart with Docker Compose (Aura + LibreChat + Phoenix)

### DIFF
--- a/examples/quickstart/.env.example
+++ b/examples/quickstart/.env.example
@@ -1,0 +1,12 @@
+# Copy this file to .env and fill in your API key(s).
+#
+#   cp .env.example .env
+
+# Required: at least one LLM provider key
+OPENAI_API_KEY=sk-...
+
+# Optional: Anthropic (uncomment the anthropic block in config.toml)
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# Optional: Mezmo MCP server
+# MEZMO_API_KEY=...

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,0 +1,109 @@
+# Aura Quickstart
+
+One command to spin up a fully working AI agent stack:
+
+- **Aura** — the AI agent server
+- **LibreChat** — a ChatGPT-style web UI connected to Aura
+- **Phoenix** — an LLM trace viewer for inspecting every tool call, prompt, and token
+
+## Setup
+
+### 1. Add your API key
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and paste your OpenAI (or Anthropic) API key.
+
+### 2. Start everything
+
+```bash
+docker compose up
+```
+
+### 3. Open the UIs
+
+| Service | URL | Description |
+|---------|-----|-------------|
+| LibreChat | <http://localhost:3080> | Chat with your agent |
+| Phoenix | <http://localhost:6006> | Inspect LLM traces |
+| Aura API | <http://localhost:3000> | OpenAI-compatible API |
+
+**LibreChat first-time setup:** Create your user account on the signup page. The agent model is pre-configured as "Aura".
+
+## Customize Your Agent
+
+Edit `config.toml` in this directory, then restart:
+
+```bash
+docker compose restart aura
+```
+
+### Switch LLM provider
+
+Uncomment the Anthropic or Ollama block in `config.toml` and set the matching API key in `.env`.
+
+### Add MCP tool servers
+
+Uncomment the `[mcp]` section in `config.toml` and point it at your MCP server:
+
+```toml
+[mcp]
+sanitize_schemas = true
+
+[mcp.servers.my_tools]
+transport = "http_streamable"
+url = "http://host.docker.internal:9000/mcp"
+```
+
+Use `host.docker.internal` to reach services running on your host machine.
+
+### Add RAG (vector search)
+
+Uncomment the `[[vector_stores]]` section in `config.toml`. You'll need a Qdrant instance — you can add one to the compose file or point at an external one.
+
+### Full configuration reference
+
+See [`examples/reference.toml`](../reference.toml) for all available options.
+
+## Architecture
+
+```
+┌───────────────────────────────────────────────────┐
+│  docker compose                                   │
+│                                                   │
+│  ┌────────────┐     ┌──────────┐    ┌──────────┐  │
+│  │ LibreChat  │────▶│   Aura   │───▶│ Phoenix  │  │
+│  │   :3080    │     │  :3030   │    │  :6006   │  │
+│  └─────┬──────┘     └────┬─────┘    └──────────┘  │
+│        │                 │          OTel traces   │
+│  ┌─────┴──────┐          │                        │
+│  │  MongoDB   │          │                        │
+│  │ (LibreChat │          │                        │
+│  │  storage)  │          │                        │
+│  └────────────┘          │                        │
+└──────────────────────────┼────────────────────────┘
+         ▲                 │
+         │                 ▼
+      Browser         LLM Provider
+                     (OpenAI, etc.)
+```
+
+- **LibreChat** sends chat requests to Aura's OpenAI-compatible `/v1/chat/completions` endpoint. MongoDB is used by LibreChat internally for user accounts and conversation history — Aura does not use it.
+- **Aura** calls the configured LLM provider, executes MCP tools, and streams responses back
+- **Phoenix** receives OpenTelemetry traces from Aura so you can inspect every step
+
+## Troubleshooting
+
+**LibreChat shows "no models available"**
+Aura may still be starting. Wait for the health check to pass (`docker compose logs aura --tail 5`) and refresh.
+
+**"connection refused" in Aura logs**
+If referencing services on your host, use `host.docker.internal` instead of `localhost` in `config.toml`.
+
+**Reset everything**
+
+```bash
+docker compose down -v
+```

--- a/examples/quickstart/config.toml
+++ b/examples/quickstart/config.toml
@@ -1,0 +1,62 @@
+# Aura Quickstart Configuration
+#
+# Customize this file to change your agent's behavior, LLM provider,
+# tools, and RAG pipelines. Changes take effect on restart.
+#
+# For all available options, see: examples/reference.toml
+
+# ── LLM Provider ────────────────────────────────────────────────────
+# Switch providers by uncommenting the relevant block below.
+
+[llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+
+# Anthropic:
+# provider = "anthropic"
+# api_key = "{{ env.ANTHROPIC_API_KEY }}"
+# model = "claude-sonnet-4-20250514"
+
+# Ollama (local, no API key needed):
+# provider = "ollama"
+# model = "llama3.1"
+# base_url = "http://host.docker.internal:11434"
+# fallback_tool_parsing = true
+
+# ── Agent ───────────────────────────────────────────────────────────
+
+[agent]
+name = "Aura Assistant"
+system_prompt = """
+You are a helpful assistant with access to external tools and
+knowledge bases. Use them to provide accurate, grounded answers.
+"""
+# Maximum tool-calling rounds per user turn
+turn_depth = 5
+
+# ── MCP Tool Servers (optional) ─────────────────────────────────────
+# Uncomment and configure to give your agent access to external tools.
+#
+# [mcp]
+# sanitize_schemas = true
+#
+# [mcp.servers.my_tools]
+# transport = "http_streamable"
+# url = "http://host.docker.internal:9000/mcp"
+# description = "My MCP tool server"
+
+# ── Vector Stores / RAG (optional) ──────────────────────────────────
+# Uncomment to enable retrieval-augmented generation with Qdrant.
+#
+# [[vector_stores]]
+# name = "docs"
+# type = "qdrant"
+# url = "http://host.docker.internal:6334"
+# collection_name = "my_collection"
+# context_prefix = "Relevant documentation"
+#
+# [vector_stores.embedding_model]
+# provider = "openai"
+# model = "text-embedding-3-small"
+# api_key = "{{ env.OPENAI_API_KEY }}"

--- a/examples/quickstart/configs/librechat.yaml
+++ b/examples/quickstart/configs/librechat.yaml
@@ -1,0 +1,21 @@
+# LibreChat configuration for the Aura quickstart.
+# See: https://docs.librechat.ai/install/configuration/custom_config.html
+
+version: 1.1.5
+
+endpoints:
+  custom:
+    - name: "Aura"
+      apiKey: "not_used"
+      baseURL: "http://aura:3000/v1"
+      models:
+        default:
+          - "aura"
+        fetch: false
+      titleConvo: true
+      titleModel: "aura"
+      summarize: false
+      forcePrompt: false
+      modelDisplayLabel: "Aura"
+      addParams:
+        stream: true

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -1,0 +1,98 @@
+services:
+  # ── Aura Agent Server ───────────────────────────────────────────────
+  aura:
+    image: mezmo/aura:1
+    container_name: aura
+    command:
+      - ./aura-web-server
+      - --verbose
+    ports:
+      - "3000:3000"
+    environment:
+      HOST: "0.0.0.0"
+      PORT: "3000"
+      CONFIG_PATH: "/app/config/config.toml"
+
+      # LLM API keys (from .env)
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+
+      # Optional: Mezmo
+      MEZMO_API_KEY: "${MEZMO_API_KEY:-}"
+
+      # Streaming — custom events disabled because LibreChat's SSE
+      # parser doesn't skip unknown event types (aura.session_info, etc.)
+      AURA_CUSTOM_EVENTS: "false"
+      AURA_EMIT_REASONING: "false"
+      TOOL_RESULT_MODE: "none"
+
+      # OpenTelemetry → Phoenix
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://phoenix:4317"
+      OTEL_RECORD_CONTENT: "true"
+    volumes:
+      - ./config.toml:/app/config/config.toml:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - aura-quickstart
+
+  # ── LibreChat (Chat UI) ────────────────────────────────────────────
+  librechat-mongodb:
+    image: mongo:latest
+    container_name: aura-qs-mongodb
+    volumes:
+      - mongodb-data:/data/db
+    restart: unless-stopped
+    networks:
+      - aura-quickstart
+
+  librechat:
+    image: ghcr.io/danny-avila/librechat:v0.7.8
+    container_name: aura-qs-librechat
+    ports:
+      - "3080:3080"
+    depends_on:
+      aura:
+        condition: service_healthy
+      librechat-mongodb:
+        condition: service_started
+    environment:
+      MONGO_URI: "mongodb://librechat-mongodb:27017/LibreChat"
+      HOST: "0.0.0.0"
+      PORT: "3080"
+      ENDPOINTS: "custom"
+      ALLOW_REGISTRATION: "true"
+      CONFIG_PATH: "/app/librechat.yaml"
+      # Session secrets (change these in production)
+      CREDS_KEY: "f34be427ebb29de8d88c107a71546019685ed8b241d8f2ed00c3df97ad2566f0"
+      CREDS_IV: "e2341419ec3dd3d19b13a1a87fafcbfb"
+      JWT_SECRET: "16f8c0ef4a5d391b26034086c628469d3f9f497f08163ab9b40137092f2909ef"
+      JWT_REFRESH_SECRET: "eaa5191f2914e30b9387fd84e254e4ba6fc51b4654968a9b0803b456a54b8418"
+    volumes:
+      - ./configs/librechat.yaml:/app/librechat.yaml:ro
+    restart: unless-stopped
+    networks:
+      - aura-quickstart
+
+  # ── Phoenix (LLM Trace Viewer) ─────────────────────────────────────
+  phoenix:
+    image: arizephoenix/phoenix:latest
+    container_name: aura-qs-phoenix
+    ports:
+      - "6006:6006"   # UI
+      - "4317:4317"   # OTLP gRPC
+    restart: unless-stopped
+    networks:
+      - aura-quickstart
+
+networks:
+  aura-quickstart:
+    driver: bridge
+
+volumes:
+  mongodb-data:


### PR DESCRIPTION
Self-contained examples/quickstart/ that spins up the full stack with a single `docker compose up`:
- Aura agent server (mezmo/aura:1.13.1 from Docker Hub)
- LibreChat v0.7.8 chat UI, pre-wired to Aura
- Phoenix LLM trace viewer with OTel gRPC ingestion

Includes editable config.toml, .env.example, and LibreChat config.

ref: LOG-22815