### PR TITLE
feat: add support for aliased agents listed/selected via /v1/models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ logs/
 config.local.toml
 *.local.*
 config.toml
+config
 
 # Docker compose local env files (may contain secrets)
 compose/env/*.local

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aura"
-version = "1.14.8"
+version = "1.14.12"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "aura-config"
-version = "1.14.8"
+version = "1.14.12"
 dependencies = [
  "anyhow",
  "aura",
@@ -471,6 +471,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
+ "tempfile",
  "thiserror 2.0.16",
  "tokio",
  "toml",
@@ -480,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "aura-test-utils"
-version = "1.14.8"
+version = "1.14.12"
 dependencies = [
  "reqwest",
  "serde",
@@ -490,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "aura-web-server"
-version = "1.14.8"
+version = "1.14.12"
 dependencies = [
  "actix-web",
  "actix-web-lab",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A production-ready framework for composing AI agents from declarative TOML confi
 
 Key capabilities:
 
-- Declarative agent composition via TOML with multi-provider LLM support
+- Declarative agent composition via TOML with multi-provider LLM support and multi-agent serving
 - Dynamic [MCP](https://modelcontextprotocol.io) tool discovery across HTTP, SSE, and STDIO transports
 - Automatic schema sanitization for OpenAI function-calling compatibility
 - RAG pipeline integration with in-memory and external vector stores
@@ -89,8 +89,11 @@ Run the server:
 # Default: reads config.toml
 cargo run --bin aura-web-server
 
-# Custom config path
+# Custom config file
 CONFIG_PATH=my-config.toml cargo run --bin aura-web-server
+
+# Config directory (serves multiple agents)
+CONFIG_PATH=configs/ cargo run --bin aura-web-server
 
 # Host/port override
 HOST=0.0.0.0 PORT=3000 cargo run --bin aura-web-server
@@ -103,7 +106,7 @@ Core server options:
 
 | Option                       | Env Variable               | Default       | Description                         |
 | ---------------------------- | -------------------------- | ------------- | ----------------------------------- |
-| `--config`                   | `CONFIG_PATH`              | `config.toml` | Path to TOML config                 |
+| `--config`                   | `CONFIG_PATH`              | `config.toml` | Path to TOML config file or directory |
 | `--host`                     | `HOST`                     | `127.0.0.1`   | Bind host                           |
 | `--port`                     | `PORT`                     | `8080`        | Bind port                           |
 | `--streaming-timeout-secs`   | `STREAMING_TIMEOUT_SECS`   | `900`         | Max SSE request duration            |
@@ -127,10 +130,18 @@ API examples:
 # Health
 curl http://localhost:8080/health
 
+# List available models (agents)
+curl http://localhost:8080/v1/models
+
 # OpenAI-compatible chat completion
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"messages": [{"role": "user", "content": "Hello"}]}'
+
+# Select a specific agent by name or alias via the model field
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "my-agent", "messages": [{"role": "user", "content": "Hello"}]}'
 
 # Streaming response
 curl -X POST http://localhost:8080/v1/chat/completions \
@@ -144,10 +155,43 @@ For LibreChat/OpenWebUI integration, see [development/README.md](development/REA
 
 ## Configuration
 
+`CONFIG_PATH` can point to a single TOML file or a directory of `.toml` files. When pointed at a directory, Aura loads every `.toml` file and serves each as a selectable agent. Clients choose an agent via the `model` field in chat completion requests — the same field that tools like LibreChat, OpenWebUI, and CLI clients use to present a model picker.
+
+### Multiple Agents
+
+To serve multiple agents, create a directory with one TOML file per agent:
+
+```
+configs/
+├── research-assistant.toml
+├── devops-agent.toml
+└── code-reviewer.toml
+```
+
+```bash
+CONFIG_PATH=configs/ cargo run --bin aura-web-server
+```
+
+Each agent is identified by its `alias` (if set) or `name`. Clients discover available agents via `GET /v1/models` and select one by passing its identifier as the `model` field in requests. When no `model` is specified, the server resolves the agent via `DEFAULT_AGENT`, or automatically when only one config is loaded.
+
+The `alias` field provides a stable, client-facing identifier that is independent of the agent's display name:
+
+```toml
+[agent]
+name = "DevOps Assistant"
+alias = "devops"             # clients send "model": "devops"
+system_prompt = "You are a DevOps expert."
+model_owner = "mezmo"        # override owned_by in /v1/models (defaults to LLM provider)
+```
+
+Aliases must be unique across all loaded configs. If two configs share the same `name` and neither has an alias, loading fails with a validation error.
+
+### Configuration Sections
+
 Configuration sections:
 
 - `[llm]`: provider and model configuration.
-- `[agent]`: system prompt and runtime behavior.
+- `[agent]`: identity, system prompt, and runtime behavior.
 - `[[vector_stores]]`: optional RAG/vector store configuration.
 - `[mcp]` and `[mcp.servers.*]`: MCP configuration, schema sanitization, and transports.
 
@@ -188,6 +232,7 @@ headers = { "Authorization" = "Bearer {{ env.MCP_TOKEN }}" }
 
 [agent]
 name = "Assistant"
+alias = "my-assistant"       # optional: stable client-facing identifier
 system_prompt = "You are a helpful assistant."
 turn_depth = 2
 ```

--- a/crates/aura-config/Cargo.toml
+++ b/crates/aura-config/Cargo.toml
@@ -41,6 +41,9 @@ regex = { workspace = true }
 # Logging for binaries
 tracing-subscriber = { workspace = true }
 
+[dev-dependencies]
+tempfile = "3"
+
 [[bin]]
 name = "debug_config"
 path = "src/bin/debug_config.rs"

--- a/crates/aura-config/src/bin/architecture_diagram.rs
+++ b/crates/aura-config/src/bin/architecture_diagram.rs
@@ -14,220 +14,231 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config_path = env::args()
         .nth(1)
         .unwrap_or_else(|| "config.toml".to_string());
-    let config = load_config(&config_path)?;
+    let configs = load_config(&config_path)?;
 
     println!("\n🏗️  RIG.RS ARCHITECTURE DIAGRAM FROM CONFIG");
     println!("═══════════════════════════════════════════════════════════");
+    println!("  {} agent(s) loaded\n", configs.len());
 
-    // Current Implementation (What's Actually Built)
-    println!("\n📋 CURRENT IMPLEMENTATION (What's Actually Reified):");
-    println!("┌─────────────────────────────────────────────────────────┐");
-    println!("│                    🤖 SIMPLE AGENT                      │");
-    println!("│                                                         │");
+    for (i, config) in configs.iter().enumerate() {
+        let agent_id = config.agent.alias.as_deref().unwrap_or(&config.agent.name);
 
-    let (provider, model) = match &config.llm {
-        aura_config::config::LlmConfig::OpenAI { model, .. } => ("openai", model.clone()),
-        aura_config::config::LlmConfig::Anthropic { model, .. } => ("anthropic", model.clone()),
-        aura_config::config::LlmConfig::Bedrock { model, .. } => ("bedrock", model.clone()),
-        aura_config::config::LlmConfig::Gemini { model, .. } => ("gemini", model.clone()),
-        aura_config::config::LlmConfig::Ollama { model, .. } => ("ollama", model.clone()),
-    };
-
-    match provider {
-        "openai" => {
-            println!("│  ┌─────────────────────────────────────────────────┐    │");
-            println!("│  │           🧠 OpenAI LLM Client                  │    │");
-            println!("│  │                                                 │    │");
-            println!("│  │  Provider: {provider}                        │    │");
-            println!("│  │  Model: {model}                     │    │");
-            println!(
-                "│  │  System Prompt: {}...        │    │",
-                config
-                    .agent
-                    .system_prompt
-                    .chars()
-                    .take(20)
-                    .collect::<String>()
-            );
-            println!("│  └─────────────────────────────────────────────────┘    │");
+        if i > 0 {
+            println!("\n───────────────────────────────────────────────────────────\n");
         }
-        "anthropic" => {
-            println!("│  ┌─────────────────────────────────────────────────┐    │");
-            println!("│  │          🧠 Anthropic LLM Client                │    │");
-            println!("│  │                                                 │    │");
-            println!("│  │  Provider: {provider}                      │    │");
-            println!("│  │  Model: {model}                        │    │");
-            println!(
-                "│  │  System Prompt: {}...        │    │",
-                config
-                    .agent
-                    .system_prompt
-                    .chars()
-                    .take(20)
-                    .collect::<String>()
-            );
-            println!("│  └─────────────────────────────────────────────────┘    │");
-        }
-        "bedrock" => {
-            println!("│  ┌─────────────────────────────────────────────────┐    │");
-            println!("│  │          🌩️  AWS Bedrock LLM Client             │    │");
-            println!("│  │                                                 │    │");
-            println!("│  │  Provider: {provider}                      │    │");
-            println!("│  │  Model: {model}       │    │");
-            println!(
-                "│  │  System Prompt: {}...        │    │",
-                config
-                    .agent
-                    .system_prompt
-                    .chars()
-                    .take(20)
-                    .collect::<String>()
-            );
-            println!("│  └─────────────────────────────────────────────────┘    │");
-        }
-        other => {
-            println!("│  ┌─────────────────────────────────────────────────┐    │");
-            println!("│  │            🧠 {other} LLM Client                 │    │");
-            println!("│  │                                                 │    │");
-            println!("│  │  ❌ NOT YET IMPLEMENTED                         │    │");
-            println!("│  └─────────────────────────────────────────────────┘    │");
-        }
-    }
-    println!("│                                                         │");
-    println!("│  ❌ NO TOOLS CONNECTED                                  │");
-    println!("│  ❌ NO MCP SERVERS CONNECTED                            │");
-    println!("│  ❌ NO VECTOR STORE CONNECTED                           │");
-    println!("└─────────────────────────────────────────────────────────┘");
 
-    // Configuration Available (What Could Be Built)
-    println!("\n🎯 TARGET ARCHITECTURE (What Config Defines):");
-    println!("┌─────────────────────────────────────────────────────────┐");
-    println!("│                  🤖 INTELLIGENT AGENT                   │");
-    println!("│                                                         │");
-    println!("│  ┌─────────────────────────────────────────────────┐    │");
-    println!("│  │              🧠 LLM PROVIDER                    │    │");
-    println!("│  │                                                 │    │");
-    println!("│  │  Provider: {provider}                        │    │");
-    println!("│  │  Model: {model}                     │    │");
-    println!(
-        "│  │  Temperature: {}                           │    │",
-        config.agent.temperature.unwrap_or(0.7)
-    );
-    println!("│  └─────────────────────────────────────────────────┘    │");
-    println!("│                          │                              │");
-    println!("│                          ▼                              │");
+        println!("  Agent {}/{}: {}", i + 1, configs.len(), agent_id);
 
-    // Tools Section
-    if let Some(ref tools) = config.tools {
-        println!("│  ┌─────────────────────────────────────────────────┐    │");
-        println!("│  │                🔧 TOOLS                         │    │");
-        println!("│  │                                                 │    │");
-        if tools.filesystem {
-            println!("│  │  📁 Filesystem Tool (Rig built-in)             │    │");
-        }
-        for custom_tool in &tools.custom_tools {
-            println!("│  │  🔨 Custom Tool: {custom_tool}                         │    │");
-        }
-        println!("│  └─────────────────────────────────────────────────┘    │");
-        println!("│                          │                              │");
-        println!("│                          ▼                              │");
-    }
+        // Current Implementation (What's Actually Built)
+        println!("\n📋 CURRENT IMPLEMENTATION (What's Actually Reified):");
+        println!("┌─────────────────────────────────────────────────────────┐");
+        println!("│                    🤖 SIMPLE AGENT                      │");
+        println!("│                                                         │");
 
-    // MCP Servers Section
-    if let Some(ref mcp_config) = config.mcp {
-        println!("│  ┌─────────────────────────────────────────────────┐    │");
-        println!("│  │              🌐 MCP SERVERS                     │    │");
-        println!("│  │                                                 │    │");
+        let (provider, model) = match &config.llm {
+            aura_config::config::LlmConfig::OpenAI { model, .. } => ("openai", model.clone()),
+            aura_config::config::LlmConfig::Anthropic { model, .. } => ("anthropic", model.clone()),
+            aura_config::config::LlmConfig::Bedrock { model, .. } => ("bedrock", model.clone()),
+            aura_config::config::LlmConfig::Gemini { model, .. } => ("gemini", model.clone()),
+            aura_config::config::LlmConfig::Ollama { model, .. } => ("ollama", model.clone()),
+        };
 
-        for (name, server) in &mcp_config.servers {
-            match server {
-                aura_config::McpServerConfig::HttpStreamable { url, .. } => {
-                    println!("│  │  🌊 {name} (HTTP Streamable)                   │    │");
-                    println!(
-                        "│  │     URL: {}              │    │",
-                        if url.len() > 25 {
-                            format!("{}...", &url[..25])
-                        } else {
-                            url.clone()
-                        }
-                    );
-                }
-                aura_config::McpServerConfig::Stdio { cmd, .. } => {
-                    println!("│  │  💻 {name} (STDIO)                             │    │");
-                    println!("│  │     Command: {cmd:?}                           │    │");
-                }
+        match provider {
+            "openai" => {
+                println!("│  ┌─────────────────────────────────────────────────┐    │");
+                println!("│  │           🧠 OpenAI LLM Client                  │    │");
+                println!("│  │                                                 │    │");
+                println!("│  │  Provider: {provider}                        │    │");
+                println!("│  │  Model: {model}                     │    │");
+                println!(
+                    "│  │  System Prompt: {}...        │    │",
+                    config
+                        .agent
+                        .system_prompt
+                        .chars()
+                        .take(20)
+                        .collect::<String>()
+                );
+                println!("│  └─────────────────────────────────────────────────┘    │");
+            }
+            "anthropic" => {
+                println!("│  ┌─────────────────────────────────────────────────┐    │");
+                println!("│  │          🧠 Anthropic LLM Client                │    │");
+                println!("│  │                                                 │    │");
+                println!("│  │  Provider: {provider}                      │    │");
+                println!("│  │  Model: {model}                        │    │");
+                println!(
+                    "│  │  System Prompt: {}...        │    │",
+                    config
+                        .agent
+                        .system_prompt
+                        .chars()
+                        .take(20)
+                        .collect::<String>()
+                );
+                println!("│  └─────────────────────────────────────────────────┘    │");
+            }
+            "bedrock" => {
+                println!("│  ┌─────────────────────────────────────────────────┐    │");
+                println!("│  │          🌩️  AWS Bedrock LLM Client             │    │");
+                println!("│  │                                                 │    │");
+                println!("│  │  Provider: {provider}                      │    │");
+                println!("│  │  Model: {model}       │    │");
+                println!(
+                    "│  │  System Prompt: {}...        │    │",
+                    config
+                        .agent
+                        .system_prompt
+                        .chars()
+                        .take(20)
+                        .collect::<String>()
+                );
+                println!("│  └─────────────────────────────────────────────────┘    │");
+            }
+            other => {
+                println!("│  ┌─────────────────────────────────────────────────┐    │");
+                println!("│  │            🧠 {other} LLM Client                 │    │");
+                println!("│  │                                                 │    │");
+                println!("│  │  ❌ NOT YET IMPLEMENTED                         │    │");
+                println!("│  └─────────────────────────────────────────────────┘    │");
             }
         }
+        println!("│                                                         │");
+        println!("│  ❌ NO TOOLS CONNECTED                                  │");
+        println!("│  ❌ NO MCP SERVERS CONNECTED                            │");
+        println!("│  ❌ NO VECTOR STORE CONNECTED                           │");
+        println!("└─────────────────────────────────────────────────────────┘");
+
+        // Configuration Available (What Could Be Built)
+        println!("\n🎯 TARGET ARCHITECTURE (What Config Defines):");
+        println!("┌─────────────────────────────────────────────────────────┐");
+        println!("│                  🤖 INTELLIGENT AGENT                   │");
+        println!("│                                                         │");
+        println!("│  ┌─────────────────────────────────────────────────┐    │");
+        println!("│  │              🧠 LLM PROVIDER                    │    │");
+        println!("│  │                                                 │    │");
+        println!("│  │  Provider: {provider}                        │    │");
+        println!("│  │  Model: {model}                     │    │");
+        println!(
+            "│  │  Temperature: {}                           │    │",
+            config.agent.temperature.unwrap_or(0.7)
+        );
         println!("│  └─────────────────────────────────────────────────┘    │");
         println!("│                          │                              │");
         println!("│                          ▼                              │");
-    }
 
-    // Vector Store Section
-    println!("│  ┌─────────────────────────────────────────────────┐    │");
-    println!("│  │              🗃️  VECTOR STORE                    │    │");
-    println!("│  │                                                 │    │");
-    if !config.vector_stores.is_empty() {
-        let store = &config.vector_stores[0]; // Show first store
-        println!(
-            "│  │  Type: {} ({} stores)              │    │",
-            store.store_type,
-            config.vector_stores.len()
-        );
+        // Tools Section
+        if let Some(ref tools) = config.tools {
+            println!("│  ┌─────────────────────────────────────────────────┐    │");
+            println!("│  │                🔧 TOOLS                         │    │");
+            println!("│  │                                                 │    │");
+            if tools.filesystem {
+                println!("│  │  📁 Filesystem Tool (Rig built-in)             │    │");
+            }
+            for custom_tool in &tools.custom_tools {
+                println!("│  │  🔨 Custom Tool: {custom_tool}                         │    │");
+            }
+            println!("│  └─────────────────────────────────────────────────┘    │");
+            println!("│                          │                              │");
+            println!("│                          ▼                              │");
+        }
+
+        // MCP Servers Section
+        if let Some(ref mcp_config) = config.mcp {
+            println!("│  ┌─────────────────────────────────────────────────┐    │");
+            println!("│  │              🌐 MCP SERVERS                     │    │");
+            println!("│  │                                                 │    │");
+
+            for (name, server) in &mcp_config.servers {
+                match server {
+                    aura_config::McpServerConfig::HttpStreamable { url, .. } => {
+                        println!("│  │  🌊 {name} (HTTP Streamable)                   │    │");
+                        println!(
+                            "│  │     URL: {}              │    │",
+                            if url.len() > 25 {
+                                format!("{}...", &url[..25])
+                            } else {
+                                url.clone()
+                            }
+                        );
+                    }
+                    aura_config::McpServerConfig::Stdio { cmd, .. } => {
+                        println!("│  │  💻 {name} (STDIO)                             │    │");
+                        println!("│  │     Command: {cmd:?}                           │    │");
+                    }
+                }
+            }
+            println!("│  └─────────────────────────────────────────────────┘    │");
+            println!("│                          │                              │");
+            println!("│                          ▼                              │");
+        }
+
+        // Vector Store Section
+        println!("│  ┌─────────────────────────────────────────────────┐    │");
+        println!("│  │              🗃️  VECTOR STORE                    │    │");
         println!("│  │                                                 │    │");
-        println!("│  │  ┌─────────────────────────────────────────┐    │    │");
-        println!("│  │  │        🔤 EMBEDDING MODEL               │    │    │");
-        println!("│  │  │                                         │    │    │");
-        println!(
-            "│  │  │  Provider: {}                │    │    │",
-            store.embedding_model.provider
-        );
-        println!(
-            "│  │  │  Model: {}    │    │    │",
-            store.embedding_model.model
-        );
-    } else {
-        println!("│  │  No vector stores configured               │    │");
-        println!("│  │                                                 │    │");
-        println!("│  │  ┌─────────────────────────────────────────┐    │    │");
-        println!("│  │  │        🔤 NO EMBEDDING MODEL            │    │    │");
-        println!("│  │  │                                         │    │    │");
-        println!("│  │  │  Provider: N/A              │    │    │");
-        println!("│  │  │  Model: N/A                 │    │    │");
-    }
-    println!("│  │  └─────────────────────────────────────────┘    │    │");
-    println!("│  └─────────────────────────────────────────────────┘    │");
-    println!("└─────────────────────────────────────────────────────────┘");
+        if !config.vector_stores.is_empty() {
+            let store = &config.vector_stores[0]; // Show first store
+            println!(
+                "│  │  Type: {} ({} stores)              │    │",
+                store.store_type,
+                config.vector_stores.len()
+            );
+            println!("│  │                                                 │    │");
+            println!("│  │  ┌─────────────────────────────────────────┐    │    │");
+            println!("│  │  │        🔤 EMBEDDING MODEL               │    │    │");
+            println!("│  │  │                                         │    │    │");
+            println!(
+                "│  │  │  Provider: {}                │    │    │",
+                store.embedding_model.provider
+            );
+            println!(
+                "│  │  │  Model: {}    │    │    │",
+                store.embedding_model.model
+            );
+        } else {
+            println!("│  │  No vector stores configured               │    │");
+            println!("│  │                                                 │    │");
+            println!("│  │  ┌─────────────────────────────────────────┐    │    │");
+            println!("│  │  │        🔤 NO EMBEDDING MODEL            │    │    │");
+            println!("│  │  │                                         │    │    │");
+            println!("│  │  │  Provider: N/A              │    │    │");
+            println!("│  │  │  Model: N/A                 │    │    │");
+        }
+        println!("│  │  └─────────────────────────────────────────┘    │    │");
+        println!("│  └─────────────────────────────────────────────────┘    │");
+        println!("└─────────────────────────────────────────────────────────┘");
 
-    // Configuration vs Implementation Gap
-    println!("\n⚠️  IMPLEMENTATION GAPS:");
-    println!("┌─────────────────────────────────────────────────────────┐");
-    println!("│                  🚧 MISSING INTEGRATIONS                │");
-    println!("│                                                         │");
-
-    if config.mcp.is_some() {
-        println!("│  🔴 MCP Server Integration                              │");
-        println!("│     → Need to connect MCP servers to agent tools       │");
-        println!("│     → Requires rig::agent.tool() integration           │");
+        // Configuration vs Implementation Gap
+        println!("\n⚠️  IMPLEMENTATION GAPS:");
+        println!("┌─────────────────────────────────────────────────────────┐");
+        println!("│                  🚧 MISSING INTEGRATIONS                │");
         println!("│                                                         │");
-    }
 
-    println!("│  🔴 Vector Store Integration                            │");
-    println!("│     → Need to create vector store from config          │");
-    println!("│     → Need document ingestion pipeline                 │");
-    println!("│     → Need to connect to agent for RAG queries         │");
-    println!("│                                                         │");
+        if config.mcp.is_some() {
+            println!("│  🔴 MCP Server Integration                              │");
+            println!("│     → Need to connect MCP servers to agent tools       │");
+            println!("│     → Requires rig::agent.tool() integration           │");
+            println!("│                                                         │");
+        }
 
-    if let Some(ref tools) = config.tools
-        && tools.filesystem
-    {
-        println!("│  🔴 Filesystem Tool Integration                         │");
-        println!("│     → Need to add filesystem tool to agent             │");
-        println!("│     → Configure file access permissions                │");
+        println!("│  🔴 Vector Store Integration                            │");
+        println!("│     → Need to create vector store from config          │");
+        println!("│     → Need document ingestion pipeline                 │");
+        println!("│     → Need to connect to agent for RAG queries         │");
         println!("│                                                         │");
-    }
 
-    println!("└─────────────────────────────────────────────────────────┘");
+        if let Some(ref tools) = config.tools
+            && tools.filesystem
+        {
+            println!("│  🔴 Filesystem Tool Integration                         │");
+            println!("│     → Need to add filesystem tool to agent             │");
+            println!("│     → Configure file access permissions                │");
+            println!("│                                                         │");
+        }
+
+        println!("└─────────────────────────────────────────────────────────┘");
+    }
 
     // Implementation Roadmap
     println!("\n🗺️  IMPLEMENTATION ROADMAP:");

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -243,6 +243,8 @@ pub struct ToolsConfig {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AgentConfig {
     pub name: String,
+    #[serde(default)]
+    pub alias: Option<String>,
     pub system_prompt: String,
     #[serde(default)]
     pub context: Vec<String>,
@@ -260,16 +262,31 @@ pub struct AgentConfig {
     /// reporting in streaming events (aura.session_info).
     #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
     pub context_window: Option<u32>,
+    /// Creation timestamp in milliseconds since epoch (defaults to current time)
+    #[serde(default = "default_created_at")]
+    pub created_at: u64,
+    /// Override the `owned_by` field in /v1/models responses.
+    /// When omitted, defaults to the underlying LLM provider (e.g. "openai", "anthropic").
+    #[serde(default)]
+    pub model_owner: Option<String>,
 }
 
 fn default_turn_depth() -> Option<usize> {
     Some(5)
 }
 
+fn default_created_at() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_millis() as u64
+}
+
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
             name: "Assistant".to_string(),
+            alias: None,
             system_prompt: "You are a helpful assistant.".to_string(),
             context: Vec::new(),
             temperature: Some(0.7),
@@ -277,6 +294,8 @@ impl Default for AgentConfig {
             max_tokens: None,
             turn_depth: default_turn_depth(),
             context_window: None,
+            created_at: default_created_at(),
+            model_owner: None,
         }
     }
 }

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -630,6 +630,233 @@ system_prompt = "Test"
     }
 
     #[test]
+    fn test_alias_field_parsing() {
+        let config_str = r#"
+[llm]
+provider = "ollama"
+model = "llama3.2"
+
+[agent]
+name = "Test"
+alias = "my-alias"
+system_prompt = "Test"
+"#;
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+        assert_eq!(config.agent.alias, Some("my-alias".to_string()));
+    }
+
+    #[test]
+    fn test_alias_field_defaults_to_none() {
+        let config_str = r#"
+[llm]
+provider = "ollama"
+model = "llama3.2"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+        assert_eq!(config.agent.alias, None);
+    }
+
+    #[test]
+    fn test_load_config_single_file() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("config.toml");
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        write!(
+            f,
+            r#"
+[llm]
+provider = "ollama"
+model = "llama3.2"
+
+[agent]
+name = "Agent1"
+system_prompt = "Hello"
+"#
+        )
+        .unwrap();
+
+        let configs = crate::load_config(&file_path).expect("Failed to load config");
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0].agent.name, "Agent1");
+    }
+
+    #[test]
+    fn test_load_config_directory() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+
+        for (name, agent_name) in [("a.toml", "Agent A"), ("b.toml", "Agent B")] {
+            let mut f = std::fs::File::create(dir.path().join(name)).unwrap();
+            write!(
+                f,
+                r#"
+[llm]
+provider = "ollama"
+model = "llama3.2"
+
+[agent]
+name = "{agent_name}"
+system_prompt = "Hello"
+"#
+            )
+            .unwrap();
+        }
+
+        // Non-toml files should be ignored
+        std::fs::File::create(dir.path().join("readme.md")).unwrap();
+
+        let configs = crate::load_config(dir.path()).expect("Failed to load configs");
+        assert_eq!(configs.len(), 2);
+        assert_eq!(configs[0].agent.name, "Agent A");
+        assert_eq!(configs[1].agent.name, "Agent B");
+    }
+
+    #[test]
+    fn test_load_config_empty_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = crate::load_config(dir.path());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("No .toml configuration files found"));
+    }
+
+    #[test]
+    fn test_duplicate_alias_validation() {
+        use crate::validate_unique_identifiers;
+        let mut c1 = crate::Config::default();
+        c1.agent.alias = Some("same-alias".to_string());
+        let mut c2 = crate::Config::default();
+        c2.agent.alias = Some("same-alias".to_string());
+
+        let result = validate_unique_identifiers(&[c1, c2]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("unique alias"));
+    }
+
+    #[test]
+    fn test_duplicate_name_without_alias_validation() {
+        use crate::validate_unique_identifiers;
+        let mut c1 = crate::Config::default();
+        c1.agent.name = "Same Name".to_string();
+        let mut c2 = crate::Config::default();
+        c2.agent.name = "Same Name".to_string();
+
+        let result = validate_unique_identifiers(&[c1, c2]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("same agent name"));
+    }
+
+    #[test]
+    fn test_alias_collides_with_name_validation() {
+        use crate::validate_unique_identifiers;
+        let mut c1 = crate::Config::default();
+        c1.agent.name = "MyAgent".to_string();
+        // c1 has no alias, so "MyAgent" is its identifier
+
+        let mut c2 = crate::Config::default();
+        c2.agent.name = "Other".to_string();
+        c2.agent.alias = Some("MyAgent".to_string());
+
+        let result = validate_unique_identifiers(&[c1, c2]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("same agent name"));
+    }
+
+    #[test]
+    fn test_same_name_with_different_aliases_is_ok() {
+        use crate::validate_unique_identifiers;
+        let mut c1 = crate::Config::default();
+        c1.agent.name = "Same".to_string();
+        c1.agent.alias = Some("alias-1".to_string());
+
+        let mut c2 = crate::Config::default();
+        c2.agent.name = "Same".to_string();
+        c2.agent.alias = Some("alias-2".to_string());
+
+        let result = validate_unique_identifiers(&[c1, c2]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_created_at_defaults_to_current_time() {
+        let config_str = r#"
+[llm]
+provider = "ollama"
+model = "llama3.2"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let before = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+        let after = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        assert!(
+            config.agent.created_at >= before && config.agent.created_at <= after,
+            "created_at should default to current time in ms"
+        );
+    }
+
+    #[test]
+    fn test_created_at_explicit_value() {
+        let config_str = r#"
+[llm]
+provider = "ollama"
+model = "llama3.2"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+created_at = 1677649963000
+"#;
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+        assert_eq!(config.agent.created_at, 1677649963000);
+    }
+
+    #[test]
+    fn test_model_owner_defaults_to_none() {
+        let config_str = r#"
+[llm]
+provider = "ollama"
+model = "llama3.2"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+        assert_eq!(config.agent.model_owner, None);
+    }
+
+    #[test]
+    fn test_model_owner_explicit_value() {
+        let config_str = r#"
+[llm]
+provider = "ollama"
+model = "llama3.2"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+model_owner = "mezmo"
+"#;
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+        assert_eq!(config.agent.model_owner, Some("mezmo".to_string()));
+    }
+
+    #[test]
     fn test_ollama_config_all_params() {
         println!("\n=== TEST_OLLAMA_CONFIG_ALL_PARAMS ===");
         let config_str = r#"

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -13,16 +13,81 @@ pub use env::resolve_env_vars;
 pub use error::ConfigError;
 pub use loader::ConfigLoader;
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
-/// Load and parse a TOML configuration file
-pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Config, ConfigError> {
+/// Load a single TOML file into a Config.
+fn load_single_config<P: AsRef<Path>>(path: P) -> Result<Config, ConfigError> {
     let contents = fs::read_to_string(path)?;
     let resolved = resolve_env_vars(&contents)?;
     let config: Config = toml::from_str(&resolved)?;
     config.validate()?;
     Ok(config)
+}
+
+/// Load and parse TOML configuration(s) from a file or directory.
+///
+/// - If `path` is a file, returns a single-element vec.
+/// - If `path` is a directory, loads all `.toml` files in it.
+///
+/// Light validation occurs to ensure that:
+/// - Each config can be serialized and deserialized correctly.
+/// - Each config is uniquely identifiable by alias or name.
+pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Vec<Config>, ConfigError> {
+    let path = path.as_ref();
+
+    let configs = if path.is_dir() {
+        let mut entries: Vec<_> = fs::read_dir(path)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "toml"))
+            .collect();
+        entries.sort_by_key(|e| e.path());
+
+        let mut configs = Vec::new();
+        for entry in entries {
+            configs.push(load_single_config(entry.path())?);
+        }
+        if configs.is_empty() {
+            return Err(ConfigError::Validation(
+                "No .toml configuration files found in directory".to_string(),
+            ));
+        }
+        configs
+    } else {
+        vec![load_single_config(path)?]
+    };
+
+    validate_unique_identifiers(&configs)?;
+    Ok(configs)
+}
+
+/// Validate that each config is uniquely identifiable by alias or name.
+///
+/// Each config's effective identifier is its alias (if set) or its name.
+/// All effective identifiers must be unique. Additionally, duplicate aliases
+/// get a distinct error message to help the user fix the right thing.
+pub fn validate_unique_identifiers(configs: &[Config]) -> Result<(), ConfigError> {
+    let mut seen_aliases = HashSet::new();
+    let mut seen_ids = HashSet::new();
+
+    for config in configs {
+        let id = config.agent.alias.as_deref().unwrap_or(&config.agent.name);
+
+        if config.agent.alias.is_some() && !seen_aliases.insert(id) {
+            return Err(ConfigError::Validation(
+                "Configurations must have a unique alias!".to_string(),
+            ));
+        }
+
+        if !seen_ids.insert(id) {
+            return Err(ConfigError::Validation(
+                "Multiple configurations with the same agent name! Use an alias to differentiate between two agents with the same name.".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Load config from a string (useful for testing)

--- a/crates/aura-web-server/README.md
+++ b/crates/aura-web-server/README.md
@@ -27,8 +27,11 @@ cargo build --release --bin aura-web-server
 # Start with default config (config.toml)
 cargo run --bin aura-web-server
 
-# Or with custom configuration
+# Or with custom configuration file
 CONFIG_PATH=my-config.toml cargo run --bin aura-web-server
+
+# Or with a directory of configs (serves multiple agents)
+CONFIG_PATH=configs/ cargo run --bin aura-web-server
 
 # Custom host/port
 HOST=0.0.0.0 PORT=3000 cargo run --bin aura-web-server
@@ -45,16 +48,38 @@ Response:
 {"status": "healthy"}
 ```
 
+### List Models (Agents)
+```bash
+GET /v1/models
+```
+Returns all loaded agents. Each agent's `alias` (or `name` if no alias is set) is its model `id`. The `owned_by` field defaults to the underlying LLM provider (e.g. `"openai"`, `"anthropic"`) and can be overridden with `model_owner` in the agent config. Clients like LibreChat and OpenWebUI use this endpoint to populate their model picker.
+
+Response:
+```json
+{
+  "object": "list",
+  "data": [
+    {"id": "devops", "object": "model", "created": 1677649963, "owned_by": "mezmo"},
+    {"id": "research-assistant", "object": "model", "created": 1677649963, "owned_by": "mezmo"}
+  ]
+}
+```
+
 ### Chat Completions
 ```bash
 POST /v1/chat/completions
 Content-Type: application/json
 ```
 
+The `model` field selects which agent handles the request by matching against agent `alias` or `name`. When `model` is omitted, the server resolves the agent in this order:
+1. `DEFAULT_AGENT` environment variable
+2. Automatic selection when only one config is loaded
+3. Returns a 400 error if multiple configs are loaded and no default is set
+
 Request body:
 ```json
 {
-  "model": "gpt-4o-mini",
+  "model": "devops",
   "messages": [
     {"role": "user", "content": "What tools do you have available?"}
   ]
@@ -86,11 +111,23 @@ Response:
 # Health check
 curl -X GET http://127.0.0.1:8080/health
 
-# Chat completion
+# List available agents
+curl http://127.0.0.1:8080/v1/models
+
+# Chat completion (uses DEFAULT_AGENT when model is omitted)
 curl -X POST http://127.0.0.1:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-4o-mini",
+    "messages": [
+      {"role": "user", "content": "What tools do you have available?"}
+    ]
+  }'
+
+# Chat completion with a specific agent
+curl -X POST http://127.0.0.1:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "devops",
     "messages": [
       {"role": "user", "content": "What tools do you have available?"}
     ]
@@ -143,7 +180,7 @@ Example configurations are in the [`examples/`](../../examples/) directory.
 
 ## Architecture
 
-- **Pre-built Agent**: Agent is built once at startup from TOML config
+- **Multi-Agent Serving**: Load multiple agents from a config directory, selectable via the `model` field
 - **Stateless Requests**: Each HTTP request is processed independently
 - **Multi-Turn Support**: Conversation history passed via messages array
 - **OpenAI Compatible**: Request/response schemas match OpenAI's format
@@ -154,9 +191,10 @@ Example configurations are in the [`examples/`](../../examples/) directory.
 **Docker**: See [DOCKER.md](../../DOCKER.md) for containerized deployment
 
 **Environment Variables**:
-- `CONFIG_PATH` - Path to configuration file (default: `config.toml`)
+- `CONFIG_PATH` - Path to configuration file or directory (default: `config.toml`)
 - `HOST` - Server bind address (default: `127.0.0.1`)
 - `PORT` - Server port (default: `8080`)
+- `DEFAULT_AGENT` - Default agent name or alias when `model` is omitted from requests. Not required when only one configuration is loaded via `CONFIG_PATH`.
 
 ## See Also
 

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -144,6 +144,7 @@ struct RequestSetup {
     query: String,
     chat_history: Vec<aura::Message>,
     agent: Arc<Agent>,
+    config: aura_config::Config,
     completion_id: String,
     model_str: String,
     created_timestamp: u64,
@@ -183,8 +184,27 @@ async fn prepare_request(
     // dropping system role messages and filtering empty content.
     let chat_history = convert_chat_messages(&req.messages);
 
+    // Find the matching config: explicit model > DEFAULT_AGENT > single-config fallback
+    // This logic allows users to omit the model field if they only have one config or if they set a default_agent,
+    // improving usability for simple cases while still supporting multiple agents.
+    let config = if let Some(model_name) = req.model.as_deref().or(data.default_agent.as_deref()) {
+        data.configs
+            .iter()
+            .find(|c| c.agent.alias.as_deref().unwrap_or(&c.agent.name) == model_name)
+            .cloned()
+            .ok_or_else(|| {
+                HttpResponse::NotFound().json(ChatCompletionErrorResponse::ModelNotFound(
+                    model_name.to_string(),
+                ))
+            })?
+    } else if data.configs.len() == 1 {
+        data.configs[0].clone()
+    } else {
+        return Err(HttpResponse::BadRequest().json(ChatCompletionErrorResponse::ModelNotProvided));
+    };
+
     // Build a fresh agent for this request
-    let agent = match build_agent_for_request(&data.config, req_headers_map).await {
+    let agent = match build_agent_for_request(&config, req_headers_map).await {
         Ok(agent) => agent,
         Err(response) => return Err(response),
     };
@@ -199,6 +219,7 @@ async fn prepare_request(
         query,
         chat_history,
         agent,
+        config,
         completion_id,
         model_str,
         created_timestamp,
@@ -278,7 +299,7 @@ fn build_completion_config(
         None
     };
     let request_id = format!("req_{}", Uuid::new_v4().simple());
-    let fallback_tool_parsing = data.config.is_fallback_tool_parsing_enabled();
+    let fallback_tool_parsing = setup.config.is_fallback_tool_parsing_enabled();
 
     let stream_config = StreamConfig::new(
         emit_custom_events,
@@ -616,21 +637,31 @@ pub async fn health() -> HttpResponse {
     }))
 }
 
-/// OpenAI-compatible model listing endpoint
+/// OpenAI-compatible model listing endpoint.
+/// Each model `id` maps to an agent's `alias` (if set) or `name` from the TOML config.
 pub async fn list_models(data: web::Data<AppState>) -> HttpResponse {
-    let (provider, model) = data.config.llm.model_info();
-    let model_id = format!("{provider}/{model}");
+    let models: Vec<serde_json::Value> = data
+        .configs
+        .iter()
+        .map(|config| {
+            let id = config.agent.alias.as_deref().unwrap_or(&config.agent.name);
+            let created = config.agent.created_at / 1000;
+            let owned_by = config.agent.model_owner.clone().unwrap_or_else(|| {
+                let (provider, _) = config.llm.model_info();
+                provider.to_string()
+            });
+            serde_json::json!({
+                "id": id,
+                "object": "model",
+                "created": created,
+                "owned_by": owned_by
+            })
+        })
+        .collect();
 
     HttpResponse::Ok().json(serde_json::json!({
         "object": "list",
-        "data": [
-            {
-                "id": model_id,
-                "object": "model",
-                "created": 1677649963,
-                "owned_by": provider
-            }
-        ]
+        "data": models
     }))
 }
 

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -84,6 +84,11 @@ struct Args {
     /// Default: 30 seconds
     #[arg(long, env = "SHUTDOWN_TIMEOUT_SECS", default_value = "30")]
     shutdown_timeout_secs: u64,
+
+    /// Default agent name or alias, used when `model` is omitted from the request.
+    /// Not required when only one configuration is loaded via CONFIG_PATH.
+    #[arg(long, env = "DEFAULT_AGENT")]
+    default_agent: Option<String>,
 }
 
 /// Middleware that rejects new requests with 503 when shutdown_token is cancelled.
@@ -121,8 +126,8 @@ async fn run() -> std::io::Result<()> {
 
     info!("Loading configuration from: {}", args.config);
 
-    let config = match load_config(&args.config) {
-        Ok(cfg) => cfg,
+    let configs = match load_config(&args.config) {
+        Ok(cfgs) => cfgs,
         Err(e) => {
             error!("Failed to load configuration: {}", e);
             return Err(std::io::Error::new(
@@ -132,9 +137,34 @@ async fn run() -> std::io::Result<()> {
         }
     };
 
-    let config_arc = Arc::new(config);
-    let (provider, model) = config_arc.llm.model_info();
-    info!("Aura initialized with {}/{}", provider, model);
+    for config in &configs {
+        let id = config.agent.alias.as_deref().unwrap_or(&config.agent.name);
+        let (provider, model) = config.llm.model_info();
+        info!("Loaded agent '{}' ({}/{})", id, provider, model);
+    }
+
+    // Validate DEFAULT_AGENT matches a loaded config
+    if let Some(ref default_agent) = args.default_agent {
+        let exists = configs
+            .iter()
+            .any(|c| c.agent.alias.as_deref().unwrap_or(&c.agent.name) == default_agent);
+        if !exists {
+            error!(
+                "DEFAULT_AGENT '{}' does not match any loaded agent name or alias",
+                default_agent
+            );
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "DEFAULT_AGENT '{}' does not match any loaded agent name or alias",
+                    default_agent
+                ),
+            ));
+        }
+        info!("Default agent: '{}'", default_agent);
+    }
+
+    let configs_arc = Arc::new(configs);
 
     // Two-phase shutdown: gate (immediate 503) → grace period → stream drain ([DONE])
     let shutdown_token = CancellationToken::new();
@@ -145,7 +175,7 @@ async fn run() -> std::io::Result<()> {
 
     // Create app state
     let app_state = web::Data::new(AppState {
-        config: config_arc,
+        configs: configs_arc,
         tool_result_mode: args.tool_result_mode,
         tool_result_max_length: args.tool_result_max_length,
         streaming_buffer_size: args.streaming_buffer_size,
@@ -156,6 +186,7 @@ async fn run() -> std::io::Result<()> {
         shutdown_token: shutdown_token.clone(),
         stream_shutdown_token: stream_shutdown_token.clone(),
         active_requests: active_requests.clone(),
+        default_agent: args.default_agent.clone(),
     });
 
     info!(

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -48,7 +48,7 @@ impl ActiveRequestTracker {
 
 /// Application state
 pub struct AppState {
-    pub config: Arc<aura_config::Config>,
+    pub configs: Arc<Vec<aura_config::Config>>,
     pub tool_result_mode: ToolResultMode,
     /// Maximum length for tool results (0 = no truncation)
     pub tool_result_max_length: usize,
@@ -67,6 +67,8 @@ pub struct AppState {
     pub stream_shutdown_token: CancellationToken,
     /// Tracks in-flight requests for early shutdown when all requests complete
     pub active_requests: Arc<ActiveRequestTracker>,
+    /// Default agent name or alias, used when `model` is omitted from the request
+    pub default_agent: Option<String>,
 }
 
 /// OpenAI-compatible message role
@@ -111,6 +113,57 @@ pub struct ChatCompletionRequest {
     /// OpenAI-compatible metadata field (up to 16 key-value pairs)
     #[serde(default)]
     pub metadata: Option<HashMap<String, String>>,
+}
+
+/// OpenAI-compatible error responses for chat completion requests.
+pub enum ChatCompletionErrorResponse {
+    /// Model parameter was not provided (HTTP 400).
+    ModelNotProvided,
+    /// Model was specified but does not match any configured agent (HTTP 404).
+    ModelNotFound(String),
+}
+
+#[derive(Serialize)]
+struct ChatCompletionErrorDetail {
+    message: String,
+    #[serde(rename = "type")]
+    error_type: String,
+    param: String,
+    code: String,
+}
+
+#[derive(Serialize)]
+struct ChatCompletionErrorEnvelope {
+    error: ChatCompletionErrorDetail,
+}
+
+impl Serialize for ChatCompletionErrorResponse {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let (message, code) = match self {
+            ChatCompletionErrorResponse::ModelNotProvided => (
+                "you must provide a model parameter".to_string(),
+                "missing_required_parameter".to_string(),
+            ),
+            ChatCompletionErrorResponse::ModelNotFound(model_name) => (
+                format!(
+                    "The model `{}` does not exist or you do not have access to it.",
+                    model_name
+                ),
+                "model_not_found".to_string(),
+            ),
+        };
+
+        let envelope = ChatCompletionErrorEnvelope {
+            error: ChatCompletionErrorDetail {
+                message,
+                error_type: "invalid_request_error".to_string(),
+                param: "model".to_string(),
+                code,
+            },
+        };
+
+        envelope.serialize(serializer)
+    }
 }
 
 /// OpenAI-compatible choice structure
@@ -222,5 +275,33 @@ mod tests {
             .await
             .expect("wait_for_drain should resolve when count reaches 0")
             .expect("task should not panic");
+    }
+
+    #[test]
+    fn test_model_not_provided_serialization() {
+        let error = ChatCompletionErrorResponse::ModelNotProvided;
+        let json: serde_json::Value = serde_json::to_value(&error).unwrap();
+
+        assert_eq!(
+            json["error"]["message"],
+            "you must provide a model parameter"
+        );
+        assert_eq!(json["error"]["type"], "invalid_request_error");
+        assert_eq!(json["error"]["param"], "model");
+        assert_eq!(json["error"]["code"], "missing_required_parameter");
+    }
+
+    #[test]
+    fn test_model_not_found_serialization() {
+        let error = ChatCompletionErrorResponse::ModelNotFound("gpt-5".to_string());
+        let json: serde_json::Value = serde_json::to_value(&error).unwrap();
+
+        assert_eq!(
+            json["error"]["message"],
+            "The model `gpt-5` does not exist or you do not have access to it."
+        );
+        assert_eq!(json["error"]["type"], "invalid_request_error");
+        assert_eq!(json["error"]["param"], "model");
+        assert_eq!(json["error"]["code"], "model_not_found");
     }
 }

--- a/crates/aura-web-server/tests/aura_events_test.rs
+++ b/crates/aura-web-server/tests/aura_events_test.rs
@@ -23,7 +23,7 @@ async fn send_tool_request(client: &reqwest::Client) -> reqwest::Response {
     client
         .post(format!("{AURA_SERVER}/v1/chat/completions"))
         .json(&json!({
-            "model": "gpt-4o",
+            "model": "test-assistant",
             "messages": [{
                 "role": "user",
                 "content": "List all the available files in the mock directory. Use the list_files tool."
@@ -319,7 +319,7 @@ async fn test_session_id_correlation() {
     let response = client
         .post(format!("{AURA_SERVER}/v1/chat/completions"))
         .json(&json!({
-            "model": "gpt-4o",
+            "model": "test-assistant",
             "messages": [{
                 "role": "user",
                 "content": "List files in the mock directory"
@@ -477,7 +477,7 @@ async fn test_aura_tool_complete_failure_detection() {
     let response = client
         .post(format!("{AURA_SERVER}/v1/chat/completions"))
         .json(&json!({
-            "model": "gpt-4o",
+            "model": "test-assistant",
             "messages": [{
                 "role": "user",
                 "content": "Please call the failing_tool with the error_message 'Test error for integration test'. This tool is expected to fail."
@@ -796,7 +796,7 @@ async fn test_multiple_tools_fifo_ordering() {
     let response = client
         .post(format!("{AURA_SERVER}/v1/chat/completions"))
         .json(&json!({
-            "model": "gpt-4o",
+            "model": "test-assistant",
             "messages": [{
                 "role": "user",
                 "content": "Call chain_tool with steps=3 to trigger multiple sequential tool calls."

--- a/crates/aura-web-server/tests/concurrent_streaming_isolation_test.rs
+++ b/crates/aura-web-server/tests/concurrent_streaming_isolation_test.rs
@@ -62,7 +62,7 @@ async fn test_concurrent_streaming_isolation() {
             let response = client_clone
                 .post(format!("{AURA_SERVER}/v1/chat/completions"))
                 .json(&json!({
-                    "model": "gpt-4o",
+                    "model": "test-assistant",
                     "messages": [{
                         "role": "user",
                         "content": format!("Say only the number {} and nothing else.", unique_number)
@@ -214,7 +214,7 @@ async fn test_rapid_sequential_streaming() {
         let response = client
             .post(format!("{AURA_SERVER}/v1/chat/completions"))
             .json(&json!({
-                "model": "gpt-4o",
+                "model": "test-assistant",
                 "messages": [{
                     "role": "user",
                     "content": format!("Say hello #{}", i + 1)

--- a/crates/aura-web-server/tests/fastmcp_structured_content_test.rs
+++ b/crates/aura-web-server/tests/fastmcp_structured_content_test.rs
@@ -27,7 +27,7 @@ async fn test_list_metrics_streaming_no_json_error() {
         .header("X-OpenWebUI-User-Id", &session_id)
         .header("X-OpenWebUI-Session-Id", &session_id)
         .json(&json!({
-            "model": "gpt-4o-mini",
+            "model": "test-assistant",
             "messages": [
                 {
                     "role": "user",
@@ -140,7 +140,7 @@ async fn test_list_metrics_non_streaming() {
         .header("X-OpenWebUI-User-Id", &session_id)
         .header("X-OpenWebUI-Session-Id", &session_id)
         .json(&json!({
-            "model": "gpt-4o-mini",
+            "model": "test-assistant",
             "messages": [
                 {
                     "role": "user",
@@ -201,7 +201,7 @@ async fn test_structured_content_error_handling() {
         .header("X-OpenWebUI-User-Id", &session_id)
         .header("X-OpenWebUI-Session-Id", &session_id)
         .json(&json!({
-            "model": "gpt-4o-mini",
+            "model": "test-assistant",
             "messages": [
                 {
                     "role": "user",

--- a/crates/aura-web-server/tests/header_forwarding_tests.rs
+++ b/crates/aura-web-server/tests/header_forwarding_tests.rs
@@ -22,7 +22,7 @@ async fn send_chat_request_with_headers(
     let mut request = client
         .post(format!("{AURA_SERVER}/v1/chat/completions"))
         .json(&json!({
-            "model": "gpt-4o",
+            "model": "test-assistant",
             "messages": [{"role": "user", "content": message}],
             "stream": false,
             "metadata": {

--- a/crates/aura-web-server/tests/proactive_tool_ui_tests.rs
+++ b/crates/aura-web-server/tests/proactive_tool_ui_tests.rs
@@ -22,7 +22,7 @@ async fn send_chat_request(
     client
         .post(format!("{}/v1/chat/completions", AURA_SERVER))
         .json(&json!({
-            "model": "gpt-4o",
+            "model": "test-assistant",
             "messages": messages,
             "stream": stream,
             "metadata": {

--- a/crates/aura-web-server/tests/streaming_tests.rs
+++ b/crates/aura-web-server/tests/streaming_tests.rs
@@ -22,7 +22,7 @@ async fn send_chat_request(
     client
         .post(format!("{AURA_SERVER}/v1/chat/completions"))
         .json(&json!({
-            "model": "gpt-4o",
+            "model": "test-assistant",
             "messages": messages,
             "stream": stream,
             "metadata": {
@@ -277,7 +277,7 @@ async fn test_streaming_error_handling() {
     let response = client
         .post(format!("{AURA_SERVER}/v1/chat/completions"))
         .json(&json!({
-            "model": "gpt-4o",
+            "model": "test-assistant",
             "messages": [],  // Invalid: empty messages
             "stream": true
         }))
@@ -845,7 +845,7 @@ async fn test_streaming_response_headers() {
     let response = client
         .post(format!("{AURA_SERVER}/v1/chat/completions"))
         .json(&json!({
-            "model": "gpt-4o",
+            "model": "test-assistant",
             "messages": [{"role": "user", "content": "Say hello"}],
             "stream": true,
             "metadata": {
@@ -905,7 +905,7 @@ async fn test_consecutive_requests_tool_execution() {
     let response1 = client
         .post(format!("{AURA_SERVER}/v1/chat/completions"))
         .json(&json!({
-            "model": "gpt-4o",
+            "model": "test-assistant",
             "messages": [{
                 "role": "user",
                 "content": "Please list the files in the current directory."
@@ -971,7 +971,7 @@ async fn test_consecutive_requests_tool_execution() {
     let response2 = client
         .post(format!("{AURA_SERVER}/v1/chat/completions"))
         .json(&json!({
-            "model": "gpt-4o",
+            "model": "test-assistant",
             "messages": [{
                 "role": "user",
                 "content": "Please list the files in the current directory."

--- a/crates/aura-web-server/tests/test-config.toml
+++ b/crates/aura-web-server/tests/test-config.toml
@@ -51,6 +51,7 @@ api_key = "{{ env.OPENAI_API_KEY }}"
 # Agent Configuration - Generic assistant for testing
 [agent]
 name = "Test Assistant"
+alias = "test-assistant"
 system_prompt = """
 You are a test assistant. Call tools immediately when requested.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       # Server configuration
       HOST: "0.0.0.0"
       PORT: "3030"
-      CONFIG_PATH: "/app/config/config.toml"
+      CONFIG_PATH: "/app/config/config.toml"  # Can also be a directory for multi-agent serving
       
       # Logging
       RUST_LOG: "info,aura_config=debug,aura=debug"

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,16 @@ export OPENAI_API_KEY="sk-..."
 CONFIG_PATH=examples/minimal/openai.toml cargo run --bin aura-web-server
 ```
 
+### Serving Multiple Agents
+
+Point `CONFIG_PATH` at a directory to serve every `.toml` file as a selectable agent:
+
+```bash
+CONFIG_PATH=examples/complete/ cargo run --bin aura-web-server
+```
+
+Clients discover agents via `GET /v1/models` and select one with the `model` field in chat requests. Each agent is identified by its `alias` (if set) or `name`.
+
 ## Structure
 
 ```

--- a/examples/complete/devops-assistant.toml
+++ b/examples/complete/devops-assistant.toml
@@ -28,6 +28,7 @@ Authorization = "Bearer {{ env.GITHUB_PERSONAL_ACCESS_TOKEN }}"
 
 [agent]
 name = "DevOps Assistant"
+model_owner = "mezmo"
 system_prompt = """
 You are a DevOps assistant with access to GitHub.
 Help with code review, PR management, and repo exploration.

--- a/examples/complete/incident-response-datadog.toml
+++ b/examples/complete/incident-response-datadog.toml
@@ -39,6 +39,8 @@ DD-APPLICATION-KEY = "{{ env.DD_APPLICATION_KEY }}"
 
 [agent]
 name = "Incident Response Agent"
+alias = "incident-response/datadog"
+model_owner = "mezmo"
 system_prompt = """
 You are an incident response agent with access to PagerDuty and
 Datadog. Follow this triage workflow:

--- a/examples/complete/incident-response-mezmo.toml
+++ b/examples/complete/incident-response-mezmo.toml
@@ -37,6 +37,8 @@ Authorization = "Bearer {{ env.MEZMO_API_KEY }}"
 
 [agent]
 name = "Incident Response Agent"
+alias = "incident-response/mezmo"
+model_owner = "mezmo"
 system_prompt = """
 You are an incident response agent with access to PagerDuty and
 Mezmo. Follow this triage workflow:

--- a/examples/complete/kubernetes-sre.toml
+++ b/examples/complete/kubernetes-sre.toml
@@ -40,6 +40,7 @@ description = "Prometheus metrics queries and alert status"
 
 [agent]
 name = "Kubernetes SRE Agent"
+model_owner = "mezmo"
 system_prompt = """
 You are a Kubernetes SRE assistant. Help with cluster operations
 and monitoring using the available tools.

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -63,6 +63,10 @@ Use `host.docker.internal` to reach services running on your host machine.
 
 Uncomment the `[[vector_stores]]` section in `config.toml`. You'll need a Qdrant instance — you can add one to the compose file or point at an external one.
 
+### Serve multiple agents
+
+Create a `configs/` directory with one TOML file per agent, update the `CONFIG_PATH` in `docker-compose.yml` to point to the directory, and mount it. Clients which support picking models will see each agent in their model picker via `GET /v1/models`.
+
 ### Full configuration reference
 
 See [`examples/reference.toml`](../reference.toml) for all available options.

--- a/examples/quickstart/config.toml
+++ b/examples/quickstart/config.toml
@@ -28,6 +28,7 @@ model = "gpt-5.2"
 
 [agent]
 name = "Aura Assistant"
+# alias = "aura"  # optional: stable identifier for model selection by clients
 system_prompt = """
 You are a helpful assistant with access to external tools and
 knowledge bases. Use them to provide accurate, grounded answers.

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       HOST: "0.0.0.0"
       PORT: "3000"
-      CONFIG_PATH: "/app/config/config.toml"
+      CONFIG_PATH: "/app/config/config.toml"  # Can also be a directory for multi-agent serving
 
       # LLM API keys (from .env)
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -124,6 +124,10 @@ custom_tools = []
 # ── Agent ───────────────────────────────────────────────────────────
 [agent]
 name = "Assistant"
+# alias = "my-assistant"  # optional: stable identifier for client model selection
+#                         # Clients send this as the "model" field in requests.
+#                         # If omitted, the agent name is used as the identifier.
+#                         # Must be unique across all loaded configs.
 system_prompt = """
 You are a helpful assistant with access to external tools and
 knowledge bases. Use them to provide accurate, grounded answers.
@@ -133,6 +137,10 @@ Workflow:
 2. Correlate findings across sources.
 3. Return actionable findings and next steps.
 """
+# created_at = 1677649963000   # optional: creation timestamp in ms since epoch
+#                              # Used in /v1/models response. Defaults to current time.
+# model_owner = "mezmo"        # override `owned_by` in /v1/models responses.
+#                              # Defaults to the LLM provider (e.g. "openai", "anthropic").
 # reasoning_effort = "medium"  # minimal, low, medium, high (provider support varies)
 # temperature = 0.7
 # Maximum tool-calling rounds per user turn. Higher values allow


### PR DESCRIPTION
With this feature you can quickly test and iterate over multiple agent configurations. In clients like LibreChat or OpenWebUI you can select your agent from the "models" list. In custom integrations like CLI tools or custom front-ends, you can control the agent used by sending `model` with your requests.

- List all agents via `/v1/models` endpoint
  - The name of the agent will be sent as `model` from `/v1/models`
  - If you have agents that share the same name, an error will now occur at start-up
  - You can differentiate agents by providing an alias such as `incident-report/mezmo` or `incident-report/datadog`.
  - When an alias is provided, it will be `model` from `/v1/models`
- Send `model` with chat completion request to choose agent

**Model Resolution Changes:**

Previously, when the model field was omitted from a chat completion request, the server silently used the first loaded config. This made multi-agent deployments error-prone — clients could accidentally hit the wrong agent.

Model resolution now follows a clear priority chain:
1. Explicit model from the request body
2. DEFAULT_AGENT environment variable (validated at startup against loaded configs)
3. Automatic selection when only one config is loaded
4. 400 error with missing_required_parameter per the OpenAI API chat completion spec

**Error Response Changes:**

Error responses use a new ChatCompletionErrorResponse enum with two variants (ModelNotProvided, ModelNotFound) that serialize to OpenAI-compatible error JSON with message, type, param, and code fields. The 404 ModelNotFound response also matches the OpenAI API spec for unrecognized model identifiers.

**Agent Config Field Additions:**

New agent config fields ([agent] in TOML):
- created_at: timestamp in ms since epoch, defaults to current time at config load. Used in `/v1/models` created field.
- model_owner: overrides the owned_by field in /v1/models.
  - Defaults to the underlying LLM provider name (e.g. "openai", "anthropic"), enabling provider icons in clients that support it.

**Other changes:**
- architecture_diagram.rs now iterates all loaded configs instead of only the first
- Added 6 tests: created_at defaults/explicit, model_owner defaults/explicit, error response serialization for both variants
- Updated README, web-server README, and reference.toml

**To test:**
- cargo test -p aura-config -p aura-web-server — all unit tests
- Send a request without model to a multi-agent server (no DEFAULT_AGENT) → expect 400
- Send a request with an unknown model → expect 404
- Set DEFAULT_AGENT=<agent-name> and send without model → expect it routes correctly
- Set DEFAULT_AGENT=nonexistent and start the server → expect startup failure
- Single-config mode: omit model and DEFAULT_AGENT → expect automatic selection
- Check /v1/models for created and owned_by values with/without the new fields

_Feel free to test with LibreChat and OpenWebUI as well!_

Ref: LOG-22925