### PR TITLE
fix(orchestration): route MCP progress events to SSE in orchestration…

### DIFF
--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -1146,14 +1146,15 @@ impl StreamingAgent for Agent {
 pub async fn build_streaming_agent(
     config: &crate::config::AgentConfig,
 ) -> Result<Arc<dyn StreamingAgent>, Box<dyn std::error::Error + Send + Sync>> {
-    // Import Orchestrator only when needed (keeps orchestration coupling minimal)
-    use crate::orchestration::Orchestrator;
+    use crate::orchestration::OrchestratorFactory;
 
     if config.orchestration_enabled() {
-        // Use multi-agent orchestrator: plan -> execute (workers) -> synthesize
-        tracing::info!("Building Orchestrator (orchestration.enabled = true)");
-        let orchestrator = Orchestrator::new(config.clone()).await?;
-        Ok(Arc::new(orchestrator))
+        // Use multi-agent orchestrator: plan -> execute (workers) -> synthesize.
+        // OrchestratorFactory is lightweight — the real Orchestrator is created
+        // lazily inside stream() to avoid duplicate MCP connections and persistence.
+        tracing::info!("Building OrchestratorFactory (orchestration.enabled = true)");
+        let factory = OrchestratorFactory::new(config.clone());
+        Ok(Arc::new(factory))
     } else {
         // Standard single-agent mode
         tracing::info!("Building Agent (orchestration.enabled = false)");

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -49,8 +49,8 @@ pub use orchestration::tools::{
 };
 pub use orchestration::{
     ArtifactsConfig, EventContext, OrchestrationConfig, OrchestrationStreamEvent, Orchestrator,
-    OrchestratorEvent, Plan, PlanAttemptFailure, PlanningResponse, RoutingMode, Task, TaskJson,
-    TaskStatus, TimeoutsConfig,
+    OrchestratorEvent, OrchestratorFactory, Plan, PlanAttemptFailure, PlanningResponse,
+    RoutingMode, Task, TaskJson, TaskStatus, TimeoutsConfig,
 };
 pub use provider_agent::{
     FinalResponseInfo, StreamError, StreamItem, StreamedAssistantContent, StreamedUserContent,

--- a/crates/aura/src/orchestration/factory.rs
+++ b/crates/aura/src/orchestration/factory.rs
@@ -1,0 +1,208 @@
+//! Lightweight factory for orchestration streaming.
+//!
+//! `OrchestratorFactory` implements `StreamingAgent` without constructing a full
+//! `Orchestrator` up front. The real orchestrator is created lazily inside `stream()`
+//! when a request arrives. This avoids duplicate MCP connections, persistence
+//! directories, and ensures MCP progress notifications route correctly.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::stream::{self, BoxStream};
+use tokio::sync::{RwLock, watch};
+use tokio_util::sync::CancellationToken;
+
+use crate::config::AgentConfig;
+use crate::mcp::McpManager;
+use crate::provider_agent::{StreamError, StreamItem};
+use crate::streaming::StreamingAgent;
+
+use super::orchestrator::{spawn_cancellation_watcher, spawn_tool_event_forwarder, Orchestrator, STREAM_CHUNK_SIZE};
+
+/// Lightweight wrapper that implements `StreamingAgent` for orchestration mode.
+///
+/// Instead of constructing a full `Orchestrator` (with MCP connections, persistence)
+/// at build time, this factory defers construction to `stream()`.
+/// This eliminates the duplicate-orchestrator problem where the "factory" instance's
+/// resources were never used.
+pub struct OrchestratorFactory {
+    agent_config: AgentConfig,
+    /// HTTP request ID stored by `set_mcp_request_id`, passed to inner orchestrator.
+    request_id: Arc<RwLock<Option<String>>>,
+    /// Handle to the inner orchestrator's MCP manager, set after spawn creates it.
+    /// Used by `cancel_and_close_mcp` for client disconnect propagation.
+    inner_mcp: Arc<RwLock<Option<Arc<McpManager>>>>,
+}
+
+impl OrchestratorFactory {
+    pub fn new(agent_config: AgentConfig) -> Self {
+        Self {
+            agent_config,
+            request_id: Arc::new(RwLock::new(None)),
+            inner_mcp: Arc::new(RwLock::new(None)),
+        }
+    }
+}
+
+#[async_trait]
+impl StreamingAgent for OrchestratorFactory {
+    fn get_provider_info(&self) -> (&str, &str) {
+        self.agent_config.llm.model_info()
+    }
+
+    async fn stream(
+        &self,
+        query: &str,
+        chat_history: Vec<rig::completion::Message>,
+        cancel_token: CancellationToken,
+    ) -> Result<BoxStream<'static, Result<StreamItem, StreamError>>, StreamError> {
+        let query = query.to_string();
+        let chat_history = chat_history.clone();
+        let mut agent_config = self.agent_config.clone();
+
+        // Create channel for orchestrator events
+        let (event_tx, event_rx) =
+            tokio::sync::mpsc::channel::<Result<StreamItem, StreamError>>(100);
+
+        // Inject conversation history for worker access via get_conversation_context tool
+        agent_config.orchestration_chat_history = Some(Arc::new(chat_history.clone()));
+
+        // Capture request ID and inner_mcp handle for the spawned task
+        let request_id = self.request_id.clone();
+        let inner_mcp = self.inner_mcp.clone();
+
+        let cancel_token_clone = cancel_token.clone();
+        // Capture the current span (agent.stream root) so child spans nest correctly in Phoenix.
+        let parent_span = tracing::Span::current();
+        tokio::spawn(tracing::Instrument::instrument(
+            async move {
+                let orchestrator = match Orchestrator::new(agent_config).await {
+                    Ok(o) => o,
+                    Err(e) => {
+                        let _ = event_tx.send(Err(e)).await;
+                        return;
+                    }
+                };
+
+                // Bridge: set MCP request ID on the inner orchestrator so progress
+                // notifications route to the correct SSE subscriber.
+                if let Some(ref mcp_manager) = orchestrator.mcp_manager {
+                    if let Some(ref req_id) = *request_id.read().await {
+                        mcp_manager.set_current_request(req_id).await;
+                    }
+                    // Publish inner MCP manager so cancel_and_close_mcp can reach it.
+                    *inner_mcp.write().await = Some(Arc::clone(mcp_manager));
+                }
+
+                // Forward tool call events from workers to SSE stream
+                spawn_tool_event_forwarder(
+                    &orchestrator.tool_call_observer,
+                    event_tx.clone(),
+                    cancel_token_clone.clone(),
+                );
+
+                tokio::select! {
+                    result = orchestrator.run_orchestration(&query, chat_history, event_tx.clone()) => {
+                        match result {
+                            Ok(final_result) => {
+                                // Emit final response as text chunks
+                                for chunk in final_result.chars().collect::<Vec<_>>().chunks(STREAM_CHUNK_SIZE) {
+                                    let text: String = chunk.iter().collect();
+                                    let _ = event_tx.send(Ok(StreamItem::StreamAssistantItem(
+                                        crate::provider_agent::StreamedAssistantContent::Text(text)
+                                    ))).await;
+                                }
+
+                                // Emit Final marker
+                                let _ = event_tx.send(Ok(StreamItem::Final(
+                                    crate::provider_agent::FinalResponseInfo {
+                                        content: final_result,
+                                        usage: Default::default(),
+                                    }
+                                ))).await;
+                            }
+                            Err(e) => {
+                                let _ = event_tx.send(Err(e)).await;
+                            }
+                        }
+                    }
+                    _ = cancel_token_clone.cancelled() => {
+                        tracing::info!("Orchestration cancelled");
+                        if let Some(ref mcp_manager) = orchestrator.mcp_manager {
+                            let cancelled = mcp_manager
+                                .cancel_and_close_all("orchestration", "Client disconnected or timeout")
+                                .await;
+                            if cancelled > 0 {
+                                tracing::info!("Cancelled {} MCP request(s) during orchestration shutdown", cancelled);
+                            }
+                        }
+                    }
+                }
+
+                // Clear inner MCP handle on exit so stale references don't linger.
+                *inner_mcp.write().await = None;
+            },
+            parent_span,
+        ));
+
+        // Convert receiver to stream
+        let stream = stream::unfold(event_rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        });
+
+        Ok(Box::pin(stream))
+    }
+
+    async fn stream_with_timeout(
+        &self,
+        query: &str,
+        chat_history: Vec<rig::completion::Message>,
+        timeout: Duration,
+        request_id: &str,
+    ) -> (
+        BoxStream<'static, Result<StreamItem, StreamError>>,
+        watch::Sender<bool>,
+        crate::UsageState,
+    ) {
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let cancel_token = CancellationToken::new();
+        let watcher_cancel_token = cancel_token.clone();
+        let request_id_owned = request_id.to_string();
+
+        // Fire-and-forget: task self-terminates when cancel_tx is dropped or timeout fires.
+        let _watcher_handle =
+            spawn_cancellation_watcher(cancel_rx, timeout, watcher_cancel_token, request_id_owned);
+
+        let stream = match self.stream(query, chat_history, cancel_token).await {
+            Ok(s) => s,
+            Err(e) => Box::pin(stream::once(async move { Err(e) })),
+        };
+
+        // Orchestration has its own usage tracking; return a fresh state for the handler.
+        (stream, cancel_tx, crate::UsageState::new())
+    }
+
+    async fn cancel_and_close_mcp(&self, request_id: &str, reason: &str) -> usize {
+        if let Some(ref mcp_manager) = *self.inner_mcp.read().await {
+            mcp_manager.cancel_and_close_all(request_id, reason).await
+        } else {
+            0
+        }
+    }
+
+    async fn set_mcp_request_id(&self, request_id: &str) {
+        *self.request_id.write().await = Some(request_id.to_string());
+        // Also forward to inner MCP if already constructed (unlikely but safe)
+        if let Some(ref mcp_manager) = *self.inner_mcp.read().await {
+            mcp_manager.set_current_request(request_id).await;
+        }
+    }
+
+    async fn clear_mcp_request_id(&self) {
+        *self.request_id.write().await = None;
+        if let Some(ref mcp_manager) = *self.inner_mcp.read().await {
+            mcp_manager.clear_current_request().await;
+        }
+    }
+}

--- a/crates/aura/src/orchestration/mod.rs
+++ b/crates/aura/src/orchestration/mod.rs
@@ -18,8 +18,9 @@
 //!
 //! # Architecture
 //!
-//! The orchestrator implements `StreamingAgent`, allowing it to be used as a
-//! drop-in replacement for the standard `Agent`. It coordinates:
+//! `OrchestratorFactory` implements `StreamingAgent`, allowing it to be used as a
+//! drop-in replacement for the standard `Agent`. It creates the real `Orchestrator`
+//! lazily inside `stream()` to avoid duplicate resource allocation. It coordinates:
 //!
 //! 1. **Coordinator** - decomposes queries into plans
 //! 2. **Workers** - execute individual tasks
@@ -28,11 +29,11 @@
 //! # Example Usage
 //!
 //! ```ignore
-//! use aura::{AgentConfig, Orchestrator, StreamingAgent};
+//! use aura::{AgentConfig, OrchestratorFactory, StreamingAgent};
 //!
 //! let config = AgentConfig::from_file("config.toml")?;
 //! let agent: Box<dyn StreamingAgent> = if config.orchestration_enabled() {
-//!     Box::new(Orchestrator::new(config).await?)
+//!     Box::new(OrchestratorFactory::new(config))
 //! } else {
 //!     Box::new(Agent::new(&config).await?)
 //! };
@@ -43,6 +44,7 @@
 mod config;
 mod duplicate_call_guard;
 mod events;
+mod factory;
 mod observer_wrapper;
 mod orchestrator;
 mod persistence;
@@ -59,6 +61,7 @@ pub use config::{
 };
 pub use events::{OrchestratorEvent, RoutingMode};
 pub use observer_wrapper::ObserverWrapper;
+pub use factory::OrchestratorFactory;
 pub use orchestrator::Orchestrator;
 pub use persistence::{
     ExecutionPersistence, RunManifest, RunStatus, TaskExecutionRecord, TaskSummary, ToolCallRecord,

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -1,8 +1,9 @@
 //! Orchestrator agent for multi-agent workflows.
 //!
-//! The orchestrator implements the `StreamingAgent` trait, enabling drop-in
-//! replacement for single-agent mode. It decomposes queries into tasks,
-//! executes them (potentially in parallel), and synthesizes results.
+//! The orchestrator decomposes queries into tasks, executes them (potentially
+//! in parallel), and synthesizes results. `StreamingAgent` is implemented by
+//! `OrchestratorFactory` (see `factory.rs`), which creates an `Orchestrator`
+//! lazily inside `stream()` to avoid duplicate resource allocation.
 //!
 //! # Architecture
 //!
@@ -42,8 +43,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
-use async_trait::async_trait;
-use futures::stream::{self, BoxStream};
 use rig::client::CompletionClient;
 use tokio::sync::{Mutex, watch};
 use tokio_util::sync::CancellationToken;
@@ -52,7 +51,6 @@ use crate::Agent;
 use crate::config::{AgentConfig, LlmConfig};
 use crate::mcp::McpManager;
 use crate::provider_agent::{BuilderState, ProviderAgent, StreamError, StreamItem};
-use crate::streaming::StreamingAgent;
 use crate::string_utils::safe_truncate;
 use crate::tool_call_observer::ToolCallObserver;
 
@@ -74,7 +72,7 @@ use super::types::{
 // ============================================================================
 
 /// Number of characters per chunk when streaming the final orchestration response.
-const STREAM_CHUNK_SIZE: usize = 50;
+pub(super) const STREAM_CHUNK_SIZE: usize = 50;
 
 /// Maximum ReAct depth for the planning coordinator.
 /// Defense-in-depth alongside stream_and_collect's early exit.
@@ -127,7 +125,7 @@ struct CoordinatorTools {
 /// returns `Err`, the `select!` resolves, and the sleep future is dropped
 /// (cancelling the timer via tokio's standard drop semantics).
 #[must_use = "task runs independently; bind with `let _handle =` to document fire-and-forget intent"]
-fn spawn_cancellation_watcher(
+pub(super) fn spawn_cancellation_watcher(
     cancel_rx: watch::Receiver<bool>,
     timeout: Duration,
     cancel_token: CancellationToken,
@@ -274,7 +272,7 @@ fn tool_event_to_orchestrator_event(
 ///
 /// Listens on the observer's broadcast channel and converts `ToolEvent`s
 /// to `OrchestratorEvent`s, sending them through the event channel.
-fn spawn_tool_event_forwarder(
+pub(super) fn spawn_tool_event_forwarder(
     observer: &ToolCallObserver,
     event_tx: tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>,
     cancel_token: CancellationToken,
@@ -327,11 +325,11 @@ pub struct Orchestrator {
 
     /// Tool call observer for coordinator visibility into worker tool execution.
     /// Wired to emit OrchestratorEvent for real-time SSE streaming via spawn_tool_event_forwarder.
-    tool_call_observer: ToolCallObserver,
+    pub(super) tool_call_observer: ToolCallObserver,
 
     /// Shared MCP manager for tool discovery and cancellation.
     /// Arc-wrapped so workers can share the same connections.
-    mcp_manager: Option<Arc<McpManager>>,
+    pub(super) mcp_manager: Option<Arc<McpManager>>,
 
     /// Execution persistence for debugging and retry intelligence
     persistence: Arc<Mutex<ExecutionPersistence>>,
@@ -3794,7 +3792,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             orchestration.routing = tracing::field::Empty,
         )
     )]
-    async fn run_orchestration(
+    pub(super) async fn run_orchestration(
         &self,
         query: &str,
         chat_history: Vec<rig::completion::Message>,
@@ -4513,157 +4511,9 @@ Assign tasks to the worker whose tools best match the required operations."#,
     }
 }
 
-#[async_trait]
-impl StreamingAgent for Orchestrator {
-    fn get_provider_info(&self) -> (&str, &str) {
-        self.agent_config.llm.model_info()
-    }
-
-    async fn stream(
-        &self,
-        query: &str,
-        chat_history: Vec<rig::completion::Message>,
-        cancel_token: CancellationToken,
-    ) -> Result<BoxStream<'static, Result<StreamItem, StreamError>>, StreamError> {
-        let query = query.to_string();
-        let chat_history = chat_history.clone();
-
-        // Create channel for orchestrator events
-        let (event_tx, event_rx) =
-            tokio::sync::mpsc::channel::<Result<StreamItem, StreamError>>(100);
-
-        // Clone self fields for the spawned task
-        let mut agent_config = self.agent_config.clone();
-        // Inject conversation history for worker access via get_conversation_context tool
-        agent_config.orchestration_chat_history = Some(Arc::new(chat_history.clone()));
-
-        // Spawn orchestration in background task
-        // Note: Creates a fresh Orchestrator with its own MCP connections and persistence run.
-        // The factory instance (self) only exists to satisfy the StreamingAgent trait.
-        let cancel_token_clone = cancel_token.clone();
-        // Capture the current span (agent.stream root) so child spans nest correctly in Phoenix.
-        let parent_span = tracing::Span::current();
-        tokio::spawn(tracing::Instrument::instrument(
-            async move {
-                let orchestrator = match Orchestrator::new(agent_config).await {
-                    Ok(o) => o,
-                    Err(e) => {
-                        let _ = event_tx.send(Err(e)).await;
-                        return;
-                    }
-                };
-
-                // Forward tool call events from workers to SSE stream
-                spawn_tool_event_forwarder(
-                    &orchestrator.tool_call_observer,
-                    event_tx.clone(),
-                    cancel_token_clone.clone(),
-                );
-
-                tokio::select! {
-                    result = orchestrator.run_orchestration(&query, chat_history, event_tx.clone()) => {
-                        match result {
-                            Ok(final_result) => {
-                                // Emit final response as text chunks
-                                // Split into chunks to simulate streaming
-                                for chunk in final_result.chars().collect::<Vec<_>>().chunks(STREAM_CHUNK_SIZE) {
-                                    let text: String = chunk.iter().collect();
-                                    let _ = event_tx.send(Ok(StreamItem::StreamAssistantItem(
-                                        crate::provider_agent::StreamedAssistantContent::Text(text)
-                                    ))).await;
-                                }
-
-                                // Emit Final marker
-                                let _ = event_tx.send(Ok(StreamItem::Final(
-                                    crate::provider_agent::FinalResponseInfo {
-                                        content: final_result,
-                                        usage: Default::default(),
-                                    }
-                                ))).await;
-                            }
-                            Err(e) => {
-                                let _ = event_tx.send(Err(e)).await;
-                            }
-                        }
-                    }
-                    _ = cancel_token_clone.cancelled() => {
-                        tracing::info!("Orchestration cancelled");
-                        // Best-effort: send notifications/cancelled to the inner orchestrator's
-                        // MCP connections (coordinator tools like list_tools, inspect_tool_params).
-                        // Note: Worker-level MCP connections are handled via drop when the spawned
-                        // task returns, since workers create independent Agent instances. Clean
-                        // protocol-level cancellation for worker MCP calls would require propagating
-                        // CancellationToken through Rig's tool execution layer.
-                        let cancelled = orchestrator
-                            .cancel_and_close_mcp("orchestration", "Client disconnected or timeout")
-                            .await;
-                        if cancelled > 0 {
-                            tracing::info!("Cancelled {} MCP request(s) during orchestration shutdown", cancelled);
-                        }
-                    }
-                }
-            },
-            parent_span,
-        ));
-
-        // Convert receiver to stream
-        let stream = stream::unfold(event_rx, |mut rx| async move {
-            rx.recv().await.map(|item| (item, rx))
-        });
-
-        Ok(Box::pin(stream))
-    }
-
-    async fn stream_with_timeout(
-        &self,
-        query: &str,
-        chat_history: Vec<rig::completion::Message>,
-        timeout: Duration,
-        request_id: &str,
-    ) -> (
-        BoxStream<'static, Result<StreamItem, StreamError>>,
-        watch::Sender<bool>,
-        crate::UsageState,
-    ) {
-        let (cancel_tx, cancel_rx) = watch::channel(false);
-        let cancel_token = CancellationToken::new();
-        let watcher_cancel_token = cancel_token.clone();
-        let request_id_owned = request_id.to_string();
-
-        // Fire-and-forget: task self-terminates when cancel_tx is dropped or timeout fires.
-        let _watcher_handle =
-            spawn_cancellation_watcher(cancel_rx, timeout, watcher_cancel_token, request_id_owned);
-
-        // Get the stream — returned directly, no wrapper needed
-        let stream = match self.stream(query, chat_history, cancel_token).await {
-            Ok(s) => s,
-            Err(e) => Box::pin(stream::once(async move { Err(e) })),
-        };
-
-        // Orchestration has its own usage tracking; return a fresh state for the handler.
-        (stream, cancel_tx, crate::UsageState::new())
-    }
-
-    async fn cancel_and_close_mcp(&self, request_id: &str, reason: &str) -> usize {
-        if let Some(ref mcp_manager) = self.mcp_manager {
-            mcp_manager.cancel_and_close_all(request_id, reason).await
-        } else {
-            0
-        }
-    }
-
-    async fn set_mcp_request_id(&self, request_id: &str) {
-        if let Some(ref mcp_manager) = self.mcp_manager {
-            mcp_manager.set_current_request(request_id).await;
-        }
-    }
-
-    async fn clear_mcp_request_id(&self) {
-        if let Some(ref mcp_manager) = self.mcp_manager {
-            mcp_manager.clear_current_request().await;
-        }
-    }
-}
+// StreamingAgent is implemented by OrchestratorFactory (see factory.rs),
+// which creates an Orchestrator lazily inside stream() to avoid duplicate
+// MCP connections and persistence directories.
 
 /// Truncate a query string for logging.
 fn truncate_query(query: &str, max_len: usize) -> String {


### PR DESCRIPTION
… mode

Introduce OrchestratorFactory, a lightweight StreamingAgent that defers Orchestrator construction to stream(). Previously, Orchestrator::new() ran twice per request — once at setup (factory) and once inside the tokio::spawn that runs orchestration — because &self can't move into the task. The factory's MCP clients received the HTTP request ID but the inner orchestrator's did not, silently dropping aura.progress events. The double construction also created duplicate persistence directories and wasted MCP connections.

OrchestratorFactory stores only AgentConfig and two Arc<RwLock> bridges: one to pass the request ID into the spawned task, and one to expose the inner orchestrator's MCP manager for client-disconnect cancellation.

ref: LOG-23565