### PR TITLE
feat(orchestration): add OTel tracing spans to orchestration mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,7 +2165,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3108,7 +3108,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.31",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -3145,7 +3145,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3360,7 +3360,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.28.0"
-source = "git+https://github.com/mezmo/rig.git?rev=e0b57e7a#e0b57e7aed60cd19f8f1895490fd51b6757fe0a4"
+source = "git+https://github.com/mezmo/rig.git?rev=b885e4cc#b885e4cc325108a235ec02852b1ae51c297373b3"
 dependencies = [
  "as-any",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mezmo/aura"
 
 [workspace.dependencies]
-rig-core = { git = "https://github.com/mezmo/rig.git", rev = "e0b57e7a", features = ["rmcp"] }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "b885e4cc", features = ["rmcp"] }
 # Pinned to exact versions compatible with our rig-core 0.28.x fork.
 # Newer versions pull in rig-core 0.31+ which is semver-incompatible with the fork.
 rig-bedrock = "=0.3.10"
@@ -70,5 +70,5 @@ reqwest = { version = "0.12", features = ["json", "stream"] }
 
 # Patch rig-core to use the fork with streaming hook + span propagation fix
 [patch.crates-io]
-rig-core = { git = "https://github.com/mezmo/rig.git", rev = "e0b57e7a" }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "b885e4cc" }
 

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -587,9 +587,9 @@ fn handle_stream_item(
 
             vec![]
         }
-        StreamItem::FinalMarker => {
-            // Internal marker - filtered out
-            tracing::debug!("Received final marker");
+        StreamItem::FinalMarker | StreamItem::TurnUsage(_) => {
+            // Internal markers - filtered out
+            tracing::debug!("Received final/turn-usage marker");
             vec![]
         }
         StreamItem::OrchestratorEvent(event) => handle_orchestrator_event(config, ctx, event),

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -765,7 +765,7 @@ impl Agent {
                     usage = response.usage;
                     break;
                 }
-                Ok(StreamItem::FinalMarker) => {
+                Ok(StreamItem::FinalMarker) | Ok(StreamItem::TurnUsage(_)) => {
                     // Per-turn marker — not end-of-stream. Continue collecting.
                 }
                 Ok(_) => {

--- a/crates/aura/src/fallback_tool_stream.rs
+++ b/crates/aura/src/fallback_tool_stream.rs
@@ -114,7 +114,7 @@ impl FallbackToolExecutor {
                         // Forward the original text
                         yield item;
                     }
-                    Ok(StreamItem::Final(_)) | Ok(StreamItem::FinalMarker) => {
+                    Ok(StreamItem::Final(_)) | Ok(StreamItem::FinalMarker) | Ok(StreamItem::TurnUsage(_)) => {
                         // Stream is ending - check if buffered text contains a tool call
                         // BUT only if no proper tool_calls were already executed
                         let (buffered_text, has_native_tool_calls) = {

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -28,10 +28,10 @@
 //! agent.stream (AGENT, ROOT)        <- Phoenix root span, lives for full stream duration
 //!   ├── user.id, session.id, metadata, input.value, output.value, tokens
 //!   └── agent.turn (LLM)           <- from Rig fork (reuses agent.stream as parent)
-//!       ├── chat_streaming (LLM)    <- from Rig
 //!       ├── execute_tool (TOOL)     <- from Rig (no error status — see below)
 //!       │   └── mcp.tool_call (TOOL) <- from Aura, canonical tool span with error status
-//!       └── chat_streaming (LLM)    <- from Rig
+//!       └── execute_tool (TOOL)
+//!           └── mcp.tool_call (TOOL)
 //! ```
 //!
 //! ### Orchestration mode
@@ -43,7 +43,7 @@
 //!         │   └── agent.turn (LLM) → ...
 //!         └── orchestration.iteration (CHAIN)    <- per plan-execute-synth-eval cycle
 //!             ├── orchestration.worker (AGENT)   <- per worker task
-//!             │   └── agent.turn (LLM) → chat_streaming → execute_tool → mcp.tool_call
+//!             │   └── agent.turn (LLM) → execute_tool → mcp.tool_call
 //!             ├── orchestration.synthesis (CHAIN)
 //!             │   └── agent.turn (LLM) → ...
 //!             └── orchestration.evaluation (CHAIN)

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -22,6 +22,8 @@
 //! `output.value`, token counts, `user.id`, `session.id`, `metadata`) live on
 //! this span.
 //!
+//! ### Single-agent mode
+//!
 //! ```text
 //! agent.stream (AGENT, ROOT)        <- Phoenix root span, lives for full stream duration
 //!   ├── user.id, session.id, metadata, input.value, output.value, tokens
@@ -30,7 +32,25 @@
 //!       ├── execute_tool (TOOL)     <- from Rig (no error status — see below)
 //!       │   └── mcp.tool_call (TOOL) <- from Aura, canonical tool span with error status
 //!       └── chat_streaming (LLM)    <- from Rig
+//! ```
 //!
+//! ### Orchestration mode
+//!
+//! ```text
+//! agent.stream (AGENT, ROOT)
+//!   └── orchestration (CHAIN)                   <- full orchestration lifecycle
+//!         ├── orchestration.planning (CHAIN)     <- coordinator routing/planning
+//!         │   └── agent.turn (LLM) → ...
+//!         └── orchestration.iteration (CHAIN)    <- per plan-execute-synth-eval cycle
+//!             ├── orchestration.worker (AGENT)   <- per worker task
+//!             │   └── agent.turn (LLM) → chat_streaming → execute_tool → mcp.tool_call
+//!             ├── orchestration.synthesis (CHAIN)
+//!             │   └── agent.turn (LLM) → ...
+//!             └── orchestration.evaluation (CHAIN)
+//!                 └── agent.turn (LLM) → ...
+//! ```
+//!
+//! ```text
 //! chat_completions (separate trace)  <- HTTP infrastructure
 //!   └── streaming_completion         <- HTTP infrastructure
 //! ```
@@ -39,6 +59,10 @@
 //! so that `Span::current()` is active when rig's `send()` runs. Rig reuses
 //! the caller's span instead of creating its own `invoke_agent` span,
 //! keeping `agent.turn` as a direct child of `agent.stream`.
+//!
+//! For orchestration, the spawned task in `Orchestrator::stream()` is
+//! instrumented with the `agent.stream` span so that all orchestration
+//! child spans nest correctly under the trace root.
 //!
 //! Tool errors are only recorded on the `mcp.tool_call` child span (by
 //! `mcp_tool_execution.rs`), not on Rig's `execute_tool` parent.  This is

--- a/crates/aura/src/openinference_exporter.rs
+++ b/crates/aura/src/openinference_exporter.rs
@@ -72,10 +72,16 @@ fn infer_span_kind(name: &str) -> &'static str {
         "chat" | "chat_streaming" | "agent.turn" => "LLM",
         // Tool execution spans
         "execute_tool" | "mcp.tool_call" => "TOOL",
-        // Aura agent orchestration
-        "agent.stream" | "agent.prompt" | "agent.chat" => "AGENT",
-        // Aura chain / entry-point spans
-        "chat_completions" | "streaming_completion" => "CHAIN",
+        // Aura agent orchestration (worker is an autonomous agent with its own LLM + tools)
+        "agent.stream" | "agent.prompt" | "agent.chat" | "orchestration.worker" => "AGENT",
+        // Aura chain / entry-point spans + orchestration phases
+        "chat_completions"
+        | "streaming_completion"
+        | "orchestration"
+        | "orchestration.planning"
+        | "orchestration.iteration"
+        | "orchestration.synthesis"
+        | "orchestration.evaluation" => "CHAIN",
         // Safe default
         _ => "CHAIN",
     }

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -725,6 +725,11 @@ impl Orchestrator {
                     Ok(StreamItem::FinalMarker) => {
                         // Per-turn marker — not end-of-stream. Continue collecting.
                     }
+                    Ok(StreamItem::TurnUsage(turn)) => {
+                        usage.input_tokens += turn.input_tokens;
+                        usage.output_tokens += turn.output_tokens;
+                        usage.total_tokens += turn.total_tokens;
+                    }
                     Err(e) => return Err(e),
                     _ => {} // ToolCall, ToolCallDelta, ToolResult — rig handles execution
                 }
@@ -766,8 +771,8 @@ impl Orchestrator {
     /// - Short-circuits after first `ToolResult` when `decision_ready()` returns true
     /// - Falls back to normal completion for text-only responses
     ///
-    /// Usage may be zero when short-circuiting before `Final` — acceptable for
-    /// coordinator calls where token accounting is not critical.
+    /// Per-turn usage is captured from `TurnUsage` events even when
+    /// short-circuiting before the terminal `Final`.
     async fn stream_and_collect(
         &self,
         agent: &Agent,
@@ -828,8 +833,16 @@ impl Orchestrator {
                             tr.call_id.as_deref().unwrap_or("-")
                         );
                         if decision_ready().await {
-                            tracing::debug!("{}: decision captured, exiting stream early", phase);
-                            break; // Drop stream — prevents rig re-prompt
+                            tracing::debug!("{}: decision captured, reading turn usage", phase);
+                            // Read one more item to capture per-turn token usage
+                            // before dropping the stream. With the always-yield-Final
+                            // fix in Rig, TurnUsage is the next item after ToolResult.
+                            if let Some(Ok(StreamItem::TurnUsage(turn))) = stream.next().await {
+                                usage.input_tokens += turn.input_tokens;
+                                usage.output_tokens += turn.output_tokens;
+                                usage.total_tokens += turn.total_tokens;
+                            }
+                            break;
                         }
                     }
                     // Final response — authoritative content + usage
@@ -837,6 +850,11 @@ impl Orchestrator {
                         content = info.content;
                         usage = info.usage;
                         break;
+                    }
+                    Ok(StreamItem::TurnUsage(turn)) => {
+                        usage.input_tokens += turn.input_tokens;
+                        usage.output_tokens += turn.output_tokens;
+                        usage.total_tokens += turn.total_tokens;
                     }
                     Ok(StreamItem::FinalMarker) => break,
                     // MaxDepthError: success if decision was captured, error otherwise

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -886,6 +886,11 @@ impl Orchestrator {
     /// Falls back to text-based plan parsing if no routing tool was called.
     /// Enforces config flags: converts Direct/Clarification to single-task
     /// Orchestrated when `allow_direct_answers`/`allow_clarification` is false.
+    #[tracing::instrument(
+        name = "orchestration.planning",
+        skip_all,
+        fields(orchestration.phase = "planning")
+    )]
     async fn plan_with_routing(
         &self,
         query: &str,
@@ -991,7 +996,16 @@ impl Orchestrator {
                 )
                 .await
             {
-                Ok(r) => r,
+                Ok(r) => {
+                    crate::logging::set_token_usage(
+                        &tracing::Span::current(),
+                        r.usage.input_tokens,
+                        r.usage.output_tokens,
+                        r.usage.total_tokens,
+                        0,
+                    );
+                    r
+                }
                 Err(e) if is_context_overflow_error(e.as_ref()) => {
                     let suggestion = context_overflow_suggestion("planning");
                     return Err(
@@ -2985,6 +2999,15 @@ Assign tasks to the worker whose tools best match the required operations."#,
     }
 
     /// Execute a single task using a worker agent.
+    #[tracing::instrument(
+        name = "orchestration.worker",
+        skip_all,
+        fields(
+            orchestration.task_id = task_id,
+            orchestration.worker = tracing::field::Empty,
+            orchestration.task = tracing::field::Empty,
+        )
+    )]
     async fn execute_task(
         &self,
         task_id: usize,
@@ -2997,6 +3020,16 @@ Assign tasks to the worker whose tools best match the required operations."#,
             worker_name,
             plan_goal,
         } = params;
+
+        {
+            let span = tracing::Span::current();
+            let (task_preview, _) = safe_truncate(task_description, 200);
+            span.record("orchestration.task", task_preview);
+            if let Some(name) = worker_name {
+                span.record("orchestration.worker", *name);
+            }
+        }
+
         // Create worker with persistence context (attempt 1 for now - retry logic is Phase 2+)
         let attempt = 1;
         let start_time = std::time::Instant::now();
@@ -3043,6 +3076,18 @@ Assign tasks to the worker whose tools best match the required operations."#,
             )
             .await;
         let duration_ms = start_time.elapsed().as_millis() as u64;
+
+        // Record token usage on the orchestration.worker span
+        if let Ok(ref response) = result {
+            let span = tracing::Span::current();
+            crate::logging::set_token_usage(
+                &span,
+                response.usage.input_tokens,
+                response.usage.output_tokens,
+                response.usage.total_tokens,
+                0,
+            );
+        }
 
         // Detect context overflow in worker and provide actionable message
         let result = match result {
@@ -3093,6 +3138,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
             }
         }
 
+        {
+            let span = tracing::Span::current();
+            match &result {
+                Ok(_) => crate::logging::set_span_ok(&span),
+                Err(e) => crate::logging::set_span_error(&span, e.to_string()),
+            }
+        }
         result
     }
 
@@ -3216,6 +3268,14 @@ Assign tasks to the worker whose tools best match the required operations."#,
     /// combine results into a coherent response.
     ///
     /// Also persists the synthesis artifacts via ExecutionPersistence.
+    #[tracing::instrument(
+        name = "orchestration.synthesis",
+        skip_all,
+        fields(
+            orchestration.phase = "synthesis",
+            orchestration.completed_tasks = tracing::field::Empty,
+        )
+    )]
     async fn synthesize(
         &self,
         plan: &Plan,
@@ -3228,6 +3288,11 @@ Assign tasks to the worker whose tools best match the required operations."#,
             .iter()
             .filter(|t| t.status == TaskStatus::Complete && t.result.is_some())
             .collect();
+
+        tracing::Span::current().record(
+            "orchestration.completed_tasks",
+            completed_tasks.len() as i64,
+        );
 
         if completed_tasks.is_empty() {
             // All tasks failed
@@ -3309,6 +3374,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         tracing::debug!(
                             "LLM synthesis successful for {} tasks",
                             completed_tasks.len()
+                        );
+                        crate::logging::set_token_usage(
+                            &tracing::Span::current(),
+                            response.usage.input_tokens,
+                            response.usage.output_tokens,
+                            response.usage.total_tokens,
+                            0,
                         );
                         response.content
                     }
@@ -3403,6 +3475,14 @@ Assign tasks to the worker whose tools best match the required operations."#,
     /// the LLM fails or doesn't call the tool.
     ///
     /// Returns an `EvaluationResult` containing the score, reasoning, and gaps.
+    #[tracing::instrument(
+        name = "orchestration.evaluation",
+        skip_all,
+        fields(
+            orchestration.phase = "evaluation",
+            orchestration.quality_score = tracing::field::Empty,
+        )
+    )]
     async fn evaluate(
         &self,
         plan: &Plan,
@@ -3451,6 +3531,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     .await
                 {
                     Ok(response) => {
+                        crate::logging::set_token_usage(
+                            &tracing::Span::current(),
+                            response.usage.input_tokens,
+                            response.usage.output_tokens,
+                            response.usage.total_tokens,
+                            0,
+                        );
                         // Read the evaluation from the tool's shared state
                         let eval = decision.lock().await.take();
                         match eval {
@@ -3527,6 +3614,11 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 tracing::warn!("Failed to persist evaluation: {}", e);
             }
         }
+
+        tracing::Span::current().record(
+            "orchestration.quality_score",
+            format!("{:.2}", eval_result.score).as_str(),
+        );
 
         tracing::info!(
             "Evaluation: score={:.2}, reasoning={}",
@@ -3623,12 +3715,25 @@ Assign tasks to the worker whose tools best match the required operations."#,
     /// - `Direct` → emit event, return response
     /// - `Clarification` → emit event, return question
     /// - `Orchestrated` → delegate to `run_orchestration_loop()`
+    #[tracing::instrument(
+        name = "orchestration",
+        skip_all,
+        fields(
+            orchestration.goal = tracing::field::Empty,
+            orchestration.max_iterations = self.config.max_planning_cycles,
+            orchestration.routing = tracing::field::Empty,
+        )
+    )]
     async fn run_orchestration(
         &self,
         query: &str,
         chat_history: Vec<rig::completion::Message>,
         event_tx: tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>,
     ) -> Result<String, StreamError> {
+        let span = tracing::Span::current();
+        let (goal_preview, _) = safe_truncate(query, 200);
+        span.record("orchestration.goal", goal_preview);
+
         let orchestration_start = Instant::now();
         let default_turn_depth = self
             .agent_config
@@ -3648,11 +3753,12 @@ Assign tasks to the worker whose tools best match the required operations."#,
             .plan_with_routing(query, &chat_history, None, Some(&event_tx))
             .await?;
 
-        match response {
+        let result = match response {
             PlanningResponse::Direct {
                 response,
                 routing_rationale,
             } => {
+                span.record("orchestration.routing", "direct");
                 Self::emit_event(
                     &event_tx,
                     OrchestratorEvent::DirectAnswer {
@@ -3668,6 +3774,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 options,
                 routing_rationale,
             } => {
+                span.record("orchestration.routing", "clarification");
                 Self::emit_event(
                     &event_tx,
                     OrchestratorEvent::ClarificationNeeded {
@@ -3680,6 +3787,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 Ok(question)
             }
             PlanningResponse::Orchestrated { .. } | PlanningResponse::StepsPlan { .. } => {
+                span.record("orchestration.routing", "orchestrated");
                 let routing_rationale = response.routing_rationale().to_string();
                 let planning_summary = response.planning_summary().unwrap_or_default().to_string();
                 let plan = response
@@ -3706,7 +3814,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 )
                 .await
             }
+        };
+
+        match &result {
+            Ok(_) => crate::logging::set_span_ok(&span),
+            Err(e) => crate::logging::set_span_error(&span, e.to_string()),
         }
+        result
     }
 
     /// The plan-execute-synthesize-evaluate loop.
@@ -3736,6 +3850,19 @@ Assign tasks to the worker whose tools best match the required operations."#,
             iteration += 1;
             self.current_iteration.store(iteration, Ordering::Relaxed);
             let elapsed = orchestration_start.elapsed().as_secs_f64();
+
+            // Create a span for this iteration. Child spans (planning, worker,
+            // synthesis, evaluation) inherit this as parent via Span::current().
+            // Using enter() rather than instrument() because the loop body has
+            // break/continue control flow that can't cross async block boundaries.
+            let iter_span = tracing::info_span!(
+                "orchestration.iteration",
+                orchestration.iteration = iteration,
+                orchestration.task_count = tracing::field::Empty,
+                orchestration.quality_score = tracing::field::Empty,
+                orchestration.will_replan = tracing::field::Empty,
+            );
+            let _iter_guard = iter_span.enter();
 
             tracing::info!(
                 "Starting iteration {}/{} (elapsed={:.1}s, per_call_timeout={}s)",
@@ -3797,6 +3924,9 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 )
                 .await;
             }
+
+            // Record task count on the iteration span now that the plan is finalized
+            iter_span.record("orchestration.task_count", plan.tasks.len() as i64);
 
             // ----------------------------------------------------------------
             // EXECUTE: Run workers on tasks (parallel when possible)
@@ -4045,6 +4175,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     ],
                 };
 
+                // Record failure on the iteration span
+                iter_span.record("orchestration.quality_score", "0.00");
+                iter_span.record("orchestration.will_replan", true);
+
                 // Emit IterationComplete on failure path (was previously skipped)
                 Self::emit_event(
                     &event_tx,
@@ -4116,6 +4250,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
             let quality_met = quality_score >= self.config.quality_threshold;
             let iterations_remaining = iteration < self.config.max_planning_cycles;
             let will_replan = !quality_met && iterations_remaining;
+
+            // Record evaluation results on the iteration span
+            iter_span.record(
+                "orchestration.quality_score",
+                format!("{:.2}", quality_score).as_str(),
+            );
+            iter_span.record("orchestration.will_replan", will_replan);
 
             // Persist iteration summary
             {
@@ -4233,7 +4374,9 @@ impl StreamingAgent for Orchestrator {
         // Note: Creates a fresh Orchestrator with its own MCP connections and persistence run.
         // The factory instance (self) only exists to satisfy the StreamingAgent trait.
         let cancel_token_clone = cancel_token.clone();
-        tokio::spawn(async move {
+        // Capture the current span (agent.stream root) so child spans nest correctly in Phoenix.
+        let parent_span = tracing::Span::current();
+        tokio::spawn(tracing::Instrument::instrument(async move {
             let orchestrator = match Orchestrator::new(agent_config).await {
                 Ok(o) => o,
                 Err(e) => {
@@ -4291,7 +4434,7 @@ impl StreamingAgent for Orchestrator {
                     }
                 }
             }
-        });
+        }, parent_span));
 
         // Convert receiver to stream
         let stream = stream::unfold(event_rx, |mut rx| async move {

--- a/crates/aura/src/provider_agent.rs
+++ b/crates/aura/src/provider_agent.rs
@@ -330,6 +330,10 @@ pub enum StreamItem {
     Final(FinalResponseInfo),
     /// Internal marker for final response (filtered out before returning to caller)
     FinalMarker,
+    /// Per-turn token usage from intermediate turns (not end-of-stream).
+    /// Emitted on every Rig `Final` chunk so callers can capture usage
+    /// even when they short-circuit before the terminal `FinalResponse`.
+    TurnUsage(Usage),
     /// Orchestrator status event (plan progress, task status, etc.)
     OrchestratorEvent(OrchestratorEvent),
 }
@@ -396,7 +400,7 @@ pub type StreamError = Box<dyn std::error::Error + Send + Sync>;
 /// This function handles the conversion from rig's generic streaming types
 /// to our provider-agnostic types. The generic parameter R is the provider's
 /// streaming response type, which we don't need to inspect.
-fn map_stream_item<R>(
+fn map_stream_item<R: rig::completion::GetTokenUsage>(
     item: Result<MultiTurnStreamItem<R>, impl std::error::Error + Send + Sync + 'static>,
 ) -> Result<StreamItem, StreamError> {
     use rig::streaming::{
@@ -428,10 +432,16 @@ fn map_stream_item<R>(
                         delta: reasoning,
                     }
                 }
-                RigAssistant::Final(_) => {
-                    // Final response marker - we don't need to forward this
-                    // as we handle FinalResponse separately
-                    return Ok(StreamItem::FinalMarker);
+                RigAssistant::Final(ref resp) => {
+                    // Per-turn usage — not end-of-stream. Callers that
+                    // short-circuit (e.g. stream_and_collect) can capture
+                    // token counts from this without waiting for FinalResponse.
+                    let usage = resp.token_usage().unwrap_or(Usage {
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        total_tokens: 0,
+                    });
+                    return Ok(StreamItem::TurnUsage(usage));
                 }
             };
             Ok(StreamItem::StreamAssistantItem(mapped))

--- a/crates/aura/src/tool_wrapper.rs
+++ b/crates/aura/src/tool_wrapper.rs
@@ -428,10 +428,17 @@ where
                 return Err(validation_error);
             }
 
-            // Call inner tool (spawn to handle non-Sync futures)
+            // Call inner tool (spawn to handle non-Sync futures).
+            // Propagate the current span so mcp.tool_call nests under execute_tool.
             let inner_clone = inner.clone();
             let args_clone = clean_args.clone();
-            let result_handle = tokio::spawn(async move { inner_clone.call(args_clone).await });
+            let tool_span = tracing::Span::current();
+            let result_handle = tokio::spawn(
+                tracing::Instrument::instrument(
+                    async move { inner_clone.call(args_clone).await },
+                    tool_span,
+                )
+            );
 
             let result = match result_handle.await {
                 Ok(r) => r,

--- a/docs/tracing-spans.md
+++ b/docs/tracing-spans.md
@@ -1,0 +1,107 @@
+# Tracing Span Layout
+
+Aura exports OpenTelemetry spans via OTLP when `OTEL_EXPORTER_OTLP_ENDPOINT`
+is set. Spans follow the [OpenInference](https://github.com/Arize-ai/openinference)
+taxonomy so they render correctly in Phoenix, Jaeger, and similar tools.
+
+## Trace structure
+
+Every request produces two traces:
+
+1. **HTTP trace** — covers the request/response lifecycle
+2. **Agent trace** — covers the LLM/tool execution
+
+The agent trace is rooted at `agent.stream` with `parent: None` so Phoenix
+sees it as an independent trace root with all LLM I/O attributes.
+
+### HTTP trace (both modes)
+
+```text
+chat_completions (CHAIN)
+  └── streaming_completion (CHAIN)
+```
+
+### Single-agent mode
+
+```text
+agent.stream (AGENT, ROOT)
+  └── agent.turn (LLM)
+      ├── execute_tool (TOOL)
+      │   └── mcp.tool_call (TOOL)
+      └── execute_tool (TOOL)
+          └── mcp.tool_call (TOOL)
+```
+
+### Orchestration mode
+
+```text
+agent.stream (AGENT, ROOT)
+  └── orchestration (CHAIN)
+        ├── orchestration.planning (CHAIN)
+        │   └── agent.turn (LLM) → execute_tool → mcp.tool_call
+        └── orchestration.iteration (CHAIN)
+            ├── orchestration.worker (AGENT)
+            │   └── agent.turn (LLM) → execute_tool → mcp.tool_call
+            ├── orchestration.synthesis (CHAIN)
+            │   └── agent.turn (LLM) → ...
+            └── orchestration.evaluation (CHAIN)
+                └── agent.turn (LLM) → execute_tool → mcp.tool_call
+```
+
+## Span attributes
+
+### Agent root (`agent.stream`)
+
+`user.id`, `session.id`, `metadata`, `input.value`, `output.value`,
+`llm.token_count.prompt`, `llm.token_count.completion`, `llm.token_count.total`
+
+### Orchestration spans
+
+| Span | Attributes |
+|------|-----------|
+| `orchestration` | `orchestration.goal`, `orchestration.max_iterations`, `orchestration.routing` (direct/clarification/orchestrated) |
+| `orchestration.planning` | `orchestration.phase` |
+| `orchestration.iteration` | `orchestration.iteration`, `orchestration.task_count`, `orchestration.quality_score`, `orchestration.will_replan` |
+| `orchestration.worker` | `orchestration.task_id`, `orchestration.worker`, `orchestration.task` |
+| `orchestration.synthesis` | `orchestration.phase`, `orchestration.completed_tasks` |
+| `orchestration.evaluation` | `orchestration.phase`, `orchestration.quality_score` |
+
+Token usage (`llm.token_count.*`) is recorded on all orchestration phase
+spans (planning, worker, synthesis, evaluation).
+
+## OpenInference span kinds
+
+Span kind is inferred from the span name by the custom exporter in
+`openinference_exporter.rs`:
+
+| Kind | Spans |
+|------|-------|
+| **LLM** | `chat_streaming`, `agent.turn` |
+| **TOOL** | `execute_tool`, `mcp.tool_call` |
+| **AGENT** | `agent.stream`, `orchestration.worker` |
+| **CHAIN** | `chat_completions`, `streaming_completion`, `orchestration`, `orchestration.planning`, `orchestration.iteration`, `orchestration.synthesis`, `orchestration.evaluation` |
+
+## Span parenting
+
+- `agent.stream` is created with `parent: None` to break the link from the
+  HTTP handler trace, making it an independent trace root in Phoenix.
+- The `tokio::spawn` in `handlers.rs` is instrumented with `agent.stream` so
+  Rig's `agent.turn` becomes a direct child.
+- In orchestration mode, `Orchestrator::stream()` instruments its spawned task
+  with the `agent.stream` span so all orchestration child spans nest under the
+  trace root.
+- `ToolWrapper::call` propagates the current span into its `tokio::spawn` so
+  `mcp.tool_call` nests under Rig's `execute_tool`.
+
+## Content recording
+
+When `OTEL_RECORD_CONTENT=true`, prompt/completion text and tool
+arguments/results are recorded as span attributes, truncated to
+`OTEL_CONTENT_MAX_LENGTH` (default 1000 bytes, rounded to a UTF-8 boundary).
+
+## Known limitations
+
+- **Tool error propagation**: Tool errors are only recorded on the
+  `mcp.tool_call` child span (by `mcp_tool_execution.rs`), not on Rig's
+  `execute_tool` parent. This is intentional — `mcp.tool_call` is the
+  canonical TOOL span for Phoenix.


### PR DESCRIPTION
Add structured tracing spans covering all orchestration phases: orchestration, planning, iteration, worker, synthesis, evaluation. Record rich attributes (goal, routing, task metadata, quality score, token usage) and map span kinds in the OpenInference exporter.

Fix span propagation: tokio::spawn in Orchestrator::stream() and ToolWrapper::call now inherit the parent span so child spans nest correctly under agent.stream in Phoenix/Jaeger.

Known limitation: token counts on planning and evaluation spans will be zero until an upstream Rig change lands to always yield per-turn Final regardless of is_text_response.

ref: LOG-23471