### PR TITLE
chore: update persistence config

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ max_planning_cycles = 3
 tools_in_planning = "summary"
 allow_direct_answers = true
 allow_clarification = true
-memory_dir = "/tmp/orchestration-memory"
+execution_memory_base_path = "/tmp/orchestration-memory"
 
 [orchestration.worker.operations]
 description = "Operational analysis and diagnostics"
@@ -297,7 +297,7 @@ For a fuller multi-worker example, see [configs/example-workers.toml](configs/ex
 | `max_tools_per_worker` | int | `10` | Cap on MCP tools exposed to each worker |
 | `worker_system_prompt` | string | — | Optional global system prompt prepended to all workers |
 | `coordinator_vector_stores` | list | `[]` | Vector stores available to the coordinator agent |
-| `memory_dir` | string | — | Directory for cross-iteration artifact persistence |
+| `execution_memory_base_path` | string | — | File based directory for cross-iteration artifact persistence. Artifacts allow for continuation of previous processing as well as debugging potential failed workflows. Note: no automatic cleanup of artifacts occurs. |
 | `result_artifact_threshold` | int | `4000` | Character count above which worker results are saved as artifacts |
 | `result_summary_length` | int | `2000` | Max characters for artifact summaries passed to coordinator |
 | `timeouts.per_call_timeout_secs` | int | `0` | Per-tool-call timeout in seconds (0 = disabled) |

--- a/configs/example-math-orchestration.toml
+++ b/configs/example-math-orchestration.toml
@@ -62,7 +62,7 @@ description = "Mock MCP server providing math and file tools for testing"
 enabled = true
 max_planning_cycles = 2
 quality_threshold = 0.7
-memory_dir = "/tmp/aura-math-orchestration"
+execution_memory_base_path = "/tmp/aura-math-orchestration"
 
 # Routing behavior
 allow_direct_answers = true

--- a/configs/integration-orchestration.toml
+++ b/configs/integration-orchestration.toml
@@ -43,7 +43,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 60
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-orchestration-test"
+execution_memory_base_path = "/tmp/aura-orchestration-test"
 
 [orchestration.worker.arithmetic]
 description = "Basic arithmetic: addition, subtraction, multiplication, division, modulo, rounding"

--- a/configs/integration-sre-orchestration.toml
+++ b/configs/integration-sre-orchestration.toml
@@ -45,7 +45,7 @@ tools_in_planning = "full"
 per_call_timeout_secs = 90
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-sre-orchestration-test"
+execution_memory_base_path = "/tmp/aura-sre-orchestration-test"
 
 [orchestration.worker.k8s-discovery]
 description = "Kubernetes workload and service discovery: list namespaces, workloads, services, and inspect details"

--- a/configs/math-orchestration-claude-thinking.toml
+++ b/configs/math-orchestration-claude-thinking.toml
@@ -57,7 +57,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 60
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-claude-thinking"
+execution_memory_base_path = "/tmp/aura-math-claude-thinking"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration-glm.toml
+++ b/configs/math-orchestration-glm.toml
@@ -47,7 +47,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 60
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-glm"
+execution_memory_base_path = "/tmp/aura-math-glm"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration-gpt5-thinking.toml
+++ b/configs/math-orchestration-gpt5-thinking.toml
@@ -58,7 +58,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 60
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-gpt5-thinking"
+execution_memory_base_path = "/tmp/aura-math-gpt5-thinking"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration-gpt5.toml
+++ b/configs/math-orchestration-gpt5.toml
@@ -57,7 +57,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 60
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-gpt5"
+execution_memory_base_path = "/tmp/aura-math-gpt5"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration-ministral.toml
+++ b/configs/math-orchestration-ministral.toml
@@ -47,7 +47,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 180
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-ministral"
+execution_memory_base_path = "/tmp/aura-math-ministral"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration-nemotron.toml
+++ b/configs/math-orchestration-nemotron.toml
@@ -47,7 +47,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 60
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-nemotron"
+execution_memory_base_path = "/tmp/aura-math-nemotron"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration-opus-bedrock.toml
+++ b/configs/math-orchestration-opus-bedrock.toml
@@ -50,7 +50,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 60
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-opus-bedrock"
+execution_memory_base_path = "/tmp/aura-math-opus-bedrock"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration-qwen-thinking.toml
+++ b/configs/math-orchestration-qwen-thinking.toml
@@ -47,7 +47,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 120
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-qwen-thinking"
+execution_memory_base_path = "/tmp/aura-math-qwen-thinking"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration-qwen3.toml
+++ b/configs/math-orchestration-qwen3.toml
@@ -48,7 +48,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 120
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-qwen3"
+execution_memory_base_path = "/tmp/aura-math-qwen3"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration-qwen35-ollama.toml
+++ b/configs/math-orchestration-qwen35-ollama.toml
@@ -45,7 +45,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 120
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-qwen35-ollama"
+execution_memory_base_path = "/tmp/aura-math-qwen35-ollama"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration-qwen35-thinking.toml
+++ b/configs/math-orchestration-qwen35-thinking.toml
@@ -48,7 +48,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 120
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-qwen35-thinking"
+execution_memory_base_path = "/tmp/aura-math-qwen35-thinking"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration-qwen35.toml
+++ b/configs/math-orchestration-qwen35.toml
@@ -48,7 +48,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 120
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-qwen35"
+execution_memory_base_path = "/tmp/aura-math-qwen35"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration-sonnet.toml
+++ b/configs/math-orchestration-sonnet.toml
@@ -58,7 +58,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 60
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-sonnet"
+execution_memory_base_path = "/tmp/aura-math-sonnet"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/math-orchestration.toml
+++ b/configs/math-orchestration.toml
@@ -65,7 +65,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 60
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-math-orchestration"
+execution_memory_base_path = "/tmp/aura-math-orchestration"
 
 # Arithmetic worker: basic operations
 [orchestration.worker.arithmetic]

--- a/configs/sre-orchestration.toml
+++ b/configs/sre-orchestration.toml
@@ -67,7 +67,7 @@ tools_in_planning = "summary"
 per_call_timeout_secs = 180
 
 [orchestration.artifacts]
-memory_dir = "/tmp/aura-sre-orchestration"
+execution_memory_base_path = "/tmp/aura-sre-orchestration"
 
 # Kubernetes discovery worker
 [orchestration.worker.k8s-discovery]

--- a/crates/aura-config/src/builder.rs
+++ b/crates/aura-config/src/builder.rs
@@ -139,7 +139,7 @@ impl RigBuilder {
                     per_call_timeout_secs: orch.timeouts.per_call_timeout_secs,
                 },
                 artifacts: aura::orchestration::ArtifactsConfig {
-                    memory_dir: orch.artifacts.memory_dir.clone(),
+                    execution_memory_base_path: orch.artifacts.execution_memory_base_path.clone(),
                     result_artifact_threshold: orch.artifacts.result_artifact_threshold,
                     result_summary_length: orch.artifacts.result_summary_length,
                     session_history_turns: orch.artifacts.session_history_turns,

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -53,8 +53,8 @@ impl Default for TimeoutsConfig {
 /// Artifact configuration for orchestration (aura-config side).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArtifactsConfig {
-    #[serde(default, alias = "memory_path")]
-    pub memory_dir: Option<String>,
+    #[serde(default, alias = "memory_dir", alias = "memory_path")]
+    pub execution_memory_base_path: Option<String>,
     #[serde(default = "default_result_artifact_threshold")]
     pub result_artifact_threshold: usize,
     #[serde(default = "default_result_summary_length")]
@@ -70,7 +70,7 @@ fn default_session_history_turns() -> usize {
 impl Default for ArtifactsConfig {
     fn default() -> Self {
         Self {
-            memory_dir: None,
+            execution_memory_base_path: None,
             result_artifact_threshold: default_result_artifact_threshold(),
             result_summary_length: default_result_summary_length(),
             session_history_turns: default_session_history_turns(),
@@ -157,8 +157,8 @@ struct RawOrchestrationConfig {
     #[serde(default)]
     artifacts: Option<ArtifactsConfig>,
     // Flat artifact fields (backward compat)
-    #[serde(default, alias = "memory_path")]
-    memory_dir: Option<String>,
+    #[serde(default, alias = "memory_dir", alias = "memory_path")]
+    execution_memory_base_path: Option<String>,
     #[serde(default)]
     result_artifact_threshold: Option<usize>,
     #[serde(default)]
@@ -177,8 +177,8 @@ impl<'de> Deserialize<'de> for OrchestrationConfig {
         let timeouts = raw.timeouts.unwrap_or_default();
 
         let mut artifacts = raw.artifacts.unwrap_or_default();
-        if let Some(v) = raw.memory_dir {
-            artifacts.memory_dir = Some(v);
+        if let Some(v) = raw.execution_memory_base_path {
+            artifacts.execution_memory_base_path = Some(v);
         }
         if let Some(v) = raw.result_artifact_threshold {
             artifacts.result_artifact_threshold = v;

--- a/crates/aura-web-server/tests/test-config.toml
+++ b/crates/aura-web-server/tests/test-config.toml
@@ -53,6 +53,7 @@ api_key = "{{ env.OPENAI_API_KEY }}"
 [agent]
 name = "Test Assistant"
 alias = "test-assistant"
+execution_memory_base_path = "/tmp"
 system_prompt = """
 You are a test assistant. Call tools immediately when requested.
 

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -84,7 +84,7 @@ pub struct AgentConfig {
     pub orchestration_chat_history: Option<Arc<Vec<rig::completion::Message>>>,
 
     /// Session ID for grouping orchestration runs under a shared namespace (not serialized).
-    /// When set, persistence paths become `{memory_dir}/{session_id}/{run_id}/...`.
+    /// When set, persistence paths become `{execution_memory_base_path}/{session_id}/{run_id}/...`.
     /// Threaded from the web server's `chat_session_id`.
     #[serde(skip)]
     pub session_id: Option<String>,

--- a/crates/aura/src/orchestration/config.rs
+++ b/crates/aura/src/orchestration/config.rs
@@ -239,7 +239,7 @@ impl Default for TimeoutsConfig {
 ///
 /// ```toml
 /// [orchestration.artifacts]
-/// memory_dir = "/tmp/aura-orchestration"
+/// execution_memory_base_path = "/tmp/aura-orchestration"
 /// result_artifact_threshold = 4000
 /// result_summary_length = 2000
 /// ```
@@ -254,12 +254,12 @@ pub struct ArtifactsConfig {
     /// - Tool call records with reasoning
     /// - Synthesis and result artifacts
     ///
-    /// Structure: `<memory_dir>/<run_id>/iteration-{n}/...`
+    /// Structure: `<execution_memory_base_path>/<run_id>/iteration-{n}/...`
     /// A `latest` symlink points to the most recent run.
     ///
     /// If not set, execution persistence is disabled.
-    #[serde(default, alias = "memory_path")]
-    pub memory_dir: Option<String>,
+    #[serde(default, alias = "memory_dir", alias = "memory_path")]
+    pub execution_memory_base_path: Option<String>,
 
     /// Character threshold for writing large results to artifact files.
     /// Results exceeding this length are written to disk with an inline summary.
@@ -286,7 +286,7 @@ fn default_session_history_turns() -> usize {
 impl Default for ArtifactsConfig {
     fn default() -> Self {
         Self {
-            memory_dir: None,
+            execution_memory_base_path: None,
             result_artifact_threshold: default_result_artifact_threshold(),
             result_summary_length: default_result_summary_length(),
             session_history_turns: default_session_history_turns(),
@@ -323,14 +323,14 @@ impl Default for ArtifactsConfig {
 /// per_call_timeout_secs = 120
 ///
 /// [orchestration.artifacts]
-/// memory_dir = "/tmp/aura-orchestration"
+/// execution_memory_base_path = "/tmp/aura-orchestration"
 /// ```
 ///
 /// # Backward Compatibility
 ///
 /// The following flat fields are still accepted at the `[orchestration]` level
 /// and mapped into their sub-tables during deserialization:
-/// - `memory_dir` / `memory_path` → `artifacts.memory_dir`
+/// - `execution_memory_base_path` / `memory_dir` / `memory_path` → `artifacts.execution_memory_base_path`
 /// - `result_artifact_threshold` → `artifacts.result_artifact_threshold`
 /// - `result_summary_length` → `artifacts.result_summary_length`
 #[derive(Debug, Clone, Serialize)]
@@ -406,9 +406,9 @@ impl OrchestrationConfig {
         self.timeouts.per_call_timeout_secs
     }
 
-    /// Optional memory/persistence directory.
-    pub fn memory_dir(&self) -> Option<&str> {
-        self.artifacts.memory_dir.as_deref()
+    /// Optional base path for execution persistence.
+    pub fn execution_memory_base_path(&self) -> Option<&str> {
+        self.artifacts.execution_memory_base_path.as_deref()
     }
 
     /// Character threshold for artifact extraction.
@@ -578,8 +578,8 @@ impl Default for OrchestrationConfig {
 ///
 /// Accepts:
 /// - New format: `[orchestration.timeouts]` and `[orchestration.artifacts]` sub-tables
-/// - Old format: `memory_dir`, `memory_path`, `result_artifact_threshold`,
-///   `result_summary_length` at root level
+/// - Old format: `execution_memory_base_path`, `memory_dir`, `memory_path`,
+///   `result_artifact_threshold`, `result_summary_length` at root level
 ///
 /// Flat fields take precedence over sub-table values when both are present
 /// (shouldn't happen in practice, but provides predictable behavior).
@@ -619,8 +619,8 @@ struct RawOrchestrationConfig {
     artifacts: Option<ArtifactsConfig>,
 
     // --- Flat artifact fields (backward compat) ---
-    #[serde(default, alias = "memory_path")]
-    memory_dir: Option<String>,
+    #[serde(default, alias = "memory_dir", alias = "memory_path")]
+    execution_memory_base_path: Option<String>,
     #[serde(default)]
     result_artifact_threshold: Option<usize>,
     #[serde(default)]
@@ -640,8 +640,8 @@ impl<'de> Deserialize<'de> for OrchestrationConfig {
 
         // Build artifacts: flat fields override sub-table defaults
         let mut artifacts = raw.artifacts.unwrap_or_default();
-        if let Some(v) = raw.memory_dir {
-            artifacts.memory_dir = Some(v);
+        if let Some(v) = raw.execution_memory_base_path {
+            artifacts.execution_memory_base_path = Some(v);
         }
         if let Some(v) = raw.result_artifact_threshold {
             artifacts.result_artifact_threshold = v;
@@ -697,7 +697,7 @@ mod tests {
         // Artifact threshold defaults (sub-table)
         assert_eq!(config.result_artifact_threshold(), 4000);
         assert_eq!(config.result_summary_length(), 2000);
-        assert!(config.memory_dir().is_none());
+        assert!(config.execution_memory_base_path().is_none());
         assert_eq!(config.session_history_turns(), 3);
     }
 
@@ -1210,7 +1210,7 @@ mod tests {
             result_summary_length = 3000
         "#;
         let config: OrchestrationConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.memory_dir(), Some("/tmp/test"));
+        assert_eq!(config.execution_memory_base_path(), Some("/tmp/test"));
         assert_eq!(config.result_artifact_threshold(), 5000);
         assert_eq!(config.result_summary_length(), 3000);
     }
@@ -1224,13 +1224,13 @@ mod tests {
             per_call_timeout_secs = 45
 
             [artifacts]
-            memory_dir = "/tmp/new-style"
+            execution_memory_base_path = "/tmp/new-style"
             result_artifact_threshold = 8000
             result_summary_length = 1500
         "#;
         let config: OrchestrationConfig = toml::from_str(toml).unwrap();
         assert_eq!(config.per_call_timeout_secs(), 45);
-        assert_eq!(config.memory_dir(), Some("/tmp/new-style"));
+        assert_eq!(config.execution_memory_base_path(), Some("/tmp/new-style"));
         assert_eq!(config.result_artifact_threshold(), 8000);
         assert_eq!(config.result_summary_length(), 1500);
     }
@@ -1252,7 +1252,7 @@ mod tests {
             memory_path = "/tmp/alias-test"
         "#;
         let config: OrchestrationConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.memory_dir(), Some("/tmp/alias-test"));
+        assert_eq!(config.execution_memory_base_path(), Some("/tmp/alias-test"));
     }
 
     #[test]
@@ -1262,7 +1262,7 @@ mod tests {
             memory_path = "/tmp/flat-alias"
         "#;
         let config: OrchestrationConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.memory_dir(), Some("/tmp/flat-alias"));
+        assert_eq!(config.execution_memory_base_path(), Some("/tmp/flat-alias"));
     }
 
     // ========================================================================
@@ -1281,7 +1281,7 @@ mod tests {
             enabled = true
 
             [artifacts]
-            memory_dir = "/tmp/test"
+            execution_memory_base_path = "/tmp/test"
             session_history_turns = 5
         "#;
         let config: OrchestrationConfig = toml::from_str(toml).unwrap();

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -376,18 +376,18 @@ impl Orchestrator {
         let (tool_call_observer, _rx) = ToolCallObserver::new(32);
 
         // Initialize execution persistence for debugging and retry intelligence
-        let persistence = if let Some(memory_dir) = orchestration_config.memory_dir() {
+        let persistence = if let Some(base_path) = orchestration_config.execution_memory_base_path() {
             tracing::info!(
                 "Orchestrator: Initializing execution persistence at: {}",
-                memory_dir
+                base_path
             );
             Arc::new(Mutex::new(
-                ExecutionPersistence::new(memory_dir, agent_config.session_id.clone())
+                ExecutionPersistence::new(base_path, agent_config.session_id.clone())
                     .await
                     .map_err(|e| format!("Failed to initialize persistence: {}", e))?,
             ))
         } else {
-            tracing::info!("Orchestrator: Persistence disabled (no memory_dir configured)");
+            tracing::info!("Orchestrator: Persistence disabled (no execution_memory_base_path configured)");
             Arc::new(Mutex::new(ExecutionPersistence::disabled()))
         };
 
@@ -397,7 +397,7 @@ impl Orchestrator {
         let journal_enabled = std::env::var("AURA_PROMPT_JOURNAL")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
-        let prompt_journal = if orchestration_config.memory_dir().is_some() {
+        let prompt_journal = if orchestration_config.execution_memory_base_path().is_some() {
             let guard = persistence.lock().await;
             let run_id = guard.run_id().to_string();
             let run_path = guard.run_path().to_path_buf();
@@ -1763,12 +1763,12 @@ Assign tasks to the worker whose tools best match the required operations."#,
 
         // Load and inject session history from prior runs
         if self.config.session_history_turns() > 0
-            && let Some(memory_dir) = self.config.memory_dir()
+            && let Some(base_path) = self.config.execution_memory_base_path()
         {
             let persistence = self.persistence.lock().await;
             if let Some(session_id) = persistence.session_id() {
                 let manifests = super::persistence::load_session_manifests(
-                    std::path::Path::new(memory_dir),
+                    std::path::Path::new(base_path),
                     session_id,
                     persistence.run_id(),
                     self.config.session_history_turns(),

--- a/crates/aura/src/orchestration/persistence.rs
+++ b/crates/aura/src/orchestration/persistence.rs
@@ -8,25 +8,37 @@
 //!
 //! With session_id (web server path):
 //! ```text
-//! {base_path}/{session_id}/
-//! ├── latest -> {run_id}/              # Symlink to most recent run in session
+//! {execution_memory_base_path}/{session_id}/
+//! ├── latest -> {run_id}/                   # Symlink to most recent run in session
 //! └── {run_id}/
-//!     ├── manifest.json                # Typed run manifest (RunManifest)
-//!     ├── artifacts/                   # Run-level result artifacts
-//!     │   └── task-0-result.txt
-//!     └── iteration-{n}/              # One flat dir per iteration
+//!     ├── manifest.json                     # Typed run manifest (RunManifest)
+//!     ├── artifacts/                        # Run-level result artifacts
+//!     │   └── task-{number}-result.txt
+//!     └── iteration-{number}/               # One flat dir per iteration
+//!         ├── evaluation.prompt.txt
+//!         ├── evaluation.response.txt
+//!         ├── evaluation.result.json
 //!         ├── plan.json
-//!         ├── ...
+//!         ├── planning.prompt.txt
+//!         ├── planning.response.txt
+//!         ├── summary.json
+//!         ├── synthesis.prompt.txt
+//!         ├── synthesis.response.txt
+//!         ├── task-{number}.attempt-{number}.prompt.txt
+//!         ├── task-{number}.attempt-{number}.response.txt
+//!         ├── task-{number}.attempt-{number}.result.json
+//!         └── task-{number}.attempt-{number}.tool-calls.json
 //! ```
 //!
 //! Without session_id (CLI/test path):
 //! ```text
-//! {base_path}/
+//! {execution_memory_base_path}/
 //! ├── latest -> {run_id}/
 //! └── {run_id}/
 //!     ├── manifest.json
 //!     ├── artifacts/
-//!     └── iteration-{n}/
+//!     └── iteration-{number}/
+//!         ├── * (see above)
 //! ```
 
 use serde::{Deserialize, Serialize};
@@ -143,10 +155,15 @@ pub struct TaskExecutionRecord {
 /// Manages execution artifact persistence (async).
 #[derive(Clone)]
 pub struct ExecutionPersistence {
+    /// Base directory for this run's artifacts (e.g. `{base_path}/{session_id}/{run_id}/`).
     base_path: PathBuf,
+    /// Unique identifier for this run (UUID).
     run_id: String,
+    /// Session ID for this run (if any, used for grouping runs in web server).
     session_id: Option<String>,
+    /// Current iteration number (starts at 0, increments on replan).
     current_iteration: usize,
+    /// Whether persistence is enabled (if false, all methods are no-ops).
     enabled: bool,
 }
 
@@ -245,10 +262,13 @@ impl ExecutionPersistence {
         self.current_iteration
     }
 
-    /// Get iteration directory path (flat, directly under run dir).
-    fn iteration_path(&self) -> PathBuf {
-        self.base_path
-            .join(format!("iteration-{}", self.current_iteration))
+    /// Get iteration directory path (flat, directly under run dir), creating it if needed.
+    async fn create_or_get_iteration_path(&self) -> io::Result<PathBuf> {
+        let iter_path = self
+            .base_path
+            .join(format!("iteration-{}", self.current_iteration));
+        fs::create_dir_all(&iter_path).await?;
+        Ok(iter_path)
     }
 
     /// Build a dot-namespaced filename for a task attempt artifact.
@@ -262,8 +282,7 @@ impl ExecutionPersistence {
             return Ok(PathBuf::new());
         }
 
-        let iter_path = self.iteration_path();
-        fs::create_dir_all(&iter_path).await?;
+        let iter_path = self.create_or_get_iteration_path().await?;
 
         let plan_path = iter_path.join("plan.json");
         let json = serde_json::to_string_pretty(plan)
@@ -280,8 +299,7 @@ impl ExecutionPersistence {
             return Ok(PathBuf::new());
         }
 
-        let iter_path = self.iteration_path();
-        fs::create_dir_all(&iter_path).await?;
+        let iter_path = self.create_or_get_iteration_path().await?;
 
         fs::write(iter_path.join("planning.prompt.txt"), prompt).await?;
         fs::write(iter_path.join("planning.response.txt"), response).await?;
@@ -302,8 +320,7 @@ impl ExecutionPersistence {
             return Ok(PathBuf::new());
         }
 
-        let iter_path = self.iteration_path();
-        fs::create_dir_all(&iter_path).await?;
+        let iter_path = self.create_or_get_iteration_path().await?;
 
         // Write prompt and response with namespaced filenames
         let prompt_file = self.task_attempt_filename(task_id, attempt, "prompt.txt");
@@ -339,8 +356,7 @@ impl ExecutionPersistence {
             return Ok(PathBuf::new());
         }
 
-        let iter_path = self.iteration_path();
-        fs::create_dir_all(&iter_path).await?;
+        let iter_path = self.create_or_get_iteration_path().await?;
 
         fs::write(iter_path.join("synthesis.prompt.txt"), prompt).await?;
         fs::write(iter_path.join("synthesis.response.txt"), response).await?;
@@ -361,8 +377,7 @@ impl ExecutionPersistence {
             return Ok(PathBuf::new());
         }
 
-        let iter_path = self.iteration_path();
-        fs::create_dir_all(&iter_path).await?;
+        let iter_path = self.create_or_get_iteration_path().await?;
 
         fs::write(iter_path.join("evaluation.prompt.txt"), prompt).await?;
         fs::write(iter_path.join("evaluation.response.txt"), response).await?;
@@ -395,8 +410,7 @@ impl ExecutionPersistence {
             "timestamp": chrono::Utc::now().to_rfc3339(),
         });
 
-        let iter_path = self.iteration_path();
-        fs::create_dir_all(&iter_path).await?;
+        let iter_path = self.create_or_get_iteration_path().await?;
 
         let summary_path = iter_path.join("summary.json");
         let json = serde_json::to_string_pretty(&summary)
@@ -534,9 +548,7 @@ impl ExecutionPersistence {
             return Ok(());
         }
 
-        let iter_path = self.iteration_path();
-        fs::create_dir_all(&iter_path).await?;
-
+        let iter_path = self.create_or_get_iteration_path().await?;
         let tool_file = self.task_attempt_filename(task_id, attempt, "tool-calls.json");
         let tool_calls_path = iter_path.join(&tool_file);
 

--- a/crates/aura/src/orchestration/prompt_journal.rs
+++ b/crates/aura/src/orchestration/prompt_journal.rs
@@ -4,8 +4,8 @@
 //! showing every prompt sent to the LLM across the full orchestration lifecycle.
 //! Each entry is labeled by phase and iteration.
 //!
-//! The journal is written to `{memory_dir}/{run_id}/prompt-journal.md` and is
-//! accessible via the `latest` symlink at `{memory_dir}/latest/prompt-journal.md`.
+//! The journal is written to `{execution_memory_base_path}/{run_id}/prompt-journal.md` and is
+//! accessible via the `latest` symlink at `{execution_memory_base_path}/latest/prompt-journal.md`.
 
 use std::fmt;
 use std::io::{self, Write};

--- a/crates/aura/src/orchestration/templates.rs
+++ b/crates/aura/src/orchestration/templates.rs
@@ -579,7 +579,7 @@ TOOL USAGE:
             allow_clarification: true,
             workers,
             artifacts: ArtifactsConfig {
-                memory_dir: Some("/tmp/aura-math-orchestration".to_string()),
+                execution_memory_base_path: Some("/tmp/aura-math-orchestration".to_string()),
                 ..Default::default()
             },
             ..Default::default()

--- a/e2e-eval/analyze-session-history-eval.py
+++ b/e2e-eval/analyze-session-history-eval.py
@@ -8,7 +8,7 @@ tool-calls.json). No SSE regex.
 
 Usage:
   python3 e2e-eval/analyze-session-history-eval.py \
-    --memory-dir /tmp/aura-math-opus-bedrock \
+    --execution-persistence-base-path /tmp/aura-math-opus-bedrock \
     --session-id session_e2e_<ts>_opus-bedrock \
     [--independent-session-ids id1,id2,id3,id4,id5]
 """
@@ -61,9 +61,9 @@ def load_json(path):
         return None
 
 
-def find_run_dirs(memory_dir, session_id):
+def find_run_dirs(execution_memory_base_path, session_id):
     """Find all run directories under a session, excluding 'latest' symlink."""
-    session_dir = os.path.join(memory_dir, session_id)
+    session_dir = os.path.join(execution_memory_base_path, session_id)
     if not os.path.isdir(session_dir):
         return []
     runs = []
@@ -198,11 +198,11 @@ def check_redundant_tools(turn_key, tool_names):
 
 # ── Main Analysis ─────────────────────────────────────────────────────
 
-def analyze_session(memory_dir, session_id):
+def analyze_session(execution_memory_base_path, session_id):
     """Analyze a session run and return per-turn metrics."""
-    run_dirs = find_run_dirs(memory_dir, session_id)
+    run_dirs = find_run_dirs(execution_memory_base_path, session_id)
     if not run_dirs:
-        print(f"ERROR: No run directories found in {memory_dir}/{session_id}", file=sys.stderr)
+        print(f"ERROR: No run directories found in {execution_memory_base_path}/{session_id}", file=sys.stderr)
         return None
 
     # Extract metrics from all runs
@@ -328,17 +328,17 @@ def print_scorecard(turn_metrics):
     print(f"  Total tools:      {total_tools} (session)")
 
 
-def find_independent_run_dirs(memory_dir):
+def find_independent_run_dirs(execution_memory_base_path):
     """Find run directories for independent mode (no session grouping).
 
     Independent runs from run-model-comparison.sh don't use session IDs,
-    so run dirs (UUIDs with manifest.json) are directly under memory_dir.
+    so run dirs (UUIDs with manifest.json) are directly under execution_memory_base_path.
     """
-    if not os.path.isdir(memory_dir):
+    if not os.path.isdir(execution_memory_base_path):
         return []
     runs = []
-    for entry in os.listdir(memory_dir):
-        run_path = os.path.join(memory_dir, entry)
+    for entry in os.listdir(execution_memory_base_path):
+        run_path = os.path.join(execution_memory_base_path, entry)
         if entry == "latest" or not os.path.isdir(run_path):
             continue
         # Skip session directories (session_e2e_* contain nested run dirs)
@@ -350,26 +350,26 @@ def find_independent_run_dirs(memory_dir):
     return sorted(runs)
 
 
-def analyze_independent(memory_dir, run_ids=None):
+def analyze_independent(execution_memory_base_path, run_ids=None):
     """Analyze independent runs for tool count comparison.
 
-    If run_ids provided, looks for those specific run dirs under memory_dir.
+    If run_ids provided, looks for those specific run dirs under execution_memory_base_path.
     Otherwise, finds all non-session run dirs with manifests.
     """
     total_tools = 0
     if run_ids:
         for rid in run_ids:
             # Try as session_id first, then as direct run_id
-            run_dirs = find_run_dirs(memory_dir, rid)
+            run_dirs = find_run_dirs(execution_memory_base_path, rid)
             if not run_dirs:
-                rd = os.path.join(memory_dir, rid)
+                rd = os.path.join(execution_memory_base_path, rid)
                 if os.path.isdir(rd):
                     run_dirs = [rd]
             for rd in run_dirs:
                 m = extract_turn_metrics(rd)
                 total_tools += m["tool_call_count"]
     else:
-        for rd in find_independent_run_dirs(memory_dir):
+        for rd in find_independent_run_dirs(execution_memory_base_path):
             m = extract_turn_metrics(rd)
             total_tools += m["tool_call_count"]
     return total_tools
@@ -405,7 +405,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Analyze session history eval — measures coordinator use of session history"
     )
-    parser.add_argument("--memory-dir", required=True, help="Persistence base directory (e.g. /tmp/aura-math-opus-bedrock)")
+    parser.add_argument("--execution-persistence-base-path", required=True, help="Persistence base directory (e.g. /tmp/aura-math-opus-bedrock)")
     parser.add_argument("--session-id", required=True, help="Session ID for the dependent-prompt session run")
     parser.add_argument("--independent-session-ids", help="Comma-separated session IDs for independent baseline runs")
     parser.add_argument("--json-export", help="Path to export metrics as JSON")
@@ -414,11 +414,11 @@ def main():
     print("=" * 72)
     print("  Session History Eval — Artifact Analysis")
     print("=" * 72)
-    print(f"  Memory dir:  {args.memory_dir}")
+    print(f"  Persistence base path:  {args.execution_memory_base_path}")
     print(f"  Session ID:  {args.session_id}")
     print()
 
-    result = analyze_session(args.memory_dir, args.session_id)
+    result = analyze_session(args.execution_memory_base_path, args.session_id)
     if result is None:
         sys.exit(1)
 
@@ -444,7 +444,7 @@ def main():
     # Comparison mode
     if args.independent_session_ids:
         indep_ids = [s.strip() for s in args.independent_session_ids.split(",")]
-        indep_tools = analyze_independent(args.memory_dir, indep_ids)
+        indep_tools = analyze_independent(args.execution_memory_base_path, indep_ids)
         session_tools = sum(
             m["tool_call_count"]
             for m in turn_metrics.values()

--- a/e2e-eval/run-session-e2e.sh
+++ b/e2e-eval/run-session-e2e.sh
@@ -182,8 +182,8 @@ print(text[:500])
   fi
 
   # Check persistence directory for planning prompt containing session history
-  local memory_dir
-  memory_dir=$(grep -o 'memory_dir = "[^"]*"' "$RESULTS_DIR/$model_name/config-info.txt" 2>/dev/null | cut -d'"' -f2 || echo "")
+  local execution_memory_base_path
+  execution_memory_base_path=$(grep -o 'execution_memory_base_path = "[^"]*"' "$RESULTS_DIR/$model_name/config-info.txt" 2>/dev/null | cut -d'"' -f2 || echo "")
 
   printf "  %-25s %6dms  tools=%-2s %-4s" "$label" "$elapsed_ms" "$tool_calls" "$status"
   if [[ "$completed" == "yes" ]]; then
@@ -231,7 +231,7 @@ for idx in "${!CONFIGS[@]}"; do
   echo "--- $model ($config) ---"
 
   # Save config info
-  grep -E "memory_dir|session_history_turns|model" "$config" > "$outdir/config-info.txt" 2>/dev/null || true
+  grep -E "execution_memory_base_path|session_history_turns|model" "$config" > "$outdir/config-info.txt" 2>/dev/null || true
 
   # Start server
   CONFIG_PATH="$config" AURA_CUSTOM_EVENTS=true AURA_EMIT_REASONING=true AURA_PROMPT_JOURNAL=true \
@@ -273,11 +273,11 @@ print(json.dumps(history))
   echo ""
 
   # ── Analyze session artifacts ──────────────────────────────────
-  memory_dir=$(grep -o 'memory_dir *= *"[^"]*"' "$config" | head -1 | cut -d'"' -f2 || echo "")
-  if [[ -n "$memory_dir" ]]; then
-    echo "  Session artifacts ($memory_dir):"
+  execution_memory_base_path=$(grep -o 'execution_memory_base_path *= *"[^"]*"' "$config" | head -1 | cut -d'"' -f2 || echo "")
+  if [[ -n "$execution_memory_base_path" ]]; then
+    echo "  Session artifacts ($execution_memory_base_path):"
 
-    session_dir="$memory_dir/$SESSION_ID"
+    session_dir="$execution_memory_base_path/$SESSION_ID"
     if [[ -d "$session_dir" ]]; then
       manifest_count=$(find "$session_dir" -maxdepth 2 -name "manifest.json" ! -path "*/latest/*" 2>/dev/null | wc -l | tr -d ' ')
       echo "    Session dir: $session_dir"


### PR DESCRIPTION
summary: swapped out the artifacts config from memory_dir to execution_persistence_base_path to be a bit more concise. The previous memory_dir and memory_path are still supported. Updated all docs and examples. Also cleaned up some duplicate directory creation code in persistence.

ref: LOG-23545