### PR TITLE
feat(examples): add orchestration mode quickstart with math MCP

### DIFF
--- a/examples/quickstart-orchestration-math/.env.example
+++ b/examples/quickstart-orchestration-math/.env.example
@@ -1,0 +1,12 @@
+# Copy this file to .env and fill in your API key(s).
+#
+#   cp .env.example .env
+
+# Required: at least one LLM provider key
+OPENAI_API_KEY=sk-...
+
+# Optional: Anthropic (uncomment the anthropic block in config.toml)
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# Optional: Mezmo
+# MEZMO_API_KEY=...

--- a/examples/quickstart-orchestration-math/README.md
+++ b/examples/quickstart-orchestration-math/README.md
@@ -1,0 +1,137 @@
+# Aura Orchestration Quickstart — Math MCP
+
+One command to spin up Aura in **orchestration mode** with a math tool server:
+
+- **Aura** — the AI agent server running in orchestration mode (`mezmo/aura:orchestration`)
+- **Math MCP** — an MCP server providing arithmetic, statistics, and trigonometry tools
+- **LibreChat** — a ChatGPT-style web UI connected to Aura
+- **Phoenix** — an LLM trace viewer for inspecting every tool call, prompt, and token
+
+## How Orchestration Mode Works
+
+In orchestration mode Aura routes each request through a **coordinator** that decides how to respond:
+
+- **Direct answer** — simple, single-step requests are answered immediately
+- **Worker dispatch** — complex or multi-step problems are decomposed into a plan and delegated to specialized workers, each with access to a filtered subset of tools
+- **Clarification** — vague requests prompt the coordinator to ask for more detail
+
+This quickstart defines three workers backed by the math MCP server:
+
+| Worker | Tools | Example task |
+|---|---|---|
+| `arithmetic` | add, subtract, multiply, division, modulo, floor, ceiling, round, sum | "Multiply 12 by 7, then subtract 4" |
+| `statistics` | mean, median, mode, min, max | "Find the mean and median of [3, 7, 2, 9, 5]" |
+| `trigonometry` | sin, cos, tan, arcsin, arccos, arctan, radiansToDegrees, degreesToRadians | "Compute sin(30°) and cos(60°)" |
+
+## Setup
+
+### 1. Add your API key
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and paste your OpenAI (or Anthropic) API key.
+
+### 2. Start everything
+
+```bash
+docker compose up --build
+```
+
+The `--build` flag is required on first run to build the math MCP image.
+
+### 3. Open the UIs
+
+| Service | URL | Description |
+|---------|-----|-------------|
+| LibreChat | <http://localhost:3080> | Chat with your agent |
+| Phoenix | <http://localhost:6006> | Inspect LLM traces |
+| Aura API | <http://localhost:3000> | OpenAI-compatible API |
+
+**LibreChat first-time setup:** Create your user account on the signup page. The agent model is pre-configured as "Aura".
+
+## Try It Out
+
+Once everything is up, try these prompts in LibreChat:
+
+**Direct answer** (no workers dispatched):
+> What is 2 + 2?
+
+**Multi-step orchestration** (coordinator dispatches arithmetic worker):
+> Calculate (3 + 7) × 2, then subtract 5 from the result.
+
+**Mixed domain** (coordinator dispatches arithmetic + statistics workers):
+> Multiply each of [1, 2, 3, 4] by 3, then find the mean of the results.
+
+**Clarification trigger**:
+> Compute the thing.
+
+Watch Phoenix at <http://localhost:6006> to see the full trace of coordinator planning and worker execution.
+
+## Customize
+
+Edit `config.toml` and restart Aura:
+
+```bash
+docker compose restart aura
+```
+
+### Switch LLM provider
+
+Uncomment the Anthropic block in `config.toml` and set `ANTHROPIC_API_KEY` in `.env`.
+
+### Adjust routing behavior
+
+```toml
+[orchestration]
+allow_direct_answers = true   # set false to always dispatch workers
+allow_clarification = true    # set false to never ask for clarification
+max_planning_cycles = 2       # coordinator retries on low-quality plans
+quality_threshold = 0.7       # minimum plan quality score (0.0–1.0)
+```
+
+### Add or modify workers
+
+Each `[orchestration.worker.<name>]` section defines a worker. The `mcp_filter` list controls which tools from the math MCP server that worker can use.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  docker compose                                         │
+│                                                         │
+│  ┌────────────┐     ┌──────────────────────────────┐    │
+│  │ LibreChat  │────▶│   Aura (orchestration mode)  │    │
+│  │   :3080    │     │           :3000              │    │
+│  └─────┬──────┘     └──────┬───────────────────────┘    │
+│        │                   │                            │
+│  ┌─────┴──────┐     ┌──────▼──────┐   ┌────────────┐   │
+│  │  MongoDB   │     │  Math MCP   │   │  Phoenix   │   │
+│  │ (LibreChat │     │    :8081    │   │   :6006    │   │
+│  │  storage)  │     │             │   │            │   │
+│  └────────────┘     └─────────────┘   └────────────┘   │
+└─────────────────────────────────────────────────────────┘
+         ▲                                    ▲
+         │                                    │
+      Browser                           OTel traces
+```
+
+- **LibreChat** sends chat requests to Aura's OpenAI-compatible `/v1/chat/completions` endpoint
+- **Aura** runs a coordinator LLM that routes requests, dispatches workers, and streams responses
+- **Math MCP** exposes arithmetic, statistics, and trigonometry tools via the MCP protocol
+- **Phoenix** receives OpenTelemetry traces so you can inspect every coordinator and worker step
+
+## Troubleshooting
+
+**`math-mcp` build fails**
+The Dockerfile clones `EthanHenrickson/math-mcp` from GitHub. Ensure you have internet access during `docker compose up --build`.
+
+**LibreChat shows "no models available"**
+Aura may still be starting (it waits for math-mcp to be healthy first). Check `docker compose logs aura --tail 5` and refresh.
+
+**Reset everything**
+
+```bash
+docker compose down -v
+```

--- a/examples/quickstart-orchestration-math/config.toml
+++ b/examples/quickstart-orchestration-math/config.toml
@@ -1,0 +1,129 @@
+# Aura Orchestration Quickstart — Math MCP
+#
+# Orchestration mode routes requests through a coordinator agent that
+# decomposes problems into tasks and dispatches them to specialized workers.
+# Each worker has access to a filtered subset of MCP tools.
+#
+# This config connects to the math-mcp service defined in docker-compose.yml.
+# For all available options, see: examples/reference.toml
+
+# ── LLM Provider ────────────────────────────────────────────────────
+
+[llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.4-mini"
+
+# Anthropic:
+# provider = "anthropic"
+# api_key = "{{ env.ANTHROPIC_API_KEY }}"
+# model = "claude-sonnet-4-20250514"
+
+# ── Agent (Coordinator) ─────────────────────────────────────────────
+# In orchestration mode the [agent] system_prompt is given to the
+# coordinator. It provides routing guidance and domain context.
+
+[agent]
+name = "Math Orchestrator"
+system_prompt = """
+You are a math assistant coordinator. You decompose math problems into
+specialized tasks and delegate to the appropriate worker.
+
+ROUTING GUIDANCE:
+- Simple single-operation arithmetic (e.g., "What is 2+2?"): answer directly
+- Multi-step calculations or mixed domains: create a plan with workers
+- Vague or ambiguous requests: ask for clarification
+
+IMPORTANT: Always delegate calculations to workers — do not compute results yourself.
+"""
+turn_depth = 5
+
+# ── MCP Tool Server ──────────────────────────────────────────────────
+# Points at the math-mcp container defined in docker-compose.yml.
+
+[mcp]
+sanitize_schemas = true
+
+[mcp.servers.math]
+transport = "http_streamable"
+url = "http://math-mcp:8081/mcp"
+headers = {}
+description = "Math MCP server providing arithmetic, statistics, and trigonometry tools"
+
+# ── Orchestration ───────────────────────────────────────────────────
+
+[orchestration]
+enabled = true
+max_planning_cycles = 2
+quality_threshold = 0.7
+allow_direct_answers = true
+allow_clarification = true
+tools_in_planning = "summary"
+
+[orchestration.timeouts]
+per_call_timeout_secs = 60
+
+[orchestration.artifacts]
+memory_dir = "/tmp/aura-orchestration"
+
+# Worker: arithmetic
+# Handles basic arithmetic operations using the math MCP tools.
+
+[orchestration.worker.arithmetic]
+description = "Basic arithmetic: addition, subtraction, multiplication, division, modulo, rounding"
+turn_depth = 5
+mcp_filter = ["add", "subtract", "multiply", "division", "modulo", "floor", "ceiling", "round", "sum"]
+preamble = """
+You are an Arithmetic Specialist completing one assigned task.
+
+Use your math tools for every calculation — do not compute results in your head.
+When a tool returns a result, that result is authoritative. Report it as your answer and stop.
+
+Example:
+Task: Multiply 20 by 3
+→ Call multiply(firstNumber=20, secondNumber=3)
+→ Tool returns: 60
+→ Result: 60
+"""
+
+# Worker: statistics
+# Handles statistical analysis using the math MCP tools.
+
+[orchestration.worker.statistics]
+description = "Statistical analysis: mean, median, mode, min, max"
+turn_depth = 5
+mcp_filter = ["mean", "median", "mode", "min", "max"]
+preamble = """
+You are a Statistics Specialist completing one assigned task.
+
+Use your statistical tools for analysis — do not compute statistics manually.
+When a tool returns a result, that result is authoritative. Report it as your answer and stop.
+
+Example:
+Task: Compute the mean of [1, 2, 3]
+→ Call mean(numbers=[1, 2, 3])
+→ Tool returns: 2.0
+→ Result: 2.0
+"""
+
+# Worker: trigonometry
+# Handles trigonometric calculations using the math MCP tools.
+
+[orchestration.worker.trigonometry]
+description = "Trigonometric functions and angle conversions"
+turn_depth = 5
+mcp_filter = ["sin", "cos", "tan", "arcsin", "arccos", "arctan", "radiansToDegrees", "degreesToRadians"]
+preamble = """
+You are a Trigonometry Specialist completing one assigned task.
+
+Use your trig tools for all calculations — do not compute results manually.
+When a tool returns a result, that result is authoritative. Report it as your answer and stop.
+
+Example:
+Task: Compute sin(45°)
+→ Call degreesToRadians(degrees=45)
+→ Tool returns: 0.7853981633974483
+→ Call sin(radians=0.7853981633974483)
+→ Tool returns: 0.7071067811865476
+→ Result: 0.7071067811865476
+"""

--- a/examples/quickstart-orchestration-math/configs/librechat.yaml
+++ b/examples/quickstart-orchestration-math/configs/librechat.yaml
@@ -1,0 +1,21 @@
+# LibreChat configuration for the Aura orchestration quickstart.
+# See: https://docs.librechat.ai/install/configuration/custom_config.html
+
+version: 1.1.5
+
+endpoints:
+  custom:
+    - name: "Aura"
+      apiKey: "not_used"
+      baseURL: "http://aura:3000/v1"
+      models:
+        default:
+          - "aura"
+        fetch: false
+      titleConvo: true
+      titleModel: "aura"
+      summarize: false
+      forcePrompt: false
+      modelDisplayLabel: "Aura"
+      addParams:
+        stream: true

--- a/examples/quickstart-orchestration-math/docker-compose.yml
+++ b/examples/quickstart-orchestration-math/docker-compose.yml
@@ -1,0 +1,125 @@
+services:
+  # ── Math MCP Server ─────────────────────────────────────────────────
+  # Provides arithmetic, statistics, and trigonometry tools via MCP.
+  # Built from the math-mcp/ Dockerfile in this directory.
+  math-mcp:
+    build:
+      context: ./math-mcp
+    container_name: aura-qs-math-mcp
+    ports:
+      - "8081:8081"
+    healthcheck:
+      test: >
+        curl -sf http://localhost:8081/mcp -X POST
+        -H "Content-Type: application/json"
+        -H "Accept: application/json, text/event-stream"
+        -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"healthcheck","version":"1.0"}},"id":1}'
+        > /dev/null || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      - aura-quickstart
+
+  # ── Aura Agent Server (Orchestration Mode) ──────────────────────────
+  aura:
+    image: mezmo/aura:orchestration
+    container_name: aura
+    command:
+      - ./aura-web-server
+      - --verbose
+    ports:
+      - "3000:3000"
+    environment:
+      HOST: "0.0.0.0"
+      PORT: "3000"
+      CONFIG_PATH: "/app/config/config.toml"
+
+      # LLM API keys (from .env)
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+
+      # Optional: Mezmo
+      MEZMO_API_KEY: "${MEZMO_API_KEY:-}"
+
+      # Streaming — custom events disabled because LibreChat's SSE
+      # parser doesn't skip unknown event types (aura.session_info, etc.)
+      AURA_CUSTOM_EVENTS: "false"
+      AURA_EMIT_REASONING: "false"
+      TOOL_RESULT_MODE: "none"
+
+      # OpenTelemetry → Phoenix
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://phoenix:4317"
+      OTEL_RECORD_CONTENT: "true"
+    volumes:
+      - ./config.toml:/app/config/config.toml:ro
+    depends_on:
+      math-mcp:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - aura-quickstart
+
+  # ── LibreChat (Chat UI) ────────────────────────────────────────────
+  librechat-mongodb:
+    image: mongo:latest
+    container_name: aura-qs-mongodb
+    volumes:
+      - mongodb-data:/data/db
+    restart: unless-stopped
+    networks:
+      - aura-quickstart
+
+  librechat:
+    image: ghcr.io/danny-avila/librechat:v0.7.8
+    container_name: aura-qs-librechat
+    ports:
+      - "3080:3080"
+    depends_on:
+      aura:
+        condition: service_healthy
+      librechat-mongodb:
+        condition: service_started
+    environment:
+      MONGO_URI: "mongodb://librechat-mongodb:27017/LibreChat"
+      HOST: "0.0.0.0"
+      PORT: "3080"
+      ENDPOINTS: "custom"
+      ALLOW_REGISTRATION: "true"
+      CONFIG_PATH: "/app/librechat.yaml"
+      # Session secrets (change these in production)
+      CREDS_KEY: "f34be427ebb29de8d88c107a71546019685ed8b241d8f2ed00c3df97ad2566f0"
+      CREDS_IV: "e2341419ec3dd3d19b13a1a87fafcbfb"
+      JWT_SECRET: "16f8c0ef4a5d391b26034086c628469d3f9f497f08163ab9b40137092f2909ef"
+      JWT_REFRESH_SECRET: "eaa5191f2914e30b9387fd84e254e4ba6fc51b4654968a9b0803b456a54b8418"
+    volumes:
+      - ./configs/librechat.yaml:/app/librechat.yaml:ro
+    restart: unless-stopped
+    networks:
+      - aura-quickstart
+
+  # ── Phoenix (LLM Trace Viewer) ─────────────────────────────────────
+  phoenix:
+    image: arizephoenix/phoenix:latest
+    container_name: aura-qs-phoenix
+    ports:
+      - "6006:6006"   # UI
+      - "4317:4317"   # OTLP gRPC
+    restart: unless-stopped
+    networks:
+      - aura-quickstart
+
+networks:
+  aura-quickstart:
+    driver: bridge
+
+volumes:
+  mongodb-data:

--- a/examples/quickstart-orchestration-math/math-mcp/Dockerfile
+++ b/examples/quickstart-orchestration-math/math-mcp/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install mcp-proxy globally
+RUN npm install -g mcp-proxy
+
+# Clone and build math-mcp
+RUN apk add --no-cache git curl \
+    && git clone https://github.com/EthanHenrickson/math-mcp.git \
+    && cd math-mcp \
+    && npm install \
+    && npm run build:stdio \
+    && apk del git
+
+EXPOSE 8081
+
+# Protocol-level healthcheck: verify MCP JSON-RPC responds to initialize
+HEALTHCHECK --interval=5s --timeout=5s --retries=10 --start-period=15s \
+    CMD curl -sf http://localhost:8081/mcp -X POST \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json, text/event-stream" \
+        -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"healthcheck","version":"1.0"}},"id":1}' \
+        > /dev/null || exit 1
+
+CMD ["mcp-proxy", "--port", "8081", "--", "node", "/app/math-mcp/build/index.js"]


### PR DESCRIPTION
Adds a self-contained quickstart at examples/quickstart-orchestration-math/
that demonstrates Aura's orchestration mode backed by the math MCP server.

- Uses mezmo/aura:orchestration image
- Includes math-mcp/Dockerfile (node:20-alpine + mcp-proxy wrapping EthanHenrickson/math-mcp)
- docker-compose.yml brings up math-mcp, aura, librechat, mongodb, and phoenix
- config.toml configures orchestration with arithmetic, statistics, and trigonometry workers
- Each worker has mcp_filter scoped to its domain tools
- README covers setup, example prompts, architecture, and customization