### PR TITLE
chore(config): moved llm specific configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ For LibreChat/OpenWebUI integration, see [development/README.md](development/REA
 
 ## Configuration
 
+> **Breaking changes (10 April 2026)**: Several fields have moved from `[agent]` to `[llm]` and Ollama-specific fields have been consolidated under `[llm.additional_params]`. Configs that have not been updated will fail to parse. See [./docs/breaking-changes/20260410-agent-llm-toml-configuration.md](docs/breaking-changes/20260410-agent-llm-toml-configuration.md) for migration details.
+
 `CONFIG_PATH` can point to a single TOML file or a directory of `.toml` files. When pointed at a directory, Aura loads every `.toml` file and serves each as a selectable agent. Clients choose an agent via the `model` field in chat completion requests — the same field that tools like LibreChat, OpenWebUI, and CLI clients use to present a model picker.
 
 ### Multiple Agents
@@ -222,6 +224,7 @@ Minimal example:
 provider = "openai"
 api_key = "{{ env.OPENAI_API_KEY }}"
 model = "gpt-5.2"
+context_window = 128000
 
 [mcp.servers.my_server]
 transport = "http_streamable"
@@ -409,6 +412,7 @@ Detailed test guidance: [crates/aura-web-server/tests/README.md](crates/aura-web
 - [docs/ollama-guide.md](docs/ollama-guide.md): Ollama configuration, fallback tool parsing, and local model guidance.
 - [docs/rig-fork-changes.md](docs/rig-fork-changes.md): Rig fork changes and rationale.
 - [development/README.md](development/README.md): LibreChat/OpenWebUI setup and header-forwarding examples.
+- [20260410-configuration-breaking-changes.md](20260410-configuration-breaking-changes.md): breaking configuration changes from 10 April 2026 — field migrations from `[agent]` to `[llm]` and Ollama parameter consolidation.
 
 ## Architecture
 

--- a/configs/integration-orchestration.toml
+++ b/configs/integration-orchestration.toml
@@ -7,6 +7,7 @@
 provider = "openai"
 api_key = "{{ env.OPENAI_API_KEY }}"
 model = "gpt-5.1"
+temperature = 0.3
 
 [agent]
 name = "Math Orchestrator Test"
@@ -20,7 +21,6 @@ ROUTING GUIDANCE:
 - Vague or ambiguous requests: ask for clarification
 """
 turn_depth = 5
-temperature = 0.3
 
 [mcp]
 sanitize_schemas = true

--- a/configs/integration-sre-orchestration.toml
+++ b/configs/integration-sre-orchestration.toml
@@ -7,6 +7,7 @@
 provider = "openai"
 api_key = "{{ env.OPENAI_API_KEY }}"
 model = "gpt-5.1"
+temperature = 0.3
 
 [agent]
 name = "SRE Orchestrator Test"
@@ -22,7 +23,6 @@ ROUTING GUIDANCE:
 - Simple factual questions about the cluster: answer directly if possible
 """
 turn_depth = 8
-temperature = 0.3
 
 [mcp]
 sanitize_schemas = true

--- a/configs/math-orchestration-claude-thinking.toml
+++ b/configs/math-orchestration-claude-thinking.toml
@@ -19,6 +19,8 @@
 provider = "anthropic"
 api_key = "{{ env.ANTHROPIC_API_KEY }}"
 model = "claude-sonnet-4-5-20250929"
+temperature = 1.0
+additional_params = { thinking = { type = "enabled", budget_tokens = 8000 } }
 
 [agent]
 name = "Math Orchestrator (Thinking)"
@@ -31,8 +33,6 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-temperature = 1.0
-additional_params = { thinking = { type = "enabled", budget_tokens = 8000 } }
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-glm.toml
+++ b/configs/math-orchestration-glm.toml
@@ -10,6 +10,7 @@ provider = "openai"
 api_key = "no-key-needed"
 base_url = "http://localhost:11435/v1"
 model = "glm-64k-p6"
+temperature = 0.3
 
 [agent]
 name = "Math Orchestrator"
@@ -22,7 +23,6 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-gpt5-thinking.toml
+++ b/configs/math-orchestration-gpt5-thinking.toml
@@ -21,6 +21,7 @@
 provider = "openai"
 api_key = "{{ env.OPENAI_API_KEY }}"
 model = "gpt-5.1"
+reasoning_effort = "medium"
 
 [agent]
 name = "Math Orchestrator"
@@ -33,7 +34,6 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-reasoning_effort = "medium"
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-ministral.toml
+++ b/configs/math-orchestration-ministral.toml
@@ -10,6 +10,7 @@ provider = "openai"
 api_key = "no-key-needed"
 base_url = "http://localhost:11435/v1"
 model = "ministral3-64k"
+temperature = 0.3
 
 [agent]
 name = "Math Orchestrator"
@@ -22,7 +23,6 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-nemotron.toml
+++ b/configs/math-orchestration-nemotron.toml
@@ -10,6 +10,7 @@ provider = "openai"
 api_key = "no-key-needed"
 base_url = "http://localhost:11435/v1"
 model = "nemotron-64k-p6"
+temperature = 0.3
 
 [agent]
 name = "Math Orchestrator"
@@ -22,7 +23,6 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-opus-bedrock.toml
+++ b/configs/math-orchestration-opus-bedrock.toml
@@ -11,6 +11,8 @@
 provider = "bedrock"
 model = "global.anthropic.claude-opus-4-5-20251101-v1:0"
 region = "{{ env.AWS_REGION | default: 'us-east-1' }}"
+temperature = 1.0
+additional_params = { thinking = { type = "enabled", budget_tokens = 8000 } }
 
 [agent]
 name = "Math Orchestrator (Opus Bedrock)"
@@ -23,8 +25,7 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-temperature = 1.0
-additional_params = { thinking = { type = "enabled", budget_tokens = 8000 } }
+
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-qwen-thinking.toml
+++ b/configs/math-orchestration-qwen-thinking.toml
@@ -10,6 +10,7 @@ provider = "openai"
 api_key = "no-key-needed"
 base_url = "http://localhost:11435/v1"
 model = "qwen3-thinking-64k-p2"
+temperature = 0.3
 
 [agent]
 name = "Math Orchestrator"
@@ -22,7 +23,6 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-qwen3.toml
+++ b/configs/math-orchestration-qwen3.toml
@@ -8,6 +8,10 @@ provider = "openai"
 api_key = "no-key-needed"
 base_url = "http://localhost:11435/v1"
 model = "qwen3-instruct-64k-p2"
+temperature = 0.3
+
+[llm.additional_params.chat_template_kwargs]
+enable_thinking = false
 
 [agent]
 name = "Math Orchestrator"
@@ -20,10 +24,6 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-temperature = 0.3
-
-[agent.additional_params.chat_template_kwargs]
-enable_thinking = false
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-qwen35-ollama.toml
+++ b/configs/math-orchestration-qwen35-ollama.toml
@@ -8,6 +8,7 @@ provider = "openai"
 api_key = "no-key-needed"
 base_url = "http://localhost:11434/v1"
 model = "qwen3.5:35b-a3b"
+temperature = 0.3
 
 [agent]
 name = "Math Orchestrator"
@@ -20,7 +21,6 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-qwen35-thinking.toml
+++ b/configs/math-orchestration-qwen35-thinking.toml
@@ -8,6 +8,10 @@ provider = "openai"
 api_key = "no-key-needed"
 base_url = "http://localhost:11435/v1"
 model = "qwen35-64k-p3"
+temperature = 0.3
+
+[llm.additional_params.chat_template_kwargs]
+enable_thinking = true
 
 [agent]
 name = "Math Orchestrator"
@@ -20,10 +24,6 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-temperature = 0.3
-
-[agent.additional_params.chat_template_kwargs]
-enable_thinking = true
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-qwen35.toml
+++ b/configs/math-orchestration-qwen35.toml
@@ -8,6 +8,10 @@ provider = "openai"
 api_key = "no-key-needed"
 base_url = "http://localhost:11435/v1"
 model = "qwen35-64k-p3"
+temperature = 0.3
+
+[llm.additional_params.chat_template_kwargs]
+enable_thinking = false
 
 [agent]
 name = "Math Orchestrator"
@@ -20,10 +24,6 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-temperature = 0.3
-
-[agent.additional_params.chat_template_kwargs]
-enable_thinking = false
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-sonnet.toml
+++ b/configs/math-orchestration-sonnet.toml
@@ -21,6 +21,7 @@
 provider = "anthropic"
 api_key = "{{ env.ANTHROPIC_API_KEY }}"
 model = "claude-sonnet-4-5-20250929"
+temperature = 0.3
 
 [agent]
 name = "Math Orchestrator"
@@ -33,7 +34,6 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration.toml
+++ b/configs/math-orchestration.toml
@@ -25,6 +25,7 @@ base_url = "http://localhost:11435/v1"
 # model = "gpt-5.1"
 model = "qwen3-coder-64k-p2"
 # model = "deepseek-r1:32b"
+temperature = 0.3
 
 # [llm.additional_params]
 # think = true  # only works in streaming mode; breaks worker (non-streaming) calls
@@ -40,7 +41,6 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
-temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/sre-orchestration.toml
+++ b/configs/sre-orchestration.toml
@@ -22,10 +22,12 @@
 provider = "openai"
 api_key = "{{ env.OPENAI_API_KEY }}"
 model = "gpt-5.1"
+temperature = 0.3
 
 # --- ollama config (commented out) ---
 # provider = "ollama"
 # model = "qwen3-coder:30b"
+# [llm.additional_params]
 # num_ctx = 262144
 
 [agent]
@@ -41,7 +43,6 @@ ROUTING GUIDANCE:
 - Multi-domain tasks (e.g., discover then monitor): create a plan with multiple workers
 - Simple factual questions about the cluster: answer directly if possible
 """
-temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/crates/aura-config/src/bin/architecture_diagram.rs
+++ b/crates/aura-config/src/bin/architecture_diagram.rs
@@ -36,22 +36,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("│                                                         │");
 
         let (provider, model) = match &config.llm {
-            aura_config::config::LlmConfig::OpenAI { model, .. } => ("openai", model.clone()),
-            aura_config::config::LlmConfig::Anthropic { model, .. } => ("anthropic", model.clone()),
-            aura_config::config::LlmConfig::Bedrock { model, .. } => ("bedrock", model.clone()),
-            aura_config::config::LlmConfig::Gemini { model, .. } => ("gemini", model.clone()),
-            aura_config::config::LlmConfig::Ollama { model, .. } => ("ollama", model.clone()),
+            aura::config::LlmConfig::OpenAI { model, .. } => ("openai", model.clone()),
+            aura::config::LlmConfig::Anthropic { model, .. } => ("anthropic", model.clone()),
+            aura::config::LlmConfig::Bedrock { model, .. } => ("bedrock", model.clone()),
+            aura::config::LlmConfig::Gemini { model, .. } => ("gemini", model.clone()),
+            aura::config::LlmConfig::Ollama { model, .. } => ("ollama", model.clone()),
         };
 
+        let provider_padded = format!("{provider:13}");
+        let model_padded = format!("{model:19}");
         match provider {
             "openai" => {
                 println!("│  ┌─────────────────────────────────────────────────┐    │");
                 println!("│  │           🧠 OpenAI LLM Client                  │    │");
                 println!("│  │                                                 │    │");
-                println!("│  │  Provider: {provider}                        │    │");
-                println!("│  │  Model: {model}                     │    │");
+                println!("│  │  Provider: {provider_padded}                        │    │");
+                println!("│  │  Model: {model_padded}                     │    │");
                 println!(
-                    "│  │  System Prompt: {}...        │    │",
+                    "│  │  System Prompt: {}...         │    │",
                     config
                         .agent
                         .system_prompt
@@ -65,8 +67,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("│  ┌─────────────────────────────────────────────────┐    │");
                 println!("│  │          🧠 Anthropic LLM Client                │    │");
                 println!("│  │                                                 │    │");
-                println!("│  │  Provider: {provider}                      │    │");
-                println!("│  │  Model: {model}                        │    │");
+                println!("│  │  Provider: {provider_padded}                        │    │");
+                println!("│  │  Model: {model_padded}                     │    │");
                 println!(
                     "│  │  System Prompt: {}...        │    │",
                     config
@@ -82,8 +84,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("│  ┌─────────────────────────────────────────────────┐    │");
                 println!("│  │          🌩️  AWS Bedrock LLM Client             │    │");
                 println!("│  │                                                 │    │");
-                println!("│  │  Provider: {provider}                      │    │");
-                println!("│  │  Model: {model}       │    │");
+                println!("│  │  Provider: {provider_padded}                        │    │");
+                println!("│  │  Model: {model_padded}                     │    │");
                 println!(
                     "│  │  System Prompt: {}...        │    │",
                     config
@@ -119,10 +121,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("│  │                                                 │    │");
         println!("│  │  Provider: {provider}                        │    │");
         println!("│  │  Model: {model}                     │    │");
-        println!(
-            "│  │  Temperature: {}                           │    │",
-            config.agent.temperature.unwrap_or(0.7)
-        );
         println!("│  └─────────────────────────────────────────────────┘    │");
         println!("│                          │                              │");
         println!("│                          ▼                              │");
@@ -152,7 +150,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             for (name, server) in &mcp_config.servers {
                 match server {
                     aura_config::McpServerConfig::HttpStreamable { url, .. } => {
-                        println!("│  │  🌊 {name} (HTTP Streamable)                   │    │");
+                        println!("│  │  🌊 {name} (HTTP Streamable)              │    │");
                         println!(
                             "│  │     URL: {}              │    │",
                             if url.len() > 25 {
@@ -197,13 +195,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 store.embedding_model.model
             );
         } else {
-            println!("│  │  No vector stores configured               │    │");
+            println!("│  │  No vector stores configured.                   │    │");
             println!("│  │                                                 │    │");
             println!("│  │  ┌─────────────────────────────────────────┐    │    │");
             println!("│  │  │        🔤 NO EMBEDDING MODEL            │    │    │");
             println!("│  │  │                                         │    │    │");
-            println!("│  │  │  Provider: N/A              │    │    │");
-            println!("│  │  │  Model: N/A                 │    │    │");
+            println!("│  │  │  Provider: N/A                          │    │    │");
+            println!("│  │  │  Model: N/A                             │    │    │");
         }
         println!("│  │  └─────────────────────────────────────────┘    │    │");
         println!("│  └─────────────────────────────────────────────────┘    │");
@@ -217,23 +215,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         if config.mcp.is_some() {
             println!("│  🔴 MCP Server Integration                              │");
-            println!("│     → Need to connect MCP servers to agent tools       │");
-            println!("│     → Requires rig::agent.tool() integration           │");
+            println!("│     → Need to connect MCP servers to agent tools        │");
+            println!("│     → Requires rig::agent.tool() integration            │");
             println!("│                                                         │");
         }
 
         println!("│  🔴 Vector Store Integration                            │");
-        println!("│     → Need to create vector store from config          │");
-        println!("│     → Need document ingestion pipeline                 │");
-        println!("│     → Need to connect to agent for RAG queries         │");
+        println!("│     → Need to create vector store from config           │");
+        println!("│     → Need document ingestion pipeline                  │");
+        println!("│     → Need to connect to agent for RAG queries          │");
         println!("│                                                         │");
 
         if let Some(ref tools) = config.tools
             && tools.filesystem
         {
             println!("│  🔴 Filesystem Tool Integration                         │");
-            println!("│     → Need to add filesystem tool to agent             │");
-            println!("│     → Configure file access permissions                │");
+            println!("│     → Need to add filesystem tool to agent              │");
+            println!("│     → Configure file access permissions                 │");
             println!("│                                                         │");
         }
 
@@ -242,49 +240,49 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Implementation Roadmap
     println!("\n🗺️  IMPLEMENTATION ROADMAP:");
-    println!("┌─────────────────────────────────────────────────────────┐");
-    println!("│                    📋 NEXT STEPS                        │");
-    println!("│                                                         │");
-    println!("│  1️⃣  MCP Server Integration                              │");
-    println!("│      • Create MCP client connections from config       │");
-    println!("│      • Add MCP tools to agent with .tool()             │");
-    println!("│                                                         │");
-    println!("│  2️⃣  Vector Store Implementation                         │");
-    println!("│      • Create vector store from VectorStoreConfig      │");
-    println!("│      • Implement document ingestion                    │");
-    println!("│      • Add RAG retrieval to agent                      │");
-    println!("│                                                         │");
-    println!("│  3️⃣  Tools Integration                                   │");
-    println!("│      • Add filesystem tools to agent                   │");
-    println!("│      • Configure tool permissions and access           │");
-    println!("│                                                         │");
-    println!("│  4️⃣  Advanced Features                                   │");
-    println!("│      • Multi-provider support                          │");
-    println!("│      • Dynamic tool loading                            │");
-    println!("│      • Configuration validation                        │");
-    println!("└─────────────────────────────────────────────────────────┘");
+    println!("┌──────────────────────────────────────────────────────────┐");
+    println!("│                    📋 NEXT STEPS                         │");
+    println!("│                                                          │");
+    println!("│  1️⃣  MCP Server Integration                               │");
+    println!("│      • Create MCP client connections from config.        │");
+    println!("│      • Add MCP tools to agent with .tool()               │");
+    println!("│                                                          │");
+    println!("│  2️⃣  Vector Store Implementation                          │");
+    println!("│      • Create vector store from VectorStoreConfig.       │");
+    println!("│      • Implement document ingestion                      │");
+    println!("│      • Add RAG retrieval to agent                        │");
+    println!("│                                                          │");
+    println!("│  3️⃣  Tools Integration                                    │");
+    println!("│      • Add filesystem tools to agent                     │");
+    println!("│      • Configure tool permissions and access             │");
+    println!("│                                                          │");
+    println!("│  4️⃣  Advanced Features                                    │");
+    println!("│      • Multi-provider support                            │");
+    println!("│      • Dynamic tool loading                              │");
+    println!("│      • Configuration validation                          │");
+    println!("└──────────────────────────────────────────────────────────┘");
 
     // Rig.rs API Usage
     println!("\n🔧 RIG.RS API INTEGRATION NEEDED:");
-    println!("┌─────────────────────────────────────────────────────────┐");
-    println!("│                   📚 RIG API CALLS                      │");
-    println!("│                                                         │");
-    println!("│  Current (Simple):                                      │");
-    println!("│  ```rust                                                │");
-    println!("│  let agent = client.agent(model).preamble(prompt).build()│");
-    println!("│  ```                                                    │");
-    println!("│                                                         │");
-    println!("│  Target (Full Integration):                             │");
-    println!("│  ```rust                                                │");
-    println!("│  let agent = client.agent(model)                       │");
-    println!("│      .preamble(system_prompt)                          │");
-    println!("│      .tool(filesystem_tool)                            │");
-    println!("│      .tool(mcp_tool_1)                                 │");
-    println!("│      .tool(mcp_tool_2)                                 │");
-    println!("│      .context(vector_store)                            │");
-    println!("│      .build()                                          │");
-    println!("│  ```                                                    │");
-    println!("└─────────────────────────────────────────────────────────┘");
+    println!("┌────────────────────────────────────────────────────────────┐");
+    println!("│                   📚 RIG API CA LLS                        │");
+    println!("│                                                            │");
+    println!("│  Current (Simple):                                         │");
+    println!("│  ```rust                                                   │");
+    println!("│  let agent = client.agent(model).preamble(prompt).build()  │");
+    println!("│  ```                                                       │");
+    println!("│                                                            │");
+    println!("│  Target (Full Integration):                                │");
+    println!("│  ```rust                                                   │");
+    println!("│  let agent = client.agent(model)                           │");
+    println!("│      .preamble(system_prompt)                              │");
+    println!("│      .tool(filesystem_tool)                                │");
+    println!("│      .tool(mcp_tool_1)                                     │");
+    println!("│      .tool(mcp_tool_2)                                     │");
+    println!("│      .context(vector_store)                                │");
+    println!("│      .build()                                              │");
+    println!("│  ```                                                       │");
+    println!("└────────────────────────────────────────────────────────────┘");
 
     println!("\n✅ Configuration parsing is complete and working!");
     println!("🎯 Next: Implement the missing integrations above\n");

--- a/crates/aura-config/src/bin/debug_config.rs
+++ b/crates/aura-config/src/bin/debug_config.rs
@@ -6,6 +6,7 @@ const TEST_CONFIG: &str = r#"
 provider = "openai"
 api_key = "test_openai_key"
 model = "gpt-4o-mini"
+temperature = 0.7
 
 [vector_store]
 type = "in_memory"
@@ -50,7 +51,6 @@ context = [
     "You can use tools to help answer questions.",
     "Be concise but thorough in your responses."
 ]
-temperature = 0.7
 "#;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -67,11 +67,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Test specific parts
     println!("\n🔍 Specific sections:");
     let (provider, model) = match &config.llm {
-        aura_config::config::LlmConfig::OpenAI { model, .. } => ("openai", model.as_str()),
-        aura_config::config::LlmConfig::Anthropic { model, .. } => ("anthropic", model.as_str()),
-        aura_config::config::LlmConfig::Bedrock { model, .. } => ("bedrock", model.as_str()),
-        aura_config::config::LlmConfig::Gemini { model, .. } => ("gemini", model.as_str()),
-        aura_config::config::LlmConfig::Ollama { model, .. } => ("ollama", model.as_str()),
+        aura::config::LlmConfig::OpenAI { model, .. } => ("openai", model.as_str()),
+        aura::config::LlmConfig::Anthropic { model, .. } => ("anthropic", model.as_str()),
+        aura::config::LlmConfig::Bedrock { model, .. } => ("bedrock", model.as_str()),
+        aura::config::LlmConfig::Gemini { model, .. } => ("gemini", model.as_str()),
+        aura::config::LlmConfig::Ollama { model, .. } => ("ollama", model.as_str()),
     };
     println!("LLM Provider: {provider} ({model})");
 
@@ -129,10 +129,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    println!(
-        "Agent: {} (temp: {:?})",
-        config.agent.name, config.agent.temperature
-    );
     if !config.vector_stores.is_empty() {
         println!("Vector Stores: {} configured", config.vector_stores.len());
         for (i, store) in config.vector_stores.iter().enumerate() {

--- a/crates/aura-config/src/builder.rs
+++ b/crates/aura-config/src/builder.rs
@@ -1,8 +1,8 @@
 use crate::{Config, ConfigError};
 use aura::{
-    Agent, AgentBuilder, AgentConfig, AgentSettings, EmbeddingModelConfig, LlmConfig, McpConfig,
-    McpServerConfig, OrchestrationConfig, ReasoningEffort, StreamingAgent, ToolsConfig,
-    VectorStoreConfig, orchestration::ToolVisibility as AuraToolVisibility,
+    Agent, AgentBuilder, AgentConfig, AgentSettings, EmbeddingModelConfig, McpConfig,
+    McpServerConfig, OrchestrationConfig, StreamingAgent, ToolsConfig, VectorStoreConfig,
+    orchestration::ToolVisibility as AuraToolVisibility,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -22,82 +22,13 @@ impl RigBuilder {
     }
 
     fn to_agent_config(&self) -> Result<AgentConfig, ConfigError> {
-        let llm = match &self.config.llm {
-            crate::config::LlmConfig::OpenAI {
-                api_key,
-                model,
-                base_url,
-            } => LlmConfig::OpenAI {
-                api_key: api_key.clone(),
-                model: model.clone(),
-                base_url: base_url.clone(),
-                max_tokens: None,
-            },
-            crate::config::LlmConfig::Anthropic {
-                api_key,
-                model,
-                base_url,
-            } => LlmConfig::Anthropic {
-                api_key: api_key.clone(),
-                model: model.clone(),
-                base_url: base_url.clone(),
-                max_tokens: None,
-            },
-            crate::config::LlmConfig::Bedrock {
-                model,
-                region,
-                profile,
-            } => LlmConfig::Bedrock {
-                model: model.clone(),
-                region: region.clone(),
-                profile: profile.clone(),
-                max_tokens: None,
-            },
-            crate::config::LlmConfig::Gemini {
-                api_key,
-                model,
-                base_url,
-            } => LlmConfig::Gemini {
-                api_key: api_key.clone(),
-                model: model.clone(),
-                base_url: base_url.clone(),
-                max_tokens: None,
-            },
-            crate::config::LlmConfig::Ollama {
-                model,
-                base_url,
-                fallback_tool_parsing,
-                num_ctx,
-                num_predict,
-                additional_params,
-            } => LlmConfig::Ollama {
-                model: model.clone(),
-                base_url: Some(base_url.clone()),
-                max_tokens: None,
-                fallback_tool_parsing: *fallback_tool_parsing,
-                num_ctx: *num_ctx,
-                num_predict: *num_predict,
-                additional_params: additional_params.clone(),
-            },
-        };
-
-        let reasoning_effort = self.config.agent.reasoning_effort.map(|r| match r {
-            crate::config::ReasoningEffort::Minimal => ReasoningEffort::Minimal,
-            crate::config::ReasoningEffort::Low => ReasoningEffort::Low,
-            crate::config::ReasoningEffort::Medium => ReasoningEffort::Medium,
-            crate::config::ReasoningEffort::High => ReasoningEffort::High,
-        });
+        let llm = self.config.llm.clone();
 
         let agent = AgentSettings {
             name: self.config.agent.name.clone(),
             system_prompt: self.config.agent.system_prompt.clone(),
             context: self.config.agent.context.clone(),
-            temperature: self.config.agent.temperature,
-            reasoning_effort,
-            max_tokens: self.config.agent.max_tokens,
             turn_depth: self.config.agent.turn_depth,
-            context_window: self.config.agent.context_window,
-            additional_params: self.config.agent.additional_params.clone(),
             mcp_filter: self.config.agent.mcp_filter.clone(),
         };
 

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -1,16 +1,6 @@
-use aura::config::lenient_int;
+use aura::{LlmConfig, lenient_int};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-/// Reasoning effort level for GPT-5 models
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ReasoningEffort {
-    Minimal,
-    Low,
-    Medium,
-    High,
-}
 
 /// Root configuration structure for our POC
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -274,125 +264,6 @@ impl Config {
         self.llm.is_fallback_tool_parsing_enabled()
     }
 }
-
-/// LLM provider configuration with strong typing per provider
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(tag = "provider", rename_all = "lowercase")]
-pub enum LlmConfig {
-    OpenAI {
-        api_key: String,
-        model: String,
-        #[serde(default)]
-        base_url: Option<String>,
-    },
-    Anthropic {
-        api_key: String,
-        model: String,
-        #[serde(default)]
-        base_url: Option<String>,
-    },
-    Bedrock {
-        model: String,
-        region: String,
-        /// AWS profile name (optional, uses default credentials if not specified)
-        #[serde(default)]
-        profile: Option<String>,
-    },
-    Gemini {
-        api_key: String,
-        model: String,
-        #[serde(default)]
-        base_url: Option<String>,
-    },
-    Ollama {
-        model: String,
-        #[serde(default = "default_ollama_base_url")]
-        base_url: String,
-        /// Enable fallback tool call parsing from text content.
-        /// Some Ollama models output tool calls as JSON text instead of proper tool_call structures.
-        /// When enabled, the system will attempt to parse tool calls from text responses.
-        /// Default: false
-        #[serde(default)]
-        fallback_tool_parsing: bool,
-        /// Context window size (number of tokens). Maps to Ollama's `num_ctx` option.
-        /// Default: None (uses Ollama's default, typically 2048)
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-        num_ctx: Option<u32>,
-        /// Maximum number of tokens to predict. Maps to Ollama's `num_predict` option.
-        /// Default: None (uses Ollama's default, typically 128)
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-        num_predict: Option<u32>,
-        /// Additional Ollama-specific parameters passed directly to the API.
-        /// Examples: seed, top_k, top_p, mirostat, etc.
-        /// See: https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values
-        #[serde(default)]
-        additional_params: Option<HashMap<String, serde_json::Value>>,
-    },
-}
-
-fn default_ollama_base_url() -> String {
-    "http://localhost:11434".to_string()
-}
-
-impl Default for LlmConfig {
-    fn default() -> Self {
-        LlmConfig::OpenAI {
-            api_key: String::new(),
-            model: "gpt-4o".to_string(),
-            base_url: None,
-        }
-    }
-}
-
-impl LlmConfig {
-    /// Check if fallback tool parsing is enabled.
-    ///
-    /// This is only supported for Ollama models.
-    pub fn is_fallback_tool_parsing_enabled(&self) -> bool {
-        matches!(
-            self,
-            LlmConfig::Ollama {
-                fallback_tool_parsing: true,
-                ..
-            }
-        )
-    }
-
-    /// Get LLM's model name
-    pub fn model_info(&self) -> (&str, &str) {
-        match self {
-            LlmConfig::OpenAI {
-                api_key: _,
-                model,
-                base_url: _,
-            } => ("openai", model),
-            LlmConfig::Anthropic {
-                api_key: _,
-                model,
-                base_url: _,
-            } => ("anthropic", model),
-            LlmConfig::Bedrock {
-                model,
-                region: _,
-                profile: _,
-            } => ("bedrock", model),
-            LlmConfig::Gemini {
-                api_key: _,
-                model,
-                base_url: _,
-            } => ("gemini", model),
-            LlmConfig::Ollama {
-                model,
-                base_url: _,
-                fallback_tool_parsing: _,
-                num_ctx: _,
-                num_predict: _,
-                additional_params: _,
-            } => ("ollama", model),
-        }
-    }
-}
-
 /// MCP servers configuration
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct McpConfig {
@@ -483,6 +354,7 @@ pub struct ToolsConfig {
 
 /// Agent configuration
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct AgentConfig {
     pub name: String,
     #[serde(default)]
@@ -490,20 +362,10 @@ pub struct AgentConfig {
     pub system_prompt: String,
     #[serde(default)]
     pub context: Vec<String>,
-    #[serde(default)]
-    pub temperature: Option<f64>,
-    #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
-    pub max_tokens: Option<u64>,
-    #[serde(default)]
-    pub reasoning_effort: Option<ReasoningEffort>,
     /// Maximum depth of tool calls per turn (default: 5, set to 0 to disable)
     #[serde(default = "default_turn_depth")]
     #[serde(deserialize_with = "lenient_int::deserialize_option_usize")]
     pub turn_depth: Option<usize>,
-    /// Context window size in tokens for this agent. Used for usage percentage
-    /// reporting in streaming events (aura.session_info).
-    #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-    pub context_window: Option<u32>,
     /// Creation timestamp in milliseconds since epoch (defaults to current time)
     #[serde(default = "default_created_at")]
     pub created_at: u64,
@@ -511,11 +373,6 @@ pub struct AgentConfig {
     /// When omitted, defaults to the underlying LLM provider (e.g. "openai", "anthropic").
     #[serde(default)]
     pub model_owner: Option<String>,
-    /// Additional provider-specific parameters merged into the API request.
-    /// Provider-agnostic: works for Anthropic thinking, Gemini thinking budget, etc.
-    /// Example: `{ thinking = { type = "adaptive", budget_tokens = 8000 } }`
-    #[serde(default)]
-    pub additional_params: Option<serde_json::Value>,
     /// Glob patterns for filtering which MCP tools to include.
     /// When set, only tools matching at least one pattern are added.
     /// Example: `mcp_filter = ["sin", "cos", "degreesToRadians"]`
@@ -541,14 +398,9 @@ impl Default for AgentConfig {
             alias: None,
             system_prompt: "You are a helpful assistant.".to_string(),
             context: Vec::new(),
-            temperature: Some(0.7),
-            reasoning_effort: None,
-            max_tokens: None,
             turn_depth: default_turn_depth(),
-            context_window: None,
             created_at: default_created_at(),
             model_owner: None,
-            additional_params: None,
             mcp_filter: None,
         }
     }

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::{config::McpServerConfig, load_config_from_str};
+    use aura::ReasoningEffort;
 
     const TEST_CONFIG: &str = r#"
 [llm]
@@ -8,6 +9,14 @@ provider = "openai"
 api_key = "test_openai_key"
 model = "gpt-4o-mini"
 base_url = "https://api.openai.com/v1"
+reasoning_effort = "medium"
+max_tokens = 1000
+context_window = 200000
+temperature = 0.5
+
+[llm.additional_params.thinking]
+type = "enabled"
+budget_tokens = 8000
 
 [[vector_stores]]
 name = "default"
@@ -50,7 +59,6 @@ custom_tools = ["calculator", "web_search"]
 name = "Test Assistant"
 system_prompt = "You are a test assistant."
 context = ["Context line 1", "Context line 2"]
-temperature = 0.5
 "#;
 
     #[test]
@@ -64,14 +72,37 @@ temperature = 0.5
         // Test LLM config
         println!("\n✅ Testing LLM config...");
         match &config.llm {
-            crate::config::LlmConfig::OpenAI {
+            aura::config::LlmConfig::OpenAI {
                 api_key,
                 model,
                 base_url,
+                reasoning_effort,
+                max_tokens,
+                context_window,
+                temperature,
+                additional_params,
             } => {
                 assert_eq!(api_key, "test_openai_key");
                 assert_eq!(model, "gpt-4o-mini");
                 assert_eq!(base_url, &Some("https://api.openai.com/v1".to_string()));
+                assert_eq!(reasoning_effort, &Some(ReasoningEffort::Medium));
+                assert_eq!(max_tokens, &Some(1000));
+                assert_eq!(context_window, &Some(200_000));
+                assert_eq!(temperature, &Some(0.5));
+
+                assert!(
+                    additional_params.is_some(),
+                    "additional_params should be present"
+                );
+                let params = additional_params.as_ref().unwrap();
+                let thinking = params
+                    .get("thinking")
+                    .expect("thinking params should be present");
+                assert_eq!(thinking.get("type"), Some(&serde_json::json!("enabled")));
+                assert_eq!(
+                    thinking.get("budget_tokens"),
+                    Some(&serde_json::json!(8000))
+                );
             }
             _ => panic!("Expected OpenAI LLM config"),
         }
@@ -187,7 +218,6 @@ temperature = 0.5
             config.agent.context,
             vec!["Context line 1", "Context line 2"]
         );
-        assert_eq!(config.agent.temperature, Some(0.5));
     }
 
     #[test]
@@ -220,15 +250,17 @@ system_prompt = "Basic prompt"
 
         println!("\n✅ Testing minimal config assertions...");
         match &config.llm {
-            crate::config::LlmConfig::Anthropic { model, .. } => {
+            aura::config::LlmConfig::Anthropic {
+                model, temperature, ..
+            } => {
                 assert_eq!(model, "claude-3-sonnet-20240229");
+                assert!(temperature.is_none());
             }
             _ => panic!("Expected Anthropic LLM config"),
         }
         assert!(config.mcp.is_none());
         assert!(config.tools.is_none());
         assert_eq!(config.agent.context.len(), 0);
-        assert_eq!(config.agent.temperature, None);
     }
 
     #[test]
@@ -332,7 +364,7 @@ system_prompt = "Test with env vars"
 
         println!("\n✅ Testing environment variable resolution...");
         match &config.llm {
-            crate::config::LlmConfig::OpenAI { api_key, .. } => {
+            aura::config::LlmConfig::OpenAI { api_key, .. } => {
                 assert_eq!(api_key, "mock_openai_key");
             }
             _ => panic!("Expected OpenAI LLM config"),
@@ -395,11 +427,11 @@ system_prompt = "You are a helpful assistant."
 
         println!("\n✅ Testing Ollama config assertions...");
         match &config.llm {
-            crate::config::LlmConfig::Ollama {
+            aura::config::LlmConfig::Ollama {
                 model, base_url, ..
             } => {
                 assert_eq!(model, "llama3.2");
-                assert_eq!(base_url, "http://localhost:11434"); // default value
+                assert_eq!(base_url, &Some("http://localhost:11434".into())); // default value
             }
             _ => panic!("Expected Ollama LLM config"),
         }
@@ -417,6 +449,7 @@ system_prompt = "You are a helpful assistant."
 provider = "ollama"
 model = "mistral"
 base_url = "http://my-ollama-server:11434"
+temperature = 0.8
 
 [[vector_stores]]
 name = "default"
@@ -430,7 +463,6 @@ api_key = "test_key"
 [agent]
 name = "Remote Ollama Agent"
 system_prompt = "You are a remote assistant."
-temperature = 0.8
 "#;
 
         let config =
@@ -441,66 +473,17 @@ temperature = 0.8
 
         println!("\n✅ Testing Ollama custom URL config assertions...");
         match &config.llm {
-            crate::config::LlmConfig::Ollama {
-                model, base_url, ..
+            aura::config::LlmConfig::Ollama {
+                model,
+                base_url,
+                temperature,
+                ..
             } => {
                 assert_eq!(model, "mistral");
-                assert_eq!(base_url, "http://my-ollama-server:11434");
+                assert_eq!(base_url, &Some("http://my-ollama-server:11434".into()));
+                assert_eq!(temperature, &Some(0.8));
             }
             _ => panic!("Expected Ollama LLM config"),
-        }
-        assert_eq!(config.agent.temperature, Some(0.8));
-    }
-
-    #[test]
-    fn test_ollama_config_with_num_ctx() {
-        println!("\n=== TEST_OLLAMA_CONFIG_WITH_NUM_CTX ===");
-        let config_str = r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-num_ctx = 8192
-
-[agent]
-name = "Test"
-system_prompt = "Test"
-"#;
-        let config = load_config_from_str(config_str).expect("Failed to parse config");
-
-        println!("\n🔍 Ollama Config with num_ctx:");
-        println!("{config:#?}");
-
-        match &config.llm {
-            crate::config::LlmConfig::Ollama { num_ctx, .. } => {
-                assert_eq!(*num_ctx, Some(8192));
-            }
-            _ => panic!("Expected Ollama config"),
-        }
-    }
-
-    #[test]
-    fn test_ollama_config_with_num_predict() {
-        println!("\n=== TEST_OLLAMA_CONFIG_WITH_NUM_PREDICT ===");
-        let config_str = r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-num_predict = 2048
-
-[agent]
-name = "Test"
-system_prompt = "Test"
-"#;
-        let config = load_config_from_str(config_str).expect("Failed to parse config");
-
-        println!("\n🔍 Ollama Config with num_predict:");
-        println!("{config:#?}");
-
-        match &config.llm {
-            crate::config::LlmConfig::Ollama { num_predict, .. } => {
-                assert_eq!(*num_predict, Some(2048));
-            }
-            _ => panic!("Expected Ollama config"),
         }
     }
 
@@ -528,7 +511,7 @@ system_prompt = "Test"
         println!("{config:#?}");
 
         match &config.llm {
-            crate::config::LlmConfig::Ollama {
+            aura::config::LlmConfig::Ollama {
                 additional_params, ..
             } => {
                 let params = additional_params
@@ -576,7 +559,7 @@ system_prompt = "Test"
         println!("{config:#?}");
 
         match &config.llm {
-            crate::config::LlmConfig::Ollama {
+            aura::config::LlmConfig::Ollama {
                 additional_params, ..
             } => {
                 let params = additional_params
@@ -613,16 +596,12 @@ system_prompt = "Test"
         println!("{config:#?}");
 
         match &config.llm {
-            crate::config::LlmConfig::Ollama {
+            aura::config::LlmConfig::Ollama {
                 model,
-                num_ctx,
-                num_predict,
                 additional_params,
                 ..
             } => {
                 assert_eq!(model, "llama3.2");
-                assert_eq!(*num_ctx, None);
-                assert_eq!(*num_predict, None);
                 assert!(additional_params.is_none());
             }
             _ => panic!("Expected Ollama config"),
@@ -864,13 +843,13 @@ model_owner = "mezmo"
 provider = "ollama"
 model = "llama3.2"
 base_url = "http://localhost:11434"
-num_ctx = 4096
-num_predict = 1024
 fallback_tool_parsing = true
+temperature = 0.7
 
 [llm.additional_params]
+num_ctx = 4096
+num_predict = 1024
 seed = 42
-temperature = 0.7
 
 [agent]
 name = "Full Ollama Agent"
@@ -882,25 +861,28 @@ system_prompt = "You are helpful."
         println!("{config:#?}");
 
         match &config.llm {
-            crate::config::LlmConfig::Ollama {
+            aura::config::LlmConfig::Ollama {
                 model,
                 base_url,
-                num_ctx,
-                num_predict,
                 fallback_tool_parsing,
                 additional_params,
+                max_tokens,
+                context_window,
+                temperature,
             } => {
                 assert_eq!(model, "llama3.2");
-                assert_eq!(base_url, "http://localhost:11434");
-                assert_eq!(*num_ctx, Some(4096));
-                assert_eq!(*num_predict, Some(1024));
+                assert_eq!(base_url, &Some("http://localhost:11434".into()));
+                assert_eq!(*max_tokens, None);
+                assert_eq!(*context_window, None);
+                assert_eq!(temperature, &Some(0.7));
                 assert!(*fallback_tool_parsing);
 
                 let params = additional_params
                     .as_ref()
                     .expect("additional_params should be set");
+                assert_eq!(params.get("num_ctx"), Some(&serde_json::json!(4096)));
+                assert_eq!(params.get("num_predict"), Some(&serde_json::json!(1024)));
                 assert_eq!(params.get("seed"), Some(&serde_json::json!(42)));
-                assert_eq!(params.get("temperature"), Some(&serde_json::json!(0.7)));
             }
             _ => panic!("Expected Ollama config"),
         }
@@ -913,14 +895,14 @@ system_prompt = "You are helpful."
 provider = "openai"
 api_key = "test_key"
 model = "gpt-4o"
+context_window = 200000
 
 [agent]
 name = "Test"
 system_prompt = "Test"
-context_window = 200000
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
-        assert_eq!(config.agent.context_window, Some(200_000));
+        assert_eq!(config.llm.context_window(), Some(200_000));
     }
 
     #[test]
@@ -936,7 +918,7 @@ name = "Test"
 system_prompt = "Test"
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
-        assert_eq!(config.agent.context_window, None);
+        assert_eq!(config.llm.context_window(), None);
     }
 
     #[test]
@@ -947,13 +929,81 @@ system_prompt = "Test"
 provider = "openai"
 api_key = "test_key"
 model = "gpt-4o"
+context_window = 200000.0
 
 [agent]
 name = "Test"
 system_prompt = "Test"
-context_window = 200000.0
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
-        assert_eq!(config.agent.context_window, Some(200_000));
+        assert_eq!(config.llm.context_window(), Some(200_000));
+    }
+
+    #[test]
+    fn test_removed_agent_configs_caught() {
+        // The old agent-level fields should now cause the parsing to fail
+        // so the user is aware of the breaking changes
+        let valid_config_str = r#"
+[llm]
+provider = "openai"
+api_key = "test_key"
+model = "gpt-4o"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+
+        let test_cases = [
+            ("temperature", "temperature = 0.5"),
+            ("max_tokens", "max_tokens = 1000"),
+            ("reasoning_effect", "reasoning_effect = \"medium\""),
+            ("context_window", "context_window = 200000.0"),
+            (
+                "additional_params",
+                "additional_params = { thinking = { type = \"enabled\", budget_tokens = 8000 } }",
+            ),
+        ];
+
+        for (removed_field, definition) in test_cases {
+            let expected_error = format!("unknown field `{removed_field}`");
+            let config_str = String::from(valid_config_str) + "\n" + definition;
+
+            let config = load_config_from_str(&config_str);
+            assert!(
+                config.is_err(),
+                "config parsing should fail due to removed agent-level field"
+            );
+            assert!(
+                config
+                    .unwrap_err()
+                    .to_string()
+                    .contains(expected_error.as_str())
+            );
+        }
+    }
+
+    #[test]
+    fn test_no_additional_properties_on_llm() {
+        let config_str = r#"
+[llm]
+provider = "openai"
+api_key = "test_key"
+model = "gpt-4o"
+random_field = "should not be accepted"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+
+        let config = load_config_from_str(&config_str);
+        assert!(config.is_err(), "no additional fields allowed");
+        assert!(
+            config
+                .unwrap_err()
+                .to_string()
+                .contains("unknown field `random_field`")
+        );
     }
 }

--- a/crates/aura-config/src/loader.rs
+++ b/crates/aura-config/src/loader.rs
@@ -190,9 +190,6 @@ fn merge_configs(base_config: Config, override_config: Config) -> Result<Config,
     if !override_config.agent.context.is_empty() {
         result.agent.context = override_config.agent.context;
     }
-    if override_config.agent.temperature.is_some() {
-        result.agent.temperature = override_config.agent.temperature;
-    }
 
     Ok(result)
 }

--- a/crates/aura-web-server/tests/test-config.toml
+++ b/crates/aura-web-server/tests/test-config.toml
@@ -6,6 +6,7 @@
 provider = "openai"
 api_key = "{{ env.OPENAI_API_KEY }}"
 model = "gpt-5.1"
+temperature = 0.0
 
 # MCP Configuration - Mock MCP server for tool execution tests
 # URLs use environment variables with defaults for local development.
@@ -81,5 +82,4 @@ EXAMPLES:
 - "Call slow_task with task_id='test1' and duration_seconds=5" → slow_task(task_id="test1", duration_seconds=5)
 - "Say hello" → Respond with text (no tool needed)
 """
-temperature = 0.0
 turn_depth = 3 # Lower depth for faster tests

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -26,46 +26,6 @@ use tokio::sync::watch;
 /// before tool calls, so 12 gives adequate headroom.
 pub const DEFAULT_MAX_DEPTH: usize = 12;
 
-/// Check if model supports reasoning_effort parameter
-pub(crate) fn is_reasoning_model(model: &str) -> bool {
-    model.starts_with("o1")
-        || model.starts_with("o3")
-        || model.starts_with("o4")
-        || model.starts_with("gpt-5")
-}
-
-/// Build Ollama-specific parameters for the agent builder.
-///
-/// Combines `num_ctx`, `num_predict`, and any `additional_params` into a single
-/// JSON object that gets passed to Rig's `additional_params()` method.
-///
-/// Returns `None` if no parameters are set.
-pub(crate) fn build_ollama_params(
-    num_ctx: Option<u32>,
-    num_predict: Option<u32>,
-    additional_params: Option<std::collections::HashMap<String, serde_json::Value>>,
-) -> Option<serde_json::Value> {
-    let mut params = serde_json::Map::new();
-
-    if let Some(ctx) = num_ctx {
-        params.insert("num_ctx".to_string(), serde_json::json!(ctx));
-    }
-    if let Some(predict) = num_predict {
-        params.insert("num_predict".to_string(), serde_json::json!(predict));
-    }
-    if let Some(additional) = additional_params {
-        for (key, value) in additional {
-            params.insert(key, value);
-        }
-    }
-
-    if params.is_empty() {
-        None
-    } else {
-        Some(serde_json::Value::Object(params))
-    }
-}
-
 /// Shallow-merge two JSON values at the top level.
 ///
 /// If both are objects, keys from `b` are inserted into `a` (overwriting on conflict).
@@ -141,9 +101,9 @@ pub struct Agent {
     /// Cached tool names for fallback parsing (avoids recomputing on each stream).
     /// Only populated when `fallback_tool_parsing` is enabled.
     pub(crate) fallback_tool_names: Vec<String>,
-    /// Configured context window size in tokens (from TOML config).
+    /// Configured context window size in tokens (from LLM TOML config).
     /// Used for usage percentage reporting in streaming events.
-    pub(crate) context_window: Option<u32>,
+    pub(crate) context_window: Option<u64>,
 }
 
 impl Agent {
@@ -208,6 +168,9 @@ impl Agent {
                 api_key,
                 model,
                 base_url,
+                reasoning_effort,
+                temperature,
+                additional_params,
                 ..
             } => {
                 tracing::info!("Initializing OpenAI provider");
@@ -232,29 +195,17 @@ impl Agent {
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
                 agent_builder = agent_builder.preamble(config.effective_preamble());
-                if let Some(temp) = config.agent.temperature {
-                    agent_builder = agent_builder.temperature(temp);
+                if let Some(temp) = temperature {
+                    agent_builder = agent_builder.temperature(*temp);
                 }
-                // Build combined additional_params: reasoning_effort + agent-level params
+                // Build combined additional_params: reasoning_effort
                 // Must be a single call — AgentBuilder::additional_params() replaces, not merges.
                 let mut combined_params: Option<serde_json::Value> = None;
-                if let Some(effort) = config.agent.reasoning_effort {
-                    if is_reasoning_model(model) {
-                        let effort_str = match effort {
-                            crate::config::ReasoningEffort::Minimal => "minimal",
-                            crate::config::ReasoningEffort::Low => "low",
-                            crate::config::ReasoningEffort::Medium => "medium",
-                            crate::config::ReasoningEffort::High => "high",
-                        };
-                        combined_params = Some(serde_json::json!({"reasoning_effort": effort_str}));
-                    } else {
-                        tracing::warn!(
-                            "reasoning_effort ignored for model '{}' (only supported on o1/o3/o4/gpt-5+)",
-                            model
-                        );
-                    }
+                if let Some(effort) = *reasoning_effort {
+                    combined_params =
+                        Some(serde_json::json!({"reasoning_effort": effort.to_string()}));
                 }
-                if let Some(ref params) = config.agent.additional_params {
+                if let Some(params) = additional_params {
                     combined_params = Some(match combined_params {
                         Some(existing) => merge_json(existing, params.clone()),
                         None => params.clone(),
@@ -263,7 +214,8 @@ impl Agent {
                 if let Some(params) = combined_params {
                     agent_builder = agent_builder.additional_params(params);
                 }
-                if let Some(max) = config.agent.max_tokens {
+
+                if let Some(max) = config.llm.max_tokens() {
                     agent_builder = agent_builder.max_tokens(max);
                 }
 
@@ -279,6 +231,8 @@ impl Agent {
                 api_key,
                 model,
                 base_url,
+                temperature,
+                additional_params,
                 ..
             } => {
                 tracing::info!("Initializing Anthropic provider");
@@ -301,13 +255,13 @@ impl Agent {
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
                 agent_builder = agent_builder.preamble(config.effective_preamble());
-                if let Some(temp) = config.agent.temperature {
-                    agent_builder = agent_builder.temperature(temp);
+                if let Some(temp) = temperature {
+                    agent_builder = agent_builder.temperature(*temp);
                 }
-                if let Some(max) = config.agent.max_tokens {
+                if let Some(max) = config.llm.max_tokens() {
                     agent_builder = agent_builder.max_tokens(max);
                 }
-                if let Some(ref params) = config.agent.additional_params {
+                if let Some(params) = additional_params {
                     agent_builder = agent_builder.additional_params(params.clone());
                 }
 
@@ -322,6 +276,8 @@ impl Agent {
                 model,
                 region,
                 profile,
+                temperature,
+                additional_params,
                 ..
             } => {
                 tracing::info!("Initializing AWS Bedrock provider");
@@ -358,13 +314,13 @@ impl Agent {
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
                 agent_builder = agent_builder.preamble(config.effective_preamble());
-                if let Some(temp) = config.agent.temperature {
-                    agent_builder = agent_builder.temperature(temp);
+                if let Some(temp) = temperature {
+                    agent_builder = agent_builder.temperature(*temp);
                 }
-                if let Some(max) = config.agent.max_tokens {
+                if let Some(max) = config.llm.max_tokens() {
                     agent_builder = agent_builder.max_tokens(max);
                 }
-                if let Some(ref params) = config.agent.additional_params {
+                if let Some(params) = additional_params {
                     agent_builder = agent_builder.additional_params(params.clone());
                 }
 
@@ -379,6 +335,8 @@ impl Agent {
                 api_key,
                 model,
                 base_url,
+                temperature,
+                additional_params,
                 ..
             } => {
                 tracing::info!("Initializing Gemini provider");
@@ -399,10 +357,10 @@ impl Agent {
 
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
                 agent_builder = agent_builder.preamble(config.effective_preamble());
-                if let Some(temp) = config.agent.temperature {
-                    agent_builder = agent_builder.temperature(temp);
+                if let Some(temp) = temperature {
+                    agent_builder = agent_builder.temperature(*temp);
                 }
-                if let Some(ref params) = config.agent.additional_params {
+                if let Some(params) = additional_params {
                     agent_builder = agent_builder.additional_params(params.clone());
                 }
 
@@ -416,8 +374,7 @@ impl Agent {
             LlmConfig::Ollama {
                 model,
                 base_url,
-                num_ctx,
-                num_predict,
+                temperature,
                 additional_params,
                 ..
             } => {
@@ -438,25 +395,12 @@ impl Agent {
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
                 agent_builder = agent_builder.preamble(config.effective_preamble());
-                if let Some(temp) = config.agent.temperature {
-                    agent_builder = agent_builder.temperature(temp);
+                if let Some(temp) = temperature {
+                    agent_builder = agent_builder.temperature(*temp);
                 }
 
-                // Build combined params: Ollama-specific (num_ctx, num_predict) + agent-level
-                // Must be a single call — AgentBuilder::additional_params() replaces, not merges.
-                {
-                    let mut combined =
-                        build_ollama_params(*num_ctx, *num_predict, additional_params.clone());
-                    if let Some(ref params) = config.agent.additional_params {
-                        combined = Some(match combined {
-                            Some(existing) => merge_json(existing, params.clone()),
-                            None => params.clone(),
-                        });
-                    }
-                    if let Some(params) = combined {
-                        tracing::info!("  Ollama+agent params: {}", params);
-                        agent_builder = agent_builder.additional_params(params);
-                    }
+                if let Some(params) = additional_params {
+                    agent_builder = agent_builder.additional_params(params.clone());
                 }
 
                 let builder_state = BuilderState::Initial(agent_builder);
@@ -475,7 +419,7 @@ impl Agent {
             mcp_manager,
             fallback_tool_parsing,
             fallback_tool_names,
-            context_window: config.agent.context_window,
+            context_window: config.llm.context_window(),
         })
     }
 
@@ -1000,11 +944,6 @@ impl Agent {
     pub fn mcp_manager(&self) -> Option<&McpManager> {
         self.mcp_manager.as_deref()
     }
-
-    /// Get the configured context window size in tokens.
-    pub fn context_window(&self) -> Option<u32> {
-        self.context_window
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1130,7 +1069,7 @@ impl StreamingAgent for Agent {
         Agent::clear_mcp_request_id(self).await
     }
 
-    fn context_window(&self) -> Option<u32> {
+    fn context_window(&self) -> Option<u64> {
         self.context_window
     }
 }

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -3,59 +3,9 @@
 use crate::orchestration::OrchestrationConfig;
 use crate::tool_wrapper::{ToolCallContext, ToolWrapper};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
-/// Serde helpers for accepting whole-number floats (e.g. `8000.0`) as integers.
-///
-/// Helm's YAML parser represents all numbers as Go float64, so `toToml`
-/// renders `max_tokens = 8000.0` instead of `8000`. Rather than fixing this
-/// in Helm templates, we accept both forms on the Rust side.
-pub mod lenient_int {
-    use serde::{Deserialize, Deserializer};
-
-    /// Deserialize a value that may be either an integer or a whole-number float.
-    pub fn deserialize_option_u32<'de, D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<Option<u32>, D::Error> {
-        Option::<f64>::deserialize(deserializer)?
-            .map(|f| float_to_int(f, "u32"))
-            .transpose()
-    }
-
-    pub fn deserialize_option_u64<'de, D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<Option<u64>, D::Error> {
-        Option::<f64>::deserialize(deserializer)?
-            .map(|f| float_to_int(f, "u64"))
-            .transpose()
-    }
-
-    pub fn deserialize_option_usize<'de, D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<Option<usize>, D::Error> {
-        Option::<f64>::deserialize(deserializer)?
-            .map(|f| float_to_int(f, "usize"))
-            .transpose()
-    }
-
-    fn float_to_int<T, E>(f: f64, type_name: &str) -> Result<T, E>
-    where
-        T: TryFrom<u64>,
-        E: serde::de::Error,
-    {
-        if f < 0.0 {
-            return Err(E::custom(format!(
-                "expected non-negative number for {type_name}, got {f}"
-            )));
-        }
-        if f.fract() != 0.0 {
-            return Err(E::custom(format!(
-                "expected whole number for {type_name}, got {f}"
-            )));
-        }
-        let n = f as u64;
-        T::try_from(n).map_err(|_| E::custom(format!("{f} out of range for {type_name}")))
-    }
-}
+use crate::lenient_int;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -72,8 +22,21 @@ pub enum ReasoningEffort {
     High,
 }
 
+impl fmt::Display for ReasoningEffort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            ReasoningEffort::Minimal => "minimal",
+            ReasoningEffort::Low => "low",
+            ReasoningEffort::Medium => "medium",
+            ReasoningEffort::High => "high",
+        };
+        write!(f, "{s}")
+    }
+}
+
 /// Complete configuration for building an agent
 #[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AgentConfig {
     pub llm: LlmConfig,
     pub agent: AgentSettings,
@@ -199,22 +162,47 @@ impl std::fmt::Debug for AgentConfig {
 /// LLM provider configuration with strong typing per provider
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "provider", rename_all = "lowercase")]
+#[serde(deny_unknown_fields)]
 pub enum LlmConfig {
     OpenAI {
         api_key: String,
         model: String,
         #[serde(default)]
         base_url: Option<String>,
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-        max_tokens: Option<u32>,
+        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
+        max_tokens: Option<u64>,
+        /// Context window size in tokens.
+        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
+        context_window: Option<u64>,
+        #[serde(default)]
+        reasoning_effort: Option<ReasoningEffort>,
+        /// Controls the randomness and creativity of the llm
+        #[serde(default)]
+        temperature: Option<f64>,
+        /// Additional provider-specific parameters merged into the API request.
+        /// Provider-agnostic: works for Anthropic thinking, Gemini thinking budget, etc.
+        /// Example: `{ thinking = { type = "adaptive", budget_tokens = 8000 } }`
+        #[serde(default)]
+        additional_params: Option<serde_json::Value>,
     },
     Anthropic {
         api_key: String,
         model: String,
         #[serde(default)]
         base_url: Option<String>,
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-        max_tokens: Option<u32>,
+        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
+        max_tokens: Option<u64>,
+        /// Context window size in tokens.
+        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
+        context_window: Option<u64>,
+        /// Controls the randomness and creativity of the llm
+        #[serde(default)]
+        temperature: Option<f64>,
+        /// Additional provider-specific parameters merged into the API request.
+        /// Provider-agnostic: works for Anthropic thinking, Gemini thinking budget, etc.
+        /// Example: `{ thinking = { type = "adaptive", budget_tokens = 8000 } }`
+        #[serde(default)]
+        additional_params: Option<serde_json::Value>,
     },
     Bedrock {
         model: String,
@@ -222,23 +210,50 @@ pub enum LlmConfig {
         /// AWS profile name (optional, uses default credentials if not specified)
         #[serde(default)]
         profile: Option<String>,
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-        max_tokens: Option<u32>,
+        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
+        max_tokens: Option<u64>,
+        /// Context window size in tokens.
+        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
+        context_window: Option<u64>,
+        #[serde(default)]
+        temperature: Option<f64>,
+        /// Additional provider-specific parameters merged into the API request.
+        /// Provider-agnostic: works for Anthropic thinking, Gemini thinking budget, etc.
+        /// Example: `{ thinking = { type = "adaptive", budget_tokens = 8000 } }`
+        #[serde(default)]
+        additional_params: Option<serde_json::Value>,
     },
     Gemini {
         api_key: String,
         model: String,
         #[serde(default)]
         base_url: Option<String>,
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-        max_tokens: Option<u32>,
+        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
+        max_tokens: Option<u64>,
+        /// Context window size in tokens.
+        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
+        context_window: Option<u64>,
+        /// Controls the randomness and creativity of the llm
+        #[serde(default)]
+        temperature: Option<f64>,
+        /// Additional provider-specific parameters merged into the API request.
+        /// Provider-agnostic: works for Anthropic thinking, Gemini thinking budget, etc.
+        /// Example: `{ thinking = { type = "adaptive", budget_tokens = 8000 } }`
+        #[serde(default)]
+        additional_params: Option<serde_json::Value>,
     },
     Ollama {
         model: String,
-        #[serde(default)]
+        #[serde(default = "default_ollama_base_url")]
         base_url: Option<String>,
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-        max_tokens: Option<u32>,
+        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
+        max_tokens: Option<u64>,
+        /// Context window size in tokens.
+        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
+        context_window: Option<u64>,
+        /// Controls the randomness and creativity of the llm
+        #[serde(default)]
+        temperature: Option<f64>,
         /// Parse tool calls from text output (Ollama-specific workaround).
         ///
         /// Some Ollama models (especially qwen3-coder) output tool calls as text
@@ -252,16 +267,31 @@ pub enum LlmConfig {
         /// See: `fallback_tool_parser` module for supported formats.
         #[serde(default)]
         fallback_tool_parsing: bool,
-        /// Context window size (number of tokens). Maps to Ollama's `num_ctx` option.
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-        num_ctx: Option<u32>,
-        /// Maximum number of tokens to predict. Maps to Ollama's `num_predict` option.
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-        num_predict: Option<u32>,
         /// Additional Ollama-specific parameters passed directly to the API.
+        /// Examples: seed, top_k, top_p, mirostat, etc.
+        /// See: https://github.com/ollama/ollama/blob/main/docs/modelfile.mdx#valid-parameters-and-values
         #[serde(default)]
-        additional_params: Option<HashMap<String, serde_json::Value>>,
+        additional_params: Option<serde_json::Value>,
     },
+}
+
+fn default_ollama_base_url() -> Option<String> {
+    Some("http://localhost:11434".to_string())
+}
+
+impl Default for LlmConfig {
+    fn default() -> Self {
+        LlmConfig::OpenAI {
+            api_key: String::new(),
+            model: "gpt-4o".to_string(),
+            base_url: None,
+            reasoning_effort: None,
+            max_tokens: None,
+            context_window: None,
+            temperature: None,
+            additional_params: None,
+        }
+    }
 }
 
 impl LlmConfig {
@@ -277,6 +307,49 @@ impl LlmConfig {
                 ..
             }
         )
+    }
+
+    /// Get max_tokens regardless of provider.
+    pub fn max_tokens(&self) -> Option<u64> {
+        match self {
+            LlmConfig::OpenAI { max_tokens, .. }
+            | LlmConfig::Anthropic { max_tokens, .. }
+            | LlmConfig::Bedrock { max_tokens, .. }
+            | LlmConfig::Gemini { max_tokens, .. }
+            | LlmConfig::Ollama { max_tokens, .. } => *max_tokens,
+        }
+    }
+
+    /// Get context_window regardless of provider.
+    pub fn context_window(&self) -> Option<u64> {
+        match self {
+            LlmConfig::OpenAI { context_window, .. }
+            | LlmConfig::Anthropic { context_window, .. }
+            | LlmConfig::Bedrock { context_window, .. }
+            | LlmConfig::Gemini { context_window, .. }
+            | LlmConfig::Ollama { context_window, .. } => *context_window,
+        }
+    }
+
+    /// Get additional_params regardless of provider.
+    pub fn additional_params(&self) -> Option<serde_json::Value> {
+        match self {
+            LlmConfig::OpenAI {
+                additional_params, ..
+            }
+            | LlmConfig::Anthropic {
+                additional_params, ..
+            }
+            | LlmConfig::Bedrock {
+                additional_params, ..
+            }
+            | LlmConfig::Gemini {
+                additional_params, ..
+            }
+            | LlmConfig::Ollama {
+                additional_params, ..
+            } => additional_params.clone(),
+        }
     }
 
     /// Get the model name regardless of provider.
@@ -300,6 +373,17 @@ impl LlmConfig {
             LlmConfig::Ollama { model, .. } => ("ollama", model),
         }
     }
+
+    /// Accessor for temperature regardless of provider.
+    pub fn temperature(&self) -> Option<f64> {
+        match self {
+            LlmConfig::OpenAI { temperature, .. }
+            | LlmConfig::Anthropic { temperature, .. }
+            | LlmConfig::Bedrock { temperature, .. }
+            | LlmConfig::Gemini { temperature, .. }
+            | LlmConfig::Ollama { temperature, .. } => *temperature,
+        }
+    }
 }
 
 /// Agent behavior settings
@@ -308,18 +392,8 @@ pub struct AgentSettings {
     pub name: String,
     pub system_prompt: String,
     pub context: Vec<String>,
-    pub temperature: Option<f64>,
-    pub reasoning_effort: Option<ReasoningEffort>,
-    #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
-    pub max_tokens: Option<u64>,
     #[serde(default, deserialize_with = "lenient_int::deserialize_option_usize")]
     pub turn_depth: Option<usize>,
-    /// Context window size in tokens. Used for usage percentage reporting.
-    #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-    pub context_window: Option<u32>,
-    /// Additional provider-specific parameters merged into the API request.
-    /// Provider-agnostic: works for Anthropic thinking, Gemini thinking budget, etc.
-    pub additional_params: Option<serde_json::Value>,
     /// Glob patterns for filtering which MCP tools to include.
     /// When set, only tools matching at least one pattern are added.
     /// Supports glob syntax: `*` (any chars), `?` (single char).
@@ -393,17 +467,16 @@ impl Default for AgentConfig {
                 model: "gpt-4o-mini".to_string(),
                 base_url: None,
                 max_tokens: None,
+                context_window: None,
+                temperature: None,
+                reasoning_effort: None,
+                additional_params: None,
             },
             agent: AgentSettings {
                 name: "Assistant".to_string(),
                 system_prompt: "You are a helpful assistant.".to_string(),
                 context: vec![],
-                temperature: Some(0.7),
-                reasoning_effort: None,
-                max_tokens: None,
                 turn_depth: Some(5),
-                context_window: None,
-                additional_params: None,
                 mcp_filter: None,
             },
             vector_stores: Vec::new(),
@@ -581,155 +654,5 @@ mod tests {
         assert!(config.tool_matches_filter("mezmo_pipelines"));
         assert!(config.tool_matches_filter("QueryKnowledgeBases"));
         assert!(!config.tool_matches_filter("other_tool"));
-    }
-
-    // --- lenient_int tests (from helm YAML config rendering) ---
-    use super::lenient_int;
-    use serde::Deserialize;
-
-    #[derive(Debug, Deserialize, PartialEq)]
-    struct TestU32 {
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-        val: Option<u32>,
-    }
-
-    #[derive(Debug, Deserialize, PartialEq)]
-    struct TestU64 {
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
-        val: Option<u64>,
-    }
-
-    #[derive(Debug, Deserialize, PartialEq)]
-    struct TestUsize {
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_usize")]
-        val: Option<usize>,
-    }
-
-    fn from_json<T: for<'de> Deserialize<'de>>(json: &str) -> Result<T, serde_json::Error> {
-        serde_json::from_str(json)
-    }
-
-    #[test]
-    fn accepts_integer() {
-        let t: TestU32 = from_json(r#"{"val": 8000}"#).unwrap();
-        assert_eq!(t.val, Some(8000));
-    }
-
-    #[test]
-    fn accepts_whole_float() {
-        let t: TestU32 = from_json(r#"{"val": 8000.0}"#).unwrap();
-        assert_eq!(t.val, Some(8000));
-    }
-
-    #[test]
-    fn accepts_zero_float() {
-        let t: TestU32 = from_json(r#"{"val": 0.0}"#).unwrap();
-        assert_eq!(t.val, Some(0));
-    }
-
-    #[test]
-    fn rejects_fractional_float() {
-        let result = from_json::<TestU32>(r#"{"val": 3.14}"#);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn accepts_none() {
-        let t: TestU32 = from_json(r#"{}"#).unwrap();
-        assert_eq!(t.val, None);
-    }
-
-    #[test]
-    fn u64_whole_float() {
-        let t: TestU64 = from_json(r#"{"val": 100000.0}"#).unwrap();
-        assert_eq!(t.val, Some(100000));
-    }
-
-    #[test]
-    fn usize_whole_float() {
-        let t: TestUsize = from_json(r#"{"val": 5.0}"#).unwrap();
-        assert_eq!(t.val, Some(5));
-    }
-
-    #[test]
-    fn rejects_negative() {
-        let result = from_json::<TestU32>(r#"{"val": -1.0}"#);
-        assert!(result.is_err());
-    }
-}
-
-#[cfg(test)]
-mod lenient_int_tests {
-    use super::lenient_int;
-    use serde::Deserialize;
-
-    #[derive(Debug, Deserialize, PartialEq)]
-    struct TestU32 {
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u32")]
-        val: Option<u32>,
-    }
-
-    #[derive(Debug, Deserialize, PartialEq)]
-    struct TestU64 {
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
-        val: Option<u64>,
-    }
-
-    #[derive(Debug, Deserialize, PartialEq)]
-    struct TestUsize {
-        #[serde(default, deserialize_with = "lenient_int::deserialize_option_usize")]
-        val: Option<usize>,
-    }
-
-    fn from_json<T: for<'de> Deserialize<'de>>(json: &str) -> Result<T, serde_json::Error> {
-        serde_json::from_str(json)
-    }
-
-    #[test]
-    fn accepts_integer() {
-        let t: TestU32 = from_json(r#"{"val": 8000}"#).unwrap();
-        assert_eq!(t.val, Some(8000));
-    }
-
-    #[test]
-    fn accepts_whole_float() {
-        let t: TestU32 = from_json(r#"{"val": 8000.0}"#).unwrap();
-        assert_eq!(t.val, Some(8000));
-    }
-
-    #[test]
-    fn accepts_zero_float() {
-        let t: TestU32 = from_json(r#"{"val": 0.0}"#).unwrap();
-        assert_eq!(t.val, Some(0));
-    }
-
-    #[test]
-    fn rejects_fractional_float() {
-        let result = from_json::<TestU32>(r#"{"val": 3.14}"#);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn accepts_none() {
-        let t: TestU32 = from_json(r#"{}"#).unwrap();
-        assert_eq!(t.val, None);
-    }
-
-    #[test]
-    fn u64_whole_float() {
-        let t: TestU64 = from_json(r#"{"val": 100000.0}"#).unwrap();
-        assert_eq!(t.val, Some(100000));
-    }
-
-    #[test]
-    fn usize_whole_float() {
-        let t: TestUsize = from_json(r#"{"val": 5.0}"#).unwrap();
-        assert_eq!(t.val, Some(5));
-    }
-
-    #[test]
-    fn rejects_negative() {
-        let result = from_json::<TestU32>(r#"{"val": -1.0}"#);
-        assert!(result.is_err());
     }
 }

--- a/crates/aura/src/lenient_int.rs
+++ b/crates/aura/src/lenient_int.rs
@@ -1,0 +1,126 @@
+/// Serde helpers for accepting whole-number floats (e.g. `8000.0`) as integers.
+///
+/// Helm's YAML parser represents all numbers as Go float64, so `toToml`
+/// renders `max_tokens = 8000.0` instead of `8000`. Rather than fixing this
+/// in Helm templates, we accept both forms on the Rust side.
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize a value that may be either an integer or a whole-number float.
+pub fn deserialize_option_u32<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<u32>, D::Error> {
+    Option::<f64>::deserialize(deserializer)?
+        .map(|f| float_to_int(f, "u32"))
+        .transpose()
+}
+
+pub fn deserialize_option_u64<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<u64>, D::Error> {
+    Option::<f64>::deserialize(deserializer)?
+        .map(|f| float_to_int(f, "u64"))
+        .transpose()
+}
+
+pub fn deserialize_option_usize<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<usize>, D::Error> {
+    Option::<f64>::deserialize(deserializer)?
+        .map(|f| float_to_int(f, "usize"))
+        .transpose()
+}
+
+fn float_to_int<T, E>(f: f64, type_name: &str) -> Result<T, E>
+where
+    T: TryFrom<u64>,
+    E: serde::de::Error,
+{
+    if f < 0.0 {
+        return Err(E::custom(format!(
+            "expected non-negative number for {type_name}, got {f}"
+        )));
+    }
+    if f.fract() != 0.0 {
+        return Err(E::custom(format!(
+            "expected whole number for {type_name}, got {f}"
+        )));
+    }
+    let n = f as u64;
+    T::try_from(n).map_err(|_| E::custom(format!("{f} out of range for {type_name}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TestU32 {
+        #[serde(default, deserialize_with = "deserialize_option_u32")]
+        val: Option<u32>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TestU64 {
+        #[serde(default, deserialize_with = "deserialize_option_u64")]
+        val: Option<u64>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TestUsize {
+        #[serde(default, deserialize_with = "deserialize_option_usize")]
+        val: Option<usize>,
+    }
+
+    fn from_json<T: for<'de> Deserialize<'de>>(json: &str) -> Result<T, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    #[test]
+    fn accepts_integer() {
+        let t: TestU32 = from_json(r#"{"val": 8000}"#).unwrap();
+        assert_eq!(t.val, Some(8000));
+    }
+
+    #[test]
+    fn accepts_whole_float() {
+        let t: TestU32 = from_json(r#"{"val": 8000.0}"#).unwrap();
+        assert_eq!(t.val, Some(8000));
+    }
+
+    #[test]
+    fn accepts_zero_float() {
+        let t: TestU32 = from_json(r#"{"val": 0.0}"#).unwrap();
+        assert_eq!(t.val, Some(0));
+    }
+
+    #[test]
+    fn rejects_fractional_float() {
+        let result = from_json::<TestU32>(r#"{"val": 3.14}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accepts_none() {
+        let t: TestU32 = from_json(r#"{}"#).unwrap();
+        assert_eq!(t.val, None);
+    }
+
+    #[test]
+    fn u64_whole_float() {
+        let t: TestU64 = from_json(r#"{"val": 100000.0}"#).unwrap();
+        assert_eq!(t.val, Some(100000));
+    }
+
+    #[test]
+    fn usize_whole_float() {
+        let t: TestUsize = from_json(r#"{"val": 5.0}"#).unwrap();
+        assert_eq!(t.val, Some(5));
+    }
+
+    #[test]
+    fn rejects_negative() {
+        let result = from_json::<TestU32>(r#"{"val": -1.0}"#);
+        assert!(result.is_err());
+    }
+}

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -10,6 +10,7 @@ pub mod config;
 pub mod error;
 pub mod fallback_tool_parser;
 pub mod fallback_tool_stream;
+pub mod lenient_int;
 pub mod logging;
 pub mod mcp;
 pub mod mcp_dynamic;

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -1723,7 +1723,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             self.agent_config.effective_preamble(),
             include_recon_tools,
         );
-        let temperature = self.agent_config.agent.temperature;
+        let temperature = self.agent_config.llm.temperature();
 
         // Filter vector stores for coordinator (if any configured)
         let coordinator_stores: Vec<_> = if !self.config.coordinator_vector_stores.is_empty() {
@@ -1809,7 +1809,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             .build_provider_agent_with_tools(
                 &preamble,
                 temperature,
-                self.agent_config.agent.additional_params.clone(),
+                self.agent_config.llm.additional_params(),
                 coordinator_tools,
             )
             .await?;
@@ -1844,7 +1844,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         let preamble = self
             .config
             .build_coordinator_preamble(self.agent_config.effective_preamble(), false);
-        let temperature = self.agent_config.agent.temperature;
+        let temperature = self.agent_config.llm.temperature();
 
         let coordinator_tools = CoordinatorTools {
             list_tools: None,
@@ -1859,7 +1859,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             .build_provider_agent_with_tools(
                 &preamble,
                 temperature,
-                self.agent_config.agent.additional_params.clone(),
+                self.agent_config.llm.additional_params(),
                 coordinator_tools,
             )
             .await?;
@@ -1891,7 +1891,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         let preamble = self
             .config
             .build_coordinator_preamble(self.agent_config.effective_preamble(), false);
-        let temperature = self.agent_config.agent.temperature;
+        let temperature = self.agent_config.llm.temperature();
 
         let coordinator_tools = CoordinatorTools {
             list_tools: None,
@@ -1906,7 +1906,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             .build_provider_agent_with_tools(
                 &preamble,
                 temperature,
-                self.agent_config.agent.additional_params.clone(),
+                self.agent_config.llm.additional_params(),
                 coordinator_tools,
             )
             .await?;
@@ -1939,7 +1939,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         evaluation_tool: SubmitEvaluationTool,
     ) -> Result<AgentWithPreamble, Box<dyn std::error::Error + Send + Sync>> {
         let preamble = include_str!("../prompts/evaluation_preamble.md").to_string();
-        let temperature = self.agent_config.agent.temperature;
+        let temperature = self.agent_config.llm.temperature();
 
         let coordinator_tools = CoordinatorTools {
             list_tools: None,
@@ -1954,7 +1954,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             .build_provider_agent_with_tools(
                 &preamble,
                 temperature,
-                self.agent_config.agent.additional_params.clone(),
+                self.agent_config.llm.additional_params(),
                 coordinator_tools,
             )
             .await?;
@@ -2121,7 +2121,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         worker_config: &AgentConfig,
     ) -> Result<(ProviderAgent, String), Box<dyn std::error::Error + Send + Sync>> {
         let preamble = worker_config.effective_preamble();
-        let temperature = worker_config.agent.temperature;
+        let temperature = worker_config.llm.temperature();
         let shared_mcp: Option<Arc<McpManager>> = self.mcp_manager.clone();
 
         match &worker_config.llm {
@@ -2129,6 +2129,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 api_key,
                 model,
                 base_url,
+                reasoning_effort,
+                additional_params,
                 ..
             } => {
                 let mut cb =
@@ -2146,20 +2148,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 if let Some(temp) = temperature {
                     builder = builder.temperature(temp);
                 }
-                // Build combined additional_params: reasoning_effort + agent-level
+                // Build combined additional_params: reasoning_effort
                 let mut combined_params: Option<serde_json::Value> = None;
-                if let Some(effort) = worker_config.agent.reasoning_effort
-                    && crate::builder::is_reasoning_model(model)
-                {
-                    let effort_str = match effort {
-                        crate::config::ReasoningEffort::Minimal => "minimal",
-                        crate::config::ReasoningEffort::Low => "low",
-                        crate::config::ReasoningEffort::Medium => "medium",
-                        crate::config::ReasoningEffort::High => "high",
-                    };
-                    combined_params = Some(serde_json::json!({"reasoning_effort": effort_str}));
+                if let Some(effort) = reasoning_effort {
+                    combined_params =
+                        Some(serde_json::json!({"reasoning_effort": effort.to_string()}));
                 }
-                if let Some(ref params) = worker_config.agent.additional_params {
+                if let Some(params) = additional_params {
                     combined_params = Some(match combined_params {
                         Some(existing) => crate::builder::merge_json(existing, params.clone()),
                         None => params.clone(),
@@ -2168,7 +2163,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 if let Some(params) = combined_params {
                     builder = builder.additional_params(params);
                 }
-                if let Some(max) = worker_config.agent.max_tokens {
+                if let Some(max) = worker_config.llm.max_tokens() {
                     builder = builder.max_tokens(max);
                 }
                 let state = BuilderState::Initial(builder);
@@ -2179,6 +2174,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 api_key,
                 model,
                 base_url,
+                additional_params,
                 ..
             } => {
                 let mut cb = rig::providers::anthropic::Client::<reqwest::Client>::builder()
@@ -2195,10 +2191,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 if let Some(temp) = temperature {
                     builder = builder.temperature(temp);
                 }
-                if let Some(max) = worker_config.agent.max_tokens {
+                if let Some(max) = worker_config.llm.max_tokens() {
                     builder = builder.max_tokens(max);
                 }
-                if let Some(ref params) = worker_config.agent.additional_params {
+                if let Some(params) = additional_params {
                     builder = builder.additional_params(params.clone());
                 }
                 let state = BuilderState::Initial(builder);
@@ -2209,6 +2205,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 model,
                 region,
                 profile,
+                additional_params,
                 ..
             } => {
                 use aws_config::{BehaviorVersion, Region};
@@ -2233,10 +2230,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 if let Some(temp) = temperature {
                     builder = builder.temperature(temp);
                 }
-                if let Some(max) = worker_config.agent.max_tokens {
+                if let Some(max) = worker_config.llm.max_tokens() {
                     builder = builder.max_tokens(max);
                 }
-                if let Some(ref params) = worker_config.agent.additional_params {
+                if let Some(params) = additional_params {
                     builder = builder.additional_params(params.clone());
                 }
                 let state = BuilderState::Initial(builder);
@@ -2247,6 +2244,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 api_key,
                 model,
                 base_url,
+                additional_params,
                 ..
             } => {
                 let mut cb =
@@ -2263,7 +2261,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 if let Some(temp) = temperature {
                     builder = builder.temperature(temp);
                 }
-                if let Some(ref params) = worker_config.agent.additional_params {
+                if let Some(params) = additional_params {
                     builder = builder.additional_params(params.clone());
                 }
                 let state = BuilderState::Initial(builder);
@@ -2273,8 +2271,6 @@ Assign tasks to the worker whose tools best match the required operations."#,
             LlmConfig::Ollama {
                 model,
                 base_url,
-                num_ctx,
-                num_predict,
                 additional_params,
                 ..
             } => {
@@ -2290,23 +2286,11 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 if let Some(temp) = temperature {
                     builder = builder.temperature(temp);
                 }
-                // Build combined params: Ollama-specific + agent-level (single call)
-                {
-                    let mut combined = crate::builder::build_ollama_params(
-                        *num_ctx,
-                        *num_predict,
-                        additional_params.clone(),
-                    );
-                    if let Some(ref params) = worker_config.agent.additional_params {
-                        combined = Some(match combined {
-                            Some(existing) => crate::builder::merge_json(existing, params.clone()),
-                            None => params.clone(),
-                        });
-                    }
-                    if let Some(params) = combined {
-                        builder = builder.additional_params(params);
-                    }
+
+                if let Some(params) = additional_params {
+                    builder = builder.additional_params(params.clone());
                 }
+
                 let state = BuilderState::Initial(builder);
                 let state = Agent::add_all_tools(state, worker_config, &shared_mcp).await?;
                 Ok((ProviderAgent::Ollama(state.build()), model.clone()))

--- a/crates/aura/src/stream_events.rs
+++ b/crates/aura/src/stream_events.rs
@@ -132,7 +132,7 @@ pub enum AuraStreamEvent {
         model: String,
         /// Context limit for this model (in tokens), if known
         #[serde(skip_serializing_if = "Option::is_none")]
-        model_context_limit: Option<u32>,
+        model_context_limit: Option<u64>,
         #[serde(flatten)]
         correlation: CorrelationContext,
     },
@@ -381,7 +381,7 @@ impl AuraStreamEvent {
     /// Contains model name and context limit for UI context window calculation.
     pub fn session_info(
         model: impl Into<String>,
-        model_context_limit: Option<u32>,
+        model_context_limit: Option<u64>,
         correlation: CorrelationContext,
     ) -> Self {
         Self::SessionInfo {

--- a/crates/aura/src/streaming.rs
+++ b/crates/aura/src/streaming.rs
@@ -133,7 +133,7 @@ pub trait StreamingAgent: Send + Sync {
 
     /// Return the configured context window size in tokens (from TOML config).
     /// Returns `None` if not configured (e.g., Orchestrator).
-    fn context_window(&self) -> Option<u32> {
+    fn context_window(&self) -> Option<u64> {
         None
     }
 }

--- a/deployment/helm/aura/values.yaml
+++ b/deployment/helm/aura/values.yaml
@@ -101,15 +101,17 @@ config:
   #   api_key: "{{ env.OPENAI_API_KEY }}"
   #   model: gpt-4o
   #   base_url: ""               # optional
+  #   temperature: 0.7
+  #   max_tokens: 2000
   #   region: ""                  # bedrock only
   #   profile: ""                 # bedrock only
-  #   num_ctx: 0                  # ollama only
-  #   num_predict: 0              # ollama only
   #   fallback_tool_parsing: false  # ollama only
   #   additional_params:           # → [llm.additional_params]
   #     seed: 42
   #     top_k: 40
   #     top_p: 0.9
+  #     num_ctx: 0                  # ollama only
+  #     num_predict: 0              # ollama only
 
   # -- Agent configuration → [agent]
   agent: {}
@@ -117,8 +119,6 @@ config:
   #   system_prompt: "You are a helpful assistant."
   #   context: []
   #   turn_depth: 6
-  #   temperature: 0.7
-  #   max_tokens: 2000
 
   # -- Vector stores → [[vector_stores]]
   vector_stores: []

--- a/deployment/kubernetes/aura.yaml.envsubst
+++ b/deployment/kubernetes/aura.yaml.envsubst
@@ -1,3 +1,4 @@
+---
 apiVersion: "deploy.razee.io/v1alpha2"
 kind: MustacheTemplate
 metadata:
@@ -13,6 +14,7 @@ metadata:
     razee.io/branch: "${GIT_BRANCH}"
 spec:
   env:
+
   - name: command
     optional: true
     default: '["./aura-web-server"]'

--- a/docs/breaking-changes/20260410-agent-llm-toml-configuration.md
+++ b/docs/breaking-changes/20260410-agent-llm-toml-configuration.md
@@ -1,0 +1,129 @@
+# 10 April 2026
+# !!BREAKING CHANGES!!
+
+## Summary
+
+Several fields that configure LLM behavior have been moved from the `[agent]` section to the `[llm]` section. This aligns these settings with the provider they configure and reduces duplication. The `[agent]` section now only contains agent behavior settings (system prompt, context, turn depth, tool filters, etc.).
+
+**The `[agent]` section will reject these fields with an unknown-field error.
+
+**NOTE: CONFIGS THAT HAVE NOT BEEN UPDATED WILL FAIL TO PARSE AND THE APP WILL FAIL TO START. See [Startup Errors](#startup-errors).
+
+---
+
+## Migrated Fields
+
+The following fields must move from `[agent]` to `[llm]`:
+
+| Field | Old location | New location |
+|---|---|---|
+| `temperature` | `[agent]` | `[llm]` |
+| `reasoning_effort` | `[agent]` | `[llm]` |
+| `max_tokens` | `[agent]` | `[llm]` |
+| `context_window` | `[agent]` | `[llm]` |
+| `additional_params` | `[agent]` | `[llm]` |
+
+---
+
+## Before / After Examples
+
+### temperature, reasoning_effort, context_window, max_tokens
+
+```toml
+# BEFORE
+[llm]
+provider = "openai"
+model = "gpt-5.1"
+
+[agent]
+name = "My Agent"
+system_prompt = "..."
+temperature = 0.3
+reasoning_effort = "medium"
+context_window = 128000
+max_tokens = 1000
+
+# AFTER
+[llm]
+provider = "openai"
+model = "gpt-5.1"
+reasoning_effort = "medium"
+temperature = 0.3
+context_window = 128000
+max_tokens = 1000
+
+[agent]
+name = "My Agent"
+system_prompt = "..."
+```
+
+### Anthropic/Bedrock thinking parameters
+
+```toml
+# BEFORE
+[llm]
+provider = "anthropic"
+model = "claude-sonnet-4-5-20250929"
+
+[agent]
+name = "Thinking Agent"
+system_prompt = "..."
+temperature = 1.0
+additional_params = { thinking = { type = "enabled", budget_tokens = 8000 } }
+
+# AFTER
+[llm]
+provider = "anthropic"
+model = "claude-sonnet-4-5-20250929"
+temperature = 1.0
+additional_params = { thinking = { type = "enabled", budget_tokens = 8000 } }
+
+[agent]
+name = "Thinking Agent"
+system_prompt = "..."
+```
+
+For the nested table syntax variant:
+
+```toml
+# BEFORE
+[agent.additional_params.thinking]
+type = "enabled"
+budget_tokens = 8000
+
+# AFTER
+[llm.additional_params.thinking]
+type = "enabled"
+budget_tokens = 8000
+```
+---
+
+## Ollama-Specific Changes
+
+Two Ollama-specific fields (`num_ctx`, `num_predict`) have been removed as dedicated top-level `[llm]` fields. They must now be placed under `[llm.additional_params]`.
+
+```toml
+# BEFORE
+[llm]
+provider = "ollama"
+model = "llama3.2"
+num_ctx = 8192
+num_predict = 2048
+
+# AFTER
+[llm]
+provider = "ollama"
+model = "llama3.2"
+
+[llm.additional_params]
+num_ctx = 8192
+num_predict = 2048
+```
+
+---
+
+### Startup Errors:
+
+Affected Configs: `deny_unknown_fields` on `AgentConfig` and `LlmConfig`
+
+Both `aura::config::AgentConfig` and `aura_config::config::AgentConfig` now carry `#[serde(deny_unknown_fields)]`. Any errant or stale field in either section (including the removed fields listed above) will produce a hard parse error instead of being silently ignored, calling attention to the customer.

--- a/docs/streaming-api-guide.md
+++ b/docs/streaming-api-guide.md
@@ -146,7 +146,7 @@ event: aura.session_info
 data: {"model":"gpt-5.2","model_context_limit":200000,"agent_id":"main","session_id":"sess_xyz"}
 ```
 
-Note: `model_context_limit` comes from the `context_window` field in the `[agent]` TOML config section. If `context_window` is not set, `model_context_limit` is omitted from the event.
+Note: `model_context_limit` comes from the `context_window` field in the `[llm]` TOML config section. If `context_window` is not set, `model_context_limit` is omitted from the event.
 
 ### Client Handling
 

--- a/examples/minimal/ollama.toml
+++ b/examples/minimal/ollama.toml
@@ -15,6 +15,7 @@
 provider = "ollama"
 model = "qwen3:30b-a3b"
 # base_url = "http://localhost:11434"  # default; uncomment to override
+temperature = 0.7
 
 # Enable fallback parsing for models that emit tool calls as text
 # instead of structured function-calling format.
@@ -33,5 +34,4 @@ num_ctx = 32000
 [agent]
 name = "Local Assistant"
 system_prompt = "You are a helpful assistant."
-temperature = 0.7
 turn_depth = 5

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -22,8 +22,14 @@
 provider = "openai"
 api_key = "{{ env.OPENAI_API_KEY }}"
 model = "gpt-5.2"
+# temperature = 0.7
+# reasoning_effort = "medium"  # minimal, low, medium, high (provider support varies)
 # max_tokens = 8192
 # base_url = "https://api.openai.com/v1"  # custom endpoint
+# Context window size in tokens. Used for usage percentage reporting
+# in aura.session_info streaming events. Set this to your model's
+# actual context window.
+# context_window = 200000
 
 # Anthropic alternative:
 # provider = "anthropic"
@@ -135,12 +141,6 @@ Workflow:
 #                              # Used in /v1/models response. Defaults to current time.
 # model_owner = "mezmo"        # override `owned_by` in /v1/models responses.
 #                              # Defaults to the LLM provider (e.g. "openai", "anthropic").
-# reasoning_effort = "medium"  # minimal, low, medium, high (provider support varies)
-# temperature = 0.7
 # Maximum tool-calling rounds per user turn. Higher values allow
 # deeper multi-step workflows but consume more tokens.
 turn_depth = 5
-# Context window size in tokens. Used for usage percentage reporting
-# in aura.session_info streaming events. Set this to your model's
-# actual context window.
-# context_window = 200000


### PR DESCRIPTION
summary: some llm specific configurations were either duplicated or inappropriately setup on the agent and passed down. Moved max_tokens, context_window, reasoning_effort, and additional_params to the llm config itself. Deleted the duplicated llm config classes in favor of a single class. Moved the lenient_int serde helpers to their own file. Updated model_context_limit to u64 to match RIG.

ref: LOG-23546