### PR TITLE
chore(errors): add hint to agent name collision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aura"
-version = "1.14.12"
+version = "1.16.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "aura-config"
-version = "1.14.12"
+version = "1.16.4"
 dependencies = [
  "anyhow",
  "aura",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "aura-test-utils"
-version = "1.14.12"
+version = "1.16.4"
 dependencies = [
  "reqwest",
  "serde",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "aura-web-server"
-version = "1.14.12"
+version = "1.16.4"
 dependencies = [
  "actix-web",
  "actix-web-lab",

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -75,15 +75,15 @@ pub fn validate_unique_identifiers(configs: &[Config]) -> Result<(), ConfigError
         let id = config.agent.alias.as_deref().unwrap_or(&config.agent.name);
 
         if config.agent.alias.is_some() && !seen_aliases.insert(id) {
-            return Err(ConfigError::Validation(
-                "Configurations must have a unique alias!".to_string(),
-            ));
+            return Err(ConfigError::Validation(format!(
+                "Duplicate alias '{id}'! Configurations must have a unique alias."
+            )));
         }
 
         if !seen_ids.insert(id) {
-            return Err(ConfigError::Validation(
-                "Multiple configurations with the same agent name! Use an alias to differentiate between two agents with the same name.".to_string(),
-            ));
+            return Err(ConfigError::Validation(format!(
+                "Multiple configurations with the same agent name '{id}'! Use an alias to differentiate between two agents with the same name."
+            )));
         }
     }
 


### PR DESCRIPTION
When multiple agents share the same name or alias
an error is given but currently it's up to the user to track down which agents have colliding names.

With this change, the errors given when names collide include the name or alias that is duplicated which can help save the user from going through every config manually to compare names/aliases.

Ref: LOG-23571