### PR TITLE
Duplicate guard soft failure grading

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ For a fuller multi-worker example, see [configs/example-workers.toml](configs/ex
 | `tools_in_planning` | string | `"summary"` | Tool visibility for coordinator: `"none"`, `"summary"` (names only), `"full"` (with descriptions) |
 | `max_plan_parse_retries` | int | `3` | Retries if coordinator produces unparseable plan JSON |
 | `max_tools_per_worker` | int | `10` | Cap on MCP tools exposed to each worker |
+| `duplicate_call_nudge_threshold` | int | `3` | Consecutive identical tool calls before appending guidance annotation |
+| `duplicate_call_block_threshold` | int | `5` | Consecutive identical tool calls before appending abort annotation and setting escalation flag |
 | `worker_system_prompt` | string | — | Optional global system prompt prepended to all workers |
 | `coordinator_vector_stores` | list | `[]` | Vector stores available to the coordinator agent |
 | `memory_dir` | string | — | Directory for cross-iteration artifact persistence |

--- a/configs/integration-sre-orchestration.toml
+++ b/configs/integration-sre-orchestration.toml
@@ -42,7 +42,7 @@ allow_clarification = true
 tools_in_planning = "full"
 
 [orchestration.timeouts]
-per_call_timeout_secs = 90
+per_call_timeout_secs = 60
 
 [orchestration.artifacts]
 memory_dir = "/tmp/aura-sre-orchestration-test"

--- a/crates/aura-config/src/builder.rs
+++ b/crates/aura-config/src/builder.rs
@@ -134,7 +134,8 @@ impl RigBuilder {
                 max_tools_per_worker: orch.max_tools_per_worker,
                 allow_direct_answers: orch.allow_direct_answers,
                 allow_clarification: orch.allow_clarification,
-                max_consecutive_duplicate_tool_calls: orch.max_consecutive_duplicate_tool_calls,
+                duplicate_call_nudge_threshold: orch.duplicate_call_nudge_threshold,
+                duplicate_call_block_threshold: orch.duplicate_call_block_threshold,
                 timeouts: aura::orchestration::TimeoutsConfig {
                     per_call_timeout_secs: orch.timeouts.per_call_timeout_secs,
                 },

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -102,7 +102,8 @@ pub struct OrchestrationConfig {
     pub allow_clarification: bool,
     pub tools_in_planning: ToolVisibility,
     pub max_tools_per_worker: usize,
-    pub max_consecutive_duplicate_tool_calls: Option<usize>,
+    pub duplicate_call_nudge_threshold: Option<usize>,
+    pub duplicate_call_block_threshold: Option<usize>,
     pub timeouts: TimeoutsConfig,
     pub artifacts: ArtifactsConfig,
 }
@@ -121,7 +122,8 @@ impl Default for OrchestrationConfig {
             allow_clarification: true,
             tools_in_planning: ToolVisibility::default(),
             max_tools_per_worker: default_max_tools_per_worker(),
-            max_consecutive_duplicate_tool_calls: None,
+            duplicate_call_nudge_threshold: None,
+            duplicate_call_block_threshold: None,
             timeouts: TimeoutsConfig::default(),
             artifacts: ArtifactsConfig::default(),
         }
@@ -154,7 +156,9 @@ struct RawOrchestrationConfig {
     #[serde(default = "default_max_tools_per_worker")]
     max_tools_per_worker: usize,
     #[serde(default)]
-    max_consecutive_duplicate_tool_calls: Option<usize>,
+    duplicate_call_nudge_threshold: Option<usize>,
+    #[serde(default)]
+    duplicate_call_block_threshold: Option<usize>,
     // Sub-tables
     #[serde(default)]
     timeouts: Option<TimeoutsConfig>,
@@ -206,7 +210,8 @@ impl<'de> Deserialize<'de> for OrchestrationConfig {
             allow_clarification: raw.allow_clarification,
             tools_in_planning: raw.tools_in_planning,
             max_tools_per_worker: raw.max_tools_per_worker,
-            max_consecutive_duplicate_tool_calls: raw.max_consecutive_duplicate_tool_calls,
+            duplicate_call_nudge_threshold: raw.duplicate_call_nudge_threshold,
+            duplicate_call_block_threshold: raw.duplicate_call_block_threshold,
             timeouts,
             artifacts,
         })

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -102,8 +102,8 @@ pub struct OrchestrationConfig {
     pub allow_clarification: bool,
     pub tools_in_planning: ToolVisibility,
     pub max_tools_per_worker: usize,
-    pub duplicate_call_nudge_threshold: Option<usize>,
-    pub duplicate_call_block_threshold: Option<usize>,
+    pub duplicate_call_nudge_threshold: usize,
+    pub duplicate_call_block_threshold: usize,
     pub timeouts: TimeoutsConfig,
     pub artifacts: ArtifactsConfig,
 }
@@ -122,8 +122,8 @@ impl Default for OrchestrationConfig {
             allow_clarification: true,
             tools_in_planning: ToolVisibility::default(),
             max_tools_per_worker: default_max_tools_per_worker(),
-            duplicate_call_nudge_threshold: None,
-            duplicate_call_block_threshold: None,
+            duplicate_call_nudge_threshold: default_duplicate_call_nudge_threshold(),
+            duplicate_call_block_threshold: default_duplicate_call_block_threshold(),
             timeouts: TimeoutsConfig::default(),
             artifacts: ArtifactsConfig::default(),
         }
@@ -155,10 +155,10 @@ struct RawOrchestrationConfig {
     tools_in_planning: ToolVisibility,
     #[serde(default = "default_max_tools_per_worker")]
     max_tools_per_worker: usize,
-    #[serde(default)]
-    duplicate_call_nudge_threshold: Option<usize>,
-    #[serde(default)]
-    duplicate_call_block_threshold: Option<usize>,
+    #[serde(default = "default_duplicate_call_nudge_threshold")]
+    duplicate_call_nudge_threshold: usize,
+    #[serde(default = "default_duplicate_call_block_threshold")]
+    duplicate_call_block_threshold: usize,
     // Sub-tables
     #[serde(default)]
     timeouts: Option<TimeoutsConfig>,
@@ -250,6 +250,14 @@ fn default_per_call_timeout_secs() -> u64 {
 
 fn default_max_plan_parse_retries() -> usize {
     3
+}
+
+fn default_duplicate_call_nudge_threshold() -> usize {
+    3
+}
+
+fn default_duplicate_call_block_threshold() -> usize {
+    5
 }
 
 fn default_result_artifact_threshold() -> usize {

--- a/crates/aura-web-server/tests/orchestration_events_test.rs
+++ b/crates/aura-web-server/tests/orchestration_events_test.rs
@@ -105,7 +105,7 @@ fn assert_any_routing_event(events: &[SseEvent]) {
 /// Verifies that a multi-step math query triggers orchestration planning.
 ///
 /// Query: "Calculate the mean of [10, 20, 30] then multiply the result by 3"
-/// Expected: plan_created event with task_count >= 2 (statistics + arithmetic).
+/// Expected: plan_created event with tasks array of length >= 2.
 ///
 /// NOTE: Hits a real LLM. Multi-domain queries should always produce a plan.
 #[tokio::test]
@@ -128,19 +128,19 @@ async fn test_multi_step_math_emits_plan_created() {
     }
 
     for event in &plan_events {
-        assert_event_fields(event, &["goal", "task_count", "agent_id", "session_id"]);
+        assert_event_fields(event, &["goal", "tasks", "agent_id", "session_id"]);
 
         let json: Value = serde_json::from_str(&event.data).unwrap();
-        let task_count = json["task_count"]
-            .as_u64()
-            .expect("task_count must be a number");
+        let tasks = json["tasks"]
+            .as_array()
+            .expect("tasks must be an array");
         assert!(
-            task_count >= 1,
-            "task_count should be >= 1, got {task_count}"
+            !tasks.is_empty(),
+            "tasks array should not be empty"
         );
         println!(
             "plan_created: goal={}, task_count={}",
-            json["goal"], task_count
+            json["goal"], tasks.len()
         );
     }
 }

--- a/crates/aura-web-server/tests/orchestration_events_test.rs
+++ b/crates/aura-web-server/tests/orchestration_events_test.rs
@@ -131,16 +131,12 @@ async fn test_multi_step_math_emits_plan_created() {
         assert_event_fields(event, &["goal", "tasks", "agent_id", "session_id"]);
 
         let json: Value = serde_json::from_str(&event.data).unwrap();
-        let tasks = json["tasks"]
-            .as_array()
-            .expect("tasks must be an array");
-        assert!(
-            !tasks.is_empty(),
-            "tasks array should not be empty"
-        );
+        let tasks = json["tasks"].as_array().expect("tasks must be an array");
+        assert!(!tasks.is_empty(), "tasks array should not be empty");
         println!(
             "plan_created: goal={}, task_count={}",
-            json["goal"], tasks.len()
+            json["goal"],
+            tasks.len()
         );
     }
 }

--- a/crates/aura-web-server/tests/sre_orchestration_test.rs
+++ b/crates/aura-web-server/tests/sre_orchestration_test.rs
@@ -104,7 +104,7 @@ fn assert_any_routing_event(events: &[SseEvent]) {
 /// lifecycle events (plan, tasks, tool calls, synthesis).
 ///
 /// Query asks for multi-step: discover workloads → check monitoring → create alerts.
-/// Expected: plan_created (task_count >= 2), task_started/completed pairs,
+/// Expected: plan_created (tasks array length >= 2), task_started/completed pairs,
 /// tool_call events, synthesizing, iteration_complete.
 ///
 /// LENIENCY: LLM may route to direct answer or use fewer tasks than expected.
@@ -131,19 +131,19 @@ async fn test_sre_full_workflow_emits_plan_and_tasks() {
     }
 
     for event in &plan_events {
-        assert_event_fields(event, &["goal", "task_count", "agent_id", "session_id"]);
+        assert_event_fields(event, &["goal", "tasks", "agent_id", "session_id"]);
 
         let json: Value = serde_json::from_str(&event.data).unwrap();
-        let task_count = json["task_count"]
-            .as_u64()
-            .expect("task_count must be a number");
+        let tasks = json["tasks"].as_array().expect("tasks must be an array");
         assert!(
-            task_count >= 2,
-            "Expected task_count >= 2 for SRE workflow, got {task_count}"
+            tasks.len() >= 2,
+            "Expected tasks.len() >= 2 for SRE workflow, got {}",
+            tasks.len()
         );
         println!(
             "plan_created: goal={}, task_count={}",
-            json["goal"], task_count
+            json["goal"],
+            tasks.len()
         );
     }
 

--- a/crates/aura/src/mcp_response.rs
+++ b/crates/aura/src/mcp_response.rs
@@ -11,6 +11,91 @@ use base64::Engine;
 use rmcp::model::CallToolResult;
 use tracing::{debug, info, warn};
 
+const MCP_ERROR_PREFIX: &str = "Tool returned an error: ";
+
+/// JSON-RPC 2.0 error codes that indicate input/schema validation failures.
+const SCHEMA_ERROR_CODES: [i32; 3] = [
+    -32602, // InvalidParams — malformed or missing required arguments
+    -32600, // InvalidRequest — structurally invalid JSON-RPC request
+    -32700, // ParseError — not valid JSON at all
+];
+
+/// Classified outcome of an MCP tool call, preserving error-kind fidelity
+/// that would otherwise be lost during stringification.
+///
+/// Downstream consumers (e.g., duplicate-call guard) can branch on this
+/// structurally instead of parsing string prefixes.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CallOutcome {
+    /// Tool executed successfully.
+    Success(String),
+
+    /// JSON-RPC protocol-level error indicating input validation failure
+    /// (e.g., `-32602 InvalidParams`).
+    SchemaError { content: String, code: i32 },
+
+    /// Tool error that is NOT clearly a schema/validation failure.
+    /// Includes application-level `is_error: true` responses (ambiguous)
+    /// and non-schema JSON-RPC errors (e.g., `-32603 InternalError`).
+    GeneralToolError { content: String, code: Option<i32> },
+}
+
+impl CallOutcome {
+    pub fn content(&self) -> &str {
+        match self {
+            Self::Success(s) => s,
+            Self::SchemaError { content, .. } | Self::GeneralToolError { content, .. } => content,
+        }
+    }
+
+    pub fn is_error(&self) -> bool {
+        !matches!(self, Self::Success(_))
+    }
+
+    pub fn is_schema_error(&self) -> bool {
+        matches!(self, Self::SchemaError { .. })
+    }
+
+    /// Convert to the legacy prefixed-string format consumed by existing callers.
+    pub fn into_prefixed_string(self) -> String {
+        match self {
+            Self::Success(s) => s,
+            Self::SchemaError { content, .. } | Self::GeneralToolError { content, .. } => {
+                format!("{MCP_ERROR_PREFIX}{content}")
+            }
+        }
+    }
+
+    /// Classify from a prefixed tool-output string (reverse of `into_prefixed_string`).
+    /// Used at the WrappedTool boundary where only a String is available.
+    pub fn classify_from_output(output: &str) -> Self {
+        if let Some(msg) = output.strip_prefix(MCP_ERROR_PREFIX) {
+            Self::GeneralToolError {
+                content: msg.to_string(),
+                code: None,
+            }
+        } else {
+            Self::Success(output.to_string())
+        }
+    }
+
+    /// Construct from a JSON-RPC error, mapping error codes to the
+    /// appropriate variant.
+    pub fn from_jsonrpc_error(code: i32, message: &str) -> Self {
+        if SCHEMA_ERROR_CODES.contains(&code) {
+            Self::SchemaError {
+                content: message.to_string(),
+                code,
+            }
+        } else {
+            Self::GeneralToolError {
+                content: message.to_string(),
+                code: Some(code),
+            }
+        }
+    }
+}
+
 /// Maximum size (in bytes) for extracted resource content.
 /// Content exceeding this limit is truncated with a notice.
 const MAX_RESOURCE_CONTENT_BYTES: usize = 100_000;
@@ -100,7 +185,7 @@ pub fn extract_resource_contents(resource: &rmcp::model::ResourceContents) -> St
 /// }
 /// ```
 /// Returns: `{"result": ["metric1", "metric2", ...]}`
-pub fn extract_tool_result(result: CallToolResult, tool_name: &str) -> Result<String> {
+pub fn extract_tool_result(result: CallToolResult, tool_name: &str) -> Result<CallOutcome> {
     let is_error = result.is_error.unwrap_or(false);
     if is_error {
         warn!("Tool '{}' returned error result", tool_name);
@@ -137,9 +222,12 @@ pub fn extract_tool_result(result: CallToolResult, tool_name: &str) -> Result<St
         );
 
         return if is_error {
-            Ok(format!("Tool returned an error: {}", json_str))
+            Ok(CallOutcome::GeneralToolError {
+                content: json_str,
+                code: None,
+            })
         } else {
-            Ok(json_str)
+            Ok(CallOutcome::Success(json_str))
         };
     }
 
@@ -180,9 +268,12 @@ pub fn extract_tool_result(result: CallToolResult, tool_name: &str) -> Result<St
     );
 
     if is_error {
-        Ok(format!("Tool returned an error: {}", content))
+        Ok(CallOutcome::GeneralToolError {
+            content,
+            code: None,
+        })
     } else {
-        Ok(content)
+        Ok(CallOutcome::Success(content))
     }
 }
 
@@ -205,16 +296,16 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "list_metrics").unwrap();
+        let outcome = extract_tool_result(result, "list_metrics").unwrap();
+        assert!(!outcome.is_error());
+        let extracted = outcome.content();
 
-        // Should be pretty-printed JSON
         assert!(extracted.contains("\"result\""));
         assert!(extracted.contains("metric1"));
         assert!(extracted.contains("metric2"));
         assert!(extracted.contains("metric3"));
 
-        // Verify it's valid JSON
-        let parsed: Value = serde_json::from_str(&extracted).unwrap();
+        let parsed: Value = serde_json::from_str(extracted).unwrap();
         assert_eq!(parsed["result"].as_array().unwrap().len(), 3);
     }
 
@@ -233,8 +324,8 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "echo").unwrap();
-        assert_eq!(extracted, "Hello, world!");
+        let outcome = extract_tool_result(result, "echo").unwrap();
+        assert_eq!(outcome, CallOutcome::Success("Hello, world!".to_string()));
     }
 
     #[test]
@@ -253,11 +344,11 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "test").unwrap();
+        let outcome = extract_tool_result(result, "test").unwrap();
+        let content = outcome.content();
 
-        // Should use structured content, not text
-        assert!(extracted.contains("structured"));
-        assert!(!extracted.contains("Fallback text"));
+        assert!(content.contains("structured"));
+        assert!(!content.contains("Fallback text"));
     }
 
     #[test]
@@ -269,13 +360,12 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "empty").unwrap();
-        assert_eq!(extracted, "");
+        let outcome = extract_tool_result(result, "empty").unwrap();
+        assert_eq!(outcome, CallOutcome::Success("".to_string()));
     }
 
     #[test]
-    fn test_error_text_content_prefixed() {
-        // When is_error is true, the result should be prefixed
+    fn test_error_text_content_classified() {
         let result = CallToolResult {
             content: vec![Content {
                 raw: RawContent::Text(RawTextContent {
@@ -289,18 +379,17 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "failing_tool").unwrap();
-        assert!(
-            extracted.starts_with("Tool returned an error:"),
-            "Expected error prefix, got: {}",
-            extracted
-        );
-        assert!(extracted.contains("Connection refused"));
+        let outcome = extract_tool_result(result, "failing_tool").unwrap();
+        assert!(outcome.is_error());
+        assert!(!outcome.is_schema_error());
+        assert_eq!(outcome.content(), "Connection refused");
+
+        let prefixed = outcome.into_prefixed_string();
+        assert!(prefixed.starts_with("Tool returned an error:"));
     }
 
     #[test]
-    fn test_error_structured_content_prefixed() {
-        // When is_error is true with structured content
+    fn test_error_structured_content_classified() {
         let result = CallToolResult {
             content: vec![],
             structured_content: Some(
@@ -310,13 +399,9 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "auth_tool").unwrap();
-        assert!(
-            extracted.starts_with("Tool returned an error:"),
-            "Expected error prefix, got: {}",
-            extracted
-        );
-        assert!(extracted.contains("AUTH_FAILED"));
+        let outcome = extract_tool_result(result, "auth_tool").unwrap();
+        assert!(outcome.is_error());
+        assert!(outcome.content().contains("AUTH_FAILED"));
     }
 
     #[test]
@@ -335,9 +420,8 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "test").unwrap();
-        assert_eq!(extracted, "Success message");
-        assert!(!extracted.contains("Tool returned an error"));
+        let outcome = extract_tool_result(result, "test").unwrap();
+        assert_eq!(outcome, CallOutcome::Success("Success message".to_string()));
     }
 
     // --- Embedded Resource extraction tests ---
@@ -362,7 +446,9 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "get_file").unwrap();
+        let extracted = extract_tool_result(result, "get_file")
+            .unwrap()
+            .into_prefixed_string();
         assert_eq!(extracted, "# Hello World\nThis is a readme.");
     }
 
@@ -390,7 +476,9 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "get_file").unwrap();
+        let extracted = extract_tool_result(result, "get_file")
+            .unwrap()
+            .into_prefixed_string();
         assert_eq!(extracted, "console.log('hello');");
     }
 
@@ -414,7 +502,9 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "get_file").unwrap();
+        let extracted = extract_tool_result(result, "get_file")
+            .unwrap()
+            .into_prefixed_string();
         assert!(extracted.starts_with("[Binary resource:"));
         assert!(extracted.contains("image/png"));
     }
@@ -443,7 +533,9 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "get_file").unwrap();
+        let extracted = extract_tool_result(result, "get_file")
+            .unwrap()
+            .into_prefixed_string();
         assert_eq!(extracted, r#"{"key": "value"}"#);
     }
 
@@ -468,7 +560,9 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "get_file").unwrap();
+        let extracted = extract_tool_result(result, "get_file")
+            .unwrap()
+            .into_prefixed_string();
         assert!(extracted.contains("Resource link:"));
         assert!(extracted.contains("big-file.md"));
         assert!(extracted.contains("repo://"));
@@ -519,8 +613,120 @@ mod tests {
             meta: None,
         };
 
-        let extracted = extract_tool_result(result, "get_file").unwrap();
+        let extracted = extract_tool_result(result, "get_file")
+            .unwrap()
+            .into_prefixed_string();
         assert!(extracted.contains("Successfully downloaded file"));
         assert!(extracted.contains("# File Content"));
+    }
+
+    // --- CallOutcome tests ---
+
+    #[test]
+    fn test_call_outcome_success() {
+        let outcome = CallOutcome::Success("result".to_string());
+        assert!(!outcome.is_error());
+        assert!(!outcome.is_schema_error());
+        assert_eq!(outcome.content(), "result");
+        assert_eq!(outcome.into_prefixed_string(), "result");
+    }
+
+    #[test]
+    fn test_call_outcome_schema_error() {
+        let outcome = CallOutcome::SchemaError {
+            content: "Invalid params".to_string(),
+            code: -32602,
+        };
+        assert!(outcome.is_error());
+        assert!(outcome.is_schema_error());
+        assert_eq!(outcome.content(), "Invalid params");
+        assert_eq!(
+            outcome.into_prefixed_string(),
+            "Tool returned an error: Invalid params"
+        );
+    }
+
+    #[test]
+    fn test_call_outcome_general_tool_error() {
+        let outcome = CallOutcome::GeneralToolError {
+            content: "Internal error".to_string(),
+            code: Some(-32603),
+        };
+        assert!(outcome.is_error());
+        assert!(!outcome.is_schema_error());
+        assert_eq!(outcome.content(), "Internal error");
+    }
+
+    #[test]
+    fn test_call_outcome_application_level_error_is_general() {
+        let result = CallToolResult {
+            content: vec![Content {
+                raw: RawContent::Text(RawTextContent {
+                    text: "rate limited".to_string(),
+                    meta: None,
+                }),
+                annotations: None,
+            }],
+            structured_content: None,
+            is_error: Some(true),
+            meta: None,
+        };
+
+        let outcome = extract_tool_result(result, "test").unwrap();
+        assert!(matches!(
+            outcome,
+            CallOutcome::GeneralToolError { code: None, .. }
+        ));
+        assert_eq!(outcome.content(), "rate limited");
+    }
+
+    #[test]
+    fn test_from_jsonrpc_error_invalid_params() {
+        let outcome = CallOutcome::from_jsonrpc_error(-32602, "missing field: x");
+        assert!(outcome.is_schema_error());
+        assert_eq!(outcome.content(), "missing field: x");
+        assert!(matches!(
+            outcome,
+            CallOutcome::SchemaError { code: -32602, .. }
+        ));
+    }
+
+    #[test]
+    fn test_from_jsonrpc_error_internal() {
+        let outcome = CallOutcome::from_jsonrpc_error(-32603, "server crashed");
+        assert!(!outcome.is_schema_error());
+        assert!(outcome.is_error());
+        assert!(matches!(
+            outcome,
+            CallOutcome::GeneralToolError {
+                code: Some(-32603),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_classify_from_output_success() {
+        let outcome = CallOutcome::classify_from_output("normal result");
+        assert_eq!(outcome, CallOutcome::Success("normal result".to_string()));
+    }
+
+    #[test]
+    fn test_classify_from_output_error_prefix() {
+        let outcome = CallOutcome::classify_from_output("Tool returned an error: 503");
+        assert!(outcome.is_error());
+        assert_eq!(outcome.content(), "503");
+    }
+
+    #[test]
+    fn test_classify_roundtrip() {
+        let original = CallOutcome::GeneralToolError {
+            content: "timeout".to_string(),
+            code: None,
+        };
+        let prefixed = original.clone().into_prefixed_string();
+        let reconstructed = CallOutcome::classify_from_output(&prefixed);
+        assert_eq!(reconstructed.content(), original.content());
+        assert!(reconstructed.is_error());
     }
 }

--- a/crates/aura/src/mcp_streamable_http.rs
+++ b/crates/aura/src/mcp_streamable_http.rs
@@ -238,8 +238,7 @@ impl StreamableHttpMcpClient {
         match self.client.call_tool(request_param).await {
             Ok(result) => {
                 debug!("Tool '{}' executed successfully", tool_name);
-                // Use shared response handler (supports both structured_content and text)
-                extract_tool_result(result, tool_name)
+                extract_tool_result(result, tool_name).map(|outcome| outcome.into_prefixed_string())
             }
             Err(err) => {
                 error!("Failed to execute tool '{}': {}", tool_name, err);
@@ -315,7 +314,7 @@ impl StreamableHttpMcpClient {
         match response {
             rmcp::model::ServerResult::CallToolResult(result) => {
                 debug!("Tool '{}' completed with progress tracking", tool_name);
-                let extracted = extract_tool_result(result, tool_name)?;
+                let extracted = extract_tool_result(result, tool_name)?.into_prefixed_string();
                 Ok((extracted, progress_rx))
             }
             _ => Err(anyhow::anyhow!("Unexpected response type for tool call")),
@@ -362,6 +361,7 @@ impl StreamableHttpMcpClient {
                     Ok(rmcp::model::ServerResult::CallToolResult(call_result)) => {
                         debug!("Tool '{}' completed successfully", tool_name);
                         extract_tool_result(call_result, tool_name)
+                            .map(|outcome| outcome.into_prefixed_string())
                     }
                     Ok(_) => Err(anyhow::anyhow!("Unexpected response type for tool call")),
                     Err(err) => {
@@ -469,6 +469,7 @@ impl StreamableHttpMcpClient {
             Ok(rmcp::model::ServerResult::CallToolResult(call_result)) => {
                 debug!("Tool '{}' completed successfully", tool_name);
                 extract_tool_result(call_result, tool_name)
+                    .map(|outcome| outcome.into_prefixed_string())
             }
             Ok(_) => Err(anyhow::anyhow!("Unexpected response type for tool call")),
             Err(err) => {

--- a/crates/aura/src/orchestration/config.rs
+++ b/crates/aura/src/orchestration/config.rs
@@ -112,6 +112,14 @@ fn default_max_plan_parse_retries() -> usize {
     3
 }
 
+fn default_duplicate_call_nudge_threshold() -> usize {
+    3
+}
+
+fn default_duplicate_call_block_threshold() -> usize {
+    5
+}
+
 /// Hardcoded orchestrator preamble template loaded at compile time.
 ///
 /// Contains the core orchestrator behavior with a `{{orchestration_system_prompt}}`
@@ -380,12 +388,11 @@ pub struct OrchestrationConfig {
 
     // --- Safety ---
     /// Consecutive identical tool calls before appending guidance annotation.
-    /// Default: 3.
-    pub duplicate_call_nudge_threshold: Option<usize>,
+    pub duplicate_call_nudge_threshold: usize,
 
     /// Consecutive identical tool calls before appending abort annotation
-    /// and setting the escalation flag. Default: 5.
-    pub duplicate_call_block_threshold: Option<usize>,
+    /// and setting the escalation flag.
+    pub duplicate_call_block_threshold: usize,
 
     // --- Sub-configs ---
     /// Timeout settings for LLM calls.
@@ -557,8 +564,8 @@ impl Default for OrchestrationConfig {
             worker_system_prompt: None,
             workers: HashMap::new(),
             coordinator_vector_stores: Vec::new(),
-            duplicate_call_nudge_threshold: None,
-            duplicate_call_block_threshold: None,
+            duplicate_call_nudge_threshold: default_duplicate_call_nudge_threshold(),
+            duplicate_call_block_threshold: default_duplicate_call_block_threshold(),
             timeouts: TimeoutsConfig::default(),
             artifacts: ArtifactsConfig::default(),
         }
@@ -602,10 +609,10 @@ struct RawOrchestrationConfig {
     workers: HashMap<String, WorkerConfig>,
     #[serde(default)]
     coordinator_vector_stores: Vec<String>,
-    #[serde(default)]
-    duplicate_call_nudge_threshold: Option<usize>,
-    #[serde(default)]
-    duplicate_call_block_threshold: Option<usize>,
+    #[serde(default = "default_duplicate_call_nudge_threshold")]
+    duplicate_call_nudge_threshold: usize,
+    #[serde(default = "default_duplicate_call_block_threshold")]
+    duplicate_call_block_threshold: usize,
 
     // --- Sub-tables ---
     #[serde(default)]

--- a/crates/aura/src/orchestration/config.rs
+++ b/crates/aura/src/orchestration/config.rs
@@ -379,16 +379,13 @@ pub struct OrchestrationConfig {
     pub coordinator_vector_stores: Vec<String>,
 
     // --- Safety ---
-    /// Maximum consecutive duplicate tool calls before rejection.
-    ///
-    /// When a worker calls the same tool with identical arguments and receives
-    /// the same result this many times in a row, subsequent calls are rejected
-    /// with a nudge to emit the final answer. Prevents infinite ReAct loops
-    /// in smaller/quantized models.
-    ///
-    /// Default: 2. Set to `None` / omit to use default. Set to a high value
-    /// (e.g., 999) to effectively disable.
-    pub max_consecutive_duplicate_tool_calls: Option<usize>,
+    /// Consecutive identical tool calls before appending guidance annotation.
+    /// Default: 3.
+    pub duplicate_call_nudge_threshold: Option<usize>,
+
+    /// Consecutive identical tool calls before appending abort annotation
+    /// and setting the escalation flag. Default: 5.
+    pub duplicate_call_block_threshold: Option<usize>,
 
     // --- Sub-configs ---
     /// Timeout settings for LLM calls.
@@ -560,7 +557,8 @@ impl Default for OrchestrationConfig {
             worker_system_prompt: None,
             workers: HashMap::new(),
             coordinator_vector_stores: Vec::new(),
-            max_consecutive_duplicate_tool_calls: None,
+            duplicate_call_nudge_threshold: None,
+            duplicate_call_block_threshold: None,
             timeouts: TimeoutsConfig::default(),
             artifacts: ArtifactsConfig::default(),
         }
@@ -605,7 +603,9 @@ struct RawOrchestrationConfig {
     #[serde(default)]
     coordinator_vector_stores: Vec<String>,
     #[serde(default)]
-    max_consecutive_duplicate_tool_calls: Option<usize>,
+    duplicate_call_nudge_threshold: Option<usize>,
+    #[serde(default)]
+    duplicate_call_block_threshold: Option<usize>,
 
     // --- Sub-tables ---
     #[serde(default)]
@@ -660,7 +660,8 @@ impl<'de> Deserialize<'de> for OrchestrationConfig {
             worker_system_prompt: raw.worker_system_prompt,
             workers: raw.workers,
             coordinator_vector_stores: raw.coordinator_vector_stores,
-            max_consecutive_duplicate_tool_calls: raw.max_consecutive_duplicate_tool_calls,
+            duplicate_call_nudge_threshold: raw.duplicate_call_nudge_threshold,
+            duplicate_call_block_threshold: raw.duplicate_call_block_threshold,
             timeouts,
             artifacts,
         })

--- a/crates/aura/src/orchestration/duplicate_call_guard.rs
+++ b/crates/aura/src/orchestration/duplicate_call_guard.rs
@@ -21,6 +21,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Mutex;
 
+use crate::mcp_response::CallOutcome;
 use crate::tool_wrapper::{
     ToolCallContext, ToolWrapper, TransformArgsResult, TransformOutputResult,
 };
@@ -146,6 +147,7 @@ impl ToolWrapper for DuplicateCallGuard {
     fn transform_output(
         &self,
         output: String,
+        _outcome: &CallOutcome,
         _ctx: &ToolCallContext,
         extracted: Option<&Value>,
     ) -> TransformOutputResult {
@@ -233,6 +235,10 @@ fn extract_guard_data(extracted: Option<&Value>) -> Option<(String, u64)> {
 mod tests {
     use super::*;
 
+    fn success(s: &str) -> CallOutcome {
+        CallOutcome::Success(s.to_string())
+    }
+
     #[test]
     fn test_canonicalize_args_strips_aura_reasoning() {
         let a = serde_json::json!({"number": 45, "_aura_reasoning": "Converting 45 degrees"});
@@ -253,7 +259,12 @@ mod tests {
         guard
             .validate_args(&r.args, r.extracted.as_ref(), &ctx)
             .ok();
-        guard.transform_output("0.785".to_string(), &ctx, r.extracted.as_ref());
+        guard.transform_output(
+            "0.785".to_string(),
+            &success("0.785"),
+            &ctx,
+            r.extracted.as_ref(),
+        );
 
         // Call 2 with different reasoning but same functional args
         let args2 = serde_json::json!({"number": 45, "_aura_reasoning": "Need radians for sin"});
@@ -261,7 +272,12 @@ mod tests {
         guard
             .validate_args(&r.args, r.extracted.as_ref(), &ctx)
             .ok();
-        guard.transform_output("0.785".to_string(), &ctx, r.extracted.as_ref());
+        guard.transform_output(
+            "0.785".to_string(),
+            &success("0.785"),
+            &ctx,
+            r.extracted.as_ref(),
+        );
 
         // Call 3 — should be REJECTED
         let args3 = serde_json::json!({"number": 45, "_aura_reasoning": "Yet another reason"});
@@ -302,7 +318,12 @@ mod tests {
         );
 
         // Simulate successful output
-        guard.transform_output("2.0".to_string(), &ctx, result.extracted.as_ref());
+        guard.transform_output(
+            "2.0".to_string(),
+            &success("2.0"),
+            &ctx,
+            result.extracted.as_ref(),
+        );
     }
 
     #[test]
@@ -318,7 +339,12 @@ mod tests {
                 .validate_args(&r1.args, r1.extracted.as_ref(), &ctx)
                 .is_ok()
         );
-        guard.transform_output("2.0".to_string(), &ctx, r1.extracted.as_ref());
+        guard.transform_output(
+            "2.0".to_string(),
+            &success("2.0"),
+            &ctx,
+            r1.extracted.as_ref(),
+        );
 
         // Call 2: allowed (count becomes 2 = max_duplicates)
         let r2 = guard.transform_args(args.clone(), &ctx);
@@ -327,7 +353,12 @@ mod tests {
                 .validate_args(&r2.args, r2.extracted.as_ref(), &ctx)
                 .is_ok()
         );
-        guard.transform_output("2.0".to_string(), &ctx, r2.extracted.as_ref());
+        guard.transform_output(
+            "2.0".to_string(),
+            &success("2.0"),
+            &ctx,
+            r2.extracted.as_ref(),
+        );
 
         // Call 3: REJECTED (count=2 >= max_duplicates=2)
         let r3 = guard.transform_args(args.clone(), &ctx);
@@ -350,13 +381,23 @@ mod tests {
         guard
             .validate_args(&r.args, r.extracted.as_ref(), &ctx)
             .ok();
-        guard.transform_output("2.0".to_string(), &ctx, r.extracted.as_ref());
+        guard.transform_output(
+            "2.0".to_string(),
+            &success("2.0"),
+            &ctx,
+            r.extracted.as_ref(),
+        );
 
         let r = guard.transform_args(args1.clone(), &ctx);
         guard
             .validate_args(&r.args, r.extracted.as_ref(), &ctx)
             .ok();
-        guard.transform_output("2.0".to_string(), &ctx, r.extracted.as_ref());
+        guard.transform_output(
+            "2.0".to_string(),
+            &success("2.0"),
+            &ctx,
+            r.extracted.as_ref(),
+        );
 
         // Different args → resets, allowed
         let r = guard.transform_args(args2, &ctx);
@@ -378,21 +419,36 @@ mod tests {
         guard
             .validate_args(&r.args, r.extracted.as_ref(), &ctx)
             .ok();
-        guard.transform_output("12:00".to_string(), &ctx, r.extracted.as_ref());
+        guard.transform_output(
+            "12:00".to_string(),
+            &success("12:00"),
+            &ctx,
+            r.extracted.as_ref(),
+        );
 
         // Call 2: same args, different result → resets
         let r = guard.transform_args(args.clone(), &ctx);
         guard
             .validate_args(&r.args, r.extracted.as_ref(), &ctx)
             .ok();
-        guard.transform_output("12:01".to_string(), &ctx, r.extracted.as_ref());
+        guard.transform_output(
+            "12:01".to_string(),
+            &success("12:01"),
+            &ctx,
+            r.extracted.as_ref(),
+        );
 
         // Call 3: same args, same new result → count=2
         let r = guard.transform_args(args.clone(), &ctx);
         guard
             .validate_args(&r.args, r.extracted.as_ref(), &ctx)
             .ok();
-        guard.transform_output("12:01".to_string(), &ctx, r.extracted.as_ref());
+        guard.transform_output(
+            "12:01".to_string(),
+            &success("12:01"),
+            &ctx,
+            r.extracted.as_ref(),
+        );
 
         // Call 4: REJECTED
         let r = guard.transform_args(args.clone(), &ctx);
@@ -414,13 +470,23 @@ mod tests {
         guard
             .validate_args(&r.args, r.extracted.as_ref(), &ctx)
             .ok();
-        guard.transform_output("2.0".to_string(), &ctx, r.extracted.as_ref());
+        guard.transform_output(
+            "2.0".to_string(),
+            &success("2.0"),
+            &ctx,
+            r.extracted.as_ref(),
+        );
 
         let r = guard.transform_args(args.clone(), &ctx);
         guard
             .validate_args(&r.args, r.extracted.as_ref(), &ctx)
             .ok();
-        guard.transform_output("2.0".to_string(), &ctx, r.extracted.as_ref());
+        guard.transform_output(
+            "2.0".to_string(),
+            &success("2.0"),
+            &ctx,
+            r.extracted.as_ref(),
+        );
 
         // Error resets
         guard.handle_error(ToolError::ToolCallError("timeout".into()), &ctx, None);
@@ -447,13 +513,13 @@ mod tests {
         guard
             .validate_args(&r.args, r.extracted.as_ref(), &ctx_a)
             .ok();
-        guard.transform_output("1".to_string(), &ctx_a, r.extracted.as_ref());
+        guard.transform_output("1".to_string(), &success("1"), &ctx_a, r.extracted.as_ref());
 
         let r = guard.transform_args(args.clone(), &ctx_a);
         guard
             .validate_args(&r.args, r.extracted.as_ref(), &ctx_a)
             .ok();
-        guard.transform_output("1".to_string(), &ctx_a, r.extracted.as_ref());
+        guard.transform_output("1".to_string(), &success("1"), &ctx_a, r.extracted.as_ref());
 
         // Different tool → resets
         let r = guard.transform_args(args, &ctx_b);

--- a/crates/aura/src/orchestration/duplicate_call_guard.rs
+++ b/crates/aura/src/orchestration/duplicate_call_guard.rs
@@ -1,77 +1,75 @@
-//! Duplicate tool call guard for orchestration workers.
+//! Two-stage duplicate tool call guard for orchestration workers.
 //!
 //! Catches pathological looping behavior where a model calls the same tool
 //! with identical arguments repeatedly despite receiving the same result.
-//! Common with smaller/quantized models (e.g., Qwen 3.5 Q4_K_M) that lack
-//! strong internalized "stop after result" behavior.
 //!
-//! The guard tracks consecutive identical calls per (tool_name, args) pair.
-//! After `max_duplicates` consecutive identical successful results, it rejects
-//! the call with a nudge message directing the model to emit its final answer.
+//! Uses `CallOutcome` for error-kind-aware counting:
+//! - `Success` / `SchemaError` with identical output → counter increments
+//! - `GeneralToolError` → counter unchanged (legitimate retries)
 //!
-//! Resets on:
-//! - Different tool or different args (new work)
-//! - Same args but different result (transient data)
-//! - Tool error (retries after errors are healthy)
+//! Two escalation stages, both via annotation on the real tool output:
+//! - `nudge_threshold` → appends `[DUPLICATE_CALL_GUIDANCE]`
+//! - `block_threshold` → appends `[DUPLICATE_CALL_ABORT]` + sets escalation flag
 
 use async_trait::async_trait;
-use rig::tool::ToolError;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use crate::mcp_response::CallOutcome;
 use crate::tool_wrapper::{
     ToolCallContext, ToolWrapper, TransformArgsResult, TransformOutputResult,
 };
 
-/// State for tracking consecutive duplicate calls.
+const GUIDANCE_TEMPLATE: &str = include_str!("../prompts/duplicate_call_guidance.md");
+const ABORT_TEMPLATE: &str = include_str!("../prompts/duplicate_call_abort.md");
+
+/// Hash of `(tool_name, canonical_args)` identifying a unique invocation pattern.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct CallFingerprint(u64);
+
 #[derive(Debug)]
 struct CallState {
-    /// Number of consecutive times this (tool, args) pair returned the same result.
     consecutive_count: usize,
-    /// The last successful result for comparison.
-    last_result: String,
+    last_output: String,
 }
 
-/// Guards against infinite tool-call loops by rejecting consecutive duplicate calls.
-///
-/// When a model calls the same tool with identical arguments and receives the same
-/// result `max_duplicates` times in a row, subsequent calls are rejected with a
-/// nudge message that directs the model to emit its final answer.
-///
-/// # Design
-///
-/// - Fresh instance per worker (no cross-task state leakage)
-/// - Only tracks the most recent (tool, args) pair — different tool/args resets
-/// - Resets on errors (retries after transient failures are healthy)
-/// - Resets when same args return a different result (transient data changes)
 pub struct DuplicateCallGuard {
-    max_duplicates: usize,
-    // Key: (tool_name, args_hash). Only one entry tracked at a time (last call).
-    state: Mutex<Option<(String, u64, CallState)>>,
+    nudge_threshold: usize,
+    block_threshold: usize,
+    escalation_flag: Arc<AtomicBool>,
+    state: Mutex<HashMap<CallFingerprint, CallState>>,
 }
 
 impl DuplicateCallGuard {
-    /// Create a new guard with the specified duplicate threshold.
-    ///
-    /// `max_duplicates` is the number of consecutive identical successful calls
-    /// allowed before rejection. Default: 2.
-    pub fn new(max_duplicates: usize) -> Self {
+    pub fn new(
+        nudge_threshold: usize,
+        block_threshold: usize,
+        escalation_flag: Arc<AtomicBool>,
+    ) -> Self {
         Self {
-            max_duplicates,
-            state: Mutex::new(None),
+            nudge_threshold,
+            block_threshold,
+            escalation_flag,
+            state: Mutex::new(HashMap::new()),
         }
     }
 
-    /// Compute a deterministic hash for canonical (tool_name, sorted_args).
-    fn hash_call(tool_name: &str, args: &Value) -> u64 {
+    fn fingerprint(tool_name: &str, args: &Value) -> CallFingerprint {
         let canonical = canonicalize_args(args);
         let mut hasher = DefaultHasher::new();
         tool_name.hash(&mut hasher);
         canonical.hash(&mut hasher);
-        hasher.finish()
+        CallFingerprint(hasher.finish())
+    }
+
+    fn render_template(template: &str, tool_name: &str, count: usize) -> String {
+        template
+            .replace("%%TOOL_NAME%%", tool_name)
+            .replace("%%COUNT%%", &count.to_string())
     }
 }
 
@@ -102,52 +100,18 @@ fn canonicalize_args(value: &Value) -> String {
 #[async_trait]
 impl ToolWrapper for DuplicateCallGuard {
     fn transform_args(&self, args: Value, ctx: &ToolCallContext) -> TransformArgsResult {
-        let hash = Self::hash_call(&ctx.tool_name, &args);
-        // Store the hash and tool_name in extracted for validate_args and transform_output
+        let fp = Self::fingerprint(&ctx.tool_name, &args);
         let extracted = serde_json::json!({
             "dup_guard_tool_name": ctx.tool_name,
-            "dup_guard_args_hash": hash,
+            "dup_guard_args_hash": fp.0,
         });
         TransformArgsResult::with_extracted(args, extracted)
-    }
-
-    fn validate_args(
-        &self,
-        _args: &Value,
-        extracted: Option<&Value>,
-        _ctx: &ToolCallContext,
-    ) -> Result<(), ToolError> {
-        let (tool_name, args_hash) = match extract_guard_data(extracted) {
-            Some(v) => v,
-            None => return Ok(()),
-        };
-
-        let state = self.state.lock().unwrap();
-        if let Some((ref tracked_tool, tracked_hash, ref call_state)) = *state
-            && tracked_tool == &tool_name
-            && tracked_hash == args_hash
-            && call_state.consecutive_count >= self.max_duplicates
-        {
-            let cached = &call_state.last_result;
-            let count = call_state.consecutive_count;
-            return Err(ToolError::ToolCallError(
-                format!(
-                    "[DUPLICATE TOOL CALL] You have called '{}' with identical arguments {} times \
-                     and received the same result: {}. \
-                     Write your final answer now. Do not call this tool again with the same arguments.",
-                    tool_name, count, cached
-                )
-                .into(),
-            ));
-        }
-
-        Ok(())
     }
 
     fn transform_output(
         &self,
         output: String,
-        _outcome: &CallOutcome,
+        outcome: &CallOutcome,
         _ctx: &ToolCallContext,
         extracted: Option<&Value>,
     ) -> TransformOutputResult {
@@ -156,38 +120,52 @@ impl ToolWrapper for DuplicateCallGuard {
             None => return TransformOutputResult::new(output),
         };
 
+        if matches!(outcome, CallOutcome::GeneralToolError { .. }) {
+            return TransformOutputResult::new(output);
+        }
+
+        let fp = CallFingerprint(args_hash);
         let mut state = self.state.lock().unwrap();
 
-        let is_match = state
-            .as_ref()
-            .is_some_and(|(t, h, _)| t == &tool_name && *h == args_hash);
+        if self.escalation_flag.load(Ordering::SeqCst) {
+            return TransformOutputResult::new(output);
+        }
 
-        if is_match {
-            let (_, _, call_state) = state.as_mut().unwrap();
-            if call_state.last_result == output {
-                // Same tool + same args + same result → increment
-                call_state.consecutive_count += 1;
-                tracing::debug!(
-                    "DuplicateCallGuard: '{}' identical call #{} (hash={})",
-                    tool_name,
-                    call_state.consecutive_count,
-                    args_hash
-                );
-            } else {
-                // Same args but different result → reset (transient data)
-                call_state.consecutive_count = 1;
-                call_state.last_result = output.clone();
-            }
+        let call_state = state.entry(fp).or_insert_with(|| CallState {
+            consecutive_count: 0,
+            last_output: String::new(),
+        });
+
+        if call_state.last_output == output {
+            call_state.consecutive_count += 1;
         } else {
-            // New tool or new args → fresh tracking
-            *state = Some((
+            call_state.consecutive_count = 1;
+            call_state.last_output = output.clone();
+        }
+
+        let count = call_state.consecutive_count;
+
+        if count >= self.block_threshold {
+            self.escalation_flag.store(true, Ordering::SeqCst);
+            tracing::warn!(
+                "DuplicateCallGuard: '{}' hit block threshold ({}/{})",
                 tool_name,
-                args_hash,
-                CallState {
-                    consecutive_count: 1,
-                    last_result: output.clone(),
-                },
-            ));
+                count,
+                self.block_threshold
+            );
+            let annotation = Self::render_template(ABORT_TEMPLATE, &tool_name, count);
+            return TransformOutputResult::new(format!("{output}\n\n{annotation}"));
+        }
+
+        if count >= self.nudge_threshold {
+            tracing::info!(
+                "DuplicateCallGuard: '{}' hit nudge threshold ({}/{})",
+                tool_name,
+                count,
+                self.nudge_threshold
+            );
+            let annotation = Self::render_template(GUIDANCE_TEMPLATE, &tool_name, count);
+            return TransformOutputResult::new(format!("{output}\n\n{annotation}"));
         }
 
         TransformOutputResult::new(output)
@@ -195,17 +173,10 @@ impl ToolWrapper for DuplicateCallGuard {
 
     fn handle_error(
         &self,
-        error: ToolError,
+        error: rig::tool::ToolError,
         _ctx: &ToolCallContext,
         _extracted: Option<&Value>,
-    ) -> ToolError {
-        // Only reset on non-guard errors — retries after transient failures are healthy,
-        // but we must not reset when our own rejection is routed back through handle_error
-        let error_msg = error.to_string();
-        if !error_msg.contains("[DUPLICATE TOOL CALL]") {
-            let mut state = self.state.lock().unwrap();
-            *state = None;
-        }
+    ) -> rig::tool::ToolError {
         error
     }
 }
@@ -235,58 +206,48 @@ fn extract_guard_data(extracted: Option<&Value>) -> Option<(String, u64)> {
 mod tests {
     use super::*;
 
+    fn make_guard(nudge: usize, block: usize) -> (DuplicateCallGuard, Arc<AtomicBool>) {
+        let flag = Arc::new(AtomicBool::new(false));
+        let guard = DuplicateCallGuard::new(nudge, block, flag.clone());
+        (guard, flag)
+    }
+
+    fn call(
+        guard: &DuplicateCallGuard,
+        ctx: &ToolCallContext,
+        args: &Value,
+        output: &str,
+        outcome: &CallOutcome,
+    ) -> TransformOutputResult {
+        let r = guard.transform_args(args.clone(), ctx);
+        guard.transform_output(output.to_string(), outcome, ctx, r.extracted.as_ref())
+    }
+
     fn success(s: &str) -> CallOutcome {
         CallOutcome::Success(s.to_string())
     }
 
-    #[test]
-    fn test_canonicalize_args_strips_aura_reasoning() {
-        let a = serde_json::json!({"number": 45, "_aura_reasoning": "Converting 45 degrees"});
-        let b = serde_json::json!({"number": 45, "_aura_reasoning": "Different reasoning text"});
-        let c = serde_json::json!({"number": 45});
-        assert_eq!(canonicalize_args(&a), canonicalize_args(&b));
-        assert_eq!(canonicalize_args(&a), canonicalize_args(&c));
+    fn general_error(s: &str) -> CallOutcome {
+        CallOutcome::GeneralToolError {
+            content: s.to_string(),
+            code: None,
+        }
+    }
+
+    fn schema_error(s: &str) -> CallOutcome {
+        CallOutcome::SchemaError {
+            content: s.to_string(),
+            code: -32602,
+        }
     }
 
     #[test]
-    fn test_guard_treats_different_reasoning_as_same_call() {
-        let guard = DuplicateCallGuard::new(2);
-        let ctx = ToolCallContext::new("degreesToRadians");
-
-        // Call 1 with reasoning A
-        let args1 = serde_json::json!({"number": 45, "_aura_reasoning": "Converting 45 degrees"});
-        let r = guard.transform_args(args1, &ctx);
-        guard
-            .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-            .ok();
-        guard.transform_output(
-            "0.785".to_string(),
-            &success("0.785"),
-            &ctx,
-            r.extracted.as_ref(),
-        );
-
-        // Call 2 with different reasoning but same functional args
-        let args2 = serde_json::json!({"number": 45, "_aura_reasoning": "Need radians for sin"});
-        let r = guard.transform_args(args2, &ctx);
-        guard
-            .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-            .ok();
-        guard.transform_output(
-            "0.785".to_string(),
-            &success("0.785"),
-            &ctx,
-            r.extracted.as_ref(),
-        );
-
-        // Call 3 — should be REJECTED
-        let args3 = serde_json::json!({"number": 45, "_aura_reasoning": "Yet another reason"});
-        let r = guard.transform_args(args3, &ctx);
-        assert!(
-            guard
-                .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-                .is_err()
-        );
+    fn test_canonicalize_args_strips_aura_reasoning() {
+        let a = serde_json::json!({"number": 45, "_aura_reasoning": "reason A"});
+        let b = serde_json::json!({"number": 45, "_aura_reasoning": "reason B"});
+        let c = serde_json::json!({"number": 45});
+        assert_eq!(canonicalize_args(&a), canonicalize_args(&b));
+        assert_eq!(canonicalize_args(&a), canonicalize_args(&c));
     }
 
     #[test]
@@ -297,237 +258,198 @@ mod tests {
     }
 
     #[test]
-    fn test_canonicalize_args_nested() {
-        let v = serde_json::json!({"z": [1, {"b": 2, "a": 1}], "a": "hello"});
-        let canonical = canonicalize_args(&v);
-        assert!(canonical.contains("a:\"hello\""));
-        assert!(canonical.contains("{a:1,b:2}"));
-    }
-
-    #[test]
-    fn test_guard_allows_first_calls() {
-        let guard = DuplicateCallGuard::new(2);
+    fn test_no_annotation_below_nudge() {
+        let (guard, flag) = make_guard(3, 5);
         let ctx = ToolCallContext::new("mean");
         let args = serde_json::json!({"numbers": [1, 2, 3]});
 
-        let result = guard.transform_args(args, &ctx);
-        assert!(
-            guard
-                .validate_args(&result.args, result.extracted.as_ref(), &ctx)
-                .is_ok()
-        );
-
-        // Simulate successful output
-        guard.transform_output(
-            "2.0".to_string(),
-            &success("2.0"),
-            &ctx,
-            result.extracted.as_ref(),
-        );
+        for _ in 0..2 {
+            let r = call(&guard, &ctx, &args, "2.0", &success("2.0"));
+            assert!(!r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
+            assert!(!r.output.contains("[DUPLICATE_CALL_ABORT]"));
+        }
+        assert!(!flag.load(Ordering::SeqCst));
     }
 
     #[test]
-    fn test_guard_allows_up_to_max_duplicates() {
-        let guard = DuplicateCallGuard::new(2);
+    fn test_nudge_at_threshold() {
+        let (guard, flag) = make_guard(3, 5);
         let ctx = ToolCallContext::new("mean");
         let args = serde_json::json!({"numbers": [1, 2, 3]});
 
-        // Call 1: allowed, output recorded (count=1)
-        let r1 = guard.transform_args(args.clone(), &ctx);
-        assert!(
-            guard
-                .validate_args(&r1.args, r1.extracted.as_ref(), &ctx)
-                .is_ok()
-        );
-        guard.transform_output(
-            "2.0".to_string(),
-            &success("2.0"),
-            &ctx,
-            r1.extracted.as_ref(),
-        );
+        for _ in 0..2 {
+            call(&guard, &ctx, &args, "2.0", &success("2.0"));
+        }
 
-        // Call 2: allowed (count becomes 2 = max_duplicates)
-        let r2 = guard.transform_args(args.clone(), &ctx);
-        assert!(
-            guard
-                .validate_args(&r2.args, r2.extracted.as_ref(), &ctx)
-                .is_ok()
-        );
-        guard.transform_output(
-            "2.0".to_string(),
-            &success("2.0"),
-            &ctx,
-            r2.extracted.as_ref(),
-        );
-
-        // Call 3: REJECTED (count=2 >= max_duplicates=2)
-        let r3 = guard.transform_args(args.clone(), &ctx);
-        let result = guard.validate_args(&r3.args, r3.extracted.as_ref(), &ctx);
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("DUPLICATE TOOL CALL"));
-        assert!(err_msg.contains("2.0"));
+        let r = call(&guard, &ctx, &args, "2.0", &success("2.0"));
+        assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
+        assert!(r.output.starts_with("2.0"));
+        assert!(!flag.load(Ordering::SeqCst));
     }
 
     #[test]
-    fn test_guard_resets_on_different_args() {
-        let guard = DuplicateCallGuard::new(2);
+    fn test_block_at_threshold_sets_flag() {
+        let (guard, flag) = make_guard(3, 5);
         let ctx = ToolCallContext::new("mean");
-        let args1 = serde_json::json!({"numbers": [1, 2, 3]});
-        let args2 = serde_json::json!({"numbers": [4, 5, 6]});
+        let args = serde_json::json!({"numbers": [1, 2, 3]});
 
-        // Fill up with args1
-        let r = guard.transform_args(args1.clone(), &ctx);
-        guard
-            .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-            .ok();
-        guard.transform_output(
-            "2.0".to_string(),
-            &success("2.0"),
-            &ctx,
-            r.extracted.as_ref(),
-        );
+        for _ in 0..4 {
+            call(&guard, &ctx, &args, "2.0", &success("2.0"));
+        }
 
-        let r = guard.transform_args(args1.clone(), &ctx);
-        guard
-            .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-            .ok();
-        guard.transform_output(
-            "2.0".to_string(),
-            &success("2.0"),
-            &ctx,
-            r.extracted.as_ref(),
-        );
-
-        // Different args → resets, allowed
-        let r = guard.transform_args(args2, &ctx);
-        assert!(
-            guard
-                .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-                .is_ok()
-        );
+        let r = call(&guard, &ctx, &args, "2.0", &success("2.0"));
+        assert!(r.output.contains("[DUPLICATE_CALL_ABORT]"));
+        assert!(r.output.starts_with("2.0"));
+        assert!(flag.load(Ordering::SeqCst));
     }
 
     #[test]
-    fn test_guard_resets_on_different_result() {
-        let guard = DuplicateCallGuard::new(2);
+    fn test_general_error_does_not_increment() {
+        let (guard, flag) = make_guard(2, 4);
+        let ctx = ToolCallContext::new("api");
+        let args = serde_json::json!({"q": "test"});
+
+        call(&guard, &ctx, &args, "timeout", &success("timeout"));
+
+        for _ in 0..5 {
+            let r = call(&guard, &ctx, &args, "timeout", &general_error("timeout"));
+            assert!(!r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
+            assert!(!r.output.contains("[DUPLICATE_CALL_ABORT]"));
+        }
+        assert!(!flag.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_schema_error_increments() {
+        let (guard, flag) = make_guard(2, 4);
+        let ctx = ToolCallContext::new("api");
+        let args = serde_json::json!({"bad": "field"});
+
+        call(
+            &guard,
+            &ctx,
+            &args,
+            "missing param",
+            &schema_error("missing param"),
+        );
+
+        let r = call(
+            &guard,
+            &ctx,
+            &args,
+            "missing param",
+            &schema_error("missing param"),
+        );
+        assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
+        assert!(!flag.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_different_result_resets() {
+        let (guard, _flag) = make_guard(2, 4);
         let ctx = ToolCallContext::new("get_time");
         let args = serde_json::json!({"tz": "UTC"});
 
-        // Call 1: result "12:00"
-        let r = guard.transform_args(args.clone(), &ctx);
-        guard
-            .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-            .ok();
-        guard.transform_output(
-            "12:00".to_string(),
-            &success("12:00"),
-            &ctx,
-            r.extracted.as_ref(),
-        );
+        call(&guard, &ctx, &args, "12:00", &success("12:00"));
+        call(&guard, &ctx, &args, "12:01", &success("12:01"));
 
-        // Call 2: same args, different result → resets
-        let r = guard.transform_args(args.clone(), &ctx);
-        guard
-            .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-            .ok();
-        guard.transform_output(
-            "12:01".to_string(),
-            &success("12:01"),
-            &ctx,
-            r.extracted.as_ref(),
-        );
-
-        // Call 3: same args, same new result → count=2
-        let r = guard.transform_args(args.clone(), &ctx);
-        guard
-            .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-            .ok();
-        guard.transform_output(
-            "12:01".to_string(),
-            &success("12:01"),
-            &ctx,
-            r.extracted.as_ref(),
-        );
-
-        // Call 4: REJECTED
-        let r = guard.transform_args(args.clone(), &ctx);
-        assert!(
-            guard
-                .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-                .is_err()
-        );
+        let r = call(&guard, &ctx, &args, "12:01", &success("12:01"));
+        assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
     }
 
     #[test]
-    fn test_guard_resets_on_error() {
-        let guard = DuplicateCallGuard::new(2);
-        let ctx = ToolCallContext::new("mean");
-        let args = serde_json::json!({"numbers": [1, 2, 3]});
-
-        // Fill up
-        let r = guard.transform_args(args.clone(), &ctx);
-        guard
-            .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-            .ok();
-        guard.transform_output(
-            "2.0".to_string(),
-            &success("2.0"),
-            &ctx,
-            r.extracted.as_ref(),
-        );
-
-        let r = guard.transform_args(args.clone(), &ctx);
-        guard
-            .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-            .ok();
-        guard.transform_output(
-            "2.0".to_string(),
-            &success("2.0"),
-            &ctx,
-            r.extracted.as_ref(),
-        );
-
-        // Error resets
-        guard.handle_error(ToolError::ToolCallError("timeout".into()), &ctx, None);
-
-        // Now allowed again
-        let r = guard.transform_args(args, &ctx);
-        assert!(
-            guard
-                .validate_args(&r.args, r.extracted.as_ref(), &ctx)
-                .is_ok()
-        );
-    }
-
-    #[test]
-    fn test_guard_resets_on_different_tool() {
-        let guard = DuplicateCallGuard::new(2);
+    fn test_different_tool_resets() {
+        let (guard, _flag) = make_guard(2, 4);
         let args = serde_json::json!({"x": 1});
-
         let ctx_a = ToolCallContext::new("tool_a");
         let ctx_b = ToolCallContext::new("tool_b");
 
-        // Fill up tool_a
-        let r = guard.transform_args(args.clone(), &ctx_a);
-        guard
-            .validate_args(&r.args, r.extracted.as_ref(), &ctx_a)
-            .ok();
-        guard.transform_output("1".to_string(), &success("1"), &ctx_a, r.extracted.as_ref());
+        call(&guard, &ctx_a, &args, "1", &success("1"));
+        call(&guard, &ctx_a, &args, "1", &success("1"));
 
-        let r = guard.transform_args(args.clone(), &ctx_a);
-        guard
-            .validate_args(&r.args, r.extracted.as_ref(), &ctx_a)
-            .ok();
-        guard.transform_output("1".to_string(), &success("1"), &ctx_a, r.extracted.as_ref());
+        let r = call(&guard, &ctx_b, &args, "1", &success("1"));
+        assert!(!r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
+    }
 
-        // Different tool → resets
-        let r = guard.transform_args(args, &ctx_b);
-        assert!(
-            guard
-                .validate_args(&r.args, r.extracted.as_ref(), &ctx_b)
-                .is_ok()
-        );
+    #[test]
+    fn test_flag_monotonic_after_block() {
+        let (guard, flag) = make_guard(2, 3);
+        let ctx = ToolCallContext::new("t");
+        let args = serde_json::json!({"x": 1});
+
+        for _ in 0..3 {
+            call(&guard, &ctx, &args, "r", &success("r"));
+        }
+        assert!(flag.load(Ordering::SeqCst));
+
+        let r = call(&guard, &ctx, &args, "r", &success("r"));
+        assert!(!r.output.contains("[DUPLICATE_CALL_ABORT]"));
+        assert!(flag.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_real_output_preserved() {
+        let (guard, _flag) = make_guard(2, 4);
+        let ctx = ToolCallContext::new("calc");
+        let args = serde_json::json!({"x": 5});
+
+        call(&guard, &ctx, &args, "25", &success("25"));
+        let r = call(&guard, &ctx, &args, "25", &success("25"));
+        assert!(r.output.starts_with("25"));
+        assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
+    }
+
+    #[test]
+    fn test_nudge_then_block_progression() {
+        let (guard, flag) = make_guard(3, 5);
+        let ctx = ToolCallContext::new("calc");
+        let args = serde_json::json!({"x": 5});
+
+        // Calls 1-2: below nudge_threshold=3
+        for i in 1..=2 {
+            let r = call(&guard, &ctx, &args, "25", &success("25"));
+            assert!(
+                !r.output.contains("[DUPLICATE_CALL"),
+                "unexpected annotation on call {i}"
+            );
+        }
+
+        // Calls 3-4: at/above nudge, below block
+        for _ in 3..=4 {
+            let r = call(&guard, &ctx, &args, "25", &success("25"));
+            assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
+            assert!(!r.output.contains("[DUPLICATE_CALL_ABORT]"));
+        }
+        assert!(!flag.load(Ordering::SeqCst));
+
+        // Call 5: block + flag
+        let r = call(&guard, &ctx, &args, "25", &success("25"));
+        assert!(r.output.contains("[DUPLICATE_CALL_ABORT]"));
+        assert!(flag.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_ping_pong_tracked_independently() {
+        let (guard, flag) = make_guard(3, 5);
+        let args_a = serde_json::json!({"x": 1});
+        let args_b = serde_json::json!({"x": 2});
+        let ctx = ToolCallContext::new("calc");
+
+        // Alternate: A, B, A, B — each pair's counter is independent
+        for _ in 0..2 {
+            call(&guard, &ctx, &args_a, "1", &success("1"));
+            call(&guard, &ctx, &args_b, "2", &success("2"));
+        }
+
+        // A at count=3 → nudge
+        let r = call(&guard, &ctx, &args_a, "1", &success("1"));
+        assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
+
+        // B at count=3 → nudge
+        let r = call(&guard, &ctx, &args_b, "2", &success("2"));
+        assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
+
+        assert!(!flag.load(Ordering::SeqCst));
     }
 
     #[test]
@@ -538,9 +460,7 @@ mod tests {
             {"persistence_key": "abc"}
         ]);
 
-        let result = extract_guard_data(Some(&extracted));
-        assert!(result.is_some());
-        let (name, hash) = result.unwrap();
+        let (name, hash) = extract_guard_data(Some(&extracted)).unwrap();
         assert_eq!(name, "mean");
         assert_eq!(hash, 12345);
     }
@@ -550,9 +470,7 @@ mod tests {
         let extracted =
             serde_json::json!({"dup_guard_tool_name": "sin", "dup_guard_args_hash": 99});
 
-        let result = extract_guard_data(Some(&extracted));
-        assert!(result.is_some());
-        let (name, hash) = result.unwrap();
+        let (name, hash) = extract_guard_data(Some(&extracted)).unwrap();
         assert_eq!(name, "sin");
         assert_eq!(hash, 99);
     }

--- a/crates/aura/src/orchestration/observer_wrapper.rs
+++ b/crates/aura/src/orchestration/observer_wrapper.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use crate::mcp_response::CallOutcome;
 use crate::tool_call_observer::{RetryHint, ToolCallObserver, ToolEvent};
 use crate::tool_wrapper::{
     ToolCallContext, ToolWrapper, TransformArgsResult, TransformOutputResult,
@@ -75,10 +76,10 @@ impl ToolWrapper for ObserverWrapper {
     fn transform_output(
         &self,
         output: String,
+        _outcome: &CallOutcome,
         _ctx: &ToolCallContext,
         _extracted: Option<&Value>,
     ) -> TransformOutputResult {
-        // Output passes through unchanged
         TransformOutputResult::new(output)
     }
 

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -473,8 +473,8 @@ impl Orchestrator {
             self.tool_call_observer.clone(),
             task_id,
         ));
-        let nudge = self.config.duplicate_call_nudge_threshold.unwrap_or(3);
-        let block = self.config.duplicate_call_block_threshold.unwrap_or(5);
+        let nudge = self.config.duplicate_call_nudge_threshold;
+        let block = self.config.duplicate_call_block_threshold;
         let escalation_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let duplicate_guard = Arc::new(DuplicateCallGuard::new(
             nudge,

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -98,6 +98,11 @@ struct TaskExecutionParams<'a> {
 struct AgentWithPreamble {
     agent: Agent,
     preamble: String,
+    /// Side-channel for worker→executor escalation. Set by the duplicate-call
+    /// guard when a tool-call loop is terminated; read by `execute_task` after
+    /// the multi_turn loop to convert a false `Ok` into `TaskStatus::Failed`.
+    #[allow(dead_code)]
+    escalation_flag: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Bundled coordinator tools for `build_agent_with_tools`.
@@ -469,11 +474,14 @@ impl Orchestrator {
             self.tool_call_observer.clone(),
             task_id,
         ));
-        let max_dup = self
-            .config
-            .max_consecutive_duplicate_tool_calls
-            .unwrap_or(1);
-        let duplicate_guard = Arc::new(DuplicateCallGuard::new(max_dup));
+        let nudge = self.config.duplicate_call_nudge_threshold.unwrap_or(3);
+        let block = self.config.duplicate_call_block_threshold.unwrap_or(5);
+        let escalation_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let duplicate_guard = Arc::new(DuplicateCallGuard::new(
+            nudge,
+            block,
+            escalation_flag.clone(),
+        ));
         // Observer first (emits start), then duplicate guard, then persistence (captures reasoning)
         let wrapper: Arc<dyn ToolWrapper> = Arc::new(ComposedWrapper::new(vec![
             observer_wrapper,
@@ -611,7 +619,11 @@ impl Orchestrator {
             context_window: worker_config.llm.context_window(),
         };
 
-        Ok(AgentWithPreamble { agent, preamble })
+        Ok(AgentWithPreamble {
+            agent,
+            preamble,
+            escalation_flag,
+        })
     }
 
     /// Execute a blocking chat call with timeout — for **worker tasks only**.
@@ -936,6 +948,7 @@ impl Orchestrator {
         let AgentWithPreamble {
             agent: coordinator,
             preamble: coordinator_preamble,
+            ..
         } = self.create_coordinator(Some(routing_toolset)).await?;
 
         // Build prompt components
@@ -1824,6 +1837,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 context_window: None,
             },
             preamble,
+            escalation_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
 
@@ -1872,6 +1886,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 context_window: None,
             },
             preamble,
+            escalation_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
 
@@ -1920,6 +1935,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 context_window: None,
             },
             preamble,
+            escalation_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
 
@@ -2739,6 +2755,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         let AgentWithPreamble {
             agent: worker,
             preamble: worker_preamble,
+            ..
         } = self.create_worker(task_id, attempt, *worker_name).await?;
 
         // Build the worker prompt — task-first, no original query (prevents scope creep)
@@ -3033,6 +3050,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             Ok(AgentWithPreamble {
                 agent: coordinator,
                 preamble: synth_preamble,
+                ..
             }) => {
                 // Record in prompt journal
                 self.journal_record(JournalPhase::Synthesis, &synth_preamble, &synthesis_prompt);
@@ -3189,6 +3207,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             Ok(AgentWithPreamble {
                 agent: coordinator,
                 preamble: eval_preamble,
+                ..
             }) => {
                 // Record in prompt journal
                 self.journal_record(JournalPhase::Evaluation, &eval_preamble, &eval_prompt);

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -101,7 +101,6 @@ struct AgentWithPreamble {
     /// Side-channel for worker→executor escalation. Set by the duplicate-call
     /// guard when a tool-call loop is terminated; read by `execute_task` after
     /// the multi_turn loop to convert a false `Ok` into `TaskStatus::Failed`.
-    #[allow(dead_code)]
     escalation_flag: Arc<std::sync::atomic::AtomicBool>,
 }
 
@@ -2755,7 +2754,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         let AgentWithPreamble {
             agent: worker,
             preamble: worker_preamble,
-            ..
+            escalation_flag,
         } = self.create_worker(task_id, attempt, *worker_name).await?;
 
         // Build the worker prompt — task-first, no original query (prevents scope creep)
@@ -2821,6 +2820,17 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 .into())
             }
             Err(e) => Err(e),
+        };
+
+        // Check escalation flag: guard detected a duplicate call loop but
+        // rig reported Ok. Convert to Err so the task is marked Failed and
+        // dependents are blocked in the DAG.
+        let result: Result<String, StreamError> = match result {
+            Ok(worker_output) if escalation_flag.load(std::sync::atomic::Ordering::SeqCst) => {
+                let processed = self.maybe_create_artifact(task_id, worker_output).await;
+                Err(format!("Worker blocked by duplicate call loop.\n{processed}").into())
+            }
+            other => other,
         };
 
         // Persist the worker execution

--- a/crates/aura/src/orchestration/persistence_wrapper.rs
+++ b/crates/aura/src/orchestration/persistence_wrapper.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use super::persistence::{ExecutionPersistence, ToolCallRecord};
+use crate::mcp_response::CallOutcome;
 use crate::tool_wrapper::{
     ToolCallContext, ToolWrapper, TransformArgsResult, TransformOutputResult,
 };
@@ -101,10 +102,10 @@ impl ToolWrapper for PersistenceWrapper {
     fn transform_output(
         &self,
         output: String,
+        _outcome: &CallOutcome,
         _ctx: &ToolCallContext,
         _extracted: Option<&Value>,
     ) -> TransformOutputResult {
-        // Output passes through unchanged
         TransformOutputResult::new(output)
     }
 

--- a/crates/aura/src/prompts/duplicate_call_abort.md
+++ b/crates/aura/src/prompts/duplicate_call_abort.md
@@ -1,0 +1,2 @@
+[DUPLICATE_CALL_ABORT]
+You have called '%%TOOL_NAME%%' with identical arguments %%COUNT%% times. This tool-call loop is being terminated. Summarize what you attempted and what you learned from the results you received.

--- a/crates/aura/src/prompts/duplicate_call_guidance.md
+++ b/crates/aura/src/prompts/duplicate_call_guidance.md
@@ -1,0 +1,8 @@
+[DUPLICATE_CALL_GUIDANCE]
+You have called '%%TOOL_NAME%%' with identical arguments %%COUNT%% times and received the same result each time. This is guidance, not a task failure — you still have turn budget remaining.
+
+Consider:
+- Using the result you already have to answer the question
+- Calling a different tool that might provide what you need
+- Trying different arguments if your current ones aren't producing useful output
+- Decomposing your approach into smaller steps

--- a/crates/aura/src/tool_wrapper.rs
+++ b/crates/aura/src/tool_wrapper.rs
@@ -47,6 +47,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::config::ToolContextFactory;
+use crate::mcp_response::CallOutcome;
 
 /// Context passed to wrapper methods during tool execution.
 ///
@@ -225,6 +226,7 @@ pub trait ToolWrapper: Send + Sync {
     fn transform_output(
         &self,
         output: String,
+        _outcome: &CallOutcome,
         _ctx: &ToolCallContext,
         _extracted: Option<&Value>,
     ) -> TransformOutputResult {
@@ -448,7 +450,9 @@ where
             // Transform result
             match result {
                 Ok(output) => {
-                    let transformed = wrapper.transform_output(output, &ctx, extracted.as_ref());
+                    let outcome = CallOutcome::classify_from_output(&output);
+                    let transformed =
+                        wrapper.transform_output(output, &outcome, &ctx, extracted.as_ref());
 
                     if let Some(warning) = &transformed.warning {
                         tracing::warn!("Tool wrapper warning for {}: {}", tool_name, warning);
@@ -562,12 +566,12 @@ impl ToolWrapper for ComposedWrapper {
     fn transform_output(
         &self,
         mut output: String,
+        outcome: &CallOutcome,
         ctx: &ToolCallContext,
         extracted: Option<&Value>,
     ) -> TransformOutputResult {
-        // Apply in reverse order
         for wrapper in self.wrappers.iter().rev() {
-            let result = wrapper.transform_output(output, ctx, extracted);
+            let result = wrapper.transform_output(output, outcome, ctx, extracted);
             output = result.output;
         }
         TransformOutputResult::new(output)
@@ -668,7 +672,8 @@ mod tests {
 
         // Output unchanged
         let output = "test output".to_string();
-        let result = wrapper.transform_output(output.clone(), &ctx, None);
+        let outcome = CallOutcome::Success(output.clone());
+        let result = wrapper.transform_output(output.clone(), &outcome, &ctx, None);
         assert_eq!(result.output, output);
     }
 


### PR DESCRIPTION
Enhanced the looping guard to explicitly fail dependent worker tasks and give a clearer signal to the coordinator as to why a task was force killed. Also opens up the plumbing for other worker escalates to coordinator workflows.

closes #68 #69 #70 

LOG-23734
LOG-23735
LOG-23743
