### PR TITLE
feat: add Bedrock embedding support for vector stores and br kb support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,15 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,12 +414,13 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aura"
-version = "1.16.4"
+version = "1.17.3"
 dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
  "aws-config",
+ "aws-sdk-bedrockagentruntime",
  "aws-sdk-bedrockruntime",
  "chrono",
  "futures",
@@ -456,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "aura-config"
-version = "1.16.4"
+version = "1.17.3"
 dependencies = [
  "anyhow",
  "aura",
@@ -481,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "aura-test-utils"
-version = "1.16.4"
+version = "1.17.3"
 dependencies = [
  "reqwest",
  "serde",
@@ -491,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "aura-web-server"
-version = "1.16.4"
+version = "1.17.3"
 dependencies = [
  "actix-web",
  "actix-web-lab",
@@ -537,8 +529,8 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.4",
+ "aws-smithy-json 0.61.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -557,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.8"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf26925f4a5b59eb76722b63c2892b1d70d06fa053c72e4a100ec308c1d47bc"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -593,15 +585,43 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.12"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa006bb32360ed90ac51203feafb9d02e3d21046e1fd3a450a404b90ea73e5d"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-bedrockagentruntime"
+version = "1.125.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2c4a870cd06e0daa3eab787a0da73ffa505861a688db665b589da55cfce2a9"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -609,11 +629,9 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http-body 0.4.6",
- "percent-encoding",
- "pin-project-lite",
+ "http 1.3.1",
+ "regex-lite",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -627,8 +645,8 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.4",
+ "aws-smithy-json 0.61.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -650,8 +668,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.4",
+ "aws-smithy-json 0.61.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -672,8 +690,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.4",
+ "aws-smithy-json 0.61.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -694,8 +712,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.4",
+ "aws-smithy-json 0.61.6",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -710,13 +728,13 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.5"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffc03068fbb9c8dd5ce1c6fb240678a5cffb86fb2b7b1985c999c4b83c8df68"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -733,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.6"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "127fcfad33b7dfc531141fda7e1c402ac65f88aca5511a4d31e2e3d2cd01ce9c"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -744,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.12"
+version = "0.60.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9656b85088f8d9dc7ad40f9a6c7228e1e8447cdf4b046c87e152e0805dea02fa"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -775,10 +793,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http-client"
-version = "1.1.3"
+name = "aws-smithy-http"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1053b5e587e6fa40ce5a79ea27957b04ba660baa02b28b7436f64850152234f1"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -796,7 +836,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.31",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.3",
@@ -814,10 +854,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-observability"
-version = "0.1.4"
+name = "aws-smithy-json"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1881b1ea6d313f9890710d65c158bdab6fb08c91ea825f74c1c8c357baf4cc"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -834,12 +883,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.9.3"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ab99739082da5347660c556689256438defae3bcefd66c52b095905730e404"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -850,6 +899,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -858,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.9.1"
+version = "1.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3683c5b152d2ad753607179ed71988e8cfd52964443b4f74fd8e552d0bbfeb46"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -875,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.3"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5b3a7486f6690ba25952cabf1e7d75e34d69eaff5081904a47bc79074d6457"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -910,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.9"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2fd329bf0e901ff3f60425691410c69094dc2a1f34b331f37bfc4e9ac1565a1"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -967,21 +1017,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1073,9 +1108,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"
@@ -1861,12 +1896,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,7 +2123,6 @@ dependencies = [
  "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -2109,7 +2137,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "rustls 0.23.31",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.3",
@@ -2164,7 +2192,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2348,17 +2376,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -2473,9 +2490,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -2598,14 +2615,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2678,15 +2695,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3107,7 +3115,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.31",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -3144,7 +3152,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3492,12 +3500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,18 +3557,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
@@ -3575,15 +3565,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.4.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -3635,9 +3616,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
@@ -3734,9 +3715,9 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3744,18 +3725,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3901,12 +3882,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4126,29 +4107,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4211,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4296,8 +4274,8 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls-native-certs 0.8.1",
- "rustls-pemfile 2.2.0",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
  "tokio-rustls 0.26.3",
@@ -4375,9 +4353,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -4387,9 +4365,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4398,9 +4376,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4880,15 +4858,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ uuid = { version = "1.0", features = ["v4"] }
 # AWS Bedrock dependencies
 aws-config = "1.8.0"
 aws-sdk-bedrockruntime = "1.95.0"
+aws-sdk-bedrockagentruntime = "1.125.0"
 aws-smithy-types = "1.3.2"
 base64 = "0.22.1"
 async-stream = "0.3.6"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Key capabilities:
 - Declarative agent composition via TOML with multi-provider LLM support and multi-agent serving
 - Dynamic [MCP](https://modelcontextprotocol.io) tool discovery across HTTP, SSE, and STDIO transports
 - Automatic schema sanitization for OpenAI function-calling compatibility
-- RAG pipeline integration with in-memory and external vector stores
+- RAG pipeline integration with in-memory, Qdrant, and AWS Bedrock Knowledge Base vector stores, using OpenAI or AWS Bedrock embeddings
 - Embeddable Rust core independent from configuration layer
 
 > **Looking for orchestration mode?** Multi-agent orchestration is available
@@ -196,7 +196,9 @@ Configuration sections:
 - `[[vector_stores]]`: optional RAG/vector store configuration.
 - `[mcp]` and `[mcp.servers.*]`: MCP configuration, schema sanitization, and transports.
 
-Supported providers: OpenAI, Anthropic, Bedrock, Gemini, and Ollama.
+Supported LLM providers: OpenAI, Anthropic, Bedrock, Gemini, and Ollama.
+
+Supported vector stores: `in_memory`, `qdrant`, and `bedrock_kb` (AWS Bedrock Knowledge Bases — managed RAG, no embedding model required). For `in_memory` and `qdrant`, supported embedding providers are OpenAI and AWS Bedrock. See the `[[vector_stores]]` examples in [examples/reference.toml](examples/reference.toml).
 
 Supported MCP transports:
 

--- a/crates/aura-config/src/bin/architecture_diagram.rs
+++ b/crates/aura-config/src/bin/architecture_diagram.rs
@@ -179,26 +179,35 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("│  │                                                 │    │");
         if !config.vector_stores.is_empty() {
             let store = &config.vector_stores[0]; // Show first store
+            let store_type_name = match &store.store {
+                aura_config::VectorStoreType::InMemory { .. } => "in_memory",
+                aura_config::VectorStoreType::Qdrant { .. } => "qdrant",
+                aura_config::VectorStoreType::BedrockKb { .. } => "bedrock_kb",
+            };
             println!(
                 "│  │  Type: {} ({} stores)              │    │",
-                store.store_type,
+                store_type_name,
                 config.vector_stores.len()
             );
             println!("│  │                                                 │    │");
             println!("│  │  ┌─────────────────────────────────────────┐    │    │");
-            if let Some(em) = &store.embedding_model {
-                println!("│  │  │        🔤 EMBEDDING MODEL               │    │    │");
-                println!("│  │  │                                         │    │    │");
-                println!(
-                    "│  │  │  Provider: {}                │    │    │",
-                    em.provider()
-                );
-                println!(
-                    "│  │  │  Model: {}    │    │    │",
-                    em.model()
-                );
-            } else {
-                println!("│  │  │        🔤 MANAGED EMBEDDINGS            │    │    │");
+            match &store.store {
+                aura_config::VectorStoreType::InMemory { embedding_model }
+                | aura_config::VectorStoreType::Qdrant { embedding_model, .. } => {
+                    println!("│  │  │        🔤 EMBEDDING MODEL               │    │    │");
+                    println!("│  │  │                                         │    │    │");
+                    println!(
+                        "│  │  │  Provider: {}                │    │    │",
+                        embedding_model.provider()
+                    );
+                    println!(
+                        "│  │  │  Model: {}    │    │    │",
+                        embedding_model.model()
+                    );
+                }
+                aura_config::VectorStoreType::BedrockKb { .. } => {
+                    println!("│  │  │        🔤 MANAGED EMBEDDINGS            │    │    │");
+                }
             }
         } else {
             println!("│  │  No vector stores configured               │    │");

--- a/crates/aura-config/src/bin/architecture_diagram.rs
+++ b/crates/aura-config/src/bin/architecture_diagram.rs
@@ -186,16 +186,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
             println!("│  │                                                 │    │");
             println!("│  │  ┌─────────────────────────────────────────┐    │    │");
-            println!("│  │  │        🔤 EMBEDDING MODEL               │    │    │");
-            println!("│  │  │                                         │    │    │");
-            println!(
-                "│  │  │  Provider: {}                │    │    │",
-                store.embedding_model.provider
-            );
-            println!(
-                "│  │  │  Model: {}    │    │    │",
-                store.embedding_model.model
-            );
+            if let Some(em) = &store.embedding_model {
+                println!("│  │  │        🔤 EMBEDDING MODEL               │    │    │");
+                println!("│  │  │                                         │    │    │");
+                println!(
+                    "│  │  │  Provider: {}                │    │    │",
+                    em.provider()
+                );
+                println!(
+                    "│  │  │  Model: {}    │    │    │",
+                    em.model()
+                );
+            } else {
+                println!("│  │  │        🔤 MANAGED EMBEDDINGS            │    │    │");
+            }
         } else {
             println!("│  │  No vector stores configured               │    │");
             println!("│  │                                                 │    │");

--- a/crates/aura-config/src/bin/debug_config.rs
+++ b/crates/aura-config/src/bin/debug_config.rs
@@ -137,10 +137,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Vector Stores: {} configured", config.vector_stores.len());
         for (i, store) in config.vector_stores.iter().enumerate() {
             println!("  Store {}: {} ({})", i + 1, store.name, store.store_type);
-            println!(
-                "    Embedding Model: {} {}",
-                store.embedding_model.provider, store.embedding_model.model
-            );
+            if let Some(em) = &store.embedding_model {
+                println!("    Embedding Model: {} {}", em.provider(), em.model());
+            } else {
+                println!("    Type: {} (managed embeddings)", store.store_type);
+            }
         }
     } else {
         println!("Vector Stores: None configured");

--- a/crates/aura-config/src/bin/debug_config.rs
+++ b/crates/aura-config/src/bin/debug_config.rs
@@ -136,11 +136,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !config.vector_stores.is_empty() {
         println!("Vector Stores: {} configured", config.vector_stores.len());
         for (i, store) in config.vector_stores.iter().enumerate() {
-            println!("  Store {}: {} ({})", i + 1, store.name, store.store_type);
-            if let Some(em) = &store.embedding_model {
-                println!("    Embedding Model: {} {}", em.provider(), em.model());
-            } else {
-                println!("    Type: {} (managed embeddings)", store.store_type);
+            match &store.store {
+                aura_config::VectorStoreType::InMemory { embedding_model } => {
+                    println!("  Store {}: {} (in_memory)", i + 1, store.name);
+                    println!("    Embedding Model: {} {}", embedding_model.provider(), embedding_model.model());
+                }
+                aura_config::VectorStoreType::Qdrant { embedding_model, .. } => {
+                    println!("  Store {}: {} (qdrant)", i + 1, store.name);
+                    println!("    Embedding Model: {} {}", embedding_model.provider(), embedding_model.model());
+                }
+                aura_config::VectorStoreType::BedrockKb { .. } => {
+                    println!("  Store {}: {} (bedrock_kb, managed embeddings)", i + 1, store.name);
+                }
             }
         }
     } else {

--- a/crates/aura-config/src/builder.rs
+++ b/crates/aura-config/src/builder.rs
@@ -104,16 +104,31 @@ impl RigBuilder {
             .map(|store| VectorStoreConfig {
                 name: store.name.clone(),
                 store_type: store.store_type.clone(),
-                embedding_model: EmbeddingModelConfig {
-                    provider: store.embedding_model.provider.clone(),
-                    model: store.embedding_model.model.clone(),
-                    api_key: store.embedding_model.api_key.clone(),
-                    base_url: None,
-                },
+                embedding_model: store.embedding_model.as_ref().map(|em| match em {
+                    crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
+                        EmbeddingModelConfig::OpenAI {
+                            api_key: api_key.clone(),
+                            model: model.clone(),
+                            base_url: None,
+                        }
+                    }
+                    crate::config::EmbeddingConfig::Bedrock {
+                        model,
+                        region,
+                        profile,
+                    } => EmbeddingModelConfig::Bedrock {
+                        model: model.clone(),
+                        region: region.clone(),
+                        profile: profile.clone(),
+                    },
+                }),
                 connection_string: store.url.clone(),
                 url: store.url.clone(),
                 collection_name: store.collection_name.clone(),
                 context_prefix: store.context_prefix.clone(),
+                knowledge_base_id: store.knowledge_base_id.clone(),
+                region: store.region.clone(),
+                profile: store.profile.clone(),
             })
             .collect();
 

--- a/crates/aura-config/src/builder.rs
+++ b/crates/aura-config/src/builder.rs
@@ -1,9 +1,31 @@
 use crate::{Config, ConfigError};
 use aura::{
     Agent, AgentBuilder, AgentConfig, AgentSettings, EmbeddingModelConfig, LlmConfig, McpConfig,
-    McpServerConfig, ReasoningEffort, ToolsConfig, VectorStoreConfig,
+    McpServerConfig, ReasoningEffort, ToolsConfig, VectorStoreConfig, VectorStoreType,
 };
 use std::collections::HashMap;
+
+/// Convert TOML-layer EmbeddingConfig to runtime EmbeddingModelConfig
+fn convert_embedding(em: &crate::config::EmbeddingConfig) -> EmbeddingModelConfig {
+    match em {
+        crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
+            EmbeddingModelConfig::OpenAI {
+                api_key: api_key.clone(),
+                model: model.clone(),
+                base_url: None,
+            }
+        }
+        crate::config::EmbeddingConfig::Bedrock {
+            model,
+            region,
+            profile,
+        } => EmbeddingModelConfig::Bedrock {
+            model: model.clone(),
+            region: region.clone(),
+            profile: profile.clone(),
+        },
+    }
+}
 
 pub struct RigBuilder {
     config: Config,
@@ -101,34 +123,37 @@ impl RigBuilder {
             .config
             .vector_stores
             .iter()
-            .map(|store| VectorStoreConfig {
-                name: store.name.clone(),
-                store_type: store.store_type.clone(),
-                embedding_model: store.embedding_model.as_ref().map(|em| match em {
-                    crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
-                        EmbeddingModelConfig::OpenAI {
-                            api_key: api_key.clone(),
-                            model: model.clone(),
-                            base_url: None,
+            .map(|store| {
+                let store_type = match &store.store {
+                    crate::config::VectorStoreType::InMemory { embedding_model } => {
+                        VectorStoreType::InMemory {
+                            embedding_model: convert_embedding(embedding_model),
                         }
                     }
-                    crate::config::EmbeddingConfig::Bedrock {
-                        model,
+                    crate::config::VectorStoreType::Qdrant {
+                        embedding_model,
+                        url,
+                        collection_name,
+                    } => VectorStoreType::Qdrant {
+                        embedding_model: convert_embedding(embedding_model),
+                        url: url.clone(),
+                        collection_name: collection_name.clone(),
+                    },
+                    crate::config::VectorStoreType::BedrockKb {
+                        knowledge_base_id,
                         region,
                         profile,
-                    } => EmbeddingModelConfig::Bedrock {
-                        model: model.clone(),
+                    } => VectorStoreType::BedrockKb {
+                        knowledge_base_id: knowledge_base_id.clone(),
                         region: region.clone(),
                         profile: profile.clone(),
                     },
-                }),
-                connection_string: store.url.clone(),
-                url: store.url.clone(),
-                collection_name: store.collection_name.clone(),
-                context_prefix: store.context_prefix.clone(),
-                knowledge_base_id: store.knowledge_base_id.clone(),
-                region: store.region.clone(),
-                profile: store.profile.clone(),
+                };
+                VectorStoreConfig {
+                    name: store.name.clone(),
+                    context_prefix: store.context_prefix.clone(),
+                    store: store_type,
+                }
             })
             .collect();
 

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -195,43 +195,42 @@ pub enum McpServerConfig {
 pub struct VectorStoreConfig {
     /// Unique name to identify this vector store
     pub name: String,
-    #[serde(rename = "type")]
-    pub store_type: String, // "in_memory", "qdrant", or "bedrock_kb"
-    /// Embedding model (required for in_memory and qdrant, not used for bedrock_kb)
-    #[serde(default)]
-    pub embedding_model: Option<EmbeddingConfig>,
-    /// URL for external vector stores like Qdrant (optional)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Collection name for vector stores like Qdrant (optional)
-    #[serde(default)]
-    pub collection_name: Option<String>,
     /// Optional context string describing what the vector store contains (for better LLM guidance)
     #[serde(default)]
     pub context_prefix: Option<String>,
-    /// Knowledge base ID (required for bedrock_kb)
-    #[serde(default)]
-    pub knowledge_base_id: Option<String>,
-    /// AWS region (required for bedrock_kb)
-    #[serde(default)]
-    pub region: Option<String>,
-    /// AWS profile name (optional, for bedrock_kb)
-    #[serde(default)]
-    pub profile: Option<String>,
+    /// Store-type-specific configuration
+    #[serde(flatten)]
+    pub store: VectorStoreType,
+}
+
+/// Type-specific vector store configuration, tagged by `type` field
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum VectorStoreType {
+    InMemory {
+        embedding_model: EmbeddingConfig,
+    },
+    Qdrant {
+        embedding_model: EmbeddingConfig,
+        url: String,
+        collection_name: String,
+    },
+    BedrockKb {
+        knowledge_base_id: String,
+        region: String,
+        #[serde(default)]
+        profile: Option<String>,
+    },
 }
 
 impl Default for VectorStoreConfig {
     fn default() -> Self {
         Self {
             name: "default".to_string(),
-            store_type: "in_memory".to_string(),
-            embedding_model: Some(EmbeddingConfig::default()),
-            url: None,
-            collection_name: None,
             context_prefix: None,
-            knowledge_base_id: None,
-            region: None,
-            profile: None,
+            store: VectorStoreType::InMemory {
+                embedding_model: EmbeddingConfig::default(),
+            },
         }
     }
 }
@@ -380,29 +379,9 @@ impl Config {
 
         // Validate each vector store
         for store in &self.vector_stores {
-            match store.store_type.as_str() {
-                "bedrock_kb" => {
-                    if store.knowledge_base_id.as_ref().map_or(true, |id| id.is_empty()) {
-                        return Err(crate::ConfigError::Validation(format!(
-                            "knowledge_base_id is required for bedrock_kb vector store '{}'",
-                            store.name
-                        )));
-                    }
-                    if store.region.as_ref().map_or(true, |r| r.is_empty()) {
-                        return Err(crate::ConfigError::Validation(format!(
-                            "region is required for bedrock_kb vector store '{}'",
-                            store.name
-                        )));
-                    }
-                }
-                _ => {
-                    let embedding = store.embedding_model.as_ref().ok_or_else(|| {
-                        crate::ConfigError::Validation(format!(
-                            "embedding_model is required for '{}' vector store '{}'",
-                            store.store_type, store.name
-                        ))
-                    })?;
-                    match embedding {
+            match &store.store {
+                VectorStoreType::InMemory { embedding_model } | VectorStoreType::Qdrant { embedding_model, .. } => {
+                    match embedding_model {
                         EmbeddingConfig::OpenAI { api_key, .. } => {
                             if api_key.is_empty() {
                                 return Err(crate::ConfigError::Validation(format!(
@@ -420,6 +399,9 @@ impl Config {
                             }
                         }
                     }
+                }
+                VectorStoreType::BedrockKb { .. } => {
+                    // All required fields are enforced by the enum structure
                 }
             }
         }

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -190,14 +190,16 @@ pub enum McpServerConfig {
     },
 }
 
-/// Vector store configuration (in-memory and Qdrant support)
+/// Vector store configuration (in-memory, Qdrant, and Bedrock KB)
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct VectorStoreConfig {
     /// Unique name to identify this vector store
     pub name: String,
     #[serde(rename = "type")]
-    pub store_type: String, // "in_memory" or "qdrant"
-    pub embedding_model: EmbeddingConfig,
+    pub store_type: String, // "in_memory", "qdrant", or "bedrock_kb"
+    /// Embedding model (required for in_memory and qdrant, not used for bedrock_kb)
+    #[serde(default)]
+    pub embedding_model: Option<EmbeddingConfig>,
     /// URL for external vector stores like Qdrant (optional)
     #[serde(default)]
     pub url: Option<String>,
@@ -207,6 +209,15 @@ pub struct VectorStoreConfig {
     /// Optional context string describing what the vector store contains (for better LLM guidance)
     #[serde(default)]
     pub context_prefix: Option<String>,
+    /// Knowledge base ID (required for bedrock_kb)
+    #[serde(default)]
+    pub knowledge_base_id: Option<String>,
+    /// AWS region (required for bedrock_kb)
+    #[serde(default)]
+    pub region: Option<String>,
+    /// AWS profile name (optional, for bedrock_kb)
+    #[serde(default)]
+    pub profile: Option<String>,
 }
 
 impl Default for VectorStoreConfig {
@@ -214,20 +225,58 @@ impl Default for VectorStoreConfig {
         Self {
             name: "default".to_string(),
             store_type: "in_memory".to_string(),
-            embedding_model: EmbeddingConfig::default(),
+            embedding_model: Some(EmbeddingConfig::default()),
             url: None,
             collection_name: None,
             context_prefix: None,
+            knowledge_base_id: None,
+            region: None,
+            profile: None,
         }
     }
 }
 
-/// Embedding model configuration
-#[derive(Debug, Deserialize, Serialize, Clone, Default)]
-pub struct EmbeddingConfig {
-    pub provider: String, // "openai"
-    pub model: String,    // "text-embedding-3-small"
-    pub api_key: String,
+/// Embedding model configuration with strong typing per provider
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(tag = "provider", rename_all = "lowercase")]
+pub enum EmbeddingConfig {
+    OpenAI {
+        api_key: String,
+        model: String,
+    },
+    Bedrock {
+        model: String,
+        region: String,
+        /// AWS profile name (optional, uses default credentials if not specified)
+        #[serde(default)]
+        profile: Option<String>,
+    },
+}
+
+impl Default for EmbeddingConfig {
+    fn default() -> Self {
+        EmbeddingConfig::OpenAI {
+            api_key: String::new(),
+            model: "text-embedding-3-small".to_string(),
+        }
+    }
+}
+
+impl EmbeddingConfig {
+    /// Get the provider name
+    pub fn provider(&self) -> &str {
+        match self {
+            EmbeddingConfig::OpenAI { .. } => "openai",
+            EmbeddingConfig::Bedrock { .. } => "bedrock",
+        }
+    }
+
+    /// Get the model name
+    pub fn model(&self) -> &str {
+        match self {
+            EmbeddingConfig::OpenAI { model, .. } | EmbeddingConfig::Bedrock { model, .. } => model,
+        }
+    }
 }
 
 /// Tools configuration
@@ -331,11 +380,47 @@ impl Config {
 
         // Validate each vector store
         for store in &self.vector_stores {
-            if store.embedding_model.api_key.is_empty() {
-                return Err(crate::ConfigError::Validation(format!(
-                    "Embedding model API key is required for vector store '{}'",
-                    store.name
-                )));
+            match store.store_type.as_str() {
+                "bedrock_kb" => {
+                    if store.knowledge_base_id.as_ref().map_or(true, |id| id.is_empty()) {
+                        return Err(crate::ConfigError::Validation(format!(
+                            "knowledge_base_id is required for bedrock_kb vector store '{}'",
+                            store.name
+                        )));
+                    }
+                    if store.region.as_ref().map_or(true, |r| r.is_empty()) {
+                        return Err(crate::ConfigError::Validation(format!(
+                            "region is required for bedrock_kb vector store '{}'",
+                            store.name
+                        )));
+                    }
+                }
+                _ => {
+                    let embedding = store.embedding_model.as_ref().ok_or_else(|| {
+                        crate::ConfigError::Validation(format!(
+                            "embedding_model is required for '{}' vector store '{}'",
+                            store.store_type, store.name
+                        ))
+                    })?;
+                    match embedding {
+                        EmbeddingConfig::OpenAI { api_key, .. } => {
+                            if api_key.is_empty() {
+                                return Err(crate::ConfigError::Validation(format!(
+                                    "Embedding model API key is required for vector store '{}'",
+                                    store.name
+                                )));
+                            }
+                        }
+                        EmbeddingConfig::Bedrock { region, .. } => {
+                            if region.is_empty() {
+                                return Err(crate::ConfigError::Validation(format!(
+                                    "Embedding model region is required for Bedrock provider in vector store '{}'",
+                                    store.name
+                                )));
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -82,13 +82,17 @@ temperature = 0.5
             "Should have at least one vector store"
         );
         let vector_store = &config.vector_stores[0];
-        assert_eq!(vector_store.store_type, "in_memory");
-        match vector_store.embedding_model.as_ref().unwrap() {
-            crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
-                assert_eq!(model, "text-embedding-3-small");
-                assert_eq!(api_key, "test_embedding_key");
+        match &vector_store.store {
+            crate::config::VectorStoreType::InMemory { embedding_model } => {
+                match embedding_model {
+                    crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
+                        assert_eq!(model, "text-embedding-3-small");
+                        assert_eq!(api_key, "test_embedding_key");
+                    }
+                    _ => panic!("Expected OpenAI embedding config"),
+                }
             }
-            _ => panic!("Expected OpenAI embedding config"),
+            _ => panic!("Expected InMemory vector store"),
         }
 
         // Test MCP servers
@@ -341,11 +345,16 @@ system_prompt = "Test with env vars"
             }
             _ => panic!("Expected OpenAI LLM config"),
         }
-        match config.vector_stores[0].embedding_model.as_ref().unwrap() {
-            crate::config::EmbeddingConfig::OpenAI { api_key, .. } => {
-                assert_eq!(api_key, "mock_openai_key");
+        match &config.vector_stores[0].store {
+            crate::config::VectorStoreType::InMemory { embedding_model } => {
+                match embedding_model {
+                    crate::config::EmbeddingConfig::OpenAI { api_key, .. } => {
+                        assert_eq!(api_key, "mock_openai_key");
+                    }
+                    _ => panic!("Expected OpenAI embedding config"),
+                }
             }
-            _ => panic!("Expected OpenAI embedding config"),
+            _ => panic!("Expected InMemory vector store"),
         }
 
         let mcp_config = config.mcp.expect("MCP config should be present");
@@ -939,17 +948,22 @@ system_prompt = "Test"
         let config = load_config_from_str(config_str).expect("Failed to parse config");
 
         let vector_store = &config.vector_stores[0];
-        match vector_store.embedding_model.as_ref().unwrap() {
-            crate::config::EmbeddingConfig::Bedrock {
-                model,
-                region,
-                profile,
-            } => {
-                assert_eq!(model, "amazon.titan-embed-text-v2:0");
-                assert_eq!(region, "us-west-2");
-                assert_eq!(profile, &Some("my-profile".to_string()));
+        match &vector_store.store {
+            crate::config::VectorStoreType::Qdrant { embedding_model, .. } => {
+                match embedding_model {
+                    crate::config::EmbeddingConfig::Bedrock {
+                        model,
+                        region,
+                        profile,
+                    } => {
+                        assert_eq!(model, "amazon.titan-embed-text-v2:0");
+                        assert_eq!(region, "us-west-2");
+                        assert_eq!(profile, &Some("my-profile".to_string()));
+                    }
+                    _ => panic!("Expected Bedrock embedding config"),
+                }
             }
-            _ => panic!("Expected Bedrock embedding config"),
+            _ => panic!("Expected Qdrant vector store"),
         }
     }
 
@@ -977,14 +991,19 @@ system_prompt = "Test"
         let config = load_config_from_str(config_str).expect("Failed to parse config");
 
         let vector_store = &config.vector_stores[0];
-        match vector_store.embedding_model.as_ref().unwrap() {
-            crate::config::EmbeddingConfig::Bedrock {
-                region, profile, ..
-            } => {
-                assert_eq!(region, "us-east-1");
-                assert_eq!(profile, &None);
+        match &vector_store.store {
+            crate::config::VectorStoreType::InMemory { embedding_model } => {
+                match embedding_model {
+                    crate::config::EmbeddingConfig::Bedrock {
+                        region, profile, ..
+                    } => {
+                        assert_eq!(region, "us-east-1");
+                        assert_eq!(profile, &None);
+                    }
+                    _ => panic!("Expected Bedrock embedding config"),
+                }
             }
-            _ => panic!("Expected Bedrock embedding config"),
+            _ => panic!("Expected InMemory vector store"),
         }
     }
 
@@ -1066,19 +1085,23 @@ system_prompt = "Test"
             .expect("Failed to parse bedrock_kb config");
 
         let store = &config.vector_stores[0];
-        assert_eq!(store.store_type, "bedrock_kb");
         assert_eq!(store.name, "company_docs");
-        assert_eq!(
-            store.knowledge_base_id,
-            Some("KB12345".to_string())
-        );
-        assert_eq!(store.region, Some("us-west-2".to_string()));
-        assert_eq!(store.profile, Some("my-profile".to_string()));
-        assert!(store.embedding_model.is_none());
         assert_eq!(
             store.context_prefix,
             Some("Company documentation".to_string())
         );
+        match &store.store {
+            crate::config::VectorStoreType::BedrockKb {
+                knowledge_base_id,
+                region,
+                profile,
+            } => {
+                assert_eq!(knowledge_base_id, "KB12345");
+                assert_eq!(region, "us-west-2");
+                assert_eq!(profile, &Some("my-profile".to_string()));
+            }
+            _ => panic!("Expected BedrockKb vector store"),
+        }
     }
 
     #[test]

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -83,9 +83,13 @@ temperature = 0.5
         );
         let vector_store = &config.vector_stores[0];
         assert_eq!(vector_store.store_type, "in_memory");
-        assert_eq!(vector_store.embedding_model.provider, "openai");
-        assert_eq!(vector_store.embedding_model.model, "text-embedding-3-small");
-        assert_eq!(vector_store.embedding_model.api_key, "test_embedding_key");
+        match vector_store.embedding_model.as_ref().unwrap() {
+            crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
+                assert_eq!(model, "text-embedding-3-small");
+                assert_eq!(api_key, "test_embedding_key");
+            }
+            _ => panic!("Expected OpenAI embedding config"),
+        }
 
         // Test MCP servers
         println!("\n✅ Testing MCP servers...");
@@ -337,10 +341,12 @@ system_prompt = "Test with env vars"
             }
             _ => panic!("Expected OpenAI LLM config"),
         }
-        assert_eq!(
-            config.vector_stores[0].embedding_model.api_key,
-            "mock_openai_key"
-        );
+        match config.vector_stores[0].embedding_model.as_ref().unwrap() {
+            crate::config::EmbeddingConfig::OpenAI { api_key, .. } => {
+                assert_eq!(api_key, "mock_openai_key");
+            }
+            _ => panic!("Expected OpenAI embedding config"),
+        }
 
         let mcp_config = config.mcp.expect("MCP config should be present");
         let test_server = mcp_config
@@ -904,6 +910,227 @@ system_prompt = "You are helpful."
             }
             _ => panic!("Expected Ollama config"),
         }
+    }
+
+    #[test]
+    fn test_bedrock_embedding_config_parsing() {
+        let config_str = r#"
+[llm]
+provider = "bedrock"
+model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+region = "us-east-1"
+
+[[vector_stores]]
+name = "docs"
+type = "qdrant"
+url = "http://localhost:6334"
+collection_name = "documents"
+
+[vector_stores.embedding_model]
+provider = "bedrock"
+model = "amazon.titan-embed-text-v2:0"
+region = "us-west-2"
+profile = "my-profile"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+
+        let vector_store = &config.vector_stores[0];
+        match vector_store.embedding_model.as_ref().unwrap() {
+            crate::config::EmbeddingConfig::Bedrock {
+                model,
+                region,
+                profile,
+            } => {
+                assert_eq!(model, "amazon.titan-embed-text-v2:0");
+                assert_eq!(region, "us-west-2");
+                assert_eq!(profile, &Some("my-profile".to_string()));
+            }
+            _ => panic!("Expected Bedrock embedding config"),
+        }
+    }
+
+    #[test]
+    fn test_bedrock_embedding_without_profile() {
+        let config_str = r#"
+[llm]
+provider = "bedrock"
+model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+region = "us-east-1"
+
+[[vector_stores]]
+name = "docs"
+type = "in_memory"
+
+[vector_stores.embedding_model]
+provider = "bedrock"
+model = "amazon.titan-embed-text-v2:0"
+region = "us-east-1"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+
+        let vector_store = &config.vector_stores[0];
+        match vector_store.embedding_model.as_ref().unwrap() {
+            crate::config::EmbeddingConfig::Bedrock {
+                region, profile, ..
+            } => {
+                assert_eq!(region, "us-east-1");
+                assert_eq!(profile, &None);
+            }
+            _ => panic!("Expected Bedrock embedding config"),
+        }
+    }
+
+    #[test]
+    fn test_bedrock_embedding_missing_region_fails_validation() {
+        let config_str = r#"
+[llm]
+provider = "bedrock"
+model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+region = "us-east-1"
+
+[[vector_stores]]
+name = "docs"
+type = "in_memory"
+
+[vector_stores.embedding_model]
+provider = "bedrock"
+model = "amazon.titan-embed-text-v2:0"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let result = load_config_from_str(config_str);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("region"),
+            "Error should mention missing region: {err}"
+        );
+    }
+
+    #[test]
+    fn test_openai_embedding_still_requires_api_key() {
+        // Ensure existing OpenAI validation still works after Bedrock changes
+        let config_str = r#"
+[llm]
+provider = "openai"
+api_key = "test_key"
+model = "gpt-4"
+
+[[vector_stores]]
+name = "default"
+type = "in_memory"
+
+[vector_stores.embedding_model]
+provider = "openai"
+model = "text-embedding-3-small"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let result = load_config_from_str(config_str);
+        assert!(result.is_err(), "OpenAI embedding without api_key should fail validation");
+    }
+
+    #[test]
+    fn test_bedrock_kb_config_parsing() {
+        let config_str = r#"
+[llm]
+provider = "bedrock"
+model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+region = "us-east-1"
+
+[[vector_stores]]
+name = "company_docs"
+type = "bedrock_kb"
+knowledge_base_id = "KB12345"
+region = "us-west-2"
+profile = "my-profile"
+context_prefix = "Company documentation"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let config = load_config_from_str(config_str)
+            .expect("Failed to parse bedrock_kb config");
+
+        let store = &config.vector_stores[0];
+        assert_eq!(store.store_type, "bedrock_kb");
+        assert_eq!(store.name, "company_docs");
+        assert_eq!(
+            store.knowledge_base_id,
+            Some("KB12345".to_string())
+        );
+        assert_eq!(store.region, Some("us-west-2".to_string()));
+        assert_eq!(store.profile, Some("my-profile".to_string()));
+        assert!(store.embedding_model.is_none());
+        assert_eq!(
+            store.context_prefix,
+            Some("Company documentation".to_string())
+        );
+    }
+
+    #[test]
+    fn test_bedrock_kb_missing_knowledge_base_id_fails() {
+        let config_str = r#"
+[llm]
+provider = "bedrock"
+model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+region = "us-east-1"
+
+[[vector_stores]]
+name = "kb"
+type = "bedrock_kb"
+region = "us-east-1"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let result = load_config_from_str(config_str);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("knowledge_base_id"),
+            "Error should mention knowledge_base_id: {err}"
+        );
+    }
+
+    #[test]
+    fn test_bedrock_kb_missing_region_fails() {
+        let config_str = r#"
+[llm]
+provider = "bedrock"
+model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+region = "us-east-1"
+
+[[vector_stores]]
+name = "kb"
+type = "bedrock_kb"
+knowledge_base_id = "KB12345"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let result = load_config_from_str(config_str);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("region"),
+            "Error should mention region: {err}"
+        );
     }
 
     #[test]

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -12,6 +12,7 @@ rig-core = { workspace = true }
 rig-bedrock = { workspace = true }
 aws-config = { workspace = true }
 aws-sdk-bedrockruntime = { workspace = true }
+aws-sdk-bedrockagentruntime = { workspace = true }
 
 rmcp = { workspace = true }
 futures = "0.3"

--- a/crates/aura/src/bedrock_embedding.rs
+++ b/crates/aura/src/bedrock_embedding.rs
@@ -30,12 +30,8 @@ impl AuraBedrockEmbeddingModel {
 }
 
 fn default_ndims(model: &str) -> usize {
-    if model.starts_with("amazon.titan-embed-text-v2") {
-        1024
-    } else if model.starts_with("amazon.titan-embed-text-v1") {
+    if model.starts_with("amazon.titan-embed-text-v1") {
         1536
-    } else if model.starts_with("cohere.embed-") {
-        1024
     } else {
         1024
     }

--- a/crates/aura/src/bedrock_embedding.rs
+++ b/crates/aura/src/bedrock_embedding.rs
@@ -1,0 +1,151 @@
+//! Native Bedrock embedding model for aura.
+//!
+//! Bypasses `rig-bedrock` which hard-codes the Titan v2 request shape and
+//! always serializes `dimensions: 0` when ndims is not set. This type
+//! talks to `aws-sdk-bedrockruntime` directly and emits the correct body
+//! per model family (Titan v1, Titan v2, Cohere embed v3).
+
+use aws_sdk_bedrockruntime::Client as BedrockClient;
+use aws_sdk_bedrockruntime::primitives::Blob;
+use rig::embeddings::{Embedding, EmbeddingError, EmbeddingModel};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone)]
+pub struct AuraBedrockEmbeddingModel {
+    client: BedrockClient,
+    model: String,
+    ndims: usize,
+}
+
+impl AuraBedrockEmbeddingModel {
+    pub fn new(client: BedrockClient, model: impl Into<String>, ndims: Option<usize>) -> Self {
+        let model = model.into();
+        let ndims = ndims.unwrap_or_else(|| default_ndims(&model));
+        Self {
+            client,
+            model,
+            ndims,
+        }
+    }
+}
+
+fn default_ndims(model: &str) -> usize {
+    if model.starts_with("amazon.titan-embed-text-v2") {
+        1024
+    } else if model.starts_with("amazon.titan-embed-text-v1") {
+        1536
+    } else if model.starts_with("cohere.embed-") {
+        1024
+    } else {
+        1024
+    }
+}
+
+#[derive(Serialize)]
+struct TitanV2Req<'a> {
+    #[serde(rename = "inputText")]
+    input_text: &'a str,
+    dimensions: usize,
+    normalize: bool,
+}
+
+#[derive(Serialize)]
+struct TitanV1Req<'a> {
+    #[serde(rename = "inputText")]
+    input_text: &'a str,
+}
+
+#[derive(Serialize)]
+struct CohereReq<'a> {
+    texts: Vec<&'a str>,
+    input_type: &'static str,
+    truncate: &'static str,
+}
+
+#[derive(Deserialize)]
+struct TitanResp {
+    embedding: Vec<f64>,
+}
+
+#[derive(Deserialize)]
+struct CohereResp {
+    embeddings: Vec<Vec<f64>>,
+}
+
+impl AuraBedrockEmbeddingModel {
+    async fn invoke_one(&self, text: &str) -> Result<Vec<f64>, EmbeddingError> {
+        let body = if self.model.starts_with("amazon.titan-embed-text-v2") {
+            serde_json::to_vec(&TitanV2Req {
+                input_text: text,
+                dimensions: self.ndims,
+                normalize: true,
+            })
+        } else if self.model.starts_with("amazon.titan-embed-text-v1") {
+            serde_json::to_vec(&TitanV1Req { input_text: text })
+        } else if self.model.starts_with("cohere.embed-") {
+            serde_json::to_vec(&CohereReq {
+                texts: vec![text],
+                input_type: "search_document",
+                truncate: "END",
+            })
+        } else {
+            return Err(EmbeddingError::ProviderError(format!(
+                "unsupported Bedrock embedding model: {}",
+                self.model
+            )));
+        }
+        .map_err(EmbeddingError::JsonError)?;
+
+        let resp = self
+            .client
+            .invoke_model()
+            .model_id(&self.model)
+            .content_type("application/json")
+            .accept("application/json")
+            .body(Blob::new(body))
+            .send()
+            .await
+            .map_err(|e| EmbeddingError::ProviderError(format!("{e:?}")))?;
+
+        let bytes = resp.body.into_inner();
+        if self.model.starts_with("cohere.embed-") {
+            let parsed: CohereResp =
+                serde_json::from_slice(&bytes).map_err(EmbeddingError::JsonError)?;
+            parsed
+                .embeddings
+                .into_iter()
+                .next()
+                .ok_or_else(|| EmbeddingError::ResponseError("empty cohere response".into()))
+        } else {
+            let parsed: TitanResp =
+                serde_json::from_slice(&bytes).map_err(EmbeddingError::JsonError)?;
+            Ok(parsed.embedding)
+        }
+    }
+}
+
+impl EmbeddingModel for AuraBedrockEmbeddingModel {
+    const MAX_DOCUMENTS: usize = 1;
+    type Client = BedrockClient;
+
+    fn make(client: &Self::Client, model: impl Into<String>, dims: Option<usize>) -> Self {
+        Self::new(client.clone(), model, dims)
+    }
+
+    fn ndims(&self) -> usize {
+        self.ndims
+    }
+
+    async fn embed_texts(
+        &self,
+        texts: impl IntoIterator<Item = String> + Send,
+    ) -> Result<Vec<Embedding>, EmbeddingError> {
+        let docs: Vec<String> = texts.into_iter().collect();
+        let mut out = Vec::with_capacity(docs.len());
+        for doc in docs {
+            let vec = self.invoke_one(&doc).await?;
+            out.push(Embedding { document: doc, vec });
+        }
+        Ok(out)
+    }
+}

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -1035,11 +1035,13 @@ impl AgentBuilder {
             for vector_store in &config.vector_stores {
                 tracing::info!("Store: {}", vector_store.name);
                 tracing::info!("  Type: {}", vector_store.store_type);
-                tracing::info!(
-                    "  Embedding Provider: {}",
-                    vector_store.embedding_model.provider
-                );
-                tracing::info!("  Embedding Model: {}", vector_store.embedding_model.model);
+                if let Some(em) = &vector_store.embedding_model {
+                    tracing::info!("  Embedding Provider: {}", em.provider());
+                    tracing::info!("  Embedding Model: {}", em.model());
+                }
+                if let Some(kb_id) = &vector_store.knowledge_base_id {
+                    tracing::info!("  Knowledge Base ID: {}", kb_id);
+                }
             }
         }
 

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{AgentConfig, LlmConfig, McpServerConfig},
+    config::{AgentConfig, LlmConfig, McpServerConfig, VectorStoreType},
     error::{BuilderError, BuilderResult},
     mcp::McpManager,
     provider_agent::{
@@ -1034,13 +1034,24 @@ impl AgentBuilder {
             tracing::info!("=== Vector Stores Configuration ===");
             for vector_store in &config.vector_stores {
                 tracing::info!("Store: {}", vector_store.name);
-                tracing::info!("  Type: {}", vector_store.store_type);
-                if let Some(em) = &vector_store.embedding_model {
-                    tracing::info!("  Embedding Provider: {}", em.provider());
-                    tracing::info!("  Embedding Model: {}", em.model());
-                }
-                if let Some(kb_id) = &vector_store.knowledge_base_id {
-                    tracing::info!("  Knowledge Base ID: {}", kb_id);
+                match &vector_store.store {
+                    VectorStoreType::InMemory { embedding_model } => {
+                        tracing::info!("  Type: in_memory");
+                        tracing::info!("  Embedding Provider: {}", embedding_model.provider());
+                        tracing::info!("  Embedding Model: {}", embedding_model.model());
+                    }
+                    VectorStoreType::Qdrant { embedding_model, url, collection_name } => {
+                        tracing::info!("  Type: qdrant");
+                        tracing::info!("  URL: {}", url);
+                        tracing::info!("  Collection: {}", collection_name);
+                        tracing::info!("  Embedding Provider: {}", embedding_model.provider());
+                        tracing::info!("  Embedding Model: {}", embedding_model.model());
+                    }
+                    VectorStoreType::BedrockKb { knowledge_base_id, region, .. } => {
+                        tracing::info!("  Type: bedrock_kb");
+                        tracing::info!("  Knowledge Base ID: {}", knowledge_base_id);
+                        tracing::info!("  Region: {}", region);
+                    }
                 }
             }
         }

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -193,21 +193,56 @@ pub struct AgentSettings {
 pub struct VectorStoreConfig {
     pub name: String,
     pub store_type: String,
-    pub embedding_model: EmbeddingModelConfig,
+    /// Embedding model (required for in_memory/qdrant, None for bedrock_kb)
+    pub embedding_model: Option<EmbeddingModelConfig>,
     pub connection_string: Option<String>,
     pub url: Option<String>,
     pub collection_name: Option<String>,
     /// Optional context string to prepend to search results for better RAG integration
     pub context_prefix: Option<String>,
+    /// Knowledge base ID (required for bedrock_kb)
+    pub knowledge_base_id: Option<String>,
+    /// AWS region (required for bedrock_kb)
+    pub region: Option<String>,
+    /// AWS profile name (optional, for bedrock_kb)
+    pub profile: Option<String>,
 }
 
-/// Embedding model configuration
+/// Embedding model configuration with strong typing per provider
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EmbeddingModelConfig {
-    pub provider: String,
-    pub model: String,
-    pub api_key: String,
-    pub base_url: Option<String>,
+#[serde(tag = "provider", rename_all = "lowercase")]
+pub enum EmbeddingModelConfig {
+    OpenAI {
+        api_key: String,
+        model: String,
+        #[serde(default)]
+        base_url: Option<String>,
+    },
+    Bedrock {
+        model: String,
+        region: String,
+        /// AWS profile name (optional, uses default credentials if not specified)
+        #[serde(default)]
+        profile: Option<String>,
+    },
+}
+
+impl EmbeddingModelConfig {
+    /// Get the provider name
+    pub fn provider(&self) -> &str {
+        match self {
+            EmbeddingModelConfig::OpenAI { .. } => "openai",
+            EmbeddingModelConfig::Bedrock { .. } => "bedrock",
+        }
+    }
+
+    /// Get the model name
+    pub fn model(&self) -> &str {
+        match self {
+            EmbeddingModelConfig::OpenAI { model, .. }
+            | EmbeddingModelConfig::Bedrock { model, .. } => model,
+        }
+    }
 }
 
 /// MCP (Model Context Protocol) configuration

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -192,20 +192,31 @@ pub struct AgentSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VectorStoreConfig {
     pub name: String,
-    pub store_type: String,
-    /// Embedding model (required for in_memory/qdrant, None for bedrock_kb)
-    pub embedding_model: Option<EmbeddingModelConfig>,
-    pub connection_string: Option<String>,
-    pub url: Option<String>,
-    pub collection_name: Option<String>,
     /// Optional context string to prepend to search results for better RAG integration
     pub context_prefix: Option<String>,
-    /// Knowledge base ID (required for bedrock_kb)
-    pub knowledge_base_id: Option<String>,
-    /// AWS region (required for bedrock_kb)
-    pub region: Option<String>,
-    /// AWS profile name (optional, for bedrock_kb)
-    pub profile: Option<String>,
+    /// Store-type-specific configuration
+    #[serde(flatten)]
+    pub store: VectorStoreType,
+}
+
+/// Type-specific vector store configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum VectorStoreType {
+    InMemory {
+        embedding_model: EmbeddingModelConfig,
+    },
+    Qdrant {
+        embedding_model: EmbeddingModelConfig,
+        url: String,
+        collection_name: String,
+    },
+    BedrockKb {
+        knowledge_base_id: String,
+        region: String,
+        #[serde(default)]
+        profile: Option<String>,
+    },
 }
 
 /// Embedding model configuration with strong typing per provider

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -38,7 +38,7 @@ pub mod vector_store;
 pub use builder::{Agent, AgentBuilder, FilesystemTools};
 pub use config::{
     AgentConfig, AgentSettings, EmbeddingModelConfig, LlmConfig, McpConfig, McpServerConfig,
-    ReasoningEffort, ToolsConfig, VectorStoreConfig,
+    ReasoningEffort, ToolsConfig, VectorStoreConfig, VectorStoreType,
 };
 pub use error::{BuilderError, BuilderResult};
 pub use provider_agent::{

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -27,6 +27,7 @@ mod schema_sanitize; // Private - MCP schema sanitization for OpenAI compatibili
 pub mod stream_events;
 pub mod streaming;
 pub mod streaming_request_hook;
+pub mod bedrock_embedding;
 pub(crate) mod string_utils;
 pub mod tool_error_detection;
 pub mod tool_event_broker;

--- a/crates/aura/src/vector_store.rs
+++ b/crates/aura/src/vector_store.rs
@@ -1,4 +1,7 @@
-use crate::{config::VectorStoreConfig, error::BuilderError};
+use crate::{
+    config::{EmbeddingModelConfig, VectorStoreConfig},
+    error::BuilderError,
+};
 use qdrant_client::{Qdrant, qdrant::QueryPoints};
 use rig::{
     OneOrMany,
@@ -9,10 +12,17 @@ use rig::{
         VectorStoreIndex, in_memory_store::InMemoryVectorStore, request::VectorSearchRequest,
     },
 };
+use rig_bedrock::embedding::EmbeddingModel as BedrockEmbeddingModel;
 use rig_qdrant::QdrantVectorStore;
 use serde_json::Value;
 use std::sync::Arc;
 use tracing::{debug, info};
+
+/// Qdrant store variant parameterized by embedding model type
+enum QdrantStoreKind {
+    OpenAI(QdrantVectorStore<OpenAIEmbeddingModel>),
+    Bedrock(QdrantVectorStore<BedrockEmbeddingModel>),
+}
 
 /// Vector store manager for handling document retrieval via vector search
 pub struct VectorStoreManager {
@@ -21,9 +31,24 @@ pub struct VectorStoreManager {
     pub qdrant_url: Option<String>,
     pub collection_name: Option<String>,
     pub in_memory_store: Option<Arc<InMemoryVectorStore<String>>>,
-    pub qdrant_store: Option<Arc<QdrantVectorStore<OpenAIEmbeddingModel>>>,
-    pub embedding_model: OpenAIEmbeddingModel,
+    qdrant_store: Option<Arc<QdrantStoreKind>>,
+    bedrock_kb_client: Option<Arc<aws_sdk_bedrockagentruntime::Client>>,
+    bedrock_kb_id: Option<String>,
+    embedding_provider: String,
+    embedding_model_name: String,
     pub context_prefix: Option<String>,
+}
+
+/// Helper to get the required embedding model config or return an error
+fn require_embedding_model(
+    config: &VectorStoreConfig,
+) -> Result<&EmbeddingModelConfig, BuilderError> {
+    config.embedding_model.as_ref().ok_or_else(|| {
+        BuilderError::VectorStoreError(format!(
+            "embedding_model is required for '{}' vector store '{}'",
+            config.store_type, config.name
+        ))
+    })
 }
 
 impl VectorStoreManager {
@@ -34,31 +59,103 @@ impl VectorStoreManager {
         match config.store_type.as_str() {
             "in_memory" => Self::create_in_memory_store(config).await,
             "qdrant" => Self::create_qdrant_store(config).await,
+            "bedrock_kb" => Self::create_bedrock_kb_store(config).await,
             store_type => Err(BuilderError::VectorStoreError(format!(
                 "Unsupported vector store type: {store_type}"
             ))),
         }
     }
 
+    fn create_openai_embedding_model(
+        api_key: &str,
+        model: &str,
+    ) -> Result<OpenAIEmbeddingModel, BuilderError> {
+        let client = Client::new(api_key).map_err(|e| {
+            BuilderError::VectorStoreError(format!("Failed to create OpenAI client: {e}"))
+        })?;
+        Ok(client.embedding_model(model))
+    }
+
+    async fn create_bedrock_embedding_model(
+        model: &str,
+        region: &str,
+        profile: Option<&str>,
+    ) -> Result<BedrockEmbeddingModel, BuilderError> {
+        use aws_config::{BehaviorVersion, Region};
+
+        let sdk_config = if let Some(profile_name) = profile {
+            info!(
+                "Loading AWS config with profile '{}' for Bedrock embeddings",
+                profile_name
+            );
+            aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(region.to_string()))
+                .profile_name(profile_name)
+                .load()
+                .await
+        } else {
+            info!("Loading AWS config from environment for Bedrock embeddings");
+            aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(region.to_string()))
+                .load()
+                .await
+        };
+
+        let aws_client = aws_sdk_bedrockruntime::Client::new(&sdk_config);
+        let bedrock_client = rig_bedrock::client::Client::from(aws_client);
+        info!("Bedrock embedding client initialized successfully");
+
+        Ok(bedrock_client.embedding_model(model))
+    }
+
+    /// Load AWS SDK config with optional region and profile
+    async fn load_aws_config(
+        region: &str,
+        profile: Option<&str>,
+    ) -> aws_config::SdkConfig {
+        use aws_config::{BehaviorVersion, Region};
+
+        if let Some(profile_name) = profile {
+            info!(
+                "Loading AWS config with profile '{}'",
+                profile_name
+            );
+            aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(region.to_string()))
+                .profile_name(profile_name)
+                .load()
+                .await
+        } else {
+            info!("Loading AWS config from environment");
+            aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(region.to_string()))
+                .load()
+                .await
+        }
+    }
+
     /// Create an in-memory vector store
     async fn create_in_memory_store(config: &VectorStoreConfig) -> Result<Self, BuilderError> {
+        let embedding = require_embedding_model(config)?;
+
         info!(
             "Creating in-memory vector store with {} embeddings",
-            config.embedding_model.model
+            embedding.model()
         );
 
-        // Create OpenAI embedding model
-        let embedding_model = if config.embedding_model.provider == "openai" {
-            let client = Client::new(&config.embedding_model.api_key).map_err(|e| {
-                BuilderError::VectorStoreError(format!("Failed to create OpenAI client: {e}"))
-            })?;
-            client.embedding_model(&config.embedding_model.model)
-        } else {
-            return Err(BuilderError::VectorStoreError(format!(
-                "Unsupported embedding provider: {}. Only 'openai' is supported for now.",
-                config.embedding_model.provider
-            )));
-        };
+        // Validate the embedding provider can be initialized
+        match embedding {
+            EmbeddingModelConfig::OpenAI { api_key, model, .. } => {
+                Self::create_openai_embedding_model(api_key, model)?;
+            }
+            EmbeddingModelConfig::Bedrock {
+                model,
+                region,
+                profile,
+            } => {
+                Self::create_bedrock_embedding_model(model, region, profile.as_deref()).await?;
+            }
+        }
 
         // Create an empty in-memory vector store for now
         let store = InMemoryVectorStore::from_documents(std::iter::empty::<(
@@ -75,16 +172,21 @@ impl VectorStoreManager {
             collection_name: None,
             qdrant_store: None,
             in_memory_store: Some(Arc::new(store)),
-            embedding_model,
+            bedrock_kb_client: None,
+            bedrock_kb_id: None,
+            embedding_provider: embedding.provider().to_string(),
+            embedding_model_name: embedding.model().to_string(),
             context_prefix: config.context_prefix.clone(),
         })
     }
 
     /// Create a Qdrant vector store
     async fn create_qdrant_store(config: &VectorStoreConfig) -> Result<Self, BuilderError> {
+        let embedding = require_embedding_model(config)?;
+
         info!(
             "Creating Qdrant vector store with {} embeddings",
-            config.embedding_model.model
+            embedding.model()
         );
 
         let url = config.url.as_ref().ok_or_else(|| {
@@ -108,19 +210,6 @@ impl VectorStoreManager {
             }
         };
 
-        // Create OpenAI embedding model
-        let embedding_model = if config.embedding_model.provider == "openai" {
-            let client = Client::new(&config.embedding_model.api_key).map_err(|e| {
-                BuilderError::VectorStoreError(format!("Failed to create OpenAI client: {e}"))
-            })?;
-            client.embedding_model(&config.embedding_model.model)
-        } else {
-            return Err(BuilderError::VectorStoreError(format!(
-                "Unsupported embedding provider: {}. Only 'openai' is supported for now.",
-                config.embedding_model.provider
-            )));
-        };
-
         // Create default query parameters for the collection
         let query_params = QueryPoints {
             collection_name: collection_name.clone(),
@@ -133,9 +222,27 @@ impl VectorStoreManager {
             ..Default::default()
         };
 
-        // Create the Qdrant vector store using rig-qdrant
-        let qdrant_store =
-            QdrantVectorStore::new(qdrant_client, embedding_model.clone(), query_params);
+        // Create embedding model and Qdrant store based on provider
+        let qdrant_store = match embedding {
+            EmbeddingModelConfig::OpenAI { api_key, model, .. } => {
+                let embedding_model = Self::create_openai_embedding_model(api_key, model)?;
+                let store =
+                    QdrantVectorStore::new(qdrant_client, embedding_model, query_params);
+                QdrantStoreKind::OpenAI(store)
+            }
+            EmbeddingModelConfig::Bedrock {
+                model,
+                region,
+                profile,
+            } => {
+                let embedding_model =
+                    Self::create_bedrock_embedding_model(model, region, profile.as_deref())
+                        .await?;
+                let store =
+                    QdrantVectorStore::new(qdrant_client, embedding_model, query_params);
+                QdrantStoreKind::Bedrock(store)
+            }
+        };
 
         info!("Qdrant vector store initialized successfully");
 
@@ -146,13 +253,68 @@ impl VectorStoreManager {
             collection_name: Some(collection_name.clone()),
             qdrant_store: Some(Arc::new(qdrant_store)),
             in_memory_store: None,
-            embedding_model,
+            bedrock_kb_client: None,
+            bedrock_kb_id: None,
+            embedding_provider: embedding.provider().to_string(),
+            embedding_model_name: embedding.model().to_string(),
+            context_prefix: config.context_prefix.clone(),
+        })
+    }
+
+    /// Create a Bedrock Knowledge Base vector store
+    async fn create_bedrock_kb_store(config: &VectorStoreConfig) -> Result<Self, BuilderError> {
+        let kb_id = config
+            .knowledge_base_id
+            .as_ref()
+            .ok_or_else(|| {
+                BuilderError::VectorStoreError(
+                    "knowledge_base_id is required for bedrock_kb".to_string(),
+                )
+            })?
+            .clone();
+
+        let region = config.region.as_ref().ok_or_else(|| {
+            BuilderError::VectorStoreError(
+                "region is required for bedrock_kb".to_string(),
+            )
+        })?;
+
+        info!("Creating Bedrock Knowledge Base store");
+        info!("  Knowledge Base ID: {}", kb_id);
+        info!("  Region: {}", region);
+
+        let sdk_config = Self::load_aws_config(
+            region,
+            config.profile.as_deref(),
+        )
+        .await;
+
+        let client = aws_sdk_bedrockagentruntime::Client::new(&sdk_config);
+        info!("Bedrock Knowledge Base client initialized");
+
+        Ok(Self {
+            store_name: config.name.clone(),
+            store_type: "bedrock_kb".to_string(),
+            qdrant_url: None,
+            collection_name: None,
+            qdrant_store: None,
+            in_memory_store: None,
+            bedrock_kb_client: Some(Arc::new(client)),
+            bedrock_kb_id: Some(kb_id),
+            embedding_provider: "bedrock_kb".to_string(),
+            embedding_model_name: "managed".to_string(),
             context_prefix: config.context_prefix.clone(),
         })
     }
 
     /// Add documents to the vector store
     pub async fn add_documents(&self, documents: Vec<String>) -> Result<(), BuilderError> {
+        if self.store_type == "bedrock_kb" {
+            return Err(BuilderError::VectorStoreError(
+                "Bedrock Knowledge Base is read-only; manage documents via the AWS console".to_string(),
+            ));
+        }
+
         info!("Adding {} documents to vector store", documents.len());
 
         // TODO: Implement document addition
@@ -189,12 +351,17 @@ impl VectorStoreManager {
 
                     // Perform vector search using the VectorStoreIndex trait
                     debug!("Performing vector search in Qdrant for: '{}'", query);
-                    let search_results = qdrant_store
-                        .top_n::<serde_json::Value>(search_request)
-                        .await
-                        .map_err(|e| {
-                            BuilderError::VectorStoreError(format!("Qdrant search failed: {e}"))
-                        })?;
+                    let search_results = match qdrant_store.as_ref() {
+                        QdrantStoreKind::OpenAI(store) => {
+                            store.top_n::<serde_json::Value>(search_request).await
+                        }
+                        QdrantStoreKind::Bedrock(store) => {
+                            store.top_n::<serde_json::Value>(search_request).await
+                        }
+                    }
+                    .map_err(|e| {
+                        BuilderError::VectorStoreError(format!("Qdrant search failed: {e}"))
+                    })?;
 
                     // Convert results to our SearchResult format
                     let results: Vec<SearchResult> = search_results
@@ -214,6 +381,7 @@ impl VectorStoreManager {
                     ))
                 }
             }
+            "bedrock_kb" => self.search_bedrock_kb(query, limit).await,
             "in_memory" => {
                 // For in-memory, we still need to implement search
                 debug!("In-memory search not yet implemented, returning empty results");
@@ -226,14 +394,83 @@ impl VectorStoreManager {
         }
     }
 
+    /// Search Bedrock Knowledge Base using the Retrieve API
+    async fn search_bedrock_kb(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>, BuilderError> {
+        let client = self.bedrock_kb_client.as_ref().ok_or_else(|| {
+            BuilderError::VectorStoreError(
+                "Bedrock KB client not initialized".to_string(),
+            )
+        })?;
+        let kb_id = self.bedrock_kb_id.as_ref().ok_or_else(|| {
+            BuilderError::VectorStoreError(
+                "Bedrock KB ID not set".to_string(),
+            )
+        })?;
+
+        debug!("Performing Bedrock KB retrieve for: '{}'", query);
+
+        let retrieval_query =
+            aws_sdk_bedrockagentruntime::types::KnowledgeBaseQuery::builder()
+                .text(query)
+                .build();
+
+        let retrieval_config =
+            aws_sdk_bedrockagentruntime::types::KnowledgeBaseRetrievalConfiguration::builder()
+                .vector_search_configuration(
+                    aws_sdk_bedrockagentruntime::types::KnowledgeBaseVectorSearchConfiguration::builder()
+                        .number_of_results(limit as i32)
+                        .build(),
+                )
+                .build();
+
+        let response = client
+            .retrieve()
+            .knowledge_base_id(kb_id)
+            .retrieval_query(retrieval_query)
+            .retrieval_configuration(retrieval_config)
+            .send()
+            .await
+            .map_err(|e| {
+                BuilderError::VectorStoreError(format!(
+                    "Bedrock KB retrieve failed: {e}"
+                ))
+            })?;
+
+        let results: Vec<SearchResult> = response
+            .retrieval_results
+            .into_iter()
+            .filter_map(|r| {
+                let content = r.content?.text;
+                let score = r.score.unwrap_or(0.0) as f32;
+                let metadata = r.location.map(|loc| {
+                    serde_json::json!({
+                        "type": format!("{:?}", loc.r#type),
+                    })
+                });
+                Some(SearchResult {
+                    content,
+                    score,
+                    metadata,
+                })
+            })
+            .collect();
+
+        info!("Found {} results from Bedrock KB", results.len());
+        Ok(results)
+    }
+
     /// Get vector store statistics
     pub fn get_stats(&self) -> VectorStoreStats {
         VectorStoreStats {
             store_type: self.store_type.clone(),
-            embedding_provider: "openai".to_string(), // Only OpenAI supported for now
-            embedding_model: "text-embedding-3-small".to_string(), // From config
-            document_count: 0,                        // TODO: Get actual count from store
-            index_size: 0,                            // TODO: Get actual size from store
+            embedding_provider: self.embedding_provider.clone(),
+            embedding_model: self.embedding_model_name.clone(),
+            document_count: 0, // TODO: Get actual count from store
+            index_size: 0,     // TODO: Get actual size from store
         }
     }
 
@@ -269,13 +506,17 @@ impl VectorStoreManager {
                         ))
                     })?;
 
-                let mut candidates =
-                    qdrant_store
-                        .top_n::<Value>(search_request)
-                        .await
-                        .map_err(|e| {
-                            BuilderError::VectorStoreError(format!("Qdrant search failed: {e}"))
-                        })?;
+                let mut candidates = match qdrant_store.as_ref() {
+                    QdrantStoreKind::OpenAI(store) => {
+                        store.top_n::<Value>(search_request).await
+                    }
+                    QdrantStoreKind::Bedrock(store) => {
+                        store.top_n::<Value>(search_request).await
+                    }
+                }
+                .map_err(|e| {
+                    BuilderError::VectorStoreError(format!("Qdrant search failed: {e}"))
+                })?;
 
                 // Client-side filter by payload equality
                 candidates.retain(|(_score, _id, payload)| {
@@ -294,8 +535,8 @@ impl VectorStoreManager {
                     })
                     .collect())
             }
-            "in_memory" => {
-                // No filter support for in-memory; fall back to unfiltered search
+            "bedrock_kb" | "in_memory" => {
+                // No filter support; fall back to unfiltered search
                 self.search(query, limit).await
             }
             _ => Err(BuilderError::VectorStoreError(format!(

--- a/crates/aura/src/vector_store.rs
+++ b/crates/aura/src/vector_store.rs
@@ -1,4 +1,5 @@
 use crate::{
+    bedrock_embedding::AuraBedrockEmbeddingModel as BedrockEmbeddingModel,
     config::{EmbeddingModelConfig, VectorStoreConfig},
     error::BuilderError,
 };
@@ -12,7 +13,6 @@ use rig::{
         VectorStoreIndex, in_memory_store::InMemoryVectorStore, request::VectorSearchRequest,
     },
 };
-use rig_bedrock::embedding::EmbeddingModel as BedrockEmbeddingModel;
 use rig_qdrant::QdrantVectorStore;
 use serde_json::Value;
 use std::sync::Arc;
@@ -102,10 +102,9 @@ impl VectorStoreManager {
         };
 
         let aws_client = aws_sdk_bedrockruntime::Client::new(&sdk_config);
-        let bedrock_client = rig_bedrock::client::Client::from(aws_client);
         info!("Bedrock embedding client initialized successfully");
 
-        Ok(bedrock_client.embedding_model(model))
+        Ok(BedrockEmbeddingModel::new(aws_client, model, None))
     }
 
     /// Load AWS SDK config with optional region and profile

--- a/crates/aura/src/vector_store.rs
+++ b/crates/aura/src/vector_store.rs
@@ -1,6 +1,6 @@
 use crate::{
     bedrock_embedding::AuraBedrockEmbeddingModel as BedrockEmbeddingModel,
-    config::{EmbeddingModelConfig, VectorStoreConfig},
+    config::{EmbeddingModelConfig, VectorStoreConfig, VectorStoreType},
     error::BuilderError,
 };
 use qdrant_client::{Qdrant, qdrant::QueryPoints};
@@ -39,30 +39,31 @@ pub struct VectorStoreManager {
     pub context_prefix: Option<String>,
 }
 
-/// Helper to get the required embedding model config or return an error
-fn require_embedding_model(
-    config: &VectorStoreConfig,
-) -> Result<&EmbeddingModelConfig, BuilderError> {
-    config.embedding_model.as_ref().ok_or_else(|| {
-        BuilderError::VectorStoreError(format!(
-            "embedding_model is required for '{}' vector store '{}'",
-            config.store_type, config.name
-        ))
-    })
-}
-
 impl VectorStoreManager {
     /// Create a new vector store from configuration
     pub async fn from_config(config: &VectorStoreConfig) -> Result<Self, BuilderError> {
-        info!("Initializing vector store: {}", config.store_type);
-
-        match config.store_type.as_str() {
-            "in_memory" => Self::create_in_memory_store(config).await,
-            "qdrant" => Self::create_qdrant_store(config).await,
-            "bedrock_kb" => Self::create_bedrock_kb_store(config).await,
-            store_type => Err(BuilderError::VectorStoreError(format!(
-                "Unsupported vector store type: {store_type}"
-            ))),
+        match &config.store {
+            VectorStoreType::InMemory { embedding_model } => {
+                info!("Initializing vector store: in_memory");
+                Self::create_in_memory_store(config, embedding_model).await
+            }
+            VectorStoreType::Qdrant {
+                embedding_model,
+                url,
+                collection_name,
+            } => {
+                info!("Initializing vector store: qdrant");
+                Self::create_qdrant_store(config, embedding_model, url, collection_name).await
+            }
+            VectorStoreType::BedrockKb {
+                knowledge_base_id,
+                region,
+                profile,
+            } => {
+                info!("Initializing vector store: bedrock_kb");
+                Self::create_bedrock_kb_store(config, knowledge_base_id, region, profile.as_deref())
+                    .await
+            }
         }
     }
 
@@ -134,9 +135,10 @@ impl VectorStoreManager {
     }
 
     /// Create an in-memory vector store
-    async fn create_in_memory_store(config: &VectorStoreConfig) -> Result<Self, BuilderError> {
-        let embedding = require_embedding_model(config)?;
-
+    async fn create_in_memory_store(
+        config: &VectorStoreConfig,
+        embedding: &EmbeddingModelConfig,
+    ) -> Result<Self, BuilderError> {
         info!(
             "Creating in-memory vector store with {} embeddings",
             embedding.model()
@@ -180,21 +182,16 @@ impl VectorStoreManager {
     }
 
     /// Create a Qdrant vector store
-    async fn create_qdrant_store(config: &VectorStoreConfig) -> Result<Self, BuilderError> {
-        let embedding = require_embedding_model(config)?;
-
+    async fn create_qdrant_store(
+        config: &VectorStoreConfig,
+        embedding: &EmbeddingModelConfig,
+        url: &str,
+        collection_name: &str,
+    ) -> Result<Self, BuilderError> {
         info!(
             "Creating Qdrant vector store with {} embeddings",
             embedding.model()
         );
-
-        let url = config.url.as_ref().ok_or_else(|| {
-            BuilderError::VectorStoreError("URL is required for Qdrant".to_string())
-        })?;
-
-        let collection_name = config.collection_name.as_ref().ok_or_else(|| {
-            BuilderError::VectorStoreError("Collection name is required for Qdrant".to_string())
-        })?;
 
         info!("Connecting to Qdrant at: {}", url);
         info!("Using collection: {}", collection_name);
@@ -211,7 +208,7 @@ impl VectorStoreManager {
 
         // Create default query parameters for the collection
         let query_params = QueryPoints {
-            collection_name: collection_name.clone(),
+            collection_name: collection_name.to_string(),
             query: None,
             limit: Some(5),
             offset: None,
@@ -248,8 +245,8 @@ impl VectorStoreManager {
         Ok(Self {
             store_name: config.name.clone(),
             store_type: "qdrant".to_string(),
-            qdrant_url: Some(url.clone()),
-            collection_name: Some(collection_name.clone()),
+            qdrant_url: Some(url.to_string()),
+            collection_name: Some(collection_name.to_string()),
             qdrant_store: Some(Arc::new(qdrant_store)),
             in_memory_store: None,
             bedrock_kb_client: None,
@@ -261,30 +258,19 @@ impl VectorStoreManager {
     }
 
     /// Create a Bedrock Knowledge Base vector store
-    async fn create_bedrock_kb_store(config: &VectorStoreConfig) -> Result<Self, BuilderError> {
-        let kb_id = config
-            .knowledge_base_id
-            .as_ref()
-            .ok_or_else(|| {
-                BuilderError::VectorStoreError(
-                    "knowledge_base_id is required for bedrock_kb".to_string(),
-                )
-            })?
-            .clone();
-
-        let region = config.region.as_ref().ok_or_else(|| {
-            BuilderError::VectorStoreError(
-                "region is required for bedrock_kb".to_string(),
-            )
-        })?;
-
+    async fn create_bedrock_kb_store(
+        config: &VectorStoreConfig,
+        knowledge_base_id: &str,
+        region: &str,
+        profile: Option<&str>,
+    ) -> Result<Self, BuilderError> {
         info!("Creating Bedrock Knowledge Base store");
-        info!("  Knowledge Base ID: {}", kb_id);
+        info!("  Knowledge Base ID: {}", knowledge_base_id);
         info!("  Region: {}", region);
 
         let sdk_config = Self::load_aws_config(
             region,
-            config.profile.as_deref(),
+            profile,
         )
         .await;
 
@@ -299,7 +285,7 @@ impl VectorStoreManager {
             qdrant_store: None,
             in_memory_store: None,
             bedrock_kb_client: Some(Arc::new(client)),
-            bedrock_kb_id: Some(kb_id),
+            bedrock_kb_id: Some(knowledge_base_id.to_string()),
             embedding_provider: "bedrock_kb".to_string(),
             embedding_model_name: "managed".to_string(),
             context_prefix: config.context_prefix.clone(),

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -83,7 +83,12 @@ Use `host.docker.internal` to reach services running on your host machine.
 
 ### Add RAG (vector search)
 
-Uncomment the `[[vector_stores]]` section in `config.toml`. You'll need a Qdrant instance — you can add one to the compose file or point at an external one.
+Uncomment the `[[vector_stores]]` section in `config.toml`. Options:
+
+- **Qdrant** (self-hosted): add a Qdrant instance to the compose file or point at an external one. Embeddings can be generated via OpenAI or AWS Bedrock.
+- **AWS Bedrock Knowledge Base** (managed): set `type = "bedrock_kb"` with a `knowledge_base_id` and `region`. No embedding model needed — the KB manages embeddings internally.
+
+See [`examples/reference.toml`](../reference.toml) for both.
 
 ### Serve multiple agents
 

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -95,7 +95,17 @@ Authorization = "Bearer {{ env.MCP_TOKEN }}"
 # collection_name = "documents"
 # context_prefix = "Technical documentation and API references"
 #
-# embedding_model = { provider = "openai", model = "text-embedding-3-small", api_key = "{{ env.OPENAI_API_KEY }}" }
+# [vector_stores.embedding_model]
+# provider = "openai"
+# model = "text-embedding-3-small"
+# api_key = "{{ env.OPENAI_API_KEY }}"
+#
+# AWS Bedrock embeddings (uses AWS credentials, no API key needed):
+# [vector_stores.embedding_model]
+# provider = "bedrock"
+# model = "amazon.titan-embed-text-v2:0"
+# region = "{{ env.AWS_REGION }}"
+# profile = "default"  # optional
 
 # You can add multiple vector stores. Each one becomes a separate
 # search tool the agent can call (e.g., vector_search_docs,
@@ -108,7 +118,20 @@ Authorization = "Bearer {{ env.MCP_TOKEN }}"
 # collection_name = "runbooks"
 # context_prefix = "Operational runbooks and troubleshooting guides"
 #
-# embedding_model = { provider = "openai", model = "text-embedding-3-small", api_key = "{{ env.OPENAI_API_KEY }}" }
+# [vector_stores.embedding_model]
+# provider = "openai"
+# model = "text-embedding-3-small"
+# api_key = "{{ env.OPENAI_API_KEY }}"
+
+# AWS Bedrock Knowledge Base (managed RAG - no embedding model needed):
+#
+# [[vector_stores]]
+# name = "company_docs"
+# type = "bedrock_kb"
+# knowledge_base_id = "{{ env.BEDROCK_KB_ID }}"
+# region = "{{ env.AWS_REGION }}"
+# # profile = "default"  # optional
+# context_prefix = "Company documentation"
 
 # ── Tools ───────────────────────────────────────────────────────────
 [tools]


### PR DESCRIPTION
Enable AWS Bedrock as an embedding provider alongside OpenAI for RAG vector stores, and add Bedrock Knowledge Bases as a managed vector store type.
Bedrock Embeddings:
	•	Refactor EmbeddingConfig and EmbeddingModelConfig to tagged enums matching the LlmConfig pattern
	•	Introduce QdrantStoreKind enum to support multiple embedding model types
	•	Add Bedrock client initialization with optional AWS profile support
Bedrock Knowledge Bases:
	•	Add bedrock_kb as a new vector store type using the AWS Retrieve API for managed RAG
	•	Add aws-sdk-bedrockagentruntime dependency
	•	Requires knowledge_base_id and region; no embedding model needed (KB manages embeddings internally)
Config changes:
	•	embedding_model is now optional on vector stores (not needed for bedrock_kb)
	•	Add knowledge_base_id, region, profile fields to VectorStoreConfig
Tests:
	•	Add config parsing tests for Bedrock embeddings and Knowledge Base stores
	•	Add validation tests for missing required fields
	•	Update reference.toml with Bedrock embedding and Knowledge Base examples