### PR TITLE
feat(config): nest llm under agent with per-worker overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ Key capabilities:
   - [Usage](#usage)
     - [Web API Server](#web-api-server)
   - [Configuration](#configuration)
+    - [Multiple Agents](#multiple-agents)
+    - [Configuration Sections](#configuration-sections)
     - [Orchestration](#orchestration)
+      - [Orchestration fields](#orchestration-fields)
+      - [Worker fields (`[orchestration.worker.<name>]`)](#worker-fields-orchestrationworkername)
     - [Ollama](#ollama)
     - [Observability](#observability)
   - [Docker Deployment](#docker-deployment)
@@ -53,7 +57,6 @@ aura/
 ├── examples/                # Example and reference configurations
 └── scripts/                 # CI and utility scripts
 ```
-
 
 ## Setup
 
@@ -153,7 +156,9 @@ For LibreChat/OpenWebUI integration, see [development/README.md](development/REA
 
 ## Configuration
 
-> **Breaking changes (10 April 2026)**: Several fields have moved from `[agent]` to `[llm]` and Ollama-specific fields have been consolidated under `[llm.additional_params]`. Configs that have not been updated will fail to parse. See [./docs/breaking-changes/20260410-agent-llm-toml-configuration.md](docs/breaking-changes/20260410-agent-llm-toml-configuration.md) for migration details.
+> **Breaking changes (21 April 2026)**: `[llm]` has moved under `[agent.llm]` and workers may now override the LLM via `[orchestration.worker.<name>.llm]`. See [./docs/breaking-changes/20260421-llm-under-agent.md](docs/breaking-changes/20260421-llm-under-agent.md).
+>
+> **Breaking changes (10 April 2026)**: Several fields moved from `[agent]` to `[llm]` and Ollama-specific fields have been consolidated under `[llm.additional_params]`. See [./docs/breaking-changes/20260410-agent-llm-toml-configuration.md](docs/breaking-changes/20260410-agent-llm-toml-configuration.md).
 
 `CONFIG_PATH` can point to a single TOML file or a directory of `.toml` files. When pointed at a directory, Aura loads every `.toml` file and serves each as a selectable agent. Clients choose an agent via the `model` field in chat completion requests — the same field that tools like LibreChat, OpenWebUI, and CLI clients use to present a model picker.
 
@@ -190,8 +195,8 @@ Aliases must be unique across all loaded configs. If two configs share the same 
 
 Configuration sections:
 
-- `[llm]`: provider and model configuration.
 - `[agent]`: identity, system prompt, and runtime behavior.
+- `[agent.llm]`: provider and model configuration for the agent.
 - `[[vector_stores]]`: optional RAG/vector store configuration.
 - `[mcp]` and `[mcp.servers.*]`: MCP configuration, schema sanitization, and transports.
 
@@ -220,7 +225,13 @@ The complete starter configuration is in [examples/reference.toml](examples/refe
 Minimal example:
 
 ```toml
-[llm]
+[agent]
+name = "Assistant"
+alias = "my-assistant"       # optional: stable client-facing identifier
+system_prompt = "You are a helpful assistant."
+turn_depth = 2
+
+[agent.llm]
 provider = "openai"
 api_key = "{{ env.OPENAI_API_KEY }}"
 model = "gpt-5.2"
@@ -230,12 +241,6 @@ context_window = 128000
 transport = "http_streamable"
 url = "http://localhost:8081/mcp"
 headers = { "Authorization" = "Bearer {{ env.MCP_TOKEN }}" }
-
-[agent]
-name = "Assistant"
-alias = "my-assistant"       # optional: stable client-facing identifier
-system_prompt = "You are a helpful assistant."
-turn_depth = 2
 ```
 
 Validate config parsing quickly:
@@ -270,6 +275,18 @@ preamble = "You are a knowledge specialist."
 mcp_filter = []
 vector_stores = ["docs"]
 ```
+
+Each worker inherits `[agent.llm]` by default. To run a worker against a different model (cheaper, faster, bigger context, different provider), add a _complete_ LLM configuration at `[orchestration.worker.<name>.llm]` - this must be a complete LLM configuration not just the individual LLM fields you want to "override":
+
+```toml
+[orchestration.worker.formatting.llm]
+provider = "anthropic"
+api_key = "{{ env.ANTHROPIC_API_KEY }}"
+model = "claude-haiku-4-5-20251001"
+context_window = 200000
+```
+
+The worker's resolved `context_window` is what gets reported in per-worker `aura.session_info` events.
 
 Execution loop:
 
@@ -402,7 +419,6 @@ Integration test feature flags (`crates/aura-web-server/Cargo.toml`):
 
 Detailed test guidance: [crates/aura-web-server/tests/README.md](crates/aura-web-server/tests/README.md).
 
-
 ## Documentation
 
 - [CHANGELOG.md](CHANGELOG.md): release and version history.
@@ -412,7 +428,8 @@ Detailed test guidance: [crates/aura-web-server/tests/README.md](crates/aura-web
 - [docs/ollama-guide.md](docs/ollama-guide.md): Ollama configuration, fallback tool parsing, and local model guidance.
 - [docs/rig-fork-changes.md](docs/rig-fork-changes.md): Rig fork changes and rationale.
 - [development/README.md](development/README.md): LibreChat/OpenWebUI setup and header-forwarding examples.
-- [20260410-configuration-breaking-changes.md](20260410-configuration-breaking-changes.md): breaking configuration changes from 10 April 2026 — field migrations from `[agent]` to `[llm]` and Ollama parameter consolidation.
+- [docs/breaking-changes/20260421-llm-under-agent.md](docs/breaking-changes/20260421-llm-under-agent.md): breaking configuration changes from 21 April 2026 — `[llm]` moved under `[agent.llm]` and per-worker LLM overrides.
+- [docs/breaking-changes/20260410-agent-llm-toml-configuration.md](docs/breaking-changes/20260410-agent-llm-toml-configuration.md): breaking configuration changes from 10 April 2026 — field migrations from `[agent]` to `[llm]` and Ollama parameter consolidation.
 
 ## Architecture
 

--- a/configs/example-math-orchestration.toml
+++ b/configs/example-math-orchestration.toml
@@ -24,11 +24,6 @@
 #   Orchestrated:  "Calculate (3 + 7) * 2 and also find the files in /data"
 #   Clarification: "Compute the thing"
 
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-4o-mini"
-
 [agent]
 name = "Math Orchestrator"
 # In orchestration mode, [agent].system_prompt serves as the coordinator prompt.
@@ -46,6 +41,11 @@ IMPORTANT: Always use the appropriate worker's tools for calculations.
 Do not try to compute results yourself — delegate to workers.
 """
 turn_depth = 5
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-4o-mini"
 
 # Mock MCP server (use compose service name or localhost)
 [mcp]

--- a/configs/integration-orchestration.toml
+++ b/configs/integration-orchestration.toml
@@ -3,12 +3,6 @@
 # Worker definitions mirror configs/math-orchestration.toml.
 # If you update worker mcp_filter or preambles, update both files.
 
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.1"
-temperature = 0.3
-
 [agent]
 name = "Math Orchestrator Test"
 system_prompt = """
@@ -21,6 +15,12 @@ ROUTING GUIDANCE:
 - Vague or ambiguous requests: ask for clarification
 """
 turn_depth = 5
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.1"
+temperature = 0.3
 
 [mcp]
 sanitize_schemas = true

--- a/configs/integration-sre-orchestration.toml
+++ b/configs/integration-sre-orchestration.toml
@@ -3,12 +3,6 @@
 # Exercises multi-worker Kubernetes observability workflow:
 # discover workloads → detect metrics → configure ServiceMonitors → query Prometheus → alert
 
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.1"
-temperature = 0.3
-
 [agent]
 name = "SRE Orchestrator Test"
 system_prompt = """
@@ -23,6 +17,12 @@ ROUTING GUIDANCE:
 - Simple factual questions about the cluster: answer directly if possible
 """
 turn_depth = 8
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.1"
+temperature = 0.3
 
 [mcp]
 sanitize_schemas = true

--- a/configs/math-orchestration-claude-thinking.toml
+++ b/configs/math-orchestration-claude-thinking.toml
@@ -15,13 +15,6 @@
 #   AURA_CUSTOM_EVENTS=true \
 #   cargo run --bin aura-web-server
 
-[llm]
-provider = "anthropic"
-api_key = "{{ env.ANTHROPIC_API_KEY }}"
-model = "claude-sonnet-4-5-20250929"
-temperature = 1.0
-additional_params = { thinking = { type = "enabled", budget_tokens = 8000 } }
-
 [agent]
 name = "Math Orchestrator (Thinking)"
 system_prompt = """
@@ -33,6 +26,13 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "anthropic"
+api_key = "{{ env.ANTHROPIC_API_KEY }}"
+model = "claude-sonnet-4-5-20250929"
+temperature = 1.0
+additional_params = { thinking = { type = "enabled", budget_tokens = 8000 } }
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-glm.toml
+++ b/configs/math-orchestration-glm.toml
@@ -5,13 +5,6 @@
 #
 #   cd ~/workspace/aura-math-orchestration && docker compose up -d
 
-[llm]
-provider = "openai"
-api_key = "no-key-needed"
-base_url = "http://localhost:11435/v1"
-model = "glm-64k-p6"
-temperature = 0.3
-
 [agent]
 name = "Math Orchestrator"
 system_prompt = """
@@ -23,6 +16,13 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "openai"
+api_key = "no-key-needed"
+base_url = "http://localhost:11435/v1"
+model = "glm-64k-p6"
+temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-gpt5-thinking.toml
+++ b/configs/math-orchestration-gpt5-thinking.toml
@@ -17,12 +17,6 @@
 #   Orchestrated:  "Calculate the mean of [10, 20, 30] then multiply the result by 3"
 #   Clarification: "Compute the thing"
 
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.1"
-reasoning_effort = "medium"
-
 [agent]
 name = "Math Orchestrator"
 system_prompt = """
@@ -34,6 +28,12 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.1"
+reasoning_effort = "medium"
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-gpt5.toml
+++ b/configs/math-orchestration-gpt5.toml
@@ -17,11 +17,6 @@
 #   Orchestrated:  "Calculate the mean of [10, 20, 30] then multiply the result by 3"
 #   Clarification: "Compute the thing"
 
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.1"
-
 [agent]
 name = "Math Orchestrator"
 system_prompt = """
@@ -33,6 +28,11 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.1"
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-ministral.toml
+++ b/configs/math-orchestration-ministral.toml
@@ -5,13 +5,6 @@
 #
 #   cd ~/workspace/aura-math-orchestration && docker compose up -d
 
-[llm]
-provider = "openai"
-api_key = "no-key-needed"
-base_url = "http://localhost:11435/v1"
-model = "ministral3-64k"
-temperature = 0.3
-
 [agent]
 name = "Math Orchestrator"
 system_prompt = """
@@ -23,6 +16,13 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "openai"
+api_key = "no-key-needed"
+base_url = "http://localhost:11435/v1"
+model = "ministral3-64k"
+temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-nemotron.toml
+++ b/configs/math-orchestration-nemotron.toml
@@ -5,13 +5,6 @@
 #
 #   cd ~/workspace/aura-math-orchestration && docker compose up -d
 
-[llm]
-provider = "openai"
-api_key = "no-key-needed"
-base_url = "http://localhost:11435/v1"
-model = "nemotron-64k-p6"
-temperature = 0.3
-
 [agent]
 name = "Math Orchestrator"
 system_prompt = """
@@ -23,6 +16,13 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "openai"
+api_key = "no-key-needed"
+base_url = "http://localhost:11435/v1"
+model = "nemotron-64k-p6"
+temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-opus-bedrock.toml
+++ b/configs/math-orchestration-opus-bedrock.toml
@@ -7,13 +7,6 @@
 #   export AWS_REGION="us-east-1"
 #   export AWS_PROFILE="your-profile"  # or use env creds
 
-[llm]
-provider = "bedrock"
-model = "global.anthropic.claude-opus-4-5-20251101-v1:0"
-region = "{{ env.AWS_REGION | default: 'us-east-1' }}"
-temperature = 1.0
-additional_params = { thinking = { type = "enabled", budget_tokens = 8000 } }
-
 [agent]
 name = "Math Orchestrator (Opus Bedrock)"
 system_prompt = """
@@ -26,6 +19,13 @@ ROUTING GUIDANCE:
 - Vague or ambiguous requests: ask for clarification
 """
 
+
+[agent.llm]
+provider = "bedrock"
+model = "global.anthropic.claude-opus-4-5-20251101-v1:0"
+region = "{{ env.AWS_REGION | default: 'us-east-1' }}"
+temperature = 1.0
+additional_params = { thinking = { type = "enabled", budget_tokens = 8000 } }
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-qwen-thinking.toml
+++ b/configs/math-orchestration-qwen-thinking.toml
@@ -5,13 +5,6 @@
 #
 #   cd ~/workspace/aura-math-orchestration && docker compose up -d
 
-[llm]
-provider = "openai"
-api_key = "no-key-needed"
-base_url = "http://localhost:11435/v1"
-model = "qwen3-thinking-64k-p2"
-temperature = 0.3
-
 [agent]
 name = "Math Orchestrator"
 system_prompt = """
@@ -23,6 +16,13 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "openai"
+api_key = "no-key-needed"
+base_url = "http://localhost:11435/v1"
+model = "qwen3-thinking-64k-p2"
+temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-qwen3.toml
+++ b/configs/math-orchestration-qwen3.toml
@@ -3,16 +3,6 @@
 # Uses the math-mcp server (21 real math tools) with three specialized workers.
 # Requires SSH tunnel to notanton: ssh -L 11435:127.0.0.1:8080 notanton
 
-[llm]
-provider = "openai"
-api_key = "no-key-needed"
-base_url = "http://localhost:11435/v1"
-model = "qwen3-instruct-64k-p2"
-temperature = 0.3
-
-[llm.additional_params.chat_template_kwargs]
-enable_thinking = false
-
 [agent]
 name = "Math Orchestrator"
 system_prompt = """
@@ -24,6 +14,16 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "openai"
+api_key = "no-key-needed"
+base_url = "http://localhost:11435/v1"
+model = "qwen3-instruct-64k-p2"
+temperature = 0.3
+
+[agent.llm.additional_params.chat_template_kwargs]
+enable_thinking = false
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-qwen35-ollama.toml
+++ b/configs/math-orchestration-qwen35-ollama.toml
@@ -3,13 +3,6 @@
 # Uses the math-mcp server (21 real math tools) with three specialized workers.
 # Requires Ollama running locally with qwen3.5:35b-a3b pulled.
 
-[llm]
-provider = "openai"
-api_key = "no-key-needed"
-base_url = "http://localhost:11434/v1"
-model = "qwen3.5:35b-a3b"
-temperature = 0.3
-
 [agent]
 name = "Math Orchestrator"
 system_prompt = """
@@ -21,6 +14,13 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "openai"
+api_key = "no-key-needed"
+base_url = "http://localhost:11434/v1"
+model = "qwen3.5:35b-a3b"
+temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-qwen35-thinking.toml
+++ b/configs/math-orchestration-qwen35-thinking.toml
@@ -3,16 +3,6 @@
 # Uses the math-mcp server (21 real math tools) with three specialized workers.
 # Requires SSH tunnel to notanton: ssh -L 11435:127.0.0.1:8080 notanton
 
-[llm]
-provider = "openai"
-api_key = "no-key-needed"
-base_url = "http://localhost:11435/v1"
-model = "qwen35-64k-p3"
-temperature = 0.3
-
-[llm.additional_params.chat_template_kwargs]
-enable_thinking = true
-
 [agent]
 name = "Math Orchestrator"
 system_prompt = """
@@ -24,6 +14,16 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "openai"
+api_key = "no-key-needed"
+base_url = "http://localhost:11435/v1"
+model = "qwen35-64k-p3"
+temperature = 0.3
+
+[agent.llm.additional_params.chat_template_kwargs]
+enable_thinking = true
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-qwen35.toml
+++ b/configs/math-orchestration-qwen35.toml
@@ -3,16 +3,6 @@
 # Uses the math-mcp server (21 real math tools) with three specialized workers.
 # Requires SSH tunnel to notanton: ssh -L 11435:127.0.0.1:8080 notanton
 
-[llm]
-provider = "openai"
-api_key = "no-key-needed"
-base_url = "http://localhost:11435/v1"
-model = "qwen35-64k-p3"
-temperature = 0.3
-
-[llm.additional_params.chat_template_kwargs]
-enable_thinking = false
-
 [agent]
 name = "Math Orchestrator"
 system_prompt = """
@@ -24,6 +14,16 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "openai"
+api_key = "no-key-needed"
+base_url = "http://localhost:11435/v1"
+model = "qwen35-64k-p3"
+temperature = 0.3
+
+[agent.llm.additional_params.chat_template_kwargs]
+enable_thinking = false
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration-sonnet.toml
+++ b/configs/math-orchestration-sonnet.toml
@@ -17,12 +17,6 @@
 #   Orchestrated:  "Calculate the mean of [10, 20, 30] then multiply the result by 3"
 #   Clarification: "Compute the thing"
 
-[llm]
-provider = "anthropic"
-api_key = "{{ env.ANTHROPIC_API_KEY }}"
-model = "claude-sonnet-4-5-20250929"
-temperature = 0.3
-
 [agent]
 name = "Math Orchestrator"
 system_prompt = """
@@ -34,6 +28,12 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "anthropic"
+api_key = "{{ env.ANTHROPIC_API_KEY }}"
+model = "claude-sonnet-4-5-20250929"
+temperature = 0.3
 
 [mcp]
 sanitize_schemas = false

--- a/configs/math-orchestration.toml
+++ b/configs/math-orchestration.toml
@@ -18,18 +18,6 @@
 #   Orchestrated:  "Calculate the mean of [10, 20, 30] then multiply the result by 3"
 #   Clarification: "Compute the thing"
 
-[llm]
-provider = "openai"
-api_key = "no-key-needed"
-base_url = "http://localhost:11435/v1"
-# model = "gpt-5.1"
-model = "qwen3-coder-64k-p2"
-# model = "deepseek-r1:32b"
-temperature = 0.3
-
-# [llm.additional_params]
-# think = true  # only works in streaming mode; breaks worker (non-streaming) calls
-
 [agent]
 name = "Math Orchestrator"
 system_prompt = """
@@ -41,6 +29,18 @@ ROUTING GUIDANCE:
 - Multi-step calculations or mixed domains: create a plan with workers
 - Vague or ambiguous requests: ask for clarification
 """
+
+[agent.llm]
+provider = "openai"
+api_key = "no-key-needed"
+base_url = "http://localhost:11435/v1"
+# model = "gpt-5.1"
+model = "qwen3-coder-64k-p2"
+# model = "deepseek-r1:32b"
+temperature = 0.3
+
+# [agent.llm.additional_params]
+# think = true  # only works in streaming mode; breaks worker (non-streaming) calls
 
 [mcp]
 sanitize_schemas = false

--- a/configs/sre-orchestration.toml
+++ b/configs/sre-orchestration.toml
@@ -18,18 +18,6 @@
 #   Orchestrated:  "Discover workloads in production, check Prometheus targets, create ServiceMonitors for unmonitored services"
 #   Clarification: "Fix the monitoring"
 
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.1"
-temperature = 0.3
-
-# --- ollama config (commented out) ---
-# provider = "ollama"
-# model = "qwen3-coder:30b"
-# [llm.additional_params]
-# num_ctx = 262144
-
 [agent]
 name = "SRE Orchestrator"
 system_prompt = """
@@ -43,6 +31,18 @@ ROUTING GUIDANCE:
 - Multi-domain tasks (e.g., discover then monitor): create a plan with multiple workers
 - Simple factual questions about the cluster: answer directly if possible
 """
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.1"
+temperature = 0.3
+
+# --- ollama config (commented out) ---
+# provider = "ollama"
+# model = "qwen3-coder:30b"
+# [agent.llm.additional_params]
+# num_ctx = 262144
 
 [mcp]
 sanitize_schemas = false

--- a/crates/aura-config/src/bin/architecture_diagram.rs
+++ b/crates/aura-config/src/bin/architecture_diagram.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("│                    🤖 SIMPLE AGENT                      │");
         println!("│                                                         │");
 
-        let (provider, model) = match &config.llm {
+        let (provider, model) = match &config.agent.llm {
             aura::config::LlmConfig::OpenAI { model, .. } => ("openai", model.clone()),
             aura::config::LlmConfig::Anthropic { model, .. } => ("anthropic", model.clone()),
             aura::config::LlmConfig::Bedrock { model, .. } => ("bedrock", model.clone()),

--- a/crates/aura-config/src/bin/debug_config.rs
+++ b/crates/aura-config/src/bin/debug_config.rs
@@ -2,12 +2,6 @@ use aura_config::load_config_from_str;
 
 const TEST_CONFIG: &str = r#"
 # Test configuration with environment variables set to test values
-[llm]
-provider = "openai"
-api_key = "test_openai_key"
-model = "gpt-4o-mini"
-temperature = 0.7
-
 [vector_store]
 type = "in_memory"
 
@@ -51,6 +45,12 @@ context = [
     "You can use tools to help answer questions.",
     "Be concise but thorough in your responses."
 ]
+
+[agent.llm]
+provider = "openai"
+api_key = "test_openai_key"
+model = "gpt-4o-mini"
+temperature = 0.7
 "#;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -66,7 +66,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test specific parts
     println!("\n🔍 Specific sections:");
-    let (provider, model) = match &config.llm {
+    let (provider, model) = match &config.agent.llm {
         aura::config::LlmConfig::OpenAI { model, .. } => ("openai", model.as_str()),
         aura::config::LlmConfig::Anthropic { model, .. } => ("anthropic", model.as_str()),
         aura::config::LlmConfig::Bedrock { model, .. } => ("bedrock", model.as_str()),

--- a/crates/aura-config/src/builder.rs
+++ b/crates/aura-config/src/builder.rs
@@ -22,7 +22,7 @@ impl RigBuilder {
     }
 
     fn to_agent_config(&self) -> Result<AgentConfig, ConfigError> {
-        let llm = self.config.llm.clone();
+        let llm = self.config.agent.llm.clone();
 
         let agent = AgentSettings {
             name: self.config.agent.name.clone(),
@@ -110,6 +110,7 @@ impl RigBuilder {
                             mcp_filter: worker.mcp_filter.clone(),
                             vector_stores: worker.vector_stores.clone(),
                             turn_depth: worker.turn_depth,
+                            llm: worker.llm.clone(),
                         },
                     )
                 })

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 /// Root configuration structure for our POC
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct Config {
-    pub llm: LlmConfig,
     pub mcp: Option<McpConfig>,
     /// Vector stores for RAG - optional, defaults to empty
     #[serde(default)]
@@ -33,6 +32,15 @@ pub struct WorkerConfig {
     /// Per-worker turn depth limit (overrides [agent].turn_depth).
     #[serde(default)]
     pub turn_depth: Option<usize>,
+    /// Optional per-worker LLM override.
+    ///
+    /// When set, the worker uses this LLM configuration instead of inheriting
+    /// `[agent.llm]`. This enables mixed-model orchestration — e.g. using a
+    /// cheaper model for simple tasks and a stronger one for complex analysis.
+    /// `context_window` comes from the resolved LLM, so worker budget math is
+    /// scoped to whichever model the worker actually runs.
+    #[serde(default)]
+    pub llm: Option<LlmConfig>,
 }
 
 /// Timeout configuration for orchestration (aura-config side).
@@ -261,7 +269,7 @@ impl Config {
     ///
     /// This is only supported for Ollama models.
     pub fn is_fallback_tool_parsing_enabled(&self) -> bool {
-        self.llm.is_fallback_tool_parsing_enabled()
+        self.agent.llm.is_fallback_tool_parsing_enabled()
     }
 }
 /// MCP servers configuration
@@ -378,6 +386,12 @@ pub struct AgentConfig {
     /// Example: `mcp_filter = ["sin", "cos", "degreesToRadians"]`
     #[serde(default)]
     pub mcp_filter: Option<Vec<String>>,
+    /// LLM configuration for this agent.
+    ///
+    /// Parsed from the `[agent.llm]` TOML table. Workers inherit this config
+    /// when no `[orchestration.worker.<name>.llm]` is provided.
+    #[serde(default)]
+    pub llm: LlmConfig,
 }
 
 fn default_turn_depth() -> Option<usize> {
@@ -402,6 +416,7 @@ impl Default for AgentConfig {
             created_at: default_created_at(),
             model_owner: None,
             mcp_filter: None,
+            llm: LlmConfig::default(),
         }
     }
 }
@@ -416,7 +431,7 @@ impl Config {
 
     /// Get provider name and model for response formatting.
     pub fn get_provider_info(&self) -> (&str, &str) {
-        match &self.llm {
+        match &self.agent.llm {
             LlmConfig::OpenAI { model, .. } => ("openai", model),
             LlmConfig::Anthropic { model, .. } => ("anthropic", model),
             LlmConfig::Bedrock { model, .. } => ("bedrock", model),
@@ -432,22 +447,13 @@ impl Config {
 
     /// Validate the configuration
     pub fn validate(&self) -> Result<(), crate::ConfigError> {
-        // Basic validation - check API key for OpenAI/Anthropic, skip for Bedrock
-        match &self.llm {
-            LlmConfig::OpenAI { api_key, .. }
-            | LlmConfig::Anthropic { api_key, .. }
-            | LlmConfig::Gemini { api_key, .. } => {
-                if api_key.is_empty() {
-                    return Err(crate::ConfigError::Validation(
-                        "LLM API key is required".to_string(),
-                    ));
+        validate_llm_api_key(&self.agent.llm, "agent.llm")?;
+
+        if let Some(orch) = &self.orchestration {
+            for (name, worker) in &orch.workers {
+                if let Some(worker_llm) = &worker.llm {
+                    validate_llm_api_key(worker_llm, &format!("orchestration.worker.{name}.llm"))?;
                 }
-            }
-            LlmConfig::Bedrock { .. } => {
-                // Bedrock uses AWS credentials, no API key needed
-            }
-            LlmConfig::Ollama { .. } => {
-                // Ollama runs locally, no API key needed
             }
         }
 
@@ -463,4 +469,20 @@ impl Config {
 
         Ok(())
     }
+}
+
+fn validate_llm_api_key(llm: &LlmConfig, location: &str) -> Result<(), crate::ConfigError> {
+    match llm {
+        LlmConfig::OpenAI { api_key, .. }
+        | LlmConfig::Anthropic { api_key, .. }
+        | LlmConfig::Gemini { api_key, .. } => {
+            if api_key.is_empty() {
+                return Err(crate::ConfigError::Validation(format!(
+                    "LLM API key is required for [{location}]"
+                )));
+            }
+        }
+        LlmConfig::Bedrock { .. } | LlmConfig::Ollama { .. } => {}
+    }
+    Ok(())
 }

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -4,20 +4,6 @@ mod tests {
     use aura::ReasoningEffort;
 
     const TEST_CONFIG: &str = r#"
-[llm]
-provider = "openai"
-api_key = "test_openai_key"
-model = "gpt-4o-mini"
-base_url = "https://api.openai.com/v1"
-reasoning_effort = "medium"
-max_tokens = 1000
-context_window = 200000
-temperature = 0.5
-
-[llm.additional_params.thinking]
-type = "enabled"
-budget_tokens = 8000
-
 [[vector_stores]]
 name = "default"
 type = "in_memory"
@@ -59,6 +45,21 @@ custom_tools = ["calculator", "web_search"]
 name = "Test Assistant"
 system_prompt = "You are a test assistant."
 context = ["Context line 1", "Context line 2"]
+
+[agent.llm]
+provider = "openai"
+api_key = "test_openai_key"
+model = "gpt-4o-mini"
+base_url = "https://api.openai.com/v1"
+reasoning_effort = "medium"
+max_tokens = 1000
+context_window = 200000
+temperature = 0.5
+
+[agent.llm.additional_params.thinking]
+type = "enabled"
+budget_tokens = 8000
+
 "#;
 
     #[test]
@@ -71,7 +72,7 @@ context = ["Context line 1", "Context line 2"]
 
         // Test LLM config
         println!("\n✅ Testing LLM config...");
-        match &config.llm {
+        match &config.agent.llm {
             aura::config::LlmConfig::OpenAI {
                 api_key,
                 model,
@@ -224,11 +225,6 @@ context = ["Context line 1", "Context line 2"]
     fn test_minimal_config() {
         println!("\n=== TEST_MINIMAL_CONFIG ===");
         let minimal_config = r#"
-[llm]
-provider = "anthropic"
-api_key = "test_key"
-model = "claude-3-sonnet-20240229"
-
 [[vector_stores]]
 name = "default"
 type = "in_memory"
@@ -241,6 +237,12 @@ api_key = "embed_key"
 [agent]
 name = "Minimal Agent"
 system_prompt = "Basic prompt"
+
+[agent.llm]
+provider = "anthropic"
+api_key = "test_key"
+model = "claude-3-sonnet-20240229"
+
 "#;
 
         let config = load_config_from_str(minimal_config).expect("Failed to parse minimal config");
@@ -249,7 +251,7 @@ system_prompt = "Basic prompt"
         println!("{config:#?}");
 
         println!("\n✅ Testing minimal config assertions...");
-        match &config.llm {
+        match &config.agent.llm {
             aura::config::LlmConfig::Anthropic {
                 model, temperature, ..
             } => {
@@ -267,11 +269,6 @@ system_prompt = "Basic prompt"
     fn test_config_validation() {
         // Test config with missing API key (should fail validation)
         let invalid_config = r#"
-[llm]
-provider = "openai"
-api_key = ""
-model = "gpt-4"
-
 [[vector_stores]]
 name = "default"
 type = "in_memory"
@@ -284,6 +281,12 @@ api_key = "valid_key"
 [agent]
 name = "Test"
 system_prompt = "Test"
+
+[agent.llm]
+provider = "openai"
+api_key = ""
+model = "gpt-4"
+
 "#;
 
         let result = load_config_from_str(invalid_config);
@@ -291,11 +294,6 @@ system_prompt = "Test"
 
         // Test config with missing embedding API key (should fail validation)
         let invalid_config2 = r#"
-[llm]
-provider = "openai"
-api_key = "valid_key"
-model = "gpt-4"
-
 [[vector_stores]]
 name = "default"
 type = "in_memory"
@@ -308,6 +306,12 @@ api_key = ""
 [agent]
 name = "Test"
 system_prompt = "Test"
+
+[agent.llm]
+provider = "openai"
+api_key = "valid_key"
+model = "gpt-4"
+
 "#;
 
         let result2 = load_config_from_str(invalid_config2);
@@ -318,11 +322,6 @@ system_prompt = "Test"
     fn test_environment_variable_placeholders() {
         println!("\n=== TEST_ENVIRONMENT_VARIABLE_PLACEHOLDERS ===");
         let env_config = r#"
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-4"
-
 [[vector_stores]]
 name = "default"
 type = "in_memory"
@@ -340,6 +339,12 @@ headers = { Authorization = "Bearer {{ env.TEST_API_KEY }}" }
 [agent]
 name = "Env Test"
 system_prompt = "Test with env vars"
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-4"
+
 "#;
 
         // This should work with environment variable resolution
@@ -363,7 +368,7 @@ system_prompt = "Test with env vars"
         println!("{config:#?}");
 
         println!("\n✅ Testing environment variable resolution...");
-        match &config.llm {
+        match &config.agent.llm {
             aura::config::LlmConfig::OpenAI { api_key, .. } => {
                 assert_eq!(api_key, "mock_openai_key");
             }
@@ -402,10 +407,6 @@ system_prompt = "Test with env vars"
         // Ollama with default base_url (localhost:11434)
         // Note: Ollama doesn't require an API key
         let ollama_config = r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-
 [[vector_stores]]
 name = "default"
 type = "in_memory"
@@ -418,6 +419,11 @@ api_key = "test_key"
 [agent]
 name = "Ollama Agent"
 system_prompt = "You are a helpful assistant."
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
 "#;
 
         let config = load_config_from_str(ollama_config).expect("Failed to parse Ollama config");
@@ -426,7 +432,7 @@ system_prompt = "You are a helpful assistant."
         println!("{config:#?}");
 
         println!("\n✅ Testing Ollama config assertions...");
-        match &config.llm {
+        match &config.agent.llm {
             aura::config::LlmConfig::Ollama {
                 model, base_url, ..
             } => {
@@ -445,12 +451,6 @@ system_prompt = "You are a helpful assistant."
         println!("\n=== TEST_OLLAMA_CONFIG_CUSTOM_URL ===");
         // Ollama with custom base_url
         let ollama_config = r#"
-[llm]
-provider = "ollama"
-model = "mistral"
-base_url = "http://my-ollama-server:11434"
-temperature = 0.8
-
 [[vector_stores]]
 name = "default"
 type = "in_memory"
@@ -463,6 +463,13 @@ api_key = "test_key"
 [agent]
 name = "Remote Ollama Agent"
 system_prompt = "You are a remote assistant."
+
+[agent.llm]
+provider = "ollama"
+model = "mistral"
+base_url = "http://my-ollama-server:11434"
+temperature = 0.8
+
 "#;
 
         let config =
@@ -472,7 +479,7 @@ system_prompt = "You are a remote assistant."
         println!("{config:#?}");
 
         println!("\n✅ Testing Ollama custom URL config assertions...");
-        match &config.llm {
+        match &config.agent.llm {
             aura::config::LlmConfig::Ollama {
                 model,
                 base_url,
@@ -491,26 +498,27 @@ system_prompt = "You are a remote assistant."
     fn test_ollama_config_with_additional_params() {
         println!("\n=== TEST_OLLAMA_CONFIG_WITH_ADDITIONAL_PARAMS ===");
         let config_str = r#"
-[llm]
+[agent]
+name = "Test"
+system_prompt = "Test"
+
+[agent.llm]
 provider = "ollama"
 model = "llama3.2"
 
-[llm.additional_params]
+[agent.llm.additional_params]
 mirostat = 1
 seed = 42
 top_k = 40
 top_p = 0.9
 
-[agent]
-name = "Test"
-system_prompt = "Test"
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
 
         println!("\n🔍 Ollama Config with additional_params:");
         println!("{config:#?}");
 
-        match &config.llm {
+        match &config.agent.llm {
             aura::config::LlmConfig::Ollama {
                 additional_params, ..
             } => {
@@ -535,16 +543,17 @@ system_prompt = "Test"
         }
 
         let config_str = r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-
-[llm.additional_params]
-seed = "{{ env.TEST_SEED }}"
-
 [agent]
 name = "Test"
 system_prompt = "Test"
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
+[agent.llm.additional_params]
+seed = "{{ env.TEST_SEED }}"
+
 "#;
 
         use crate::resolve_env_vars;
@@ -558,7 +567,7 @@ system_prompt = "Test"
         println!("\n🔍 Config after env var resolution:");
         println!("{config:#?}");
 
-        match &config.llm {
+        match &config.agent.llm {
             aura::config::LlmConfig::Ollama {
                 additional_params, ..
             } => {
@@ -582,20 +591,21 @@ system_prompt = "Test"
         println!("\n=== TEST_OLLAMA_CONFIG_BACKWARDS_COMPATIBLE ===");
         // Minimal Ollama config without any new fields - should still work
         let config_str = r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-
 [agent]
 name = "Test"
 system_prompt = "Test"
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
 
         println!("\n🔍 Backwards compatible Ollama Config:");
         println!("{config:#?}");
 
-        match &config.llm {
+        match &config.agent.llm {
             aura::config::LlmConfig::Ollama {
                 model,
                 additional_params,
@@ -611,14 +621,15 @@ system_prompt = "Test"
     #[test]
     fn test_alias_field_parsing() {
         let config_str = r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-
 [agent]
 name = "Test"
 alias = "my-alias"
 system_prompt = "Test"
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
         assert_eq!(config.agent.alias, Some("my-alias".to_string()));
@@ -627,13 +638,14 @@ system_prompt = "Test"
     #[test]
     fn test_alias_field_defaults_to_none() {
         let config_str = r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-
 [agent]
 name = "Test"
 system_prompt = "Test"
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
         assert_eq!(config.agent.alias, None);
@@ -648,13 +660,14 @@ system_prompt = "Test"
         write!(
             f,
             r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-
 [agent]
 name = "Agent1"
 system_prompt = "Hello"
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
 "#
         )
         .unwrap();
@@ -674,13 +687,14 @@ system_prompt = "Hello"
             write!(
                 f,
                 r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-
 [agent]
 name = "{agent_name}"
 system_prompt = "Hello"
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
 "#
             )
             .unwrap();
@@ -764,13 +778,14 @@ system_prompt = "Hello"
     #[test]
     fn test_created_at_defaults_to_current_time() {
         let config_str = r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-
 [agent]
 name = "Test"
 system_prompt = "Test"
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
 "#;
         let before = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -791,14 +806,15 @@ system_prompt = "Test"
     #[test]
     fn test_created_at_explicit_value() {
         let config_str = r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-
 [agent]
 name = "Test"
 system_prompt = "Test"
 created_at = 1677649963000
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
         assert_eq!(config.agent.created_at, 1677649963000);
@@ -807,13 +823,14 @@ created_at = 1677649963000
     #[test]
     fn test_model_owner_defaults_to_none() {
         let config_str = r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-
 [agent]
 name = "Test"
 system_prompt = "Test"
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
         assert_eq!(config.agent.model_owner, None);
@@ -822,14 +839,15 @@ system_prompt = "Test"
     #[test]
     fn test_model_owner_explicit_value() {
         let config_str = r#"
-[llm]
-provider = "ollama"
-model = "llama3.2"
-
 [agent]
 name = "Test"
 system_prompt = "Test"
 model_owner = "mezmo"
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
         assert_eq!(config.agent.model_owner, Some("mezmo".to_string()));
@@ -839,28 +857,29 @@ model_owner = "mezmo"
     fn test_ollama_config_all_params() {
         println!("\n=== TEST_OLLAMA_CONFIG_ALL_PARAMS ===");
         let config_str = r#"
-[llm]
+[agent]
+name = "Full Ollama Agent"
+system_prompt = "You are helpful."
+
+[agent.llm]
 provider = "ollama"
 model = "llama3.2"
 base_url = "http://localhost:11434"
 fallback_tool_parsing = true
 temperature = 0.7
 
-[llm.additional_params]
+[agent.llm.additional_params]
 num_ctx = 4096
 num_predict = 1024
 seed = 42
 
-[agent]
-name = "Full Ollama Agent"
-system_prompt = "You are helpful."
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
 
         println!("\n🔍 Ollama Config with all params:");
         println!("{config:#?}");
 
-        match &config.llm {
+        match &config.agent.llm {
             aura::config::LlmConfig::Ollama {
                 model,
                 base_url,
@@ -891,69 +910,61 @@ system_prompt = "You are helpful."
     #[test]
     fn test_context_window_deserializes_from_toml() {
         let config_str = r#"
-[llm]
+[agent]
+name = "Test"
+system_prompt = "Test"
+
+[agent.llm]
 provider = "openai"
 api_key = "test_key"
 model = "gpt-4o"
 context_window = 200000
 
-[agent]
-name = "Test"
-system_prompt = "Test"
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
-        assert_eq!(config.llm.context_window(), Some(200_000));
+        assert_eq!(config.agent.llm.context_window(), Some(200_000));
     }
 
     #[test]
     fn test_context_window_defaults_to_none() {
         let config_str = r#"
-[llm]
+[agent]
+name = "Test"
+system_prompt = "Test"
+
+[agent.llm]
 provider = "openai"
 api_key = "test_key"
 model = "gpt-4o"
 
-[agent]
-name = "Test"
-system_prompt = "Test"
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
-        assert_eq!(config.llm.context_window(), None);
+        assert_eq!(config.agent.llm.context_window(), None);
     }
 
     #[test]
     fn test_context_window_accepts_float() {
         // Helm renders integers as floats (e.g. 200000.0)
         let config_str = r#"
-[llm]
+[agent]
+name = "Test"
+system_prompt = "Test"
+
+[agent.llm]
 provider = "openai"
 api_key = "test_key"
 model = "gpt-4o"
 context_window = 200000.0
 
-[agent]
-name = "Test"
-system_prompt = "Test"
 "#;
         let config = load_config_from_str(config_str).expect("Failed to parse config");
-        assert_eq!(config.llm.context_window(), Some(200_000));
+        assert_eq!(config.agent.llm.context_window(), Some(200_000));
     }
 
     #[test]
     fn test_removed_agent_configs_caught() {
         // The old agent-level fields should now cause the parsing to fail
-        // so the user is aware of the breaking changes
-        let valid_config_str = r#"
-[llm]
-provider = "openai"
-api_key = "test_key"
-model = "gpt-4o"
-
-[agent]
-name = "Test"
-system_prompt = "Test"
-"#;
-
+        // so the user is aware of the breaking changes.
         let test_cases = [
             ("temperature", "temperature = 0.5"),
             ("max_tokens", "max_tokens = 1000"),
@@ -967,18 +978,20 @@ system_prompt = "Test"
 
         for (removed_field, definition) in test_cases {
             let expected_error = format!("unknown field `{removed_field}`");
-            let config_str = String::from(valid_config_str) + "\n" + definition;
-
-            let config = load_config_from_str(&config_str);
-            assert!(
-                config.is_err(),
-                "config parsing should fail due to removed agent-level field"
+            // Inject the removed field inline in [agent], with [agent.llm] after it.
+            let config_str = format!(
+                "\n[agent]\nname = \"Test\"\nsystem_prompt = \"Test\"\n{definition}\n\n\
+                 [agent.llm]\nprovider = \"openai\"\napi_key = \"test_key\"\nmodel = \"gpt-4o\"\n"
             );
+            let err_str = match load_config_from_str(&config_str) {
+                Ok(_) => panic!(
+                    "config parsing should fail due to removed agent-level field: {removed_field}"
+                ),
+                Err(e) => e.to_string(),
+            };
             assert!(
-                config
-                    .unwrap_err()
-                    .to_string()
-                    .contains(expected_error.as_str())
+                err_str.contains(expected_error.as_str()),
+                "expected error about `{removed_field}`, got: {err_str}"
             );
         }
     }
@@ -986,24 +999,192 @@ system_prompt = "Test"
     #[test]
     fn test_no_additional_properties_on_llm() {
         let config_str = r#"
-[llm]
+[agent]
+name = "Test"
+system_prompt = "Test"
+
+[agent.llm]
 provider = "openai"
 api_key = "test_key"
 model = "gpt-4o"
 random_field = "should not be accepted"
 
-[agent]
-name = "Test"
-system_prompt = "Test"
 "#;
 
-        let config = load_config_from_str(&config_str);
+        let config = load_config_from_str(config_str);
         assert!(config.is_err(), "no additional fields allowed");
         assert!(
             config
                 .unwrap_err()
                 .to_string()
                 .contains("unknown field `random_field`")
+        );
+    }
+
+    #[test]
+    fn test_worker_without_llm_inherits_from_agent() {
+        let config_str = r#"
+[agent]
+name = "Orchestrator"
+system_prompt = "You coordinate."
+
+[agent.llm]
+provider = "openai"
+api_key = "coordinator_key"
+model = "gpt-5.1"
+context_window = 128000
+
+[orchestration]
+enabled = true
+
+[orchestration.worker.math]
+description = "Does math"
+preamble = "You do math."
+"#;
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+        let orch = config.orchestration.expect("orchestration should be set");
+        let worker = orch.workers.get("math").expect("math worker should exist");
+        assert!(
+            worker.llm.is_none(),
+            "worker without [llm] override should have llm = None"
+        );
+    }
+
+    #[test]
+    fn test_worker_with_explicit_llm_override() {
+        let config_str = r#"
+[agent]
+name = "Orchestrator"
+system_prompt = "You coordinate."
+
+[agent.llm]
+provider = "openai"
+api_key = "coordinator_key"
+model = "gpt-5.1"
+context_window = 128000
+
+[orchestration]
+enabled = true
+
+[orchestration.worker.formatter]
+description = "Formats output"
+preamble = "You format."
+
+[orchestration.worker.formatter.llm]
+provider = "anthropic"
+api_key = "worker_key"
+model = "claude-haiku-4-5-20251001"
+context_window = 200000
+"#;
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+        let orch = config.orchestration.expect("orchestration should be set");
+        let worker = orch
+            .workers
+            .get("formatter")
+            .expect("formatter worker should exist");
+        let worker_llm = worker
+            .llm
+            .as_ref()
+            .expect("worker should have explicit llm override");
+        match worker_llm {
+            aura::config::LlmConfig::Anthropic {
+                model,
+                context_window,
+                ..
+            } => {
+                assert_eq!(model, "claude-haiku-4-5-20251001");
+                assert_eq!(*context_window, Some(200_000));
+            }
+            _ => panic!("expected Anthropic worker override"),
+        }
+    }
+
+    #[test]
+    fn test_all_shipped_configs_parse() {
+        // Set env vars every shipped config expects so env resolution succeeds.
+        unsafe {
+            std::env::set_var("OPENAI_API_KEY", "test-openai");
+            std::env::set_var("ANTHROPIC_API_KEY", "test-anthropic");
+            std::env::set_var("GOOGLE_API_KEY", "test-google");
+            std::env::set_var("MEZMO_API_KEY", "test-mezmo");
+            std::env::set_var("AWS_REGION", "us-east-1");
+            std::env::set_var("AWS_PROFILE", "default");
+            std::env::set_var("LLM_PROVIDER", "openai");
+            std::env::set_var("LLM_API_KEY", "test-key");
+            std::env::set_var("LLM_MODEL", "gpt-4o");
+            std::env::set_var("DD_API_KEY", "test-dd-api");
+            std::env::set_var("DD_APPLICATION_KEY", "test-dd-app");
+            std::env::set_var("PAGERDUTY_API_TOKEN", "test-pagerduty");
+            std::env::set_var("GITHUB_PERSONAL_ACCESS_TOKEN", "test-github");
+            std::env::set_var("MCP_TOKEN", "test-mcp");
+        }
+
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
+
+        let dirs = [
+            repo_root.join("configs"),
+            repo_root.join("examples/minimal"),
+            repo_root.join("examples/complete"),
+            repo_root.join("examples/quickstart"),
+        ];
+        let single_files = [
+            repo_root.join("examples/reference.toml"),
+            repo_root.join("crates/aura-web-server/tests/test-config.toml"),
+        ];
+
+        let mut failures = Vec::new();
+
+        for dir in &dirs {
+            for entry in std::fs::read_dir(dir).unwrap_or_else(|e| panic!("{dir:?}: {e}")) {
+                let entry = entry.unwrap();
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("toml") {
+                    continue;
+                }
+                if let Err(e) = crate::load_config(&path) {
+                    failures.push(format!("{}: {e}", path.display()));
+                }
+            }
+        }
+        for path in &single_files {
+            if let Err(e) = crate::load_config(path) {
+                failures.push(format!("{}: {e}", path.display()));
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "Some shipped configs failed to parse:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    #[test]
+    fn test_legacy_top_level_llm_produces_migration_error() {
+        let legacy_config = r#"
+[llm]
+provider = "openai"
+api_key = "test_key"
+model = "gpt-4o"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let err = load_config_from_str(legacy_config)
+            .expect_err("legacy top-level [llm] should be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("legacy top-level [llm]"),
+            "error should mention legacy top-level [llm]: {msg}"
+        );
+        assert!(
+            msg.contains("[agent.llm]"),
+            "error should tell the user to move it under [agent.llm]: {msg}"
         );
     }
 }

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -21,9 +21,33 @@ use std::path::Path;
 fn load_single_config<P: AsRef<Path>>(path: P) -> Result<Config, ConfigError> {
     let contents = fs::read_to_string(path)?;
     let resolved = resolve_env_vars(&contents)?;
+    check_legacy_top_level_llm(&resolved)?;
     let config: Config = toml::from_str(&resolved)?;
     config.validate()?;
     Ok(config)
+}
+
+/// Detect the legacy top-level `[llm]` table shape and emit a migration error.
+///
+/// As of 2026-04-21, `[llm]` lives under `[agent.llm]`. Without this check, a
+/// stale top-level `[llm]` table is silently ignored (Config does not use
+/// `deny_unknown_fields`) and the user gets a confusing downstream error.
+fn check_legacy_top_level_llm(toml_str: &str) -> Result<(), ConfigError> {
+    // Best-effort parse — if this fails, let the main deserialization surface
+    // the real parse error rather than masking it.
+    let Ok(value) = toml::from_str::<toml::Value>(toml_str) else {
+        return Ok(());
+    };
+    if value.get("llm").is_some() {
+        return Err(ConfigError::Validation(
+            "Configuration uses the legacy top-level [llm] table. \
+             Move it under [agent.llm] (and any [llm.additional_params] \
+             under [agent.llm.additional_params]). Workers may optionally \
+             override the LLM via [orchestration.worker.<name>.llm]."
+                .to_string(),
+        ));
+    }
+    Ok(())
 }
 
 /// Load and parse TOML configuration(s) from a file or directory.
@@ -93,6 +117,7 @@ pub fn validate_unique_identifiers(configs: &[Config]) -> Result<(), ConfigError
 /// Load config from a string (useful for testing)
 pub fn load_config_from_str(contents: &str) -> Result<Config, ConfigError> {
     let resolved = resolve_env_vars(contents)?;
+    check_legacy_top_level_llm(&resolved)?;
     let config: Config = toml::from_str(&resolved)?;
     config.validate()?;
     Ok(config)

--- a/crates/aura-config/src/loader.rs
+++ b/crates/aura-config/src/loader.rs
@@ -160,7 +160,7 @@ fn merge_configs(base_config: Config, override_config: Config) -> Result<Config,
 
     // Override LLM config if provided - with enum, we replace the entire config
     // TODO: More granular overrides would require matching variants
-    result.llm = override_config.llm;
+    result.agent.llm = override_config.agent.llm;
 
     // Override MCP config if provided
     if override_config.mcp.is_some() {

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -678,7 +678,7 @@ pub async fn list_models(data: web::Data<AppState>) -> HttpResponse {
             let id = config.agent.alias.as_deref().unwrap_or(&config.agent.name);
             let created = config.agent.created_at / 1000;
             let owned_by = config.agent.model_owner.clone().unwrap_or_else(|| {
-                let (provider, _) = config.llm.model_info();
+                let (provider, _) = config.agent.llm.model_info();
                 provider.to_string()
             });
             serde_json::json!({

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -140,7 +140,7 @@ async fn run() -> std::io::Result<()> {
 
     for config in &configs {
         let id = config.agent.alias.as_deref().unwrap_or(&config.agent.name);
-        let (provider, model) = config.llm.model_info();
+        let (provider, model) = config.agent.llm.model_info();
         info!("Loaded agent '{}' ({}/{})", id, provider, model);
     }
 

--- a/crates/aura-web-server/tests/test-config.toml
+++ b/crates/aura-web-server/tests/test-config.toml
@@ -1,13 +1,6 @@
 # Minimal Test Configuration for CI/CD
 # This config uses only publicly available services and minimal dependencies
 
-# LLM Configuration
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.1"
-temperature = 0.0
-
 # MCP Configuration - Mock MCP server for tool execution tests
 # URLs use environment variables with defaults for local development.
 # In containers, set MCP_MOCK_HOST=mock-mcp to use Docker service names.
@@ -83,3 +76,11 @@ EXAMPLES:
 - "Say hello" → Respond with text (no tool needed)
 """
 turn_depth = 3 # Lower depth for faster tests
+
+# LLM Configuration
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.1"
+temperature = 0.0
+

--- a/crates/aura/src/orchestration/config.rs
+++ b/crates/aura/src/orchestration/config.rs
@@ -1,6 +1,6 @@
 //! Configuration types for orchestration mode.
 
-use crate::config::VectorStoreConfig;
+use crate::config::{LlmConfig, VectorStoreConfig};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -194,6 +194,14 @@ pub struct WorkerConfig {
     /// per task execution. Overrides `[agent].turn_depth`. Falls back to
     /// `[agent].turn_depth` → `DEFAULT_MAX_DEPTH` (8) if not set.
     pub turn_depth: Option<usize>,
+
+    /// Optional per-worker LLM override.
+    ///
+    /// When `Some`, the worker runs with this LLM config instead of inheriting
+    /// `[agent.llm]`. The resolved `context_window` drives per-worker budget
+    /// math (e.g. scratchpad sizing, LOG-23439).
+    #[serde(default)]
+    pub llm: Option<LlmConfig>,
 }
 
 // ============================================================================

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -487,6 +487,14 @@ impl Orchestrator {
         // Create a modified config for workers with extension fields
         let mut worker_config = self.agent_config.clone();
 
+        // Resolve per-worker LLM override (falls back to [agent.llm] when absent)
+        if let Some(override_llm) = worker_name
+            .and_then(|name| self.config.workers.get(name))
+            .and_then(|w| w.llm.as_ref())
+        {
+            worker_config.llm = override_llm.clone();
+        }
+
         // Configure worker based on assignment
         if let Some(name) = worker_name {
             let worker = self.config.get_worker(name).ok_or_else(|| {
@@ -603,7 +611,7 @@ impl Orchestrator {
             mcp_manager: self.mcp_manager.clone(),
             fallback_tool_parsing: false,
             fallback_tool_names: vec![],
-            context_window: None,
+            context_window: worker_config.llm.context_window(),
         };
 
         Ok(AgentWithPreamble { agent, preamble })
@@ -5100,6 +5108,7 @@ mod tests {
                 mcp_filter: vec!["mezmo_*".to_string()],
                 vector_stores: vec![],
                 turn_depth: None,
+                llm: None,
             },
         );
         workers.insert(
@@ -5110,6 +5119,7 @@ mod tests {
                 mcp_filter: vec![],
                 vector_stores: vec![],
                 turn_depth: None,
+                llm: None,
             },
         );
 
@@ -5424,6 +5434,7 @@ Provide the synthesized response:"#,
                 mcp_filter: vec!["mezmo_*".to_string()],
                 vector_stores: vec![], // No RAG for operations
                 turn_depth: None,
+                llm: None,
             },
         );
         workers.insert(
@@ -5434,6 +5445,7 @@ Provide the synthesized response:"#,
                 mcp_filter: vec![],                            // No MCP tools
                 vector_stores: vec!["mezmo_docs".to_string()], // RAG access
                 turn_depth: None,
+                llm: None,
             },
         );
 
@@ -5496,6 +5508,7 @@ Provide the synthesized response:"#,
                 mcp_filter: vec![],
                 vector_stores: vec!["docs".to_string()],
                 turn_depth: None,
+                llm: None,
             },
         );
 
@@ -5508,6 +5521,7 @@ Provide the synthesized response:"#,
                 mcp_filter: vec![],
                 vector_stores: vec!["kb".to_string(), "runbooks".to_string()],
                 turn_depth: None,
+                llm: None,
             },
         );
 
@@ -5520,6 +5534,7 @@ Provide the synthesized response:"#,
                 mcp_filter: vec!["mezmo_*".to_string()],
                 vector_stores: vec![], // Explicitly no RAG access
                 turn_depth: None,
+                llm: None,
             },
         );
 
@@ -5651,6 +5666,7 @@ Provide the synthesized response:"#,
                 mcp_filter: vec![],
                 vector_stores: vec!["worker_store".to_string()],
                 turn_depth: None,
+                llm: None,
             },
         );
 

--- a/crates/aura/src/orchestration/templates.rs
+++ b/crates/aura/src/orchestration/templates.rs
@@ -545,6 +545,7 @@ Always verify your calculations before reporting results."
                 mcp_filter: vec!["mock_tool".to_string()],
                 vector_stores: vec![],
                 turn_depth: None,
+                llm: None,
             },
         );
         workers.insert(
@@ -568,6 +569,7 @@ TOOL USAGE:
                 mcp_filter: vec!["list_files".to_string(), "chain_tool".to_string()],
                 vector_stores: vec![],
                 turn_depth: None,
+                llm: None,
             },
         );
 

--- a/docs/breaking-changes/20260421-llm-under-agent.md
+++ b/docs/breaking-changes/20260421-llm-under-agent.md
@@ -1,0 +1,175 @@
+# 21 April 2026
+
+# !!BREAKING CHANGES!!
+
+## Summary
+
+The `[llm]` TOML section has been moved from the top level to `[agent.llm]`. LLM configuration is now a property of the agent, not a sibling of it. This unlocks **per-worker LLM overrides** in orchestration mode: each `[orchestration.worker.<name>]` may declare its own `[orchestration.worker.<name>.llm]` to run a different model (or a different provider) than the coordinator, inheriting `[agent.llm]` when omitted.
+
+**NOTE: CONFIGS THAT HAVE NOT BEEN UPDATED WILL FAIL TO PARSE AND THE APP WILL FAIL TO START.** The loader detects a top-level `[llm]` table and emits a migration error pointing to this document. See [Startup Errors](#startup-errors).
+
+---
+
+## What Moved
+
+| Field                     | Old location      | New location                      |
+| ------------------------- | ----------------- | --------------------------------- |
+| The entire `[llm]` table  | top-level `[llm]` | `[agent.llm]`                     |
+| `[llm.additional_params]` | top-level         | `[agent.llm.additional_params]`   |
+| `context_window`          | `[llm]`           | `[agent.llm]` (follows the table) |
+
+No fields were renamed — every provider-specific field inside `[llm]` keeps its name under `[agent.llm]`.
+
+---
+
+## Before / After Examples
+
+### Minimal single-agent config
+
+```toml
+# BEFORE
+[llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.1"
+context_window = 128000
+temperature = 0.3
+
+[agent]
+name = "My Agent"
+system_prompt = "..."
+turn_depth = 5
+
+# AFTER
+[agent]
+name = "My Agent"
+system_prompt = "..."
+turn_depth = 5
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.1"
+context_window = 128000
+temperature = 0.3
+```
+
+### `additional_params` nested tables
+
+```toml
+# BEFORE
+[llm]
+provider = "anthropic"
+model = "claude-sonnet-4-5-20250929"
+temperature = 1.0
+
+[llm.additional_params.thinking]
+type = "enabled"
+budget_tokens = 8000
+
+# AFTER
+[agent]
+name = "Thinking Agent"
+system_prompt = "..."
+
+[agent.llm]
+provider = "anthropic"
+model = "claude-sonnet-4-5-20250929"
+temperature = 1.0
+
+[agent.llm.additional_params.thinking]
+type = "enabled"
+budget_tokens = 8000
+```
+
+### Ollama `additional_params`
+
+```toml
+# BEFORE
+[llm]
+provider = "ollama"
+model = "qwen3:30b-a3b"
+fallback_tool_parsing = true
+
+[llm.additional_params]
+num_ctx = 32000
+think = true
+
+# AFTER
+[agent]
+name = "Local Assistant"
+system_prompt = "..."
+
+[agent.llm]
+provider = "ollama"
+model = "qwen3:30b-a3b"
+fallback_tool_parsing = true
+
+[agent.llm.additional_params]
+num_ctx = 32000
+think = true
+```
+
+---
+
+## New Capability: Per-Worker LLM Overrides
+
+Workers now accept an optional `[orchestration.worker.<name>.llm]` table. When omitted, the worker inherits `[agent.llm]` (including `context_window`). When present, the worker uses its own LLM configuration exclusively.
+
+```toml
+[agent]
+name = "Math Coordinator"
+system_prompt = "..."
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.1"
+context_window = 128000
+
+[orchestration]
+enabled = true
+
+# Inherits [agent.llm] — no override needed for the common case
+[orchestration.worker.arithmetic]
+description = "Basic arithmetic operations"
+preamble = "You are an arithmetic specialist."
+mcp_filter = ["add", "subtract", "multiply", "divide"]
+
+# Explicit override — this worker runs a cheaper model with a smaller context
+[orchestration.worker.formatting]
+description = "Formats numeric output for humans"
+preamble = "You format numbers as strings."
+mcp_filter = []
+
+[orchestration.worker.formatting.llm]
+provider = "anthropic"
+api_key = "{{ env.ANTHROPIC_API_KEY }}"
+model = "claude-haiku-4-5-20251001"
+context_window = 200000
+```
+
+The worker's resolved `context_window` is what the runtime reports in `aura.session_info` events for that worker and what downstream context-budget work (LOG-23439) will use to size per-worker scratchpads.
+
+---
+
+## Startup Errors
+
+### Top-level `[llm]` is no longer accepted
+
+The loader performs a pre-parse check before deserialization. If it sees a top-level `[llm]` table it fails with:
+
+```
+Configuration uses the legacy top-level [llm] table. Move it under
+[agent.llm] (and any [llm.additional_params] under
+[agent.llm.additional_params]). Workers may optionally override the
+LLM via [orchestration.worker.<name>.llm].
+```
+
+### `deny_unknown_fields` remains
+
+`aura_config::config::AgentConfig` and `aura::config::LlmConfig` still carry `#[serde(deny_unknown_fields)]`. Any stray field in `[agent]` or `[agent.llm]` (including the fields that were moved out of `[agent]` in the 10 April 2026 migration) still produces a hard parse error.
+
+### Worker LLM fields
+
+`[orchestration.worker.<name>.llm]` accepts the same fields as `[agent.llm]` (the full `LlmConfig` variant set per provider). The same `deny_unknown_fields` rules apply.

--- a/docs/ollama-guide.md
+++ b/docs/ollama-guide.md
@@ -5,20 +5,24 @@ Aura supports running local models through [Ollama](https://ollama.ai), includin
 ## Basic Configuration
 
 ```toml
-[llm]
+[agent]
+name = "Local Assistant"
+system_prompt = "You are a helpful assistant."
+
+[agent.llm]
 provider = "ollama"
 model = "qwen3:30b-a3b"
 # base_url = "http://localhost:11434" # optional; this default is used automatically
 fallback_tool_parsing = true
 
-[llm.additional_params]
+[agent.llm.additional_params]
 num_ctx = 32000
 think   = true
 ```
 
 `base_url` defaults to `http://localhost:11434` when omitted. Use `http://host.docker.internal:11434` when Aura runs inside a container and Ollama runs on the host.
 
-All Ollama-specific parameters (`num_ctx`, `num_predict`, `think`, `seed`, `top_k`, `top_p`, etc.) go under `[llm.additional_params]`. See [Ollama model parameters](https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values) for the full list.
+All Ollama-specific parameters (`num_ctx`, `num_predict`, `think`, `seed`, `top_k`, `top_p`, etc.) go under `[agent.llm.additional_params]`. See [Ollama model parameters](https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values) for the full list.
 
 ## Fallback Tool Parsing
 

--- a/docs/streaming-api-guide.md
+++ b/docs/streaming-api-guide.md
@@ -146,7 +146,7 @@ event: aura.session_info
 data: {"model":"gpt-5.2","model_context_limit":200000,"agent_id":"main","session_id":"sess_xyz"}
 ```
 
-Note: `model_context_limit` comes from the `context_window` field in the `[llm]` TOML config section. If `context_window` is not set, `model_context_limit` is omitted from the event.
+Note: `model_context_limit` comes from the `context_window` field in the `[agent.llm]` TOML config section (or `[orchestration.worker.<name>.llm]` for per-worker overrides). If `context_window` is not set, `model_context_limit` is omitted from the event.
 
 ### Client Handling
 

--- a/examples/complete/devops-assistant.toml
+++ b/examples/complete/devops-assistant.toml
@@ -8,11 +8,6 @@
 # Usage:
 #   CONFIG_PATH=examples/complete/devops-assistant.toml cargo run --bin aura-web-server
 
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.2"
-
 [mcp]
 sanitize_schemas = true
 
@@ -41,3 +36,9 @@ Capabilities:
 Be specific when referencing code — include file paths and line numbers.
 """
 turn_depth = 20
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+

--- a/examples/complete/incident-response-datadog.toml
+++ b/examples/complete/incident-response-datadog.toml
@@ -10,11 +10,6 @@
 # Usage:
 #   CONFIG_PATH=examples/complete/incident-response-datadog.toml cargo run --bin aura-web-server
 
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.2"
-
 [mcp]
 sanitize_schemas = true
 
@@ -52,3 +47,9 @@ Datadog. Follow this triage workflow:
 Always include timestamps and link back to source data.
 """
 turn_depth = 10
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+

--- a/examples/complete/incident-response-mezmo.toml
+++ b/examples/complete/incident-response-mezmo.toml
@@ -9,11 +9,6 @@
 # Usage:
 #   CONFIG_PATH=examples/complete/incident-response-mezmo.toml cargo run --bin aura-web-server
 
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.2"
-
 [mcp]
 sanitize_schemas = true
 
@@ -50,3 +45,9 @@ Mezmo. Follow this triage workflow:
 Always include timestamps and link back to source data.
 """
 turn_depth = 10
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+

--- a/examples/complete/kubernetes-sre-orchestrated-multi-model.toml
+++ b/examples/complete/kubernetes-sre-orchestrated-multi-model.toml
@@ -1,0 +1,134 @@
+# Orchestrated Kubernetes SRE agent — K8s cluster operations + Prometheus monitoring.
+# Inspects workloads, queries metrics, and assists with cluster troubleshooting.
+# Uses different models for the workers than the main agent uses!
+#
+# Prerequisites:
+#   export OPENAI_API_KEY="sk-..."
+#   Kubernetes context configured (kubectl access)
+#   Start the K8s MCP server:
+#     npx -y kubernetes-mcp-server@latest --port 8081 --read-only
+#   export PROMETHEUS_URL="http://localhost:9090"
+#   Start the Prometheus MCP server:
+#     docker run -i --rm -e PROMETHEUS_URL -e PROMETHEUS_MCP_SERVER_TRANSPORT=http \
+#       -e PROMETHEUS_MCP_BIND_PORT=8082 -p 8082:8082 ghcr.io/pab1it0/prometheus-mcp-server:latest
+#
+# Usage:
+#   CONFIG_PATH=examples/complete/kubernetes-sre-orchestrated-multi-model.toml cargo run --bin aura-web-server
+
+[agent]
+name = "Kubernetes SRE Agent (Orchestrated)"
+system_prompt = """
+You are an SRE assistant coordinator. You decompose Kubernetes observability
+tasks into specialized sub-tasks and delegate to the appropriate worker.
+
+ROUTING GUIDANCE:
+- Workload discovery, health checks, namespace listing, service inspection: delegate to k8s-discovery
+- Prometheus queries, target health, metrics, metric metadata: delegate to prometheus-analyst
+- Simple factual questions about the cluster: answer directly if possible
+"""
+
+[agent.llm]
+provider = "openai"
+context_window = 200_000
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.4"
+
+# --- ollama config (commented out) ---
+# provider = "ollama"
+# model = "qwen3-coder:30b"
+# [agent.llm.additional_params]
+# num_ctx = 262144
+
+[mcp]
+sanitize_schemas = false
+
+# Kubernetes — cluster inspection and management
+# https://github.com/containers/kubernetes-mcp-server
+# Start with: npx -y kubernetes-mcp-server@latest --port 8081 --read-only
+[mcp.servers.kubernetes]
+transport = "http_streamable"
+url = "http://localhost:8081/mcp"
+description = "Kubernetes SRE tools: cluster discovery, Prometheus metrics, Alertmanager rules, and ServiceMonitor management"
+
+# Prometheus — metrics and alerting
+# https://github.com/pab1it0/prometheus-mcp-server
+# Start with the docker command in the Prerequisites above.
+[mcp.servers.prometheus]
+transport = "http_streamable"
+url = "http://localhost:8082/mcp"
+description = "Prometheus metrics queries and alert status"
+
+# Tools Configuration - minimal filesystem access
+[tools]
+filesystem = true
+custom_tools = []
+
+[orchestration]
+enabled = true
+max_planning_cycles = 2
+quality_threshold = 0.7
+memory_dir = "/tmp/aura-multi-model-observability-orchestration"
+
+allow_direct_answers = true
+allow_clarification = true
+
+tools_in_planning = "full"
+
+[orchestration.timeouts]
+per_call_timeout_secs = 180
+
+# Kubernetes worker
+[orchestration.worker.k8s-discovery]
+description = "Kubernetes workload and service discovery: list namespaces, workloads, services, and inspect details"
+turn_depth = 8
+mcp_filter = [
+  "configuration_contexts_list",
+  "configuration_view",
+  "events_list",
+  "namespaces_list",
+  "nodes_log",
+  "nodes_stats_summary",
+  "nodes_top",
+  "pods_get",
+  "pods_list",
+  "pods_list_in_namespace",
+  "pods_log",
+  "pods_top",
+  "resources_get",
+  "resources_list",
+]
+preamble = """
+You are a Kubernetes Discovery Specialist. Use your tools to explore the cluster.
+Always use tools — do not guess or fabricate cluster state.
+Report workload names, kinds, replicas, labels, ports, and annotations.
+"""
+
+[orchestration.worker.k8s-discovery.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-4o"
+context_window = 128_000
+
+# Prometheus analysis worker
+[orchestration.worker.prometheus-analyst]
+description = "Prometheus metrics analysis: query metrics, check targets, inspect metadata and labels"
+turn_depth = 8
+mcp_filter = [
+  "health_check",
+  "execute_query",
+  "execute_range_query",
+  "list_metrics",
+  "get_metric_metadata",
+  "get_targets",
+]
+preamble = """
+You are a Prometheus Analyst. Use your tools to query and analyze metrics.
+Always call the appropriate tool — do not fabricate metric values.
+Report query results clearly with metric names, labels, and values.
+"""
+
+[orchestration.worker.prometheus-analyst.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-4o"
+context_window = 128_000

--- a/examples/complete/kubernetes-sre.toml
+++ b/examples/complete/kubernetes-sre.toml
@@ -14,11 +14,6 @@
 # Usage:
 #   CONFIG_PATH=examples/complete/kubernetes-sre.toml cargo run --bin aura-web-server
 
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.2"
-
 [mcp]
 sanitize_schemas = true
 
@@ -55,3 +50,9 @@ Always specify namespaces explicitly. Prefer read-only operations
 unless the user explicitly requests changes.
 """
 turn_depth = 20
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+

--- a/examples/minimal/anthropic.toml
+++ b/examples/minimal/anthropic.toml
@@ -4,11 +4,12 @@
 #   export ANTHROPIC_API_KEY="sk-ant-..."
 #   CONFIG_PATH=examples/minimal/anthropic.toml cargo run --bin aura-web-server
 
-[llm]
+[agent]
+name = "Claude Assistant"
+system_prompt = "You are a helpful assistant."
+
+[agent.llm]
 provider = "anthropic"
 api_key = "{{ env.ANTHROPIC_API_KEY }}"
 model = "claude-sonnet-4-20250514"
 
-[agent]
-name = "Claude Assistant"
-system_prompt = "You are a helpful assistant."

--- a/examples/minimal/bedrock.toml
+++ b/examples/minimal/bedrock.toml
@@ -12,12 +12,13 @@
 #   export AWS_REGION="us-east-1"
 #   CONFIG_PATH=examples/minimal/bedrock.toml cargo run --bin aura-web-server
 
-[llm]
+[agent]
+name = "Bedrock Assistant"
+system_prompt = "You are a helpful assistant."
+
+[agent.llm]
 provider = "bedrock"
 model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
 region = "{{ env.AWS_REGION }}"
 # profile = "default"  # optional AWS profile name
 
-[agent]
-name = "Bedrock Assistant"
-system_prompt = "You are a helpful assistant."

--- a/examples/minimal/gemini.toml
+++ b/examples/minimal/gemini.toml
@@ -4,11 +4,12 @@
 #   export GOOGLE_API_KEY="..."
 #   CONFIG_PATH=examples/minimal/gemini.toml cargo run --bin aura-web-server
 
-[llm]
+[agent]
+name = "Gemini Assistant"
+system_prompt = "You are a helpful assistant."
+
+[agent.llm]
 provider = "gemini"
 api_key = "{{ env.GOOGLE_API_KEY }}"
 model = "gemini-2.0-flash"
 
-[agent]
-name = "Gemini Assistant"
-system_prompt = "You are a helpful assistant."

--- a/examples/minimal/ollama.toml
+++ b/examples/minimal/ollama.toml
@@ -11,7 +11,12 @@
 #
 # See docs/ollama-guide.md for model recommendations and caveats.
 
-[llm]
+[agent]
+name = "Local Assistant"
+system_prompt = "You are a helpful assistant."
+turn_depth = 5
+
+[agent.llm]
 provider = "ollama"
 model = "qwen3:30b-a3b"
 # base_url = "http://localhost:11434"  # default; uncomment to override
@@ -24,14 +29,10 @@ fallback_tool_parsing = true
 
 # Optional Ollama-specific parameters.
 # See: https://github.com/ollama/ollama/blob/main/docs/modelfile.md
-[llm.additional_params]
+[agent.llm.additional_params]
 # Context window size in tokens. Set this to match your model's
 # capacity and available VRAM. Larger values use more memory.
 num_ctx = 32000
 # seed = 42
 # top_p = 0.95
 
-[agent]
-name = "Local Assistant"
-system_prompt = "You are a helpful assistant."
-turn_depth = 5

--- a/examples/minimal/openai.toml
+++ b/examples/minimal/openai.toml
@@ -5,11 +5,12 @@
 #   export OPENAI_API_KEY="sk-..."
 #   CONFIG_PATH=examples/minimal/openai.toml cargo run --bin aura-web-server
 
-[llm]
+[agent]
+name = "Assistant"
+system_prompt = "You are a helpful assistant."
+
+[agent.llm]
 provider = "openai"
 api_key = "{{ env.OPENAI_API_KEY }}"
 model = "gpt-4o"
 
-[agent]
-name = "Assistant"
-system_prompt = "You are a helpful assistant."

--- a/examples/quickstart/config.toml
+++ b/examples/quickstart/config.toml
@@ -8,15 +8,6 @@
 # ── LLM Provider ────────────────────────────────────────────────────
 # Provider, model, and API key are set in .env — no changes needed here.
 
-[llm]
-provider = "{{ env.LLM_PROVIDER }}"
-api_key = "{{ env.LLM_API_KEY }}"
-model = "{{ env.LLM_MODEL }}"
-# base_url = "{{ env.LLM_BASE_URL }}"    # Uncomment for Ollama
-# fallback_tool_parsing = true            # Uncomment for Ollama
-
-# ── Agent ───────────────────────────────────────────────────────────
-
 [agent]
 name = "Aura Assistant"
 # alias = "aura"  # optional: stable identifier for model selection by clients
@@ -52,3 +43,13 @@ turn_depth = 5
 # provider = "openai"
 # model = "text-embedding-3-small"
 # api_key = "{{ env.OPENAI_API_KEY }}"
+
+[agent.llm]
+provider = "{{ env.LLM_PROVIDER }}"
+api_key = "{{ env.LLM_API_KEY }}"
+model = "{{ env.LLM_MODEL }}"
+# base_url = "{{ env.LLM_BASE_URL }}"    # Uncomment for Ollama
+# fallback_tool_parsing = true            # Uncomment for Ollama
+
+# ── Agent ───────────────────────────────────────────────────────────
+

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -17,40 +17,6 @@
 #   examples/complete/kubernetes-sre.toml             - K8s MCP + Prometheus
 #   examples/complete/devops-assistant.toml           - GitHub MCP
 
-# ── LLM Provider ────────────────────────────────────────────────────
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.2"
-# temperature = 0.7
-# reasoning_effort = "medium"  # minimal, low, medium, high (provider support varies)
-# max_tokens = 8192
-# base_url = "https://api.openai.com/v1"  # custom endpoint
-# Context window size in tokens. Used for usage percentage reporting
-# in aura.session_info streaming events. Set this to your model's
-# actual context window.
-# context_window = 200000
-
-# Anthropic alternative:
-# provider = "anthropic"
-# api_key = "{{ env.ANTHROPIC_API_KEY }}"
-# model = "claude-sonnet-4-20250514"
-
-# Ollama alternative (no API key needed):
-# provider = "ollama"
-# model = "qwen3:30b-a3b"
-# fallback_tool_parsing = true
-
-# AWS Bedrock alternative:
-# provider = "bedrock"
-# model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
-# region = "{{ env.AWS_REGION }}"
-
-# Google Gemini alternative:
-# provider = "gemini"
-# api_key = "{{ env.GOOGLE_API_KEY }}"
-# model = "gemini-2.0-flash"
-
 # ── MCP Tool Servers ────────────────────────────────────────────────
 [mcp]
 # Sanitize tool schemas for OpenAI function-calling compatibility.
@@ -144,3 +110,38 @@ Workflow:
 # Maximum tool-calling rounds per user turn. Higher values allow
 # deeper multi-step workflows but consume more tokens.
 turn_depth = 5
+
+# ── LLM Provider ────────────────────────────────────────────────────
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+# temperature = 0.7
+# reasoning_effort = "medium"  # minimal, low, medium, high (provider support varies)
+# max_tokens = 8192
+# base_url = "https://api.openai.com/v1"  # custom endpoint
+# Context window size in tokens. Used for usage percentage reporting
+# in aura.session_info streaming events. Set this to your model's
+# actual context window.
+# context_window = 200000
+
+# Anthropic alternative:
+# provider = "anthropic"
+# api_key = "{{ env.ANTHROPIC_API_KEY }}"
+# model = "claude-sonnet-4-20250514"
+
+# Ollama alternative (no API key needed):
+# provider = "ollama"
+# model = "qwen3:30b-a3b"
+# fallback_tool_parsing = true
+
+# AWS Bedrock alternative:
+# provider = "bedrock"
+# model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+# region = "{{ env.AWS_REGION }}"
+
+# Google Gemini alternative:
+# provider = "gemini"
+# api_key = "{{ env.GOOGLE_API_KEY }}"
+# model = "gemini-2.0-flash"
+


### PR DESCRIPTION
Move the top-level `[llm]` TOML table under `[agent.llm]` and allow `[orchestration.worker.<name>.llm]` to override the agent LLM. Workers without an explicit override inherit `[agent.llm]`; each worker's resolved `context_window` now populates Agent.context_window so per-worker context budgets (LOG-23439) can be computed from it.

The loader pre-parses raw TOML and emits a self-contained migration error whenever a legacy top-level `[llm]` table is present, so misconfigured configs fail fast with a clear message instead of a cryptic serde error.

All shipped TOML configs, examples, README, streaming/ollama docs, and unit tests are migrated to the new shape.

WARNING: (breaking change) `[llm]` no longer parses at the top level. Move it to `[agent.llm]` (and `[llm.additional_params]` to `[agent.llm.additional_params]`). See
docs/breaking-changes/20260421-llm-under-agent.md.

Ref: LOG-23606