### PR TITLE
docs: add commit and contribution rules to claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,16 @@ This project depends on a fork of rig-core with streaming and observability fixe
 - `request_cancellation.rs` - Per-request lifecycle and disconnect detection
 - `tool_event_broker.rs` - Tool call/result correlation via FIFO queue
 
+## Commit and Contribution Rules
+
+- **No AI co-authorship**: Never add `Co-Authored-By` lines for Claude or any AI assistant. Claude cannot accept the CLA.
+- **Sign-off commits as the user**: Always sign off commits as the human user, not as Claude.
+- **Commit message format**: [Conventional Commits](https://www.conventionalcommits.org/). First line must be entirely lowercase, no trailing period, under 72 characters. Use the body to explain **what** and **why**.
+  Format: `<type>(<optional scope>): <description>`
+  Types: `feat`, `fix`, `doc`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`
+  Breaking changes: add `!` after type/scope and include a `BREAKING CHANGE:` footer.
+  If fixing an issue, include `Fixes: #<issue number>` in the footer.
+
 ## Documentation
 
 - `README.md` - Setup, configuration, and usage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -314,7 +314,7 @@ and optional footer can use lower and upper casing.
 | ---------- | ------------------------------------------------------- |
 | `feat`     | A new feature                                           |
 | `fix`      | A bug fix                                               |
-| `docs`     | Documentation only changes                              |
+| `doc`      | Documentation only changes                              |
 | `style`    | Formatting, missing semicolons, etc. (no code change)   |
 | `refactor` | Code change that neither fixes a bug nor adds a feature |
 | `perf`     | Performance improvement                                 |
@@ -329,7 +329,7 @@ feat(config): add support for gemini provider
 
 fix(streaming): correct sse event ordering on disconnect
 
-docs: add ollama troubleshooting guide
+doc: add ollama troubleshooting guide
 
 test(mcp): add header forwarding integration tests
 


### PR DESCRIPTION
Adds a new "Commit and Contribution Rules" section to CLAUDE.md with guidelines for AI-assisted contributions. This includes a no AI co-authorship policy (Claude cannot accept the CLA), human sign-off requirements, and conventional commit message formatting rules.