### PR TITLE
fix: stop breaking early on pre tool text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aura"
-version = "1.14.7"
+version = "1.14.8"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "aura-config"
-version = "1.14.7"
+version = "1.14.8"
 dependencies = [
  "anyhow",
  "aura",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "aura-test-utils"
-version = "1.14.7"
+version = "1.14.8"
 dependencies = [
  "reqwest",
  "serde",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "aura-web-server"
-version = "1.14.7"
+version = "1.14.8"
 dependencies = [
  "actix-web",
  "actix-web-lab",

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -589,7 +589,7 @@ impl Agent {
                     break;
                 }
                 Ok(StreamItem::FinalMarker) => {
-                    break;
+                    // Per-turn marker — not end-of-stream. Continue collecting.
                 }
                 Ok(_) => {
                     // Tool calls, deltas, reasoning - handled by fallback executor


### PR DESCRIPTION
Right now we mistakenly break out of our
streaming collector (makes streaming agents
compatible with non streaming calls) breaks
its loop on FinalMarker when in actually
FinalMarker is emitted at the end  of every agent turn so if the agent emits text before the tool call
we exit before we have the LLM get or or respond
to the result. Fix this by removing the early exit.

Ref: LOG-23401