### PR TITLE
feat: add Kubernetes SRE orchestration quickstart

### DIFF
--- a/examples/quickstart-k8s-sre/README.md
+++ b/examples/quickstart-k8s-sre/README.md
@@ -1,0 +1,235 @@
+# Kubernetes SRE Orchestration Quickstart
+
+Deploy an AI-powered Kubernetes SRE agent that uses **orchestration mode** to coordinate
+specialized workers -- one for cluster inspection, one for metrics analysis -- each with
+access to only the tools they need.
+
+## What You'll Build
+
+```
+                         User Query
+                             |
+                             v
+          +------------------------------------------+
+          |        Aura (Coordinator)                 |
+          |  Routes requests to the right specialist  |
+          |                                           |
+          |  +-------------------+ +----------------+ |
+          |  | cluster_inspector | | metrics_analyst| |
+          |  | K8s tools only    | | Prom tools only| |
+          |  +--------+----------+ +-------+--------+ |
+          +-----------|--------------------|----------+
+                      |                    |
+                      v                    v
+              +---------------+   +-----------------+
+              | K8s MCP       |   | Prometheus MCP  |
+              | Server        |   | Server          |
+              +-------+-------+   +--------+--------+
+                      |                    |
+                      v                    v
+              +---------------+   +-----------------+
+              | Kubernetes    |   | Prometheus      |
+              | API           |   | (OTel Demo)     |
+              +---------------+   +-----------------+
+```
+
+The **coordinator** receives user queries and dispatches them to:
+
+- **cluster_inspector** -- filtered to Kubernetes MCP tools (pods, deployments, logs, events)
+- **metrics_analyst** -- filtered to Prometheus MCP tools (PromQL queries, alerts, targets)
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- [Helm](https://helm.sh/docs/intro/install/) 3.12+
+- An OpenAI API key (or another [supported LLM provider](../../examples/reference.toml))
+
+## Setup
+
+All commands assume you're in the repo root.
+
+### 1. Create a KIND cluster
+
+```bash
+kind create cluster --name aura-sre
+```
+
+### 2. Deploy the OpenTelemetry Demo
+
+The [OpenTelemetry Demo](https://opentelemetry.io/docs/demo/) deploys a microservices
+application with Prometheus, Grafana, and Jaeger -- giving your SRE agent real
+workloads and metrics to inspect.
+
+```bash
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm install otel-demo open-telemetry/opentelemetry-demo
+```
+
+Wait for pods to come up (this takes a few minutes on first pull):
+
+```bash
+kubectl get pods -w
+```
+
+> **Tip:** Not every pod needs to be `Running` before proceeding. As long as the
+> Prometheus pod is ready, you can continue.
+
+Verify Prometheus is running and note the service name:
+
+```bash
+kubectl get svc | grep prometheus
+```
+
+You should see a service like `prometheus` on port `9090`. Note the name --
+if it differs, use it in the `--set` flag in step 3 below.
+
+### 3. Deploy the MCP servers
+
+Both MCP servers have community Helm charts. Install them with:
+
+```bash
+# Kubernetes MCP Server — read-only cluster access
+# Binds the built-in "view" ClusterRole for read access to cluster resources.
+helm install kubernetes-mcp-server \
+  oci://ghcr.io/containers/charts/kubernetes-mcp-server \
+  --set ingress.enabled=false \
+  --set config.read_only=true \
+  --set 'rbac.extraClusterRoleBindings[0].name=view' \
+  --set 'rbac.extraClusterRoleBindings[0].roleRef.name=view' \
+  --set 'rbac.extraClusterRoleBindings[0].roleRef.external=true'
+
+# Prometheus MCP Server — connected to the OTel Demo's Prometheus
+# Override probes to use TCP (the MCP server has no GET health endpoint).
+helm install prometheus-mcp-server \
+  oci://ghcr.io/pab1it0/charts/prometheus-mcp-server \
+  --set prometheus.url="http://prometheus:9090" \
+  --set livenessProbe.httpGet=null \
+  --set 'livenessProbe.tcpSocket.port=http' \
+  --set readinessProbe.httpGet=null \
+  --set 'readinessProbe.tcpSocket.port=http'
+```
+
+> **Different Prometheus service name?** Run `kubectl get svc | grep prometheus`
+> and replace the URL above with the correct service name from step 2.
+
+Verify both MCP servers are healthy before proceeding:
+
+```bash
+# Check the Kubernetes MCP server can reach the API
+kubectl logs -l app.kubernetes.io/name=kubernetes-mcp-server --tail=5
+
+# Check the Prometheus MCP server connected to Prometheus
+kubectl logs -l app.kubernetes.io/name=prometheus-mcp-server --tail=5
+```
+
+Wait for them to start:
+
+```bash
+kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=kubernetes-mcp-server --timeout=120s
+kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=prometheus-mcp-server --timeout=120s
+```
+
+### 4. Deploy Aura
+
+```bash
+export OPENAI_API_KEY="sk-..."
+
+helm install aura ./deployment/helm/aura \
+  -f examples/quickstart-k8s-sre/aura-values.yaml \
+  --set secrets.openaiApiKey="$OPENAI_API_KEY"
+```
+
+> **Using a different LLM provider?** Edit `aura-values.yaml` and update the `[llm]`
+> section. See [`examples/reference.toml`](../reference.toml) for all provider options.
+
+Wait for Aura:
+
+```bash
+kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=aura --timeout=120s
+```
+
+### 5. Try it out
+
+Launch [Aura CLI](https://hub.docker.com/r/mezmo/aura-cli) inside the cluster,
+pointed at the Aura service:
+
+```bash
+kubectl run -it --rm aura-cli \
+  --image=mezmo/aura-cli \
+  --restart=Never \
+  --env="AURA_AGENT_API_URL=http://aura:80" \
+  --env="AURA_AGENT_MODEL=kubernetes-sre"
+```
+
+This drops you into an interactive REPL. Try these queries:
+
+```
+Check the health of my cluster. Are all pods running? Are there any high CPU or memory usage concerns?
+```
+
+```
+What services are running in the default namespace and what are their error rates?
+```
+
+```
+Are there any pods in CrashLoopBackOff? If so, show me their logs and related metrics.
+```
+
+```
+Show me the top 5 pods by memory usage and check if any are close to their limits.
+```
+
+The coordinator dispatches to both workers: **cluster_inspector** checks pod
+status and events, while **metrics_analyst** queries Prometheus for resource usage.
+You can toggle the SSE event panel with `/stream` to watch the orchestration in
+real time.
+
+Type `/quit` to exit.
+
+## How the orchestration config works
+
+Open `aura-values.yaml` and look at the `config.content` section. The key pieces:
+
+**`[orchestration]`** -- enables orchestration mode. The coordinator agent receives
+every query and decides whether to answer directly, ask for clarification, or
+dispatch to workers.
+
+**`[orchestration.worker.cluster_inspector]`** -- a worker with `mcp_filter` set to
+only Kubernetes tool names. Even though both MCP servers are connected, this worker
+can only see and use K8s tools.
+
+**`[orchestration.worker.metrics_analyst]`** -- a worker with `mcp_filter` set to
+only Prometheus tool names. It can only query metrics, not touch the cluster.
+
+This separation means each worker operates with least-privilege access to tools,
+and the coordinator handles synthesis across domains.
+
+## Customizing tool filters
+
+The `mcp_filter` arrays in `aura-values.yaml` list the exact tool names exposed
+by each MCP server. The names in this quickstart were sourced from the upstream
+repos:
+
+- [kubernetes-mcp-server tools](https://github.com/containers/kubernetes-mcp-server) -- core toolset, `read_only = true`
+- [prometheus-mcp-server tools](https://github.com/pab1it0/prometheus-mcp-server) -- all tools
+
+To verify the tools Aura actually discovered at runtime:
+
+```bash
+kubectl logs -l app.kubernetes.io/name=aura | grep -i "tool"
+```
+
+> **Important:** If a tool name in `mcp_filter` doesn't match any real tool, it's
+> silently ignored. If *none* match, the worker has zero tools and will fail.
+
+## Cleanup
+
+```bash
+helm uninstall aura
+helm uninstall prometheus-mcp-server
+helm uninstall kubernetes-mcp-server
+helm uninstall otel-demo
+kind delete cluster --name aura-sre
+```

--- a/examples/quickstart-k8s-sre/aura-values.yaml
+++ b/examples/quickstart-k8s-sre/aura-values.yaml
@@ -78,7 +78,7 @@ config:
 
     [orchestration]
     enabled = true
-    max_planning_cycles = 3
+    max_planning_cycles = 2
     quality_threshold = 0.7
     allow_direct_answers = true
     allow_clarification = false
@@ -141,14 +141,20 @@ config:
       "list_metrics",
     ]
     preamble = """
-    You are a Prometheus metrics specialist. Use execute_query and
-    execute_range_query to run targeted PromQL queries for specific metrics.
+    You are a Prometheus metrics specialist.
 
-    IMPORTANT: Do NOT call list_metrics or get_metric_metadata without a
-    filter_pattern — the OTel demo has hundreds of metrics and unfiltered
-    results will exceed context limits. Always use filter_pattern to narrow
-    results (e.g. filter_pattern="cpu", filter_pattern="http_request").
+    Workflow:
+    1. Call list_metrics with a filter_pattern for the domain
+       (e.g. "cpu", "http_request", "memory").
+    2. Run execute_query or execute_range_query with the
+       exact metric name from step 1.
+    3. Use get_metric_metadata with a filter_pattern if you
+       need to understand what a metric measures.
 
-    When analyzing metrics, provide specific values with units. Flag anomalies
-    and suggest thresholds when relevant.
+    Always pass filter_pattern to list_metrics and
+    get_metric_metadata — filtered results are faster and
+    more relevant.
+
+    Be concise and decisive. Report metric values with
+    units. Flag anomalies with specific numbers.
     """

--- a/examples/quickstart-k8s-sre/aura-values.yaml
+++ b/examples/quickstart-k8s-sre/aura-values.yaml
@@ -1,0 +1,154 @@
+# Aura Helm values for Kubernetes SRE Orchestration Quickstart
+#
+# Configures Aura in orchestration mode with two specialized workers:
+#   - cluster_inspector: Kubernetes cluster operations
+#   - metrics_analyst:   Prometheus metrics and alerts
+
+replicaCount: 1
+
+image:
+  repository: mezmo/aura
+  tag: "orchestration"
+  pullPolicy: IfNotPresent
+
+server:
+  httpPort: 8080
+  loglevel: info
+  command: ["./aura-web-server"]
+  args: ["--verbose"]
+
+streaming:
+  toolResultMode: "aura"
+  # Truncate tool results to avoid blowing past TPM limits.
+  # Prometheus list_metrics / get_metric_metadata can return hundreds of
+  # metrics from the OTel demo, easily exceeding 200K tokens in one call.
+  toolResultMaxLength: 8000
+  customEvents: true
+  emitReasoning: true
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: 2
+    memory: 2Gi
+
+config:
+  content: |
+    [llm]
+    provider = "openai"
+    api_key = "{{ env.OPENAI_API_KEY }}"
+    model = "gpt-5.4-mini"
+
+    [mcp]
+    sanitize_schemas = true
+
+    # Kubernetes MCP — cluster inspection tools
+    # Service name and port from: oci://ghcr.io/containers/charts/kubernetes-mcp-server
+    [mcp.servers.kubernetes]
+    transport = "http_streamable"
+    url = "http://kubernetes-mcp-server:8080/mcp"
+    description = "Kubernetes cluster operations: pods, deployments, services, nodes, logs, events"
+
+    # Prometheus MCP — metrics and alerting tools
+    # Service name and port from: oci://ghcr.io/pab1it0/charts/prometheus-mcp-server
+    [mcp.servers.prometheus]
+    transport = "http_streamable"
+    url = "http://prometheus-mcp-server:8080/mcp"
+    description = "Prometheus metrics queries, alerts, and targets"
+
+    [agent]
+    name = "Kubernetes SRE Agent"
+    alias = "kubernetes-sre"
+    system_prompt = """
+    You are a Kubernetes SRE coordinator. Route requests to the appropriate specialist:
+
+    - Use cluster_inspector for pod status, deployments, logs, events, and node health.
+    - Use metrics_analyst for CPU/memory metrics, error rates, alerts, and PromQL queries.
+
+    For questions that span both domains, dispatch to both workers and synthesize
+    their findings into a unified diagnosis. Always specify namespaces explicitly.
+    Prefer read-only operations unless the user explicitly requests changes.
+    """
+    turn_depth = 20
+    max_tokens = 4096
+
+    # ── Orchestration ────────────────────────────────────────────────
+
+    [orchestration]
+    enabled = true
+    max_planning_cycles = 3
+    quality_threshold = 0.7
+    allow_direct_answers = true
+    allow_clarification = false
+    tools_in_planning = "summary"
+
+    [orchestration.timeouts]
+    per_call_timeout_secs = 120
+
+    [orchestration.artifacts]
+    memory_dir = "/tmp/aura-orchestration"
+
+    # ── Workers ──────────────────────────────────────────────────────
+    #
+    # Each worker uses mcp_filter to restrict which tools it can see.
+    # Tool names below match the kubernetes-mcp-server (core toolset,
+    # read-only mode) and prometheus-mcp-server source code.
+    #
+    # To verify the actual tool names discovered at runtime:
+    #   kubectl logs -l app.kubernetes.io/name=aura | grep -i "tool"
+
+    [orchestration.worker.cluster_inspector]
+    description = "Kubernetes cluster inspection: check pod status, read logs, list deployments and services, review events, assess node health"
+    turn_depth = 10
+    # Tool names from: https://github.com/containers/kubernetes-mcp-server
+    # Core toolset with read_only=true (destructive tools like pods_delete are excluded by the server)
+    mcp_filter = [
+      "configuration_view",
+      "events_list",
+      "namespaces_list",
+      "nodes_log",
+      "nodes_stats_summary",
+      "nodes_top",
+      "pods_get",
+      "pods_list",
+      "pods_list_in_namespace",
+      "pods_log",
+      "pods_top",
+      "resources_get",
+      "resources_list",
+    ]
+    preamble = """
+    You are a Kubernetes cluster specialist. Use the available tools to inspect
+    cluster state: check pod health, read logs, list deployments and services,
+    review events, and assess node status.
+
+    Always specify namespaces explicitly. Report findings with specific resource
+    names, namespaces, and status conditions.
+    """
+
+    [orchestration.worker.metrics_analyst]
+    description = "Prometheus metrics analysis: run PromQL queries for CPU, memory, error rates; check alerts, targets, and metric metadata"
+    turn_depth = 10
+    # Tool names from: https://github.com/pab1it0/prometheus-mcp-server
+    mcp_filter = [
+      "execute_query",
+      "execute_range_query",
+      "get_metric_metadata",
+      "get_targets",
+      "health_check",
+      "list_metrics",
+    ]
+    preamble = """
+    You are a Prometheus metrics specialist. Use execute_query and
+    execute_range_query to run targeted PromQL queries for specific metrics.
+
+    IMPORTANT: Do NOT call list_metrics or get_metric_metadata without a
+    filter_pattern — the OTel demo has hundreds of metrics and unfiltered
+    results will exceed context limits. Always use filter_pattern to narrow
+    results (e.g. filter_pattern="cpu", filter_pattern="http_request").
+
+    When analyzing metrics, provide specific values with units. Flag anomalies
+    and suggest thresholds when relevant.
+    """


### PR DESCRIPTION
## Summary

Adds a complete quickstart guide for deploying Aura as a Kubernetes SRE agent using orchestration mode.

## Changes

- **README.md** – Comprehensive step-by-step guide covering:
  - Architecture diagram showing coordinator and specialized workers
  - Prerequisites and cluster setup with KIND
  - OpenTelemetry Demo deployment for realistic workloads
  - MCP server installation (Kubernetes and Prometheus)
  - Aura deployment and configuration
  - Example queries demonstrating orchestration in action
  - Customization guide for tool filters
  - Cleanup instructions

- **aura-values.yaml** – Helm values configuration featuring:
  - Two specialized workers with restricted tool access:
    - `cluster_inspector` – limited to Kubernetes MCP tools only
    - `metrics_analyst` – limited to Prometheus MCP tools only
  - Orchestration mode enabled with coordinator dispatch logic
  - System prompts for coordinator and each worker
  - MCP server connections for Kubernetes and Prometheus
  - Resource requests/limits for production readiness

## Key Features

- **Least-privilege tool access**: Each worker sees only tools relevant to their domain
- **Intelligent dispatch**: Coordinator routes queries to appropriate specialists
- **Cross-domain synthesis**: Results from multiple workers are combined for comprehensive insights
- **Real workloads**: Integrates with OpenTelemetry Demo for practical scenarios