### PR TITLE
feat: add on-demand skill loading for agents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rmcp = { version = "0.12.0", features = ["transport-child-process", "client", "t
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
 toml = "0.8"
 
 # Async runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,9 @@ RUN apt-get update && apt-get install -y \
 # Create app user for security
 RUN useradd -r -s /bin/false appuser
 
-# Create app directory and config directory
+# Create app directory, config directory, and skills directory
 WORKDIR /app
-RUN mkdir -p /app/config && chown -R appuser:appuser /app
+RUN mkdir -p /app/config /app/skills && chown -R appuser:appuser /app
 
 # Copy binary from release-build stage
 COPY --from=release-build /usr/src/app/target/release/aura-web-server /app/
@@ -41,6 +41,7 @@ EXPOSE 3030
 ENV HOST=0.0.0.0
 ENV PORT=3030
 ENV CONFIG_PATH=/app/config/config.toml
+ENV AURA_SKILLS_DIR=/app/skills
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/crates/aura-config/Cargo.toml
+++ b/crates/aura-config/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.12", features = ["stream", "json"] }
 # Serialization
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 toml = { workspace = true }
 
 # Configuration
@@ -40,6 +41,9 @@ regex = { workspace = true }
 
 # Logging for binaries
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"
 
 [[bin]]
 name = "debug_config"

--- a/crates/aura-config/src/builder.rs
+++ b/crates/aura-config/src/builder.rs
@@ -1,17 +1,234 @@
-use crate::{Config, ConfigError};
+use crate::{config::LocalSkillSource, Config, ConfigError};
 use aura::{
     Agent, AgentBuilder, AgentConfig, AgentSettings, EmbeddingModelConfig, LlmConfig, McpConfig,
-    McpServerConfig, ReasoningEffort, ToolsConfig, VectorStoreConfig,
+    McpServerConfig, ReasoningEffort, SkillConfig, ToolsConfig, VectorStoreConfig,
 };
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// YAML frontmatter parsed from SKILL.md files.
+///
+/// Follows the Agent Skills specification (<https://agentskills.io/specification>).
+#[derive(Debug, serde::Deserialize)]
+struct SkillFrontmatter {
+    /// Required: must match the parent directory name, 1-64 chars,
+    /// lowercase alphanumeric and hyphens only.
+    name: String,
+    /// Required: 1-1024 chars describing what the skill does and when to use it.
+    description: String,
+}
+
+/// Validate a skill name per the Agent Skills specification.
+///
+/// Rules:
+/// - 1-64 characters
+/// - Lowercase alphanumeric and hyphens only
+/// - Must not start or end with a hyphen
+/// - Must not contain consecutive hyphens
+fn validate_skill_name(name: &str) -> Result<(), String> {
+    if name.is_empty() || name.len() > 64 {
+        return Err(format!(
+            "Skill name must be 1-64 characters, got {} characters",
+            name.len()
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return Err(format!(
+            "Skill name '{}' contains invalid characters (only lowercase alphanumeric and hyphens allowed)",
+            name
+        ));
+    }
+    if name.starts_with('-') || name.ends_with('-') {
+        return Err(format!(
+            "Skill name '{}' must not start or end with a hyphen",
+            name
+        ));
+    }
+    if name.contains("--") {
+        return Err(format!(
+            "Skill name '{}' must not contain consecutive hyphens",
+            name
+        ));
+    }
+    Ok(())
+}
+
+/// Parse YAML frontmatter delimited by `---` from a SKILL.md file.
+///
+/// Returns the parsed frontmatter struct.
+fn parse_skill_frontmatter(content: &str) -> Result<SkillFrontmatter, ConfigError> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return Err(ConfigError::Validation(
+            "SKILL.md must start with YAML frontmatter (---)".to_string(),
+        ));
+    }
+
+    let after_first = &trimmed[3..];
+    let closing = after_first.find("---").ok_or_else(|| {
+        ConfigError::Validation("SKILL.md frontmatter missing closing ---".to_string())
+    })?;
+
+    let yaml_str = &after_first[..closing];
+
+    let frontmatter: SkillFrontmatter = serde_yaml::from_str(yaml_str).map_err(|e| {
+        ConfigError::Validation(format!("Failed to parse SKILL.md frontmatter: {e}"))
+    })?;
+
+    if frontmatter.description.is_empty() {
+        return Err(ConfigError::Validation(
+            "SKILL.md frontmatter must include a non-empty 'description' field".to_string(),
+        ));
+    }
+
+    if frontmatter.description.len() > 1024 {
+        return Err(ConfigError::Validation(format!(
+            "Skill description exceeds 1024 character limit (got {} characters)",
+            frontmatter.description.len()
+        )));
+    }
+
+    validate_skill_name(&frontmatter.name).map_err(ConfigError::Validation)?;
+
+    Ok(frontmatter)
+}
+
+/// Discover skills from local source directories.
+///
+/// Scans each source directory for subdirectories containing a `SKILL.md` file.
+/// The `name` field in frontmatter must match the directory name (per the spec).
+fn discover_skills(
+    sources: &[LocalSkillSource],
+    config_dir: Option<&Path>,
+) -> Result<Vec<SkillConfig>, ConfigError> {
+    let mut skills = Vec::new();
+
+    for source in sources {
+        let source_path = PathBuf::from(&source.source);
+        let resolved = if source_path.is_absolute() {
+            source_path
+        } else if let Some(base) = config_dir {
+            base.join(&source_path)
+        } else {
+            std::env::current_dir()
+                .map_err(|e| {
+                    ConfigError::Validation(format!("Cannot resolve relative skill path: {e}"))
+                })?
+                .join(&source_path)
+        };
+
+        let resolved = resolved.canonicalize().map_err(|e| {
+            ConfigError::Validation(format!(
+                "Skill source directory '{}' not found: {e}",
+                resolved.display()
+            ))
+        })?;
+
+        tracing::info!("Discovering skills from: {}", resolved.display());
+
+        let entries = std::fs::read_dir(&resolved).map_err(|e| {
+            ConfigError::Validation(format!(
+                "Cannot read skill source directory '{}': {e}",
+                resolved.display()
+            ))
+        })?;
+
+        for entry in entries {
+            let entry = entry.map_err(|e| {
+                ConfigError::Validation(format!("Error reading skill directory entry: {e}"))
+            })?;
+
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            let skill_file = path.join("SKILL.md");
+            if !skill_file.exists() {
+                tracing::debug!("Skipping directory '{}' (no SKILL.md)", path.display());
+                continue;
+            }
+
+            let dir_name = entry.file_name().to_string_lossy().to_string();
+
+            let content = std::fs::read_to_string(&skill_file).map_err(|e| {
+                ConfigError::Validation(format!(
+                    "Failed to read SKILL.md in '{}': {e}",
+                    path.display()
+                ))
+            })?;
+
+            let frontmatter = parse_skill_frontmatter(&content)?;
+
+            // Per spec: name must match the parent directory name
+            if frontmatter.name != dir_name {
+                return Err(ConfigError::Validation(format!(
+                    "Skill name '{}' in SKILL.md does not match directory name '{}'",
+                    frontmatter.name, dir_name
+                )));
+            }
+
+            tracing::info!(
+                "  Discovered skill '{}': {}",
+                dir_name,
+                frontmatter.description
+            );
+
+            skills.push(SkillConfig {
+                name: dir_name,
+                description: frontmatter.description,
+                path: path.clone(),
+            });
+        }
+    }
+
+    // Deduplicate: keep the first occurrence, warn on duplicates
+    let mut seen: HashMap<String, PathBuf> = HashMap::new();
+    skills.retain(|skill| {
+        if let Some(existing_path) = seen.get(&skill.name) {
+            tracing::warn!(
+                "Duplicate skill '{}' found in '{}' (already loaded from '{}'), skipping",
+                skill.name,
+                skill.path.display(),
+                existing_path.display()
+            );
+            false
+        } else {
+            seen.insert(skill.name.clone(), skill.path.clone());
+            true
+        }
+    });
+
+    // Sort by name for deterministic ordering
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Ok(skills)
+}
 
 pub struct RigBuilder {
     config: Config,
+    /// Base directory for resolving relative paths (derived from config file path)
+    config_dir: Option<PathBuf>,
 }
 
 impl RigBuilder {
     pub fn new(config: Config) -> Self {
-        Self { config }
+        Self {
+            config,
+            config_dir: None,
+        }
+    }
+
+    /// Set the base directory for resolving relative paths in config.
+    ///
+    /// This is typically derived from the config file's parent directory.
+    /// Used for resolving relative skill source paths.
+    pub fn with_config_dir(mut self, config_dir: PathBuf) -> Self {
+        self.config_dir = Some(config_dir);
+        self
     }
 
     /// Get the AgentConfig for debugging purposes
@@ -86,6 +303,17 @@ impl RigBuilder {
             crate::config::ReasoningEffort::High => ReasoningEffort::High,
         });
 
+        // Build effective skill sources: explicit config > AURA_SKILLS_DIR env fallback
+        let mut skill_sources = self.config.agent.skills.local.clone();
+        if skill_sources.is_empty()
+            && let Ok(env_dir) = std::env::var("AURA_SKILLS_DIR")
+        {
+            tracing::info!("Using AURA_SKILLS_DIR fallback: {}", env_dir);
+            skill_sources.push(LocalSkillSource { source: env_dir });
+        }
+
+        let skills = discover_skills(&skill_sources, self.config_dir.as_deref())?;
+
         let agent = AgentSettings {
             name: self.config.agent.name.clone(),
             system_prompt: self.config.agent.system_prompt.clone(),
@@ -94,6 +322,7 @@ impl RigBuilder {
             reasoning_effort,
             max_tokens: self.config.agent.max_tokens,
             turn_depth: self.config.agent.turn_depth,
+            skills,
         };
 
         let vector_stores: Vec<VectorStoreConfig> = self
@@ -249,6 +478,243 @@ fn resolve_mcp_headers(
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    // -----------------------------------------------------------------------
+    // validate_skill_name tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn validate_skill_name_valid() {
+        assert!(validate_skill_name("code-review").is_ok());
+        assert!(validate_skill_name("a").is_ok());
+        assert!(validate_skill_name("my-skill-123").is_ok());
+    }
+
+    #[test]
+    fn validate_skill_name_empty() {
+        let err = validate_skill_name("").unwrap_err();
+        assert!(err.contains("1-64 characters"));
+    }
+
+    #[test]
+    fn validate_skill_name_too_long() {
+        let long_name = "a".repeat(65);
+        let err = validate_skill_name(&long_name).unwrap_err();
+        assert!(err.contains("1-64 characters"));
+    }
+
+    #[test]
+    fn validate_skill_name_max_length_ok() {
+        let name = "a".repeat(64);
+        assert!(validate_skill_name(&name).is_ok());
+    }
+
+    #[test]
+    fn validate_skill_name_uppercase_rejected() {
+        let err = validate_skill_name("Code-Review").unwrap_err();
+        assert!(err.contains("invalid characters"));
+    }
+
+    #[test]
+    fn validate_skill_name_leading_hyphen() {
+        let err = validate_skill_name("-code").unwrap_err();
+        assert!(err.contains("must not start or end with a hyphen"));
+    }
+
+    #[test]
+    fn validate_skill_name_trailing_hyphen() {
+        let err = validate_skill_name("code-").unwrap_err();
+        assert!(err.contains("must not start or end with a hyphen"));
+    }
+
+    #[test]
+    fn validate_skill_name_consecutive_hyphens() {
+        let err = validate_skill_name("code--review").unwrap_err();
+        assert!(err.contains("consecutive hyphens"));
+    }
+
+    #[test]
+    fn validate_skill_name_underscore_rejected() {
+        let err = validate_skill_name("code_review").unwrap_err();
+        assert!(err.contains("invalid characters"));
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_skill_frontmatter tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_frontmatter_valid() {
+        let content = "---\nname: my-skill\ndescription: A test skill\n---\n# Body";
+        let fm = parse_skill_frontmatter(content).unwrap();
+        assert_eq!(fm.name, "my-skill");
+        assert_eq!(fm.description, "A test skill");
+    }
+
+    #[test]
+    fn parse_frontmatter_missing_opening() {
+        let content = "name: my-skill\ndescription: A test skill\n---\n# Body";
+        let err = parse_skill_frontmatter(content).unwrap_err();
+        assert!(err.to_string().contains("must start with YAML frontmatter"));
+    }
+
+    #[test]
+    fn parse_frontmatter_missing_closing() {
+        let content = "---\nname: my-skill\ndescription: A test skill\n# Body";
+        let err = parse_skill_frontmatter(content).unwrap_err();
+        assert!(err.to_string().contains("missing closing"));
+    }
+
+    #[test]
+    fn parse_frontmatter_empty_description() {
+        let content = "---\nname: my-skill\ndescription: \"\"\n---\n# Body";
+        let err = parse_skill_frontmatter(content).unwrap_err();
+        assert!(err.to_string().contains("non-empty 'description'"));
+    }
+
+    #[test]
+    fn parse_frontmatter_description_too_long() {
+        let long_desc = "a".repeat(1025);
+        let content = format!("---\nname: my-skill\ndescription: {long_desc}\n---\n# Body");
+        let err = parse_skill_frontmatter(&content).unwrap_err();
+        assert!(err.to_string().contains("1024 character limit"));
+    }
+
+    #[test]
+    fn parse_frontmatter_invalid_name() {
+        let content = "---\nname: Code-Review\ndescription: A skill\n---\n# Body";
+        let err = parse_skill_frontmatter(content).unwrap_err();
+        assert!(err.to_string().contains("invalid characters"));
+    }
+
+    #[test]
+    fn parse_frontmatter_missing_name_field() {
+        let content = "---\ndescription: A skill\n---\n# Body";
+        let err = parse_skill_frontmatter(content).unwrap_err();
+        assert!(err.to_string().contains("Failed to parse"));
+    }
+
+    // -----------------------------------------------------------------------
+    // discover_skills tests
+    // -----------------------------------------------------------------------
+
+    fn write_skill(dir: &std::path::Path, name: &str, description: &str) {
+        let skill_dir = dir.join(name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let mut f = std::fs::File::create(skill_dir.join("SKILL.md")).unwrap();
+        write!(
+            f,
+            "---\nname: {name}\ndescription: {description}\n---\n# {name}\nContent."
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn discover_skills_happy_path() {
+        let dir = TempDir::new().unwrap();
+        write_skill(dir.path(), "alpha", "Alpha skill");
+        write_skill(dir.path(), "beta", "Beta skill");
+
+        let sources = vec![LocalSkillSource {
+            source: dir.path().to_string_lossy().to_string(),
+        }];
+        let skills = discover_skills(&sources, None).unwrap();
+
+        assert_eq!(skills.len(), 2);
+        // Should be sorted by name
+        assert_eq!(skills[0].name, "alpha");
+        assert_eq!(skills[1].name, "beta");
+    }
+
+    #[test]
+    fn discover_skills_skips_non_skill_dirs() {
+        let dir = TempDir::new().unwrap();
+        write_skill(dir.path(), "real-skill", "A real skill");
+        // Create a directory without SKILL.md
+        std::fs::create_dir_all(dir.path().join("not-a-skill")).unwrap();
+        // Create a plain file (not a directory)
+        std::fs::write(dir.path().join("readme.md"), "# README").unwrap();
+
+        let sources = vec![LocalSkillSource {
+            source: dir.path().to_string_lossy().to_string(),
+        }];
+        let skills = discover_skills(&sources, None).unwrap();
+
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "real-skill");
+    }
+
+    #[test]
+    fn discover_skills_name_mismatch_errors() {
+        let dir = TempDir::new().unwrap();
+        let skill_dir = dir.path().join("wrong-name");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let mut f = std::fs::File::create(skill_dir.join("SKILL.md")).unwrap();
+        write!(
+            f,
+            "---\nname: correct-name\ndescription: Mismatched\n---\n# Content"
+        )
+        .unwrap();
+
+        let sources = vec![LocalSkillSource {
+            source: dir.path().to_string_lossy().to_string(),
+        }];
+        let err = discover_skills(&sources, None).unwrap_err();
+        assert!(err.to_string().contains("does not match directory name"));
+    }
+
+    #[test]
+    fn discover_skills_deduplicates() {
+        let dir1 = TempDir::new().unwrap();
+        let dir2 = TempDir::new().unwrap();
+        write_skill(dir1.path(), "shared", "First copy");
+        write_skill(dir2.path(), "shared", "Second copy");
+
+        let sources = vec![
+            LocalSkillSource {
+                source: dir1.path().to_string_lossy().to_string(),
+            },
+            LocalSkillSource {
+                source: dir2.path().to_string_lossy().to_string(),
+            },
+        ];
+        let skills = discover_skills(&sources, None).unwrap();
+
+        // Duplicate should be dropped, keeping first
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].description, "First copy");
+    }
+
+    #[test]
+    fn discover_skills_relative_path_with_config_dir() {
+        let base = TempDir::new().unwrap();
+        let skills_dir = base.path().join("my-skills");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        write_skill(&skills_dir, "test-skill", "A test");
+
+        let sources = vec![LocalSkillSource {
+            source: "my-skills".to_string(),
+        }];
+        let skills = discover_skills(&sources, Some(base.path())).unwrap();
+
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "test-skill");
+    }
+
+    #[test]
+    fn discover_skills_nonexistent_source_errors() {
+        let sources = vec![LocalSkillSource {
+            source: "/nonexistent/path/to/skills".to_string(),
+        }];
+        let err = discover_skills(&sources, None).unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_mcp_headers tests
+    // -----------------------------------------------------------------------
 
     /// Build a minimal AgentConfig with one HttpStreamable MCP server.
     fn make_agent_config(

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -239,6 +239,21 @@ pub struct ToolsConfig {
     pub custom_tools: Vec<String>,
 }
 
+/// Skills configuration - supports directory-based skill discovery
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct SkillsConfig {
+    /// Local skill sources (directories containing skill subdirectories)
+    #[serde(default)]
+    pub local: Vec<LocalSkillSource>,
+}
+
+/// A local directory source for skill discovery
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct LocalSkillSource {
+    /// Path to directory containing skill subdirectories (absolute or relative to config file)
+    pub source: String,
+}
+
 /// Agent configuration
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AgentConfig {
@@ -256,6 +271,9 @@ pub struct AgentConfig {
     #[serde(default = "default_turn_depth")]
     #[serde(deserialize_with = "lenient_int::deserialize_option_usize")]
     pub turn_depth: Option<usize>,
+    /// Skills configuration for directory-based skill discovery
+    #[serde(default)]
+    pub skills: SkillsConfig,
 }
 
 fn default_turn_depth() -> Option<usize> {
@@ -272,6 +290,7 @@ impl Default for AgentConfig {
             reasoning_effort: None,
             max_tokens: None,
             turn_depth: default_turn_depth(),
+            skills: SkillsConfig::default(),
         }
     }
 }
@@ -312,6 +331,15 @@ impl Config {
                     "Embedding model API key is required for vector store '{}'",
                     store.name
                 )));
+            }
+        }
+
+        // Validate skill sources
+        for source in &self.agent.skills.local {
+            if source.source.is_empty() {
+                return Err(crate::ConfigError::Validation(
+                    "Skill source path cannot be empty".to_string(),
+                ));
             }
         }
 

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -121,8 +121,9 @@ struct ResponseContext {
 async fn build_agent_for_request(
     config: &aura_config::Config,
     req_headers: &HashMap<String, String>,
+    config_dir: &std::path::Path,
 ) -> Result<Arc<aura::Agent>, HttpResponse> {
-    let builder = RigBuilder::new(config.clone());
+    let builder = RigBuilder::new(config.clone()).with_config_dir(config_dir.to_path_buf());
     let agent = builder
         .build_agent_with_headers(Some(req_headers))
         .await
@@ -185,7 +186,7 @@ async fn prepare_request(
         .collect();
 
     // Build a fresh agent for this request
-    let agent = match build_agent_for_request(&data.config, req_headers_map).await {
+    let agent = match build_agent_for_request(&data.config, req_headers_map, &data.config_dir).await {
         Ok(agent) => agent,
         Err(response) => return Err(response),
     };

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -136,6 +136,15 @@ async fn run() -> std::io::Result<()> {
     let (provider, model) = config_arc.llm.model_info();
     info!("Aura initialized with {}/{}", provider, model);
 
+    // Derive config directory from config file's parent directory.
+    // Path::parent() on a bare filename like "config.toml" returns Some("") (empty path),
+    // so we filter that out and fall back to "." for the current directory.
+    let config_dir = std::path::Path::new(&args.config)
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+
     // Two-phase shutdown: gate (immediate 503) → grace period → stream drain ([DONE])
     let shutdown_token = CancellationToken::new();
     let stream_shutdown_token = CancellationToken::new();
@@ -153,6 +162,7 @@ async fn run() -> std::io::Result<()> {
         aura_emit_reasoning: args.aura_emit_reasoning,
         streaming_timeout_secs: args.streaming_timeout_secs,
         first_chunk_timeout_secs: args.first_chunk_timeout_secs,
+        config_dir,
         shutdown_token: shutdown_token.clone(),
         stream_shutdown_token: stream_shutdown_token.clone(),
         active_requests: active_requests.clone(),

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -61,6 +61,8 @@ pub struct AppState {
     pub streaming_timeout_secs: u64,
     /// First chunk timeout in seconds (0 = disabled). Protects against hung provider connections.
     pub first_chunk_timeout_secs: u64,
+    /// Base directory for resolving relative config paths (skill sources, etc.)
+    pub config_dir: std::path::PathBuf,
     /// Shutdown gate — cancelled immediately on SIGTERM/SIGINT to reject new requests (503)
     pub shutdown_token: CancellationToken,
     /// Stream shutdown — cancelled after grace period to terminate in-flight streams

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -48,6 +48,9 @@ uuid = { workspace = true }
 regex = "1"
 async-stream = "0.3"
 
+[dev-dependencies]
+tempfile = "3"
+
 [features]
 default = ["otel"]
 otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -6,6 +6,7 @@ use crate::{
         BuilderState, CompletionResponse, ProviderAgent, StreamError, StreamItem,
         StreamedAssistantContent,
     },
+    skill_tool::LoadSkillTool,
     tools::{FilesystemTool, ListDirTool, ReadFileTool, WriteFileTool},
     vector_dynamic::DynamicVectorSearchTool,
     vector_store::VectorStoreManager,
@@ -160,6 +161,20 @@ impl Agent {
             );
         }
 
+        // Build effective system prompt, appending skill catalog if skills are configured
+        let system_prompt = if config.agent.skills.is_empty() {
+            config.agent.system_prompt.clone()
+        } else {
+            let mut prompt = config.agent.system_prompt.clone();
+            prompt.push_str(
+                "\n\nAvailable skills (use the `load_skill` tool to load before answering):\n",
+            );
+            for skill in &config.agent.skills {
+                prompt.push_str(&format!("- {}: {}\n", skill.name, skill.description));
+            }
+            prompt
+        };
+
         // Build provider-specific agent with tools
         // Each branch creates its own completion model and agent builder,
         // adds tools using the shared BuilderState helper, then wraps in ProviderAgent
@@ -191,7 +206,7 @@ impl Agent {
 
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
-                agent_builder = agent_builder.preamble(&config.agent.system_prompt);
+                agent_builder = agent_builder.preamble(&system_prompt);
                 if let Some(temp) = config.agent.temperature {
                     agent_builder = agent_builder.temperature(temp);
                 }
@@ -249,7 +264,7 @@ impl Agent {
 
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
-                agent_builder = agent_builder.preamble(&config.agent.system_prompt);
+                agent_builder = agent_builder.preamble(&system_prompt);
                 if let Some(temp) = config.agent.temperature {
                     agent_builder = agent_builder.temperature(temp);
                 }
@@ -303,7 +318,7 @@ impl Agent {
 
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
-                agent_builder = agent_builder.preamble(&config.agent.system_prompt);
+                agent_builder = agent_builder.preamble(&system_prompt);
                 if let Some(temp) = config.agent.temperature {
                     agent_builder = agent_builder.temperature(temp);
                 }
@@ -341,7 +356,7 @@ impl Agent {
                 let completion_model = client.completion_model(model);
 
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
-                agent_builder = agent_builder.preamble(&config.agent.system_prompt);
+                agent_builder = agent_builder.preamble(&system_prompt);
                 if let Some(temp) = config.agent.temperature {
                     agent_builder = agent_builder.temperature(temp);
                 }
@@ -377,7 +392,7 @@ impl Agent {
 
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
-                agent_builder = agent_builder.preamble(&config.agent.system_prompt);
+                agent_builder = agent_builder.preamble(&system_prompt);
                 if let Some(temp) = config.agent.temperature {
                     agent_builder = agent_builder.temperature(temp);
                 }
@@ -517,6 +532,25 @@ impl Agent {
                 tracing::info!("  Adding {} STDIO tools for client group", tools.len());
                 builder_state = builder_state.add_rmcp_tools(tools, client);
             }
+        }
+
+        // Add skill loading tool if skills are configured
+        if !config.agent.skills.is_empty() {
+            tracing::info!(
+                "Adding load_skill tool with {} skills",
+                config.agent.skills.len(),
+            );
+            for skill in &config.agent.skills {
+                tracing::info!(
+                    "  Skill '{}': {} (dir: {:?})",
+                    skill.name,
+                    skill.description,
+                    skill.path
+                );
+            }
+
+            let skill_tool = LoadSkillTool::new(&config.agent.skills);
+            builder_state = builder_state.add_tool(skill_tool);
         }
 
         Ok(builder_state)

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -171,6 +171,21 @@ impl LlmConfig {
     }
 }
 
+/// Skill configuration for on-demand loading via the load_skill tool.
+///
+/// Skills follow the Agent Skills specification (<https://agentskills.io/specification>).
+/// Each skill is a directory containing a `SKILL.md` file with YAML frontmatter.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillConfig {
+    /// Unique name for this skill (must match directory name).
+    /// Lowercase alphanumeric and hyphens only, 1-64 chars.
+    pub name: String,
+    /// Human-readable description from SKILL.md frontmatter
+    pub description: String,
+    /// Absolute path to the skill directory
+    pub path: std::path::PathBuf,
+}
+
 /// Agent behavior settings
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentSettings {
@@ -183,6 +198,9 @@ pub struct AgentSettings {
     pub max_tokens: Option<u64>,
     #[serde(default, deserialize_with = "lenient_int::deserialize_option_usize")]
     pub turn_depth: Option<usize>,
+    /// On-demand skill definitions loaded via the load_skill tool
+    #[serde(default)]
+    pub skills: Vec<SkillConfig>,
 }
 
 /// Vector store configuration
@@ -258,6 +276,7 @@ impl Default for AgentConfig {
                 reasoning_effort: None,
                 max_tokens: None,
                 turn_depth: Some(5),
+                skills: Vec::new(),
             },
             vector_stores: Vec::new(),
             mcp: None,

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -25,6 +25,7 @@ pub mod rag_tools;
 pub mod request_cancellation;
 pub mod request_progress;
 mod schema_sanitize; // Private - MCP schema sanitization for OpenAI compatibility
+pub mod skill_tool;
 pub mod stream_events;
 pub mod streaming;
 pub mod streaming_request_hook;
@@ -38,7 +39,7 @@ pub mod vector_store;
 pub use builder::{Agent, AgentBuilder, FilesystemTools};
 pub use config::{
     AgentConfig, AgentSettings, EmbeddingModelConfig, LlmConfig, McpConfig, McpServerConfig,
-    ReasoningEffort, ToolsConfig, VectorStoreConfig,
+    ReasoningEffort, SkillConfig, ToolsConfig, VectorStoreConfig,
 };
 pub use error::{BuilderError, BuilderResult};
 pub use provider_agent::{
@@ -69,6 +70,7 @@ pub use request_progress::{
     subscribe as request_progress_subscribe, unsubscribe as request_progress_unsubscribe,
 };
 pub use rmcp::model::{NumberOrString, ProgressToken};
+pub use skill_tool::LoadSkillTool;
 pub use stream_events::{AgentContext, AuraStreamEvent, CorrelationContext, WorkerPhase};
 pub use streaming_request_hook::{ResponseContent, StreamingRequestHook, UsageState};
 pub use tool_error_detection::{DetectedToolError, ToolResultStatus, detect_tool_error};

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -197,6 +197,14 @@ where
     }
 }
 
+/// Ensure aura_config warnings are always visible regardless of RUST_LOG setting.
+///
+/// This is important for operational warnings like duplicate skill detection
+/// that should never be silently filtered.
+fn ensure_aura_config_warnings(filter: EnvFilter) -> EnvFilter {
+    filter.add_directive("aura_config=warn".parse().unwrap())
+}
+
 // ---------------------------------------------------------------------------
 // OTel provider / layer / filter (only when feature = "otel")
 // ---------------------------------------------------------------------------
@@ -333,6 +341,7 @@ pub fn init_logging(debug: bool, verbose: bool, binary_name: &str) {
         // Default: Only binary-specific info level logging on console
         let console_filter = EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| format!("{binary_name}=info").into());
+        let console_filter = ensure_aura_config_warnings(console_filter);
 
         let registry =
             tracing_subscriber::registry().with(fmt::layer().with_filter(console_filter));

--- a/crates/aura/src/skill_tool.rs
+++ b/crates/aura/src/skill_tool.rs
@@ -1,0 +1,355 @@
+//! On-demand skill loading tool.
+//!
+//! Provides a `load_skill` tool that the LLM can call to retrieve detailed
+//! instructions for a specific workflow. Skills follow the Agent Skills
+//! specification (<https://agentskills.io/specification>).
+//!
+//! Skills are discovered from directories containing a `SKILL.md` file with
+//! YAML frontmatter. Content is read from disk on demand, keeping the base
+//! system prompt small.
+
+use crate::config::SkillConfig;
+use rig::{completion::ToolDefinition, tool::Tool};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::fs;
+
+/// Size threshold (in bytes) above which a warning is logged.
+/// Skills are still loaded in full — the operator controls their own content
+/// and the LLM's context window is the natural limit.
+const SKILL_SIZE_WARN_THRESHOLD: usize = 524_288; // 512 KB
+
+/// Tool that loads skill content on demand from disk.
+///
+/// The LLM sees a catalog of available skills in the tool description
+/// and calls `load_skill("skill_name")` when it needs detailed instructions.
+#[derive(Debug, Clone)]
+pub struct LoadSkillTool {
+    skills: Vec<SkillConfig>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SkillError {
+    #[error("Unknown skill: '{0}'. Use one of the available skill names.")]
+    UnknownSkill(String),
+
+    #[error("Failed to read skill file: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct LoadSkillArgs {
+    /// Name of the skill to load
+    pub name: String,
+}
+
+/// Strip YAML frontmatter from content, returning only the body.
+fn strip_frontmatter(content: &str) -> &str {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return content;
+    }
+
+    let after_first = &trimmed[3..];
+    match after_first.find("---") {
+        Some(pos) => {
+            let body = &after_first[pos + 3..];
+            body.strip_prefix('\n').unwrap_or(body)
+        }
+        None => content,
+    }
+}
+
+impl LoadSkillTool {
+    /// Create a new LoadSkillTool from discovered skill configs.
+    ///
+    /// Each `SkillConfig` contains an absolute path to the skill directory.
+    pub fn new(skills: &[SkillConfig]) -> Self {
+        Self {
+            skills: skills.to_vec(),
+        }
+    }
+
+    /// Build the tool description listing all available skills.
+    fn build_description(&self) -> String {
+        let mut desc =
+            String::from("Load detailed instructions for a specific skill. Available skills:\n");
+        for skill in &self.skills {
+            desc.push_str(&format!("- {}: {}\n", skill.name, skill.description));
+        }
+        desc
+    }
+}
+
+impl Tool for LoadSkillTool {
+    const NAME: &'static str = "load_skill";
+    type Error = SkillError;
+    type Args = LoadSkillArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: self.build_description(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the skill to load"
+                    }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let skill = self
+            .skills
+            .iter()
+            .find(|s| s.name == args.name)
+            .ok_or_else(|| SkillError::UnknownSkill(args.name.clone()))?;
+
+        let skill_file = skill.path.join("SKILL.md");
+        tracing::info!("Loading skill '{}' from {:?}", skill.name, skill_file);
+
+        let content = fs::read_to_string(&skill_file).await?;
+        let body = strip_frontmatter(&content);
+        let mut result = body.to_string();
+
+        tracing::info!(
+            "Skill '{}' SKILL.md loaded ({} bytes)",
+            skill.name,
+            result.len()
+        );
+
+        // Load additional files from optional directories (references/, scripts/, assets/)
+        // if they exist, per the Agent Skills spec's progressive disclosure model.
+        // The SKILL.md body can reference these files; we include references/ automatically
+        // since they contain documentation the LLM may need.
+        let references_dir = skill.path.join("references");
+        if references_dir.is_dir()
+            && let Ok(mut entries) = tokio::fs::read_dir(&references_dir).await
+        {
+            // Collect and sort entries by filename for deterministic ordering
+            let mut ref_paths = Vec::new();
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let path = entry.path();
+                if path.is_file() {
+                    ref_paths.push(path);
+                }
+            }
+            ref_paths.sort();
+
+            for path in ref_paths {
+                match fs::read_to_string(&path).await {
+                    Ok(file_content) => {
+                        let file_name =
+                            path.file_name().unwrap_or_default().to_string_lossy();
+                        tracing::info!(
+                            "Skill '{}' reference '{}' loaded ({} bytes)",
+                            skill.name,
+                            file_name,
+                            file_content.len()
+                        );
+                        result.push_str("\n\n");
+                        result.push_str(&file_content);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Skill '{}': failed to read reference file {:?}: {}",
+                            skill.name,
+                            path,
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        if result.len() > SKILL_SIZE_WARN_THRESHOLD {
+            tracing::warn!(
+                "Skill '{}' content is large ({} bytes). This may consume significant \
+                 LLM context window. Consider splitting into smaller skills if possible.",
+                skill.name,
+                result.len()
+            );
+        }
+
+        tracing::info!(
+            "Skill '{}' fully loaded ({} bytes total)",
+            skill.name,
+            result.len()
+        );
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn make_skill_dir(
+        dir: &std::path::Path,
+        name: &str,
+        frontmatter: &str,
+        body: &str,
+    ) -> PathBuf {
+        let skill_dir = dir.join(name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let mut file = std::fs::File::create(skill_dir.join("SKILL.md")).unwrap();
+        write!(file, "{frontmatter}{body}").unwrap();
+        skill_dir
+    }
+
+    fn make_skill_configs(dir: &std::path::Path) -> Vec<SkillConfig> {
+        let path1 = make_skill_dir(
+            dir,
+            "test-skill",
+            "---\nname: test-skill\ndescription: A test skill\n---\n",
+            "# Test Skill\nThis is test content.",
+        );
+        let path2 = make_skill_dir(
+            dir,
+            "another-skill",
+            "---\nname: another-skill\ndescription: Another test skill\n---\n",
+            "# Another Skill\nMore content.",
+        );
+        vec![
+            SkillConfig {
+                name: "test-skill".to_string(),
+                description: "A test skill".to_string(),
+                path: path1,
+            },
+            SkillConfig {
+                name: "another-skill".to_string(),
+                description: "Another test skill".to_string(),
+                path: path2,
+            },
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_load_skill_success() {
+        let dir = TempDir::new().unwrap();
+        let configs = make_skill_configs(dir.path());
+        let tool = LoadSkillTool::new(&configs);
+        let result = tool
+            .call(LoadSkillArgs {
+                name: "test-skill".to_string(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(result, "# Test Skill\nThis is test content.");
+    }
+
+    #[tokio::test]
+    async fn test_load_skill_unknown() {
+        let dir = TempDir::new().unwrap();
+        let configs = make_skill_configs(dir.path());
+        let tool = LoadSkillTool::new(&configs);
+        let result = tool
+            .call(LoadSkillArgs {
+                name: "nonexistent".to_string(),
+            })
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unknown skill"));
+    }
+
+    #[tokio::test]
+    async fn test_load_skill_file_not_found() {
+        let dir = TempDir::new().unwrap();
+        let skill_dir = dir.path().join("missing-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let configs = vec![SkillConfig {
+            name: "missing-skill".to_string(),
+            description: "Missing".to_string(),
+            path: skill_dir,
+        }];
+        let tool = LoadSkillTool::new(&configs);
+        let result = tool
+            .call(LoadSkillArgs {
+                name: "missing-skill".to_string(),
+            })
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Failed to read"));
+    }
+
+    #[tokio::test]
+    async fn test_definition_lists_all_skills() {
+        let dir = TempDir::new().unwrap();
+        let configs = make_skill_configs(dir.path());
+        let tool = LoadSkillTool::new(&configs);
+        let def = tool.definition(String::new()).await;
+        assert_eq!(def.name, "load_skill");
+        assert!(def.description.contains("test-skill"));
+        assert!(def.description.contains("another-skill"));
+        assert!(def.description.contains("A test skill"));
+        assert!(def.description.contains("Another test skill"));
+    }
+
+    #[test]
+    fn test_strip_frontmatter_basic() {
+        let content = "---\nname: test\ndescription: test\n---\n# Body\nContent here.";
+        assert_eq!(strip_frontmatter(content), "# Body\nContent here.");
+    }
+
+    #[test]
+    fn test_strip_frontmatter_no_frontmatter() {
+        let content = "# Just a body\nNo frontmatter.";
+        assert_eq!(strip_frontmatter(content), content);
+    }
+
+    #[test]
+    fn test_strip_frontmatter_no_closing() {
+        let content = "---\nname: test\ndescription: test\nNo closing delimiter.";
+        assert_eq!(strip_frontmatter(content), content);
+    }
+
+    #[tokio::test]
+    async fn test_load_skill_with_references() {
+        let dir = TempDir::new().unwrap();
+        let skill_dir = dir.path().join("with-refs");
+        std::fs::create_dir_all(skill_dir.join("references")).unwrap();
+
+        // Write SKILL.md
+        let mut f = std::fs::File::create(skill_dir.join("SKILL.md")).unwrap();
+        write!(
+            f,
+            "---\nname: with-refs\ndescription: Skill with references\n---\n# Main Skill"
+        )
+        .unwrap();
+
+        // Write reference files
+        std::fs::write(
+            skill_dir.join("references/REFERENCE.md"),
+            "# Reference\nDetailed docs.",
+        )
+        .unwrap();
+
+        let configs = vec![SkillConfig {
+            name: "with-refs".to_string(),
+            description: "Skill with references".to_string(),
+            path: skill_dir,
+        }];
+
+        let tool = LoadSkillTool::new(&configs);
+        let result = tool
+            .call(LoadSkillArgs {
+                name: "with-refs".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert!(result.starts_with("# Main Skill"));
+        assert!(result.contains("# Reference\nDetailed docs."));
+    }
+}


### PR DESCRIPTION
Implement the Agent Skills specification for Aura. Skills are directories containing a SKILL.md file with YAML frontmatter. The LLM sees a catalog of available skills in its system prompt and calls a load_skill tool to retrieve detailed instructions only when needed, keeping the base prompt small.

- Add SkillsConfig and LocalSkillSource to aura-config with spec-compliant name validation (1-64 chars, lowercase alphanumeric
  + hyphens, must match directory name)
- Add skill discovery scanning source directories for SKILL.md files with AURA_SKILLS_DIR env var fallback
- Add LoadSkillTool implementing rig::tool::Tool for on-demand loading of skill instructions and reference files
- Inject skill catalog into agent system prompt during build
- Thread config_dir through web server to resolve relative skill paths
- Add /app/skills directory and AURA_SKILLS_DIR env var to Dockerfile
- Sort reference files by name for deterministic output
- Warn (without truncating) when skill content exceeds 512KB
- Add unit tests for name validation, frontmatter parsing, and skill discovery (dedup, name mismatch, relative paths)

Ref: LOG-23254