### PR TITLE
chore(ci): validate commits on push

### DIFF
--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Lint commits
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  # each new commit to a PR runs this workflow
+  # so we need to avoid a long running older one from overwriting the 'pr-<number>-latest'
+  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          show-progress: false
+          fetch-depth: 0
+
+      - name: Install cocogitto to lint commits
+        uses: taiki-e/install-action@385db9cc6bf65d19775b02084a4b698eaca9a4f2 # v2.68.19
+        with:
+          tool: cocogitto
+
+      - name: Check the commits
+        shell: bash
+        run: |
+          cog check

--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,3 @@
+from_latest_tag = true
+ignore_merge_commits = true
+tag_prefix = "v"


### PR DESCRIPTION
Validates the commits against the conventional commits standard 