### PR TITLE
fix(jenkins): fix intermittent ci failures due to instance re-use

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,8 +32,8 @@ pipeline {
     NPM_CONFIG_CACHE = '.npm'
     NPM_CONFIG_USERCONFIG = '.npm/rc'
     SPAWN_WRAP_SHIM_ROOT = '.npm'
-    RUSTUP_HOME = '/opt/rust/cargo'
-    CARGO_HOME = '/opt/rust/cargo'
+    RUSTUP_HOME = "${env.WORKSPACE}/.rustup"
+    CARGO_HOME = "${env.WORKSPACE}/.cargo"
     PATH = """${sh(
        returnStdout: true,
        script: 'echo /opt/rust/cargo/bin:\$PATH'


### PR DESCRIPTION
Updates RUSTUP_HOME and CARGO_HOME to use a workspace-local directory instead of /opt/ so that when a jenkins instance is re-used, cargo will continue to work for CI stages.

Ref: LOG-23413