### PR TITLE
fix: strip system role and empty messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.28.0"
-source = "git+https://github.com/mezmo/rig.git?branch=mezmo#0853ab1487b6cbdc4c8818e9fb8d475b8b59eaf6"
+source = "git+https://github.com/mezmo/rig.git?rev=0853ab14#0853ab1487b6cbdc4c8818e9fb8d475b8b59eaf6"
 dependencies = [
  "as-any",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mezmo/aura"
 
 [workspace.dependencies]
-rig-core = { git = "https://github.com/mezmo/rig.git", branch = "mezmo", features = ["rmcp"] }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "0853ab14", features = ["rmcp"] }
 # Pinned to exact versions compatible with our rig-core 0.28.x fork.
 # Newer versions pull in rig-core 0.31+ which is semver-incompatible with the fork.
 rig-bedrock = "=0.3.10"
@@ -70,5 +70,5 @@ reqwest = { version = "0.12", features = ["json", "stream"] }
 
 # Patch rig-core to use the fork with streaming hook + span propagation fix
 [patch.crates-io]
-rig-core = { git = "https://github.com/mezmo/rig.git", branch = "mezmo" }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "0853ab14" }
 

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -154,15 +154,13 @@ struct RequestSetup {
 /// Extract query, chat history, and build agent — shared across both code paths.
 async fn prepare_request(
     data: &web::Data<AppState>,
-    req: &ChatCompletionRequest,
+    req: &mut ChatCompletionRequest,
     chat_session_id: &str,
     req_headers_map: &HashMap<String, String>,
 ) -> Result<RequestSetup, HttpResponse> {
-    use aura::Message;
-
-    // Extract the last user message as the query
-    let query = match req.messages.last() {
-        Some(msg) if msg.role == "user" => msg.content.clone(),
+    // Pop the last message as the query — the remainder becomes chat history
+    let query = match req.messages.pop() {
+        Some(msg) if msg.role == Role::User => msg.content,
         Some(msg) => {
             return Err(HttpResponse::BadRequest().json(ErrorResponse {
                 error: ErrorDetail {
@@ -171,18 +169,19 @@ async fn prepare_request(
                 },
             }));
         }
-        None => unreachable!(), // Already checked for empty messages
+        None => {
+            return Err(HttpResponse::BadRequest().json(ErrorResponse {
+                error: ErrorDetail {
+                    message: "messages array is empty".to_string(),
+                    error_type: "invalid_request_error".to_string(),
+                },
+            }));
+        }
     };
 
-    // Convert OpenAI messages to Rig messages (all except the last user message)
-    let chat_history: Vec<Message> = req.messages[..req.messages.len() - 1]
-        .iter()
-        .map(|msg| match msg.role.as_str() {
-            "user" => Message::user(&msg.content),
-            "assistant" => Message::assistant(&msg.content),
-            _ => Message::user(&msg.content), // Fallback for system/other roles
-        })
-        .collect();
+    // Convert remaining OpenAI messages to Rig messages,
+    // dropping system role messages and filtering empty content.
+    let chat_history = convert_chat_messages(&req.messages);
 
     // Build a fresh agent for this request
     let agent = match build_agent_for_request(&data.config, req_headers_map).await {
@@ -249,7 +248,8 @@ pub async fn chat_completions(
         .filter_map(|(k, v)| v.to_str().ok().map(|val| (k.to_string(), val.to_string())))
         .collect();
 
-    let setup = match prepare_request(&data, &req, &chat_session_id, &req_headers_map).await {
+    let mut req = req.into_inner();
+    let setup = match prepare_request(&data, &mut req, &chat_session_id, &req_headers_map).await {
         Ok(s) => s,
         Err(response) => return response,
     };
@@ -473,7 +473,7 @@ fn build_json_response(
         choices: vec![ChatChoice {
             index: 0,
             message: ChatMessage {
-                role: "assistant".to_string(),
+                role: Role::Assistant,
                 content: collected.outcome.content,
             },
             finish_reason: finish_reason.to_string(),
@@ -581,6 +581,34 @@ async fn handle_streaming_completion(
         .streaming(response_stream)
 }
 
+/// Convert OpenAI-format chat messages to Rig messages, sanitizing the history:
+/// - Drops `system` role messages (Aura's preamble is the authoritative system prompt)
+/// - Filters messages with empty/whitespace-only content
+/// - Maps `user` and `assistant` roles; skips unknown roles
+fn convert_chat_messages(messages: &[ChatMessage]) -> Vec<aura::Message> {
+    use aura::Message;
+
+    messages
+        .iter()
+        .filter_map(|msg| match msg.role {
+            Role::System => {
+                tracing::warn!("Dropping system role message from chat history — Aura's preamble is authoritative");
+                None
+            }
+            _ if msg.content.trim().is_empty() => {
+                tracing::warn!(role = %msg.role, "Dropping empty message from chat history");
+                None
+            }
+            Role::User => Some(Message::user(&msg.content)),
+            Role::Assistant => Some(Message::assistant(&msg.content)),
+            Role::Unknown => {
+                tracing::warn!(role = %msg.role, "Skipping message with unknown role");
+                None
+            }
+        })
+        .collect()
+}
+
 /// Health check endpoint
 pub async fn health() -> HttpResponse {
     HttpResponse::Ok().json(serde_json::json!({
@@ -613,9 +641,85 @@ fn generate_chat_session_id() -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::types::{ChatMessage, Role};
+
+    fn msg(role: Role, content: &str) -> ChatMessage {
+        ChatMessage {
+            role,
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_system_messages_dropped() {
+        let messages = vec![
+            msg(Role::System, "You are a helpful assistant"),
+            msg(Role::User, "Hello"),
+        ];
+        let result = convert_chat_messages(&messages);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_empty_messages_filtered() {
+        let messages = vec![
+            msg(Role::User, "Hello"),
+            msg(Role::Assistant, ""),
+            msg(Role::Assistant, "   "),
+            msg(Role::User, "How are you?"),
+        ];
+        let result = convert_chat_messages(&messages);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_no_system_passthrough() {
+        let messages = vec![
+            msg(Role::User, "Hello"),
+            msg(Role::Assistant, "Hi there"),
+            msg(Role::User, "How are you?"),
+        ];
+        let result = convert_chat_messages(&messages);
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_mixed_conversation() {
+        // Simulates LibreChat-style: system + prior messages + empty assistant
+        let messages = vec![
+            msg(Role::System, "You are a helpful assistant"),
+            msg(Role::User, "What is Rust?"),
+            msg(Role::Assistant, ""),
+            msg(Role::Assistant, "Rust is a systems programming language."),
+            msg(Role::User, "Tell me more"),
+        ];
+        let result = convert_chat_messages(&messages);
+        assert_eq!(result.len(), 3); // user, assistant(non-empty), user
+    }
+
+    #[test]
+    fn test_unknown_roles_skipped() {
+        let messages = vec![
+            msg(Role::Unknown, "some tool output"),
+            msg(Role::User, "Hello"),
+        ];
+        let result = convert_chat_messages(&messages);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let result = convert_chat_messages(&[]);
+        assert!(result.is_empty());
+    }
+
+    // --- streaming / response builder tests ---
+
     use crate::streaming::{
         ChatCompletionChunkDelta, MessageRole, ToolResultMode, truncate_result,
     };
+    use crate::streaming::{StreamOutcome, UsageInfo};
 
     #[test]
     fn test_truncate_result_no_truncation_when_zero() {
@@ -675,9 +779,6 @@ mod tests {
         assert!(!json.contains("role"));
         assert!(json.contains(r#""content":"World""#));
     }
-
-    use super::*;
-    use crate::streaming::{StreamOutcome, UsageInfo};
 
     fn make_response_ctx() -> ResponseContext {
         ResponseContext {

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -69,10 +69,33 @@ pub struct AppState {
     pub active_requests: Arc<ActiveRequestTracker>,
 }
 
+/// OpenAI-compatible message role
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    System,
+    User,
+    Assistant,
+    /// Catch-all for roles we don't handle (e.g. "tool", "function")
+    #[serde(other, rename = "unknown")]
+    Unknown,
+}
+
+impl std::fmt::Display for Role {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Role::System => write!(f, "system"),
+            Role::User => write!(f, "user"),
+            Role::Assistant => write!(f, "assistant"),
+            Role::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
 /// OpenAI-compatible chat message structure
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ChatMessage {
-    pub role: String,
+    pub role: Role,
     pub content: String,
 }
 


### PR DESCRIPTION
Interaction with openwebui and librechat will post their own system messages - we don't really have a way to modify system content after build time and it can be considered an attack vector - strip both the system message (incompabible with rig without upgrading to a user message) and empty messages that can blow up bedrock providers.

Ref: LOG-23402