### PR TITLE
feat(tools): add support for client-side tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Core server options:
 | `--tool-result-mode`         | `TOOL_RESULT_MODE`         | `none`        | Tool result streaming: none, open-web-ui, aura |
 | `--tool-result-max-length`   | `TOOL_RESULT_MAX_LENGTH`   | `100`         | Max chars before truncation (aura events) |
 | `--shutdown-timeout-secs`    | `SHUTDOWN_TIMEOUT_SECS`    | `30`          | Graceful shutdown window            |
+| `--enable-client-tools`      | `ENABLE_CLIENT_TOOLS`      | `false`       | Enable client-side tool execution   |
 
 Tool result modes:
 
@@ -149,6 +150,59 @@ curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"messages": [{"role": "user", "content": "Hello"}], "stream": true}'
 ```
+
+### Client-Side Tool Execution
+
+By default, Aura executes all tools server-side via MCP. When `ENABLE_CLIENT_TOOLS=true`, clients can also define their own tools in the request using the OpenAI `tools` field. The LLM can call these tools, but instead of executing server-side, the stream terminates with `finish_reason: "tool_calls"` so the client can execute the tool locally and send results back in a follow-up request.
+
+```bash
+ENABLE_CLIENT_TOOLS=true cargo run --bin aura-web-server
+```
+
+```bash
+# 1. Send a request with client-side tool definitions
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "What time is it?"}],
+    "stream": true,
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_current_time",
+        "description": "Get the current time",
+        "parameters": {"type": "object", "properties": {}}
+      }
+    }]
+  }'
+
+# 2. Stream ends with finish_reason: "tool_calls" and a tool_calls delta.
+#    Client executes the tool locally, then sends results back:
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      {"role": "user", "content": "What time is it?"},
+      {"role": "assistant", "content": null, "tool_calls": [
+        {"id": "call_abc", "type": "function", "function": {"name": "get_current_time", "arguments": "{}"}}
+      ]},
+      {"role": "tool", "tool_call_id": "call_abc", "content": "2025-03-18T14:30:00Z"}
+    ],
+    "stream": true,
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_current_time",
+        "description": "Get the current time",
+        "parameters": {"type": "object", "properties": {}}
+      }
+    }]
+  }'
+```
+
+Client-side and server-side (MCP) tools can coexist in the same agent. The LLM sees all available tools and chooses which to call. Server-side tools execute automatically; client-side tools pause the stream for client execution.
+
+For the full streaming protocol and event details, see [docs/streaming-api-guide.md](docs/streaming-api-guide.md).
 
 SSE protocol details, event types, custom events, and client handling are documented in [docs/streaming-api-guide.md](docs/streaming-api-guide.md).
 

--- a/crates/aura-config/src/builder.rs
+++ b/crates/aura-config/src/builder.rs
@@ -1,7 +1,7 @@
 use crate::{Config, ConfigError};
 use aura::{
-    Agent, AgentBuilder, AgentConfig, AgentSettings, EmbeddingModelConfig, LlmConfig, McpConfig,
-    McpServerConfig, ReasoningEffort, ToolsConfig, VectorStoreConfig, VectorStoreType,
+    Agent, AgentConfig, AgentSettings, EmbeddingModelConfig, LlmConfig, McpConfig, McpServerConfig,
+    ReasoningEffort, ToolsConfig, VectorStoreConfig, VectorStoreType,
 };
 use std::collections::HashMap;
 
@@ -210,23 +210,15 @@ impl RigBuilder {
         })
     }
 
-    pub async fn build_agent(&self) -> Result<Agent, ConfigError> {
-        let agent_config = self.to_agent_config()?;
-        self.build_from_config(agent_config).await
-    }
-
-    pub async fn build_agent_with_headers(
+    pub async fn build_agent(
         &self,
         req_headers: Option<&HashMap<String, String>>,
+        client_tools: Option<Vec<aura::builder::ClientTool>>,
     ) -> Result<Agent, ConfigError> {
         let mut agent_config = self.to_agent_config()?;
         resolve_mcp_headers(&mut agent_config, req_headers);
-        self.build_from_config(agent_config).await
-    }
 
-    async fn build_from_config(&self, agent_config: AgentConfig) -> Result<Agent, ConfigError> {
-        AgentBuilder::new(agent_config)
-            .build_agent()
+        Agent::new(&agent_config, client_tools)
             .await
             .map_err(|e| ConfigError::Validation(format!("Failed to build agent: {e}")))
     }

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -118,24 +118,31 @@ struct ResponseContext {
 }
 
 /// Build a fresh agent for a request, applying headers_from_request mappings.
+/// If `client_tools` is provided, they are registered as passthrough tools.
 async fn build_agent_for_request(
     config: &aura_config::Config,
     req_headers: &HashMap<String, String>,
+    client_tools: Option<&[ClientToolDefinition]>,
 ) -> Result<Arc<aura::Agent>, HttpResponse> {
-    let builder = RigBuilder::new(config.clone());
-    let agent = builder
-        .build_agent_with_headers(Some(req_headers))
+    let tool_defs =
+        client_tools.map(|tools| tools.iter().map(aura::builder::ClientTool::from).collect());
+
+    let agent = RigBuilder::new(config.clone())
+        .build_agent(Some(req_headers), tool_defs)
         .await
-        .map_err(|e| {
-            error!("Failed to build agent: {}", e);
-            HttpResponse::InternalServerError().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: format!("Failed to build agent: {e}"),
-                    error_type: "internal_error".to_string(),
-                },
-            })
-        })?;
+        .map_err(|e| agent_error(&format!("Failed to build agent: {e}")))?;
+
     Ok(Arc::new(agent))
+}
+
+fn agent_error(message: &str) -> HttpResponse {
+    error!("{}", message);
+    HttpResponse::InternalServerError().json(ErrorResponse {
+        error: ErrorDetail {
+            message: message.to_string(),
+            error_type: "internal_error".to_string(),
+        },
+    })
 }
 
 /// Shared request setup extracted from the incoming ChatCompletionRequest.
@@ -150,6 +157,8 @@ struct RequestSetup {
     created_timestamp: u64,
     chat_session_id: String,
     has_chat_history: bool,
+    /// Whether the request includes client-side tool definitions
+    has_client_tools: bool,
 }
 
 /// Extract query, chat history, and build agent — shared across both code paths.
@@ -159,30 +168,9 @@ async fn prepare_request(
     chat_session_id: &str,
     req_headers_map: &HashMap<String, String>,
 ) -> Result<RequestSetup, HttpResponse> {
-    // Pop the last message as the query — the remainder becomes chat history
-    let query = match req.messages.pop() {
-        Some(msg) if msg.role == Role::User => msg.content,
-        Some(msg) => {
-            return Err(HttpResponse::BadRequest().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: format!("Last message must be from user, got: {}", msg.role),
-                    error_type: "invalid_request_error".to_string(),
-                },
-            }));
-        }
-        None => {
-            return Err(HttpResponse::BadRequest().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: "messages array is empty".to_string(),
-                    error_type: "invalid_request_error".to_string(),
-                },
-            }));
-        }
-    };
+    let has_client_tools = req.tools.is_some() && data.enable_client_tools;
 
-    // Convert remaining OpenAI messages to Rig messages,
-    // dropping system role messages and filtering empty content.
-    let chat_history = convert_chat_messages(&req.messages);
+    let (query, chat_history) = convert_chat_messages(&req.messages, has_client_tools)?;
 
     // Find the matching config: explicit model > DEFAULT_AGENT > single-config fallback
     // This logic allows users to omit the model field if they only have one config or if they set a default_agent,
@@ -204,7 +192,12 @@ async fn prepare_request(
     };
 
     // Build a fresh agent for this request
-    let agent = match build_agent_for_request(&config, req_headers_map).await {
+    let client_tools = if has_client_tools {
+        req.tools.as_deref()
+    } else {
+        None
+    };
+    let agent = match build_agent_for_request(&config, req_headers_map, client_tools).await {
         Ok(agent) => agent,
         Err(response) => return Err(response),
     };
@@ -225,6 +218,7 @@ async fn prepare_request(
         created_timestamp,
         chat_session_id: chat_session_id.to_string(),
         has_chat_history,
+        has_client_tools,
     })
 }
 
@@ -307,7 +301,8 @@ fn build_completion_config(
         data.tool_result_mode,
         data.tool_result_max_length,
     )
-    .with_fallback_tool_parsing(fallback_tool_parsing);
+    .with_fallback_tool_parsing(fallback_tool_parsing)
+    .with_client_tools(setup.has_client_tools);
 
     let turn_context = TurnContext::new(
         setup.completion_id.clone(),
@@ -495,7 +490,10 @@ fn build_json_response(
             index: 0,
             message: ChatMessage {
                 role: Role::Assistant,
-                content: collected.outcome.content,
+                content: Some(collected.outcome.content),
+                tool_calls: None,
+                tool_call_id: None,
+                name: None,
             },
             finish_reason: finish_reason.to_string(),
         }],
@@ -602,32 +600,183 @@ async fn handle_streaming_completion(
         .streaming(response_stream)
 }
 
-/// Convert OpenAI-format chat messages to Rig messages, sanitizing the history:
+/// Build a 400 Bad Request response with a standard error body.
+fn bad_request(message: impl Into<String>) -> HttpResponse {
+    HttpResponse::BadRequest().json(ErrorResponse {
+        error: ErrorDetail {
+            message: message.into(),
+            error_type: "invalid_request_error".to_string(),
+        },
+    })
+}
+
+/// Separate the query string from the history messages.
+///
+/// - **Tool follow-up** (last msg is `Role::Tool` && `client_tools_enabled`): finds the last
+///   `Role::User` via `rposition`, uses its content as the query, and returns all messages
+///   *except* that user message as history refs.
+/// - **Normal** (last msg is `Role::User`): query is the last message's content, history is
+///   everything before it.
+/// - **Otherwise**: returns an error.
+fn extract_query_and_history(
+    messages: &[ChatMessage],
+    client_tools_enabled: bool,
+) -> Result<(String, Vec<&ChatMessage>), HttpResponse> {
+    let last_msg = messages.last().unwrap(); // Caller already validated non-empty
+
+    if last_msg.role == Role::Tool && client_tools_enabled {
+        let last_user_idx = messages
+            .iter()
+            .rposition(|m| m.role == Role::User)
+            .ok_or_else(|| {
+                bad_request("Tool result messages require a preceding user message")
+            })?;
+        let query = messages[last_user_idx].content.clone().unwrap_or_default();
+        let history = messages
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != last_user_idx)
+            .map(|(_, m)| m)
+            .collect();
+        Ok((query, history))
+    } else if last_msg.role == Role::User {
+        let query = last_msg.content.clone().unwrap_or_default();
+        let history = messages[..messages.len() - 1].iter().collect();
+        Ok((query, history))
+    } else {
+        Err(bad_request(format!(
+            "Last message must be from user or tool, got: {}",
+            last_msg.role
+        )))
+    }
+}
+
+/// Dispatch a single `ChatMessage` to the appropriate role-specific converter.
+fn convert_message(msg: &ChatMessage, client_tools_enabled: bool) -> Option<aura::Message> {
+    match msg.role {
+        Role::System => {
+            tracing::warn!(
+                "Dropping system role message from chat history — Aura's preamble is authoritative"
+            );
+            None
+        }
+        Role::User => convert_user_message(msg),
+        Role::Assistant => convert_assistant_message(msg, client_tools_enabled),
+        Role::Tool => convert_tool_message(msg, client_tools_enabled),
+        Role::Unknown => {
+            tracing::warn!(role = %msg.role, "Skipping message with unknown role");
+            None
+        }
+    }
+}
+
+/// Convert a `Role::User` message, dropping it if the content is empty.
+fn convert_user_message(msg: &ChatMessage) -> Option<aura::Message> {
+    let content = msg.content.as_deref().unwrap_or("");
+    if content.trim().is_empty() {
+        tracing::warn!(role = %msg.role, "Dropping empty message from chat history");
+        return None;
+    }
+    Some(aura::Message::user(content))
+}
+
+/// Convert a `Role::Assistant` message.
+///
+/// When `client_tools_enabled` and the message carries `tool_calls`, delegates to
+/// [`convert_assistant_with_tool_calls`]. Otherwise treats it as plain text.
+fn convert_assistant_message(
+    msg: &ChatMessage,
+    client_tools_enabled: bool,
+) -> Option<aura::Message> {
+    if client_tools_enabled
+        && let Some(tool_calls) = &msg.tool_calls
+    {
+        return convert_assistant_with_tool_calls(msg, tool_calls);
+    }
+
+    let content = msg.content.as_deref().unwrap_or("");
+    if content.trim().is_empty() {
+        tracing::warn!(role = %msg.role, "Dropping empty message from chat history");
+        return None;
+    }
+    Some(aura::Message::assistant(content))
+}
+
+/// Build an assistant message containing optional text plus one or more tool calls.
+fn convert_assistant_with_tool_calls(
+    msg: &ChatMessage,
+    tool_calls: &[ChatMessageToolCall],
+) -> Option<aura::Message> {
+    use aura::{AssistantContent, OneOrMany};
+
+    let mut contents: Vec<AssistantContent> = Vec::new();
+
+    if let Some(text) = &msg.content
+        && !text.is_empty()
+    {
+        contents.push(AssistantContent::text(text));
+    }
+
+    for tc in tool_calls {
+        let args_value: serde_json::Value = serde_json::from_str(&tc.function.arguments)
+            .unwrap_or(serde_json::Value::String(tc.function.arguments.clone()));
+        contents.push(AssistantContent::tool_call(
+            tc.id.clone(),
+            tc.function.name.clone(),
+            args_value,
+        ));
+    }
+
+    if contents.is_empty() {
+        return None;
+    }
+    Some(aura::Message::Assistant {
+        id: None,
+        content: OneOrMany::many(contents).expect("non-empty assistant content"),
+    })
+}
+
+/// Convert a `Role::Tool` message to a user-content tool result.
+///
+/// Skips (with a warning) when client tools are disabled or required fields are missing.
+fn convert_tool_message(msg: &ChatMessage, client_tools_enabled: bool) -> Option<aura::Message> {
+    use aura::{OneOrMany, UserContent};
+
+    if client_tools_enabled
+        && let (Some(tool_call_id), Some(content)) = (&msg.tool_call_id, &msg.content)
+    {
+        let tool_result = UserContent::tool_result(
+            tool_call_id.clone(),
+            OneOrMany::one(aura::ToolResultContent::text(content)),
+        );
+        return Some(aura::Message::User {
+            content: OneOrMany::one(tool_result),
+        });
+    }
+    tracing::warn!(role = %msg.role, "Skipping tool message (client tools disabled or missing fields)");
+    None
+}
+
+/// Extract the user query and convert OpenAI-format chat messages to Rig messages.
+///
+/// Determines the query from the last message, splits off chat history, and sanitizes:
 /// - Drops `system` role messages (Aura's preamble is the authoritative system prompt)
 /// - Filters messages with empty/whitespace-only content
 /// - Maps `user` and `assistant` roles; skips unknown roles
-fn convert_chat_messages(messages: &[ChatMessage]) -> Vec<aura::Message> {
-    use aura::Message;
-
-    messages
-        .iter()
-        .filter_map(|msg| match msg.role {
-            Role::System => {
-                tracing::warn!("Dropping system role message from chat history — Aura's preamble is authoritative");
-                None
-            }
-            _ if msg.content.trim().is_empty() => {
-                tracing::warn!(role = %msg.role, "Dropping empty message from chat history");
-                None
-            }
-            Role::User => Some(Message::user(&msg.content)),
-            Role::Assistant => Some(Message::assistant(&msg.content)),
-            Role::Unknown => {
-                tracing::warn!(role = %msg.role, "Skipping message with unknown role");
-                None
-            }
-        })
-        .collect()
+/// - When `client_tools_enabled`, converts `Role::Tool` messages to tool results
+///   and preserves `tool_calls` on assistant messages
+///
+/// Returns `(query, chat_history)` or an error response.
+fn convert_chat_messages(
+    messages: &[ChatMessage],
+    client_tools_enabled: bool,
+) -> Result<(String, Vec<aura::Message>), HttpResponse> {
+    let (query, history_msgs) = extract_query_and_history(messages, client_tools_enabled)?;
+    let chat_history = history_msgs
+        .into_iter()
+        .filter_map(|msg| convert_message(msg, client_tools_enabled))
+        .collect();
+    Ok((query, chat_history))
 }
 
 /// Health check endpoint
@@ -678,7 +827,10 @@ mod tests {
     fn msg(role: Role, content: &str) -> ChatMessage {
         ChatMessage {
             role,
-            content: content.to_string(),
+            content: Some(content.to_string()),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
         }
     }
 
@@ -688,8 +840,9 @@ mod tests {
             msg(Role::System, "You are a helpful assistant"),
             msg(Role::User, "Hello"),
         ];
-        let result = convert_chat_messages(&messages);
-        assert_eq!(result.len(), 1);
+        let (_query, history) = convert_chat_messages(&messages, false).unwrap();
+        // System message dropped; last User extracted as query → 0 history messages
+        assert_eq!(history.len(), 0);
     }
 
     #[test]
@@ -700,8 +853,9 @@ mod tests {
             msg(Role::Assistant, "   "),
             msg(Role::User, "How are you?"),
         ];
-        let result = convert_chat_messages(&messages);
-        assert_eq!(result.len(), 2);
+        let (_query, history) = convert_chat_messages(&messages, false).unwrap();
+        // "Hello" in history, two empty assistants filtered, last User is query
+        assert_eq!(history.len(), 1);
     }
 
     #[test]
@@ -711,8 +865,9 @@ mod tests {
             msg(Role::Assistant, "Hi there"),
             msg(Role::User, "How are you?"),
         ];
-        let result = convert_chat_messages(&messages);
-        assert_eq!(result.len(), 3);
+        let (query, history) = convert_chat_messages(&messages, false).unwrap();
+        assert_eq!(query, "How are you?");
+        assert_eq!(history.len(), 2); // "Hello" + "Hi there"
     }
 
     #[test]
@@ -725,8 +880,10 @@ mod tests {
             msg(Role::Assistant, "Rust is a systems programming language."),
             msg(Role::User, "Tell me more"),
         ];
-        let result = convert_chat_messages(&messages);
-        assert_eq!(result.len(), 3); // user, assistant(non-empty), user
+        let (query, history) = convert_chat_messages(&messages, false).unwrap();
+        assert_eq!(query, "Tell me more");
+        // system dropped, empty assistant filtered → user + assistant(non-empty)
+        assert_eq!(history.len(), 2);
     }
 
     #[test]
@@ -735,14 +892,160 @@ mod tests {
             msg(Role::Unknown, "some tool output"),
             msg(Role::User, "Hello"),
         ];
-        let result = convert_chat_messages(&messages);
-        assert_eq!(result.len(), 1);
+        let (_query, history) = convert_chat_messages(&messages, false).unwrap();
+        // Unknown filtered, last User is query → 0 history
+        assert_eq!(history.len(), 0);
     }
 
     #[test]
-    fn test_empty_input() {
-        let result = convert_chat_messages(&[]);
-        assert!(result.is_empty());
+    fn test_invalid_last_role_returns_error() {
+        let messages = vec![msg(Role::Assistant, "unexpected")];
+        let result = convert_chat_messages(&messages, false);
+        assert!(result.is_err());
+    }
+
+    // --- client_tools_enabled = true tests ---
+
+    use crate::types::{ChatMessageFunctionCall, ChatMessageToolCall};
+
+    fn tool_msg(tool_call_id: &str, content: &str) -> ChatMessage {
+        ChatMessage {
+            role: Role::Tool,
+            content: Some(content.to_string()),
+            tool_calls: None,
+            tool_call_id: Some(tool_call_id.to_string()),
+            name: None,
+        }
+    }
+
+    fn assistant_with_tool_calls(
+        content: Option<&str>,
+        tool_calls: Vec<(&str, &str, &str)>,
+    ) -> ChatMessage {
+        ChatMessage {
+            role: Role::Assistant,
+            content: content.map(|s| s.to_string()),
+            tool_calls: Some(
+                tool_calls
+                    .into_iter()
+                    .map(|(id, name, args)| ChatMessageToolCall {
+                        id: id.to_string(),
+                        call_type: "function".to_string(),
+                        function: ChatMessageFunctionCall {
+                            name: name.to_string(),
+                            arguments: args.to_string(),
+                        },
+                    })
+                    .collect(),
+            ),
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    #[test]
+    fn test_tool_followup_happy_path() {
+        let messages = vec![
+            msg(Role::User, "What is the weather?"),
+            assistant_with_tool_calls(None, vec![("tc_1", "get_weather", r#"{"city":"NYC"}"#)]),
+            tool_msg("tc_1", r#"{"temp": 72}"#),
+        ];
+        let (query, history) = convert_chat_messages(&messages, true).unwrap();
+        assert_eq!(query, "What is the weather?");
+        // History: assistant with tool_calls + tool result; user message extracted as query
+        assert_eq!(history.len(), 2);
+    }
+
+    #[test]
+    fn test_tool_followup_no_preceding_user_returns_error() {
+        let messages = vec![
+            assistant_with_tool_calls(None, vec![("tc_1", "get_weather", r#"{}"#)]),
+            tool_msg("tc_1", "result"),
+        ];
+        let result = convert_chat_messages(&messages, true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_assistant_tool_calls_enabled() {
+        let messages = vec![
+            assistant_with_tool_calls(
+                Some("Let me check"),
+                vec![("tc_1", "search", r#"{"q":"rust"}"#)],
+            ),
+            msg(Role::User, "Thanks"),
+        ];
+        let (query, history) = convert_chat_messages(&messages, true).unwrap();
+        assert_eq!(query, "Thanks");
+        assert_eq!(history.len(), 1);
+        // The assistant message should be the multi-content variant
+        match &history[0] {
+            aura::Message::Assistant { content, .. } => {
+                // text + tool_call = 2 content items
+                assert_eq!(content.len(), 2);
+            }
+            other => panic!("Expected Assistant message, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_assistant_tool_calls_disabled_falls_back_to_text() {
+        // When client_tools_enabled=false, tool_calls are ignored and it's treated as plain text
+        let messages = vec![
+            assistant_with_tool_calls(
+                Some("Let me check"),
+                vec![("tc_1", "search", r#"{"q":"rust"}"#)],
+            ),
+            msg(Role::User, "Thanks"),
+        ];
+        let (_, history) = convert_chat_messages(&messages, false).unwrap();
+        assert_eq!(history.len(), 1);
+        // Should be a simple text assistant message, not the multi-content variant
+        match &history[0] {
+            aura::Message::Assistant { content, .. } => {
+                assert_eq!(content.len(), 1);
+            }
+            other => panic!("Expected Assistant message, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_tool_message_missing_fields_skipped() {
+        // Tool message without tool_call_id should be skipped even when enabled
+        let bad_tool = ChatMessage {
+            role: Role::Tool,
+            content: Some("result".to_string()),
+            tool_calls: None,
+            tool_call_id: None, // missing
+            name: None,
+        };
+        let messages = vec![
+            msg(Role::User, "First"),
+            bad_tool,
+            msg(Role::User, "Second"),
+        ];
+        let (query, history) = convert_chat_messages(&messages, true).unwrap();
+        assert_eq!(query, "Second");
+        // bad_tool skipped, "First" is the only history entry
+        assert_eq!(history.len(), 1);
+    }
+
+    #[test]
+    fn test_tool_message_missing_content_skipped() {
+        let bad_tool = ChatMessage {
+            role: Role::Tool,
+            content: None, // missing
+            tool_calls: None,
+            tool_call_id: Some("tc_1".to_string()),
+            name: None,
+        };
+        let messages = vec![
+            msg(Role::User, "First"),
+            bad_tool,
+            msg(Role::User, "Second"),
+        ];
+        let (_, history) = convert_chat_messages(&messages, true).unwrap();
+        assert_eq!(history.len(), 1);
     }
 
     // --- streaming / response builder tests ---

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -89,6 +89,13 @@ struct Args {
     /// Not required when only one configuration is loaded via CONFIG_PATH.
     #[arg(long, env = "DEFAULT_AGENT")]
     default_agent: Option<String>,
+
+    /// Enable client-side tool execution.
+    /// When enabled, clients can pass tool definitions in the request `tools` field.
+    /// The LLM can call these tools, but instead of executing server-side, the stream
+    /// terminates with `finish_reason: "tool_calls"` for the client to execute locally.
+    #[arg(long, env = "ENABLE_CLIENT_TOOLS")]
+    enable_client_tools: bool,
 }
 
 /// Middleware that rejects new requests with 503 when shutdown_token is cancelled.
@@ -188,6 +195,7 @@ async fn run() -> std::io::Result<()> {
         stream_shutdown_token: stream_shutdown_token.clone(),
         active_requests: active_requests.clone(),
         default_agent: args.default_agent.clone(),
+        enable_client_tools: args.enable_client_tools,
     });
 
     info!(

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -22,16 +22,16 @@ use crate::streaming::types::openai::UsageInfo;
 
 use super::types::{
     CHUNK_OBJECT, ChatCompletionChunk, ChatCompletionChunkChoice, ChatCompletionChunkDelta,
-    FINISH_REASON_LENGTH, FINISH_REASON_STOP, FUNCTION_TYPE, FunctionCallChunk, MessageRole,
-    StreamConfig, ToolCallChunk, ToolResultMode, ToolResultStatus, TurnContext, TurnState,
-    detect_tool_error, format_sse_chunk, truncate_result,
+    FINISH_REASON_LENGTH, FINISH_REASON_STOP, FINISH_REASON_TOOL_CALLS, FUNCTION_TYPE,
+    FunctionCallChunk, MessageRole, StreamConfig, ToolCallChunk, ToolResultMode, ToolResultStatus,
+    TurnContext, TurnState, detect_tool_error, format_sse_chunk, truncate_result,
 };
 use actix_web::web::Bytes;
 use aura::stream_events::AuraStreamEvent;
 use aura::{
-    Agent, ProgressNotification, RequestCancellation, ResponseContent, StreamError, StreamItem,
-    StreamedAssistantContent, StreamedUserContent, ToolCall, ToolLifecycleEvent, ToolResult,
-    ToolUsageEvent, UsageState,
+    Agent, PASSTHROUGH_MARKER, ProgressNotification, RequestCancellation, ResponseContent,
+    StreamError, StreamItem, StreamedAssistantContent, StreamedUserContent, ToolCall,
+    ToolLifecycleEvent, ToolResult, ToolUsageEvent, UsageState,
 };
 use futures_util::{Stream, StreamExt};
 use std::sync::Arc;
@@ -339,7 +339,7 @@ where
     // client gets clean stream termination regardless of how long MCP cleanup takes.
     match termination {
         StreamTermination::Complete | StreamTermination::StreamError(_) => {
-            send_final_events(emit_custom_events, &mut callbacks, ctx, &state, &tx).await;
+            send_final_events(config, emit_custom_events, &mut callbacks, ctx, &state, &tx).await;
         }
 
         StreamTermination::Disconnected => {
@@ -352,14 +352,14 @@ where
             let _ = cancel_tx.send(true);
             RequestCancellation::cancel(&callbacks.request_id, "timeout");
             cancel_mcp(&callbacks, "timeout").await;
-            send_final_events(emit_custom_events, &mut callbacks, ctx, &state, &tx).await;
+            send_final_events(config, emit_custom_events, &mut callbacks, ctx, &state, &tx).await;
         }
 
         StreamTermination::Shutdown => {
             // [DONE] before MCP cleanup so client gets clean termination regardless of MCP latency
             let _ = cancel_tx.send(true);
             RequestCancellation::cancel(&callbacks.request_id, "server shutdown");
-            send_final_events(emit_custom_events, &mut callbacks, ctx, &state, &tx).await;
+            send_final_events(config, emit_custom_events, &mut callbacks, ctx, &state, &tx).await;
             cancel_mcp(&callbacks, "server shutdown").await;
         }
     }
@@ -370,6 +370,7 @@ where
 
 /// Send final usage events, finish chunk, and [DONE] marker to the client.
 async fn send_final_events(
+    config: &StreamConfig,
     emit_custom_events: bool,
     callbacks: &mut StreamingCallbacks,
     ctx: &TurnContext,
@@ -412,7 +413,7 @@ async fn send_final_events(
         }
     }
 
-    let final_bytes = build_final_chunk(ctx, state);
+    let final_bytes = build_final_chunk(config, ctx, state);
     for bytes in final_bytes {
         let _ = tx.send(Ok(bytes)).await;
     }
@@ -517,6 +518,18 @@ fn process_stream_next(
         }
         Some(Err(e)) => {
             let error_str = e.to_string();
+
+            // When client tools are active and a client tool was called,
+            // the hook cancels the stream. This produces a cancellation error
+            // which is expected — treat it as normal end-of-stream.
+            if config.has_client_tools && state.has_passthrough_tool_calls {
+                tracing::info!(
+                    "Stream cancelled after client tool call (expected): {}",
+                    error_str
+                );
+                return NextItemResult::End(vec![]);
+            }
+
             tracing::error!("Stream error: {}", error_str);
 
             // Capture for OTel span recording after loop ends
@@ -752,6 +765,16 @@ fn handle_tool_result(
         tool_result.call_id
     );
 
+    // Detect passthrough tool results (client-side tools)
+    if tool_result.result.contains(PASSTHROUGH_MARKER) {
+        tracing::info!(
+            "Passthrough tool result detected for call: {} — suppressing",
+            tool_result.id
+        );
+        state.has_passthrough_tool_calls = true;
+        return vec![];
+    }
+
     let mut output = Vec::with_capacity(2);
     state.needs_separator = true;
 
@@ -928,8 +951,10 @@ fn build_text_chunk(ctx: &TurnContext, content: &str, is_first: bool) -> ChatCom
 }
 
 /// Build the final chunk with finish_reason.
-fn build_final_chunk(ctx: &TurnContext, state: &TurnState) -> Vec<Bytes> {
-    let finish_reason = if let (Some(max), Some(usage)) = (ctx.max_tokens, &state.usage_stats) {
+fn build_final_chunk(_config: &StreamConfig, ctx: &TurnContext, state: &TurnState) -> Vec<Bytes> {
+    let finish_reason = if state.has_passthrough_tool_calls {
+        FINISH_REASON_TOOL_CALLS
+    } else if let (Some(max), Some(usage)) = (ctx.max_tokens, &state.usage_stats) {
         if usage.completion_tokens >= max as u64 {
             FINISH_REASON_LENGTH
         } else {
@@ -938,7 +963,6 @@ fn build_final_chunk(ctx: &TurnContext, state: &TurnState) -> Vec<Bytes> {
     } else {
         FINISH_REASON_STOP
     };
-
     let final_chunk = ChatCompletionChunk {
         id: ctx.completion_id.clone(),
         object: CHUNK_OBJECT.to_string(),
@@ -981,6 +1005,7 @@ mod tests {
             tool_result_mode: ToolResultMode::None,
             tool_result_max_length: 1000,
             fallback_tool_parsing: false,
+            has_client_tools: false,
         };
 
         let ctx = TurnContext {

--- a/crates/aura-web-server/src/streaming/types.rs
+++ b/crates/aura-web-server/src/streaming/types.rs
@@ -109,6 +109,10 @@ pub mod config {
         /// Enable fallback tool call parsing for Ollama models.
         /// When true, text content that looks like tool calls will be parsed and executed.
         pub fallback_tool_parsing: bool,
+        /// Whether the request includes client-side tool definitions.
+        /// When true, passthrough tool results are suppressed and
+        /// `finish_reason: "tool_calls"` is used instead of `"stop"`.
+        pub has_client_tools: bool,
     }
 
     impl StreamConfig {
@@ -124,12 +128,19 @@ pub mod config {
                 tool_result_mode,
                 tool_result_max_length,
                 fallback_tool_parsing: false,
+                has_client_tools: false,
             }
         }
 
         /// Enable fallback tool call parsing (for Ollama models).
         pub fn with_fallback_tool_parsing(mut self, enabled: bool) -> Self {
             self.fallback_tool_parsing = enabled;
+            self
+        }
+
+        /// Set whether the request includes client-side tool definitions.
+        pub fn with_client_tools(mut self, has_client_tools: bool) -> Self {
+            self.has_client_tools = has_client_tools;
             self
         }
     }
@@ -152,6 +163,8 @@ pub mod context {
     pub const FINISH_REASON_STOP: &str = "stop";
     /// OpenAI finish_reason: hit max_tokens limit.
     pub const FINISH_REASON_LENGTH: &str = "length";
+    /// OpenAI finish_reason: model wants client to execute tool calls.
+    pub const FINISH_REASON_TOOL_CALLS: &str = "tool_calls";
 
     /// Immutable context for a single streaming turn (created once per request).
     #[derive(Clone)]
@@ -197,6 +210,8 @@ pub mod context {
         pub accumulated_content: String,
         /// Stream error captured for OTel span recording.
         pub stream_error: Option<String>,
+        /// Whether any passthrough (client-side) tool calls were detected in this turn.
+        pub has_passthrough_tool_calls: bool,
     }
 
     impl TurnState {
@@ -212,7 +227,8 @@ pub mod context {
 // Re-export for convenience
 pub use config::{StreamConfig, ToolResultMode};
 pub use context::{
-    CHUNK_OBJECT, FINISH_REASON_LENGTH, FINISH_REASON_STOP, FUNCTION_TYPE, TurnContext, TurnState,
+    CHUNK_OBJECT, FINISH_REASON_LENGTH, FINISH_REASON_STOP, FINISH_REASON_TOOL_CALLS,
+    FUNCTION_TYPE, TurnContext, TurnState,
 };
 pub use openai::{
     ChatCompletionChunk, ChatCompletionChunkChoice, ChatCompletionChunkDelta, FunctionCallChunk,

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -69,6 +69,8 @@ pub struct AppState {
     pub active_requests: Arc<ActiveRequestTracker>,
     /// Default agent name or alias, used when `model` is omitted from the request
     pub default_agent: Option<String>,
+    /// Enable client-side tool execution via the `tools` request field
+    pub enable_client_tools: bool,
 }
 
 /// OpenAI-compatible message role
@@ -78,7 +80,9 @@ pub enum Role {
     System,
     User,
     Assistant,
-    /// Catch-all for roles we don't handle (e.g. "tool", "function")
+    /// Tool result message (role="tool") for client-side tool follow-ups
+    Tool,
+    /// Catch-all for roles we don't handle (e.g. "function")
     #[serde(other, rename = "unknown")]
     Unknown,
 }
@@ -89,6 +93,7 @@ impl std::fmt::Display for Role {
             Role::System => write!(f, "system"),
             Role::User => write!(f, "user"),
             Role::Assistant => write!(f, "assistant"),
+            Role::Tool => write!(f, "tool"),
             Role::Unknown => write!(f, "unknown"),
         }
     }
@@ -98,7 +103,70 @@ impl std::fmt::Display for Role {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: Role,
-    pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    /// Tool calls made by the assistant (role="assistant" with tool_calls)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ChatMessageToolCall>>,
+    /// Tool call ID this message is a result for (role="tool")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    /// Tool name (role="tool")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// A tool call in a chat message (role="assistant")
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ChatMessageToolCall {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub call_type: String,
+    pub function: ChatMessageFunctionCall,
+}
+
+/// Function call details within a tool call
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ChatMessageFunctionCall {
+    pub name: String,
+    pub arguments: String,
+}
+
+/// Client-side tool definition (OpenAI `tools` field).
+///
+/// The nested `function` structure matches the OpenAI API format.
+/// Converts to `aura::builder::ClientTool` via the `From` impl.
+#[derive(Debug, Deserialize, Clone)]
+pub struct ClientToolDefinition {
+    /// Always "function" in OpenAI's API — retained for deserialization fidelity.
+    #[serde(rename = "type")]
+    #[allow(dead_code)]
+    pub tool_type: String,
+    pub function: ClientFunctionDefinition,
+}
+
+/// Function definition within a client tool
+#[derive(Debug, Deserialize, Clone)]
+pub struct ClientFunctionDefinition {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub parameters: Option<serde_json::Value>,
+}
+
+impl From<&ClientToolDefinition> for aura::builder::ClientTool {
+    fn from(def: &ClientToolDefinition) -> Self {
+        Self {
+            name: def.function.name.clone(),
+            description: def.function.description.clone().unwrap_or_default(),
+            parameters: def
+                .function
+                .parameters
+                .clone()
+                .unwrap_or(serde_json::json!({})),
+        }
+    }
 }
 
 /// OpenAI-compatible chat completions request
@@ -113,6 +181,10 @@ pub struct ChatCompletionRequest {
     /// OpenAI-compatible metadata field (up to 16 key-value pairs)
     #[serde(default)]
     pub metadata: Option<HashMap<String, String>>,
+
+    /// Client-side tool definitions (OpenAI tools field)
+    #[serde(default)]
+    pub tools: Option<Vec<ClientToolDefinition>>,
 }
 
 /// OpenAI-compatible error responses for chat completion requests.

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -2,6 +2,7 @@ use crate::{
     config::{AgentConfig, LlmConfig, McpServerConfig, VectorStoreType},
     error::{BuilderError, BuilderResult},
     mcp::McpManager,
+    passthrough_tool::PassthroughTool,
     provider_agent::{
         BuilderState, CompletionResponse, ProviderAgent, StreamError, StreamItem,
         StreamedAssistantContent,
@@ -13,6 +14,7 @@ use crate::{
 use futures::StreamExt;
 use rig::client::CompletionClient;
 use rig::completion::Usage;
+use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -98,12 +100,29 @@ pub struct Agent {
     /// Configured context window size in tokens (from TOML config).
     /// Used for usage percentage reporting in streaming events.
     context_window: Option<u32>,
+    /// Names of client-side tools (passthrough tools). When the LLM calls one of these,
+    /// the stream is terminated with `finish_reason: "tool_calls"` so the client can
+    /// execute locally and send results back.
+    client_tool_names: HashSet<String>,
+}
+
+/// A client-side tool definition passed in from the request.
+/// Used to register passthrough tools with the agent.
+pub struct ClientTool {
+    pub name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
 }
 
 impl Agent {
     /// Create a new agent from configuration.
+    ///
+    /// If `client_tools` is provided, they are registered as passthrough tools —
+    /// the LLM can call them, but they return a marker string instead of executing.
+    /// The streaming layer detects this and yields the call back to the client.
     pub async fn new(
         config: &AgentConfig,
+        client_tools: Option<Vec<ClientTool>>,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         // Initialize MCP manager first (shared across all providers)
         let mcp_manager = if let Some(mcp_config) = &config.mcp {
@@ -212,6 +231,11 @@ impl Agent {
 
                 // Add tools using the BuilderState helper
                 let builder_state = BuilderState::Initial(agent_builder);
+                let builder_state = if let Some(ref tools) = client_tools {
+                    Self::add_passthrough_tools(builder_state, tools)
+                } else {
+                    builder_state
+                };
                 let builder_state =
                     Self::add_all_tools(builder_state, config, &mcp_manager).await?;
                 let agent = builder_state.build();
@@ -252,6 +276,11 @@ impl Agent {
                 }
 
                 let builder_state = BuilderState::Initial(agent_builder);
+                let builder_state = if let Some(ref tools) = client_tools {
+                    Self::add_passthrough_tools(builder_state, tools)
+                } else {
+                    builder_state
+                };
                 let builder_state =
                     Self::add_all_tools(builder_state, config, &mcp_manager).await?;
                 let agent = builder_state.build();
@@ -306,6 +335,11 @@ impl Agent {
                 }
 
                 let builder_state = BuilderState::Initial(agent_builder);
+                let builder_state = if let Some(ref tools) = client_tools {
+                    Self::add_passthrough_tools(builder_state, tools)
+                } else {
+                    builder_state
+                };
                 let builder_state =
                     Self::add_all_tools(builder_state, config, &mcp_manager).await?;
                 let agent = builder_state.build();
@@ -341,6 +375,11 @@ impl Agent {
                 }
 
                 let builder_state = BuilderState::Initial(agent_builder);
+                let builder_state = if let Some(ref tools) = client_tools {
+                    Self::add_passthrough_tools(builder_state, tools)
+                } else {
+                    builder_state
+                };
                 let builder_state =
                     Self::add_all_tools(builder_state, config, &mcp_manager).await?;
                 let agent = builder_state.build();
@@ -385,6 +424,11 @@ impl Agent {
                 }
 
                 let builder_state = BuilderState::Initial(agent_builder);
+                let builder_state = if let Some(ref tools) = client_tools {
+                    Self::add_passthrough_tools(builder_state, tools)
+                } else {
+                    builder_state
+                };
                 let builder_state =
                     Self::add_all_tools(builder_state, config, &mcp_manager).await?;
                 let agent = builder_state.build();
@@ -392,6 +436,11 @@ impl Agent {
                 ProviderAgent::Ollama(agent)
             }
         };
+
+        let client_tool_names = client_tools
+            .as_ref()
+            .map(|tools| tools.iter().map(|t| t.name.clone()).collect())
+            .unwrap_or_default();
 
         Ok(Agent {
             inner: provider_agent,
@@ -401,7 +450,29 @@ impl Agent {
             fallback_tool_parsing,
             fallback_tool_names,
             context_window: config.agent.context_window,
+            client_tool_names,
         })
+    }
+
+    /// Add passthrough tools for client-side tool execution.
+    fn add_passthrough_tools<M>(
+        builder_state: BuilderState<M>,
+        client_tools: &[ClientTool],
+    ) -> BuilderState<M>
+    where
+        M: rig::completion::CompletionModel + Send + Sync,
+    {
+        let mut state = builder_state;
+        for tool in client_tools {
+            tracing::info!("  Adding passthrough tool: {}", tool.name);
+            let passthrough = PassthroughTool::new(
+                tool.name.clone(),
+                tool.description.clone(),
+                tool.parameters.clone(),
+            );
+            state = state.add_tool(passthrough);
+        }
+        state
     }
 
     /// Add all tools to a builder state (shared across all providers)
@@ -693,7 +764,13 @@ impl Agent {
     ) {
         let (stream, cancel_tx, usage_state) = self
             .inner
-            .stream_prompt_with_timeout(query, self.max_depth, timeout, request_id)
+            .stream_prompt_with_timeout(
+                query,
+                self.max_depth,
+                timeout,
+                request_id,
+                self.client_tool_names.clone(),
+            )
             .await;
         (
             self.maybe_wrap_with_fallback(stream),
@@ -730,7 +807,14 @@ impl Agent {
     ) {
         let (stream, cancel_tx, usage_state) = self
             .inner
-            .stream_chat_with_timeout(query, chat_history, self.max_depth, timeout, request_id)
+            .stream_chat_with_timeout(
+                query,
+                chat_history,
+                self.max_depth,
+                timeout,
+                request_id,
+                self.client_tool_names.clone(),
+            )
             .await;
         (
             self.maybe_wrap_with_fallback(stream),
@@ -1071,7 +1155,7 @@ impl AgentBuilder {
     pub async fn build_agent(&self) -> BuilderResult<Agent> {
         tracing::info!("=== Building Agent ===");
 
-        let agent = Agent::new(&self.config)
+        let agent = Agent::new(&self.config, None)
             .await
             .map_err(|e| BuilderError::AgentError(e.to_string()))?;
 

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -19,6 +19,7 @@ pub mod mcp_streamable_http;
 pub mod mcp_tool_execution;
 #[cfg(feature = "otel")]
 pub mod openinference_exporter;
+pub mod passthrough_tool;
 mod provider_agent; // Private - internal implementation detail
 pub mod rag_tools;
 pub mod request_cancellation;
@@ -41,11 +42,14 @@ pub use config::{
     ReasoningEffort, ToolsConfig, VectorStoreConfig, VectorStoreType,
 };
 pub use error::{BuilderError, BuilderResult};
+pub use passthrough_tool::{PASSTHROUGH_MARKER, PassthroughTool};
 pub use provider_agent::{
     FinalResponseInfo, StreamError, StreamItem, StreamedAssistantContent, StreamedUserContent,
     ToolCall, ToolResult,
 };
 pub use rig::completion::Message;
+pub use rig::message::{AssistantContent, ToolCall as RigToolCall, ToolResultContent, UserContent};
+pub use rig::one_or_many::OneOrMany;
 pub use streaming::StreamingAgent;
 
 // Legacy aliases (deprecated)

--- a/crates/aura/src/passthrough_tool.rs
+++ b/crates/aura/src/passthrough_tool.rs
@@ -1,0 +1,74 @@
+//! Passthrough tool for client-side tool execution.
+//!
+//! When clients send tool definitions with their chat requests (OpenAI `tools` field),
+//! those tools are registered as "passthrough" tools. The LLM can call them, but instead
+//! of executing server-side, they return a marker string. The streaming layer detects
+//! this marker and yields the tool call back to the client with `finish_reason: "tool_calls"`.
+//! The client executes locally and sends results back in the next request.
+
+use rig::completion::ToolDefinition;
+use rig::tool::Tool;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Marker string returned by passthrough tools.
+/// The streaming layer checks tool results for this value to detect client-side tool calls.
+pub const PASSTHROUGH_MARKER: &str = "__AURA_CLIENT_TOOL_PENDING__";
+
+/// A tool that passes through to the client for execution.
+///
+/// When the LLM calls this tool, it returns `PASSTHROUGH_MARKER` instead of
+/// executing anything. The streaming layer detects this marker, suppresses the
+/// tool result, and sets `finish_reason: "tool_calls"` so the client knows
+/// to execute the tool locally and send results back.
+#[derive(Debug, Clone)]
+pub struct PassthroughTool {
+    tool_name: String,
+    description: String,
+    parameters: Value,
+}
+
+impl PassthroughTool {
+    /// Create a new passthrough tool with the given name, description, and parameter schema.
+    pub fn new(tool_name: String, description: String, parameters: Value) -> Self {
+        Self {
+            tool_name,
+            description,
+            parameters,
+        }
+    }
+}
+
+/// Arguments type that accepts any JSON value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PassthroughArgs(pub Value);
+
+/// Error type for passthrough tools (never actually errors).
+#[derive(Debug, thiserror::Error)]
+#[error("passthrough tool error: {0}")]
+pub struct PassthroughError(String);
+
+impl Tool for PassthroughTool {
+    const NAME: &'static str = "passthrough_tool";
+
+    type Error = PassthroughError;
+    type Args = PassthroughArgs;
+    type Output = String;
+
+    /// Override to return the actual tool name (not the static NAME).
+    fn name(&self) -> String {
+        self.tool_name.clone()
+    }
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: self.tool_name.clone(),
+            description: self.description.clone(),
+            parameters: self.parameters.clone(),
+        }
+    }
+
+    async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(PASSTHROUGH_MARKER.to_string())
+    }
+}

--- a/crates/aura/src/provider_agent.rs
+++ b/crates/aura/src/provider_agent.rs
@@ -18,6 +18,8 @@ use std::pin::Pin;
 use std::time::Duration;
 use tokio::sync::watch;
 
+use std::collections::HashSet;
+
 use crate::streaming_request_hook::StreamingRequestHook;
 
 // Type aliases for provider-specific completion models
@@ -153,12 +155,14 @@ impl ProviderAgent {
         max_depth: usize,
         timeout: Duration,
         request_id: &str,
+        client_tool_names: HashSet<String>,
     ) -> (
         Pin<Box<dyn futures::Stream<Item = Result<StreamItem, StreamError>> + Send>>,
         watch::Sender<bool>,
         crate::streaming_request_hook::UsageState,
     ) {
         let (hook, cancel_tx, usage_state) = StreamingRequestHook::new(timeout, request_id);
+        let hook = hook.with_client_tool_names(client_tool_names);
 
         match self {
             Self::OpenAI(agent) => {
@@ -237,12 +241,14 @@ impl ProviderAgent {
         max_depth: usize,
         timeout: Duration,
         request_id: &str,
+        client_tool_names: HashSet<String>,
     ) -> (
         Pin<Box<dyn futures::Stream<Item = Result<StreamItem, StreamError>> + Send>>,
         watch::Sender<bool>,
         crate::streaming_request_hook::UsageState,
     ) {
         let (hook, cancel_tx, usage_state) = StreamingRequestHook::new(timeout, request_id);
+        let hook = hook.with_client_tool_names(client_tool_names);
 
         match self {
             Self::OpenAI(agent) => {

--- a/crates/aura/src/streaming_request_hook.rs
+++ b/crates/aura/src/streaming_request_hook.rs
@@ -36,6 +36,7 @@ use crate::tool_event_broker::{
 };
 use rig::agent::{CancelSignal, StreamingPromptHook};
 use rig::completion::{CompletionModel, GetTokenUsage, Message};
+use std::collections::HashSet;
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -257,6 +258,10 @@ pub struct StreamingRequestHook {
     request_id: String,
     /// Shared usage state (returned separately for handler access)
     usage_state: UsageState,
+    /// Names of client-side tools (passthrough tools)
+    client_tool_names: HashSet<String>,
+    /// Whether a client tool has been called in this request
+    client_tool_called: Arc<AtomicBool>,
 }
 
 impl StreamingRequestHook {
@@ -278,8 +283,16 @@ impl StreamingRequestHook {
             cancelled: rx,
             request_id: request_id.into(),
             usage_state: usage_state.clone(),
+            client_tool_names: HashSet::new(),
+            client_tool_called: Arc::new(AtomicBool::new(false)),
         };
         (hook, tx, usage_state)
+    }
+
+    /// Set client tool names for passthrough tool detection.
+    pub fn with_client_tool_names(mut self, names: HashSet<String>) -> Self {
+        self.client_tool_names = names;
+        self
     }
 
     /// Check if the request should be cancelled (timeout or external signal).
@@ -318,7 +331,18 @@ where
         _history: &[Message],
         cancel_sig: CancelSignal,
     ) -> impl Future<Output = ()> + Send {
+        let has_client_tools = !self.client_tool_names.is_empty();
+        let client_tool_called = self.client_tool_called.clone();
         async move {
+            // If client tools were called, cancel before the next LLM turn.
+            // The client needs to execute the tool and send results back.
+            if has_client_tools && client_tool_called.load(Ordering::Acquire) {
+                tracing::info!(
+                    "Client tool was called — cancelling before next LLM completion call"
+                );
+                cancel_sig.cancel();
+                return;
+            }
             self.check_and_cancel(cancel_sig, "completion call");
         }
     }
@@ -362,7 +386,17 @@ where
         let request_id = self.request_id.clone();
         let tool_call_id = id;
         let args_str = args.to_string();
+        let is_client_tool = self.client_tool_names.contains(&tool_name);
+        let client_tool_called = self.client_tool_called.clone();
         async move {
+            if is_client_tool {
+                tracing::info!(
+                    "Client tool '{}' called for request '{}' — marking for passthrough",
+                    tool_name,
+                    request_id
+                );
+                client_tool_called.store(true, Ordering::Release);
+            }
             // Parse args as JSON (fallback to empty object if invalid)
             let arguments: serde_json::Value =
                 serde_json::from_str(&args_str).unwrap_or(serde_json::json!({}));

--- a/docs/streaming-api-guide.md
+++ b/docs/streaming-api-guide.md
@@ -47,6 +47,7 @@ TOOL_RESULT_MODE=aura AURA_CUSTOM_EVENTS=true cargo run --bin aura-web-server
 | `AURA_CUSTOM_EVENTS` | `false` | Enable custom `aura.*` events |
 | `AURA_EMIT_REASONING` | `false` | Enable `aura.reasoning` events |
 | `SHUTDOWN_TIMEOUT_SECS` | `30` | Grace period (seconds) for in-flight streams on shutdown |
+| `ENABLE_CLIENT_TOOLS` | `false` | Enable client-side tool execution via the `tools` request field |
 
 ## Custom Aura Events (Optional)
 
@@ -249,7 +250,7 @@ data: [DONE]
 | Value | Meaning |
 |-------|---------|
 | `stop` | Normal completion |
-| `tool_calls` | Response included tool execution |
+| `tool_calls` | Response included tool calls — server-side tools were executed inline; client-side tools require the client to execute and send results back |
 | `length` | Response truncated due to max_tokens limit |
 
 ## Client Examples
@@ -328,6 +329,65 @@ Here are the files I found:
 ```
 
 The separator is automatically injected when text chunks resume after a `ToolResult` event.
+
+## Client-Side Tool Execution
+
+When `ENABLE_CLIENT_TOOLS=true`, clients can pass tool definitions in the request's `tools` field (OpenAI format). These are registered as passthrough tools — the LLM sees them alongside any server-side MCP tools and can call them, but they are not executed server-side.
+
+When the LLM calls a client-side tool, the stream terminates with `finish_reason: "tool_calls"` and the tool call details in the final delta. The client is responsible for:
+
+1. Executing the tool locally
+2. Sending a follow-up request with the tool result in chat history
+
+### Request with Client Tools
+
+```json
+{
+  "messages": [{"role": "user", "content": "What time is it?"}],
+  "stream": true,
+  "tools": [{
+    "type": "function",
+    "function": {
+      "name": "get_current_time",
+      "description": "Get the current time in ISO 8601 format",
+      "parameters": {"type": "object", "properties": {}}
+    }
+  }]
+}
+```
+
+### Stream Output (Client Tool Called)
+
+```
+data: {"choices":[{"delta":{"role":"assistant","content":""}}]}
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_abc","type":"function","function":{"name":"get_current_time","arguments":"{}"}}]}}]}
+data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}
+data: [DONE]
+```
+
+### Follow-Up with Tool Result
+
+The client executes the tool, then sends the result back as a `role: "tool"` message alongside the original conversation history:
+
+```json
+{
+  "messages": [
+    {"role": "user", "content": "What time is it?"},
+    {"role": "assistant", "content": null, "tool_calls": [
+      {"id": "call_abc", "type": "function", "function": {"name": "get_current_time", "arguments": "{}"}}
+    ]},
+    {"role": "tool", "tool_call_id": "call_abc", "content": "2025-03-18T14:30:00Z"}
+  ],
+  "stream": true,
+  "tools": [...]
+}
+```
+
+The server reconstructs the conversation history (including the tool call and result) and sends it to the LLM, which can then respond to the user using the tool output.
+
+### Coexistence with Server-Side Tools
+
+Client-side and MCP server-side tools coexist transparently. The LLM sees all tools and decides which to call. Server-side MCP tools execute automatically within the stream; client-side tools pause the stream for client execution. A single turn may involve server-side tool calls (executed inline) followed by a client-side tool call (which terminates the stream).
 
 ## Connection Behavior
 


### PR DESCRIPTION
This adds the ability for clients to submit a list of client-side tools, via the OpenAI chat completions request spec, and have them "passthrough" to the client instead of being executed "server-side".

Ref: LOG-23583