### PR TITLE
chore(build): allow feature branch name flexibility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,7 +159,7 @@ pipeline {
     stage('Feature Build') {
       when {
         expression {
-          CURRENT_BRANCH ==~ /feature\/(([A-Z]{2,5}-\d+.*)|aura-next(-.*)?)/
+          CURRENT_BRANCH ==~ /feature\/((.*)|aura-next(-.*)?)/
         }
       }
 


### PR DESCRIPTION
Feature branches can be feature/something and no longer have to be feature/LOG-XXXXX

Ref: LOG-23418