### PR TITLE
fix(orchestration): emit real aura.usage tokens and cost

### DIFF
--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -399,6 +399,7 @@ async fn execute_completion(setup: RequestSetup, config: CompletionConfig, deliv
         message_count: config.message_count,
         usage_state: usage_state.clone(),
         response_content: config.response_content,
+        is_orchestration: streaming_agent.is_orchestration(),
     };
     otel_ctx.record_input();
 

--- a/crates/aura-web-server/src/streaming/otel.rs
+++ b/crates/aura-web-server/src/streaming/otel.rs
@@ -30,6 +30,14 @@ pub struct StreamOtelContext {
     pub message_count: usize,
     pub usage_state: UsageState,
     pub response_content: ResponseContent,
+    /// True when the streaming agent is an orchestrator. Orchestration emits
+    /// per-phase LLM spans (`orchestration.planning`, `orchestration.worker`,
+    /// `orchestration.synthesis`, `orchestration.evaluation`) that each carry
+    /// their own `llm.token_count.*` attributes. Recording the aggregate on
+    /// the parent `agent.stream` span on top of that double-counts in
+    /// Phoenix's rollup, so `record_output` skips the token write here and
+    /// lets Phoenix sum the descendants.
+    pub is_orchestration: bool,
 }
 
 impl StreamOtelContext {
@@ -51,15 +59,21 @@ impl StreamOtelContext {
     /// Captures token usage, response content (if available), and termination status.
     pub fn record_output(&self, termination: &StreamTermination) {
         let span = tracing::Span::current();
-        let (prompt_tokens, completion_tokens, total_tokens) = self.usage_state.get_final_usage();
-        let tool_completion_tokens = self.usage_state.get_tool_completion_tokens();
-        aura::logging::set_token_usage(
-            &span,
-            prompt_tokens,
-            completion_tokens,
-            total_tokens,
-            tool_completion_tokens,
-        );
+        // In orchestration mode, per-phase spans already carry their own
+        // `llm.token_count.*` attributes; recording the aggregate on the parent
+        // `agent.stream` span would double-count under Phoenix's rollup.
+        if !self.is_orchestration {
+            let (prompt_tokens, completion_tokens, total_tokens) =
+                self.usage_state.get_final_usage();
+            let tool_completion_tokens = self.usage_state.get_tool_completion_tokens();
+            aura::logging::set_token_usage(
+                &span,
+                prompt_tokens,
+                completion_tokens,
+                total_tokens,
+                tool_completion_tokens,
+            );
+        }
 
         // Record response content for OpenInference/Phoenix visibility
         if let Some(content) = self.response_content.get() {

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -18,9 +18,13 @@
 //! ## Span hierarchy (streaming)
 //!
 //! `agent.stream` is created as a **root span** (`parent: None`) so that
-//! Phoenix sees it as the trace root.  All LLM I/O attributes (`input.value`,
-//! `output.value`, token counts, `user.id`, `session.id`, `metadata`) live on
-//! this span.
+//! Phoenix sees it as the trace root.  I/O attributes (`input.value`,
+//! `output.value`, `user.id`, `session.id`, `metadata`) always live on this
+//! span. Token counts live here in **single-agent mode only**; in
+//! **orchestration mode** they live on the per-phase child spans
+//! (`orchestration.planning`, `orchestration.worker`,
+//! `orchestration.synthesis`, `orchestration.evaluation`) so Phoenix's
+//! rollup shows the accurate aggregate without double-counting the parent.
 //!
 //! ### Single-agent mode
 //!

--- a/crates/aura/src/orchestration/factory.rs
+++ b/crates/aura/src/orchestration/factory.rs
@@ -33,23 +33,24 @@ impl OrchestratorFactory {
     pub fn new(agent_config: AgentConfig) -> Self {
         Self { agent_config }
     }
-}
 
-#[async_trait]
-impl StreamingAgent for OrchestratorFactory {
-    fn get_provider_info(&self) -> (&str, &str) {
-        self.agent_config.llm.model_info()
-    }
-
-    async fn stream(
+    /// Spawn the background orchestration task and return its event stream.
+    ///
+    /// Shared by [`stream`](Self::stream) and
+    /// [`stream_with_timeout`](Self::stream_with_timeout). The `usage_state`
+    /// handle is assigned to the inner `Orchestrator` so planning, worker,
+    /// synthesis, and evaluation turns can accumulate into it; the caller
+    /// (`stream_with_timeout`) retains a clone and hands it to the streaming
+    /// handler for the final `aura.usage` event. `stream()` passes a detached
+    /// state since its trait-visible callers don't observe usage.
+    fn spawn_orchestration_stream(
         &self,
-        query: &str,
+        query: String,
         chat_history: Vec<rig::completion::Message>,
         cancel_token: CancellationToken,
-        request_id: &str,
-    ) -> Result<BoxStream<'static, Result<StreamItem, StreamError>>, StreamError> {
-        let query = query.to_string();
-        let request_id = request_id.to_string();
+        request_id: String,
+        usage_state: crate::UsageState,
+    ) -> BoxStream<'static, Result<StreamItem, StreamError>> {
         let mut agent_config = self.agent_config.clone();
 
         // Create channel for orchestrator events
@@ -64,13 +65,16 @@ impl StreamingAgent for OrchestratorFactory {
         let parent_span = tracing::Span::current();
         tokio::spawn(tracing::Instrument::instrument(
             async move {
-                let orchestrator = match Orchestrator::new(agent_config).await {
+                let mut orchestrator = match Orchestrator::new(agent_config).await {
                     Ok(o) => o,
                     Err(e) => {
                         let _ = event_tx.send(Err(e)).await;
                         return;
                     }
                 };
+                // Share the caller's usage handle so accumulate_usage() writes
+                // are visible to the streaming handler (UsageState is Arc-backed).
+                orchestrator.usage_state = usage_state;
 
                 // Set MCP request ID for progress notification routing
                 if let Some(ref mcp_manager) = orchestrator.mcp_manager {
@@ -128,7 +132,32 @@ impl StreamingAgent for OrchestratorFactory {
             rx.recv().await.map(|item| (item, rx))
         });
 
-        Ok(Box::pin(stream))
+        Box::pin(stream)
+    }
+}
+
+#[async_trait]
+impl StreamingAgent for OrchestratorFactory {
+    fn get_provider_info(&self) -> (&str, &str) {
+        self.agent_config.llm.model_info()
+    }
+
+    async fn stream(
+        &self,
+        query: &str,
+        chat_history: Vec<rig::completion::Message>,
+        cancel_token: CancellationToken,
+        request_id: &str,
+    ) -> Result<BoxStream<'static, Result<StreamItem, StreamError>>, StreamError> {
+        // Raw-stream callers don't observe usage; hand the spawn a detached
+        // UsageState so the field is populated but nobody reads it.
+        Ok(self.spawn_orchestration_stream(
+            query.to_string(),
+            chat_history,
+            cancel_token,
+            request_id.to_string(),
+            crate::UsageState::new(),
+        ))
     }
 
     async fn stream_with_timeout(
@@ -151,16 +180,19 @@ impl StreamingAgent for OrchestratorFactory {
         let _watcher_handle =
             spawn_cancellation_watcher(cancel_rx, timeout, watcher_cancel_token, request_id_owned);
 
-        let stream = match self
-            .stream(query, chat_history, cancel_token, request_id)
-            .await
-        {
-            Ok(s) => s,
-            Err(e) => Box::pin(stream::once(async move { Err(e) })),
-        };
+        // Share one UsageState between the inner orchestrator (writer) and the
+        // streaming handler (reader) so aura.usage reflects the aggregate of
+        // all orchestration LLM turns.
+        let usage_state = crate::UsageState::new();
+        let stream = self.spawn_orchestration_stream(
+            query.to_string(),
+            chat_history,
+            cancel_token,
+            request_id.to_string(),
+            usage_state.clone(),
+        );
 
-        // Orchestration has its own usage tracking; return a fresh state for the handler.
-        (stream, cancel_tx, crate::UsageState::new())
+        (stream, cancel_tx, usage_state)
     }
 
     async fn cancel_and_close_mcp(&self, _request_id: &str, _reason: &str) -> usize {

--- a/crates/aura/src/orchestration/factory.rs
+++ b/crates/aura/src/orchestration/factory.rs
@@ -142,6 +142,10 @@ impl StreamingAgent for OrchestratorFactory {
         self.agent_config.llm.model_info()
     }
 
+    fn is_orchestration(&self) -> bool {
+        true
+    }
+
     async fn stream(
         &self,
         query: &str,

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -343,6 +343,18 @@ pub struct Orchestrator {
     /// Current orchestration iteration, set at the top of `run_orchestration_loop`.
     /// Read by `journal_record` so that iteration doesn't pollute method signatures.
     current_iteration: AtomicUsize,
+
+    /// Accumulated token usage across all LLM calls in this orchestration run
+    /// (planning, workers, synthesis, evaluation).
+    ///
+    /// Cloned from a handle owned by `OrchestratorFactory::stream_with_timeout`
+    /// so the streaming handler can read the final totals and emit `aura.usage`.
+    /// In orchestration mode we aggregate additively via
+    /// [`crate::UsageState::accumulate_usage`] so the reported prompt/completion
+    /// totals reflect *billed* tokens across every internal LLM turn, not just
+    /// the first one. Assigned by the factory after construction; see
+    /// `OrchestratorFactory::spawn_orchestration_stream`.
+    pub(super) usage_state: crate::UsageState,
 }
 
 /// Worker identity for reasoning attribution in `stream_and_forward`.
@@ -432,6 +444,7 @@ impl Orchestrator {
             persistence,
             prompt_journal,
             current_iteration: AtomicUsize::new(0),
+            usage_state: crate::UsageState::new(),
         })
     }
 
@@ -1042,6 +1055,8 @@ impl Orchestrator {
                         r.usage.total_tokens,
                         0,
                     );
+                    self.usage_state
+                        .accumulate_usage(r.usage.input_tokens, r.usage.output_tokens);
                     r
                 }
                 Err(e) if is_context_overflow_error(e.as_ref()) => {
@@ -2806,6 +2821,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 response.usage.total_tokens,
                 0,
             );
+            self.usage_state
+                .accumulate_usage(response.usage.input_tokens, response.usage.output_tokens);
         }
 
         // Detect context overflow in worker and provide actionable message
@@ -3088,6 +3105,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
                             response.usage.total_tokens,
                             0,
                         );
+                        self.usage_state.accumulate_usage(
+                            response.usage.input_tokens,
+                            response.usage.output_tokens,
+                        );
                         response.content
                     }
                     Err(e) if is_context_overflow_error(e.as_ref()) => {
@@ -3244,6 +3265,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
                             response.usage.output_tokens,
                             response.usage.total_tokens,
                             0,
+                        );
+                        self.usage_state.accumulate_usage(
+                            response.usage.input_tokens,
+                            response.usage.output_tokens,
                         );
                         // Read the evaluation from the tool's shared state
                         let eval = decision.lock().await.take();

--- a/crates/aura/src/streaming.rs
+++ b/crates/aura/src/streaming.rs
@@ -129,4 +129,17 @@ pub trait StreamingAgent: Send + Sync {
     fn context_window(&self) -> Option<u64> {
         None
     }
+
+    /// Whether this agent is an orchestrator (emits per-phase LLM spans).
+    ///
+    /// Returned `true` by the multi-agent `OrchestratorFactory`. The web-server
+    /// streaming handler uses this to suppress the total token write on the
+    /// root `agent.stream` span, because each phase (`orchestration.planning`,
+    /// `orchestration.worker`, `orchestration.synthesis`,
+    /// `orchestration.evaluation`) already carries its own `set_token_usage`
+    /// attributes. Letting Phoenix roll those descendants up is the accurate
+    /// aggregate; also recording the total on the parent double-counts.
+    fn is_orchestration(&self) -> bool {
+        false
+    }
 }

--- a/crates/aura/src/streaming_request_hook.rs
+++ b/crates/aura/src/streaming_request_hook.rs
@@ -137,6 +137,25 @@ impl UsageState {
         }
     }
 
+    /// Accumulate usage additively across multiple LLM calls.
+    ///
+    /// Unlike [`store_usage`](Self::store_usage), which captures only the *first*
+    /// turn's prompt, this adds to both prompt and completion counters. Use when
+    /// the caller already aggregates usage across independent LLM calls (e.g. the
+    /// orchestrator summing planning, workers, synthesis, and evaluation turns)
+    /// and needs the final `aura.usage` event to reflect *total billed* tokens
+    /// rather than a single-turn snapshot.
+    ///
+    /// Marks the state as initialized so the stream handler emits `aura.usage`
+    /// even when prompt was only ever accumulated through this method.
+    pub fn accumulate_usage(&self, prompt: u64, completion: u64) {
+        self.initialized.store(true, Ordering::Release);
+        self.initial_prompt_tokens
+            .fetch_add(prompt, Ordering::AcqRel);
+        self.accumulated_completion_tokens
+            .fetch_add(completion, Ordering::AcqRel);
+    }
+
     /// Add a tool ID to the pending list.
     ///
     /// Called from on_tool_result when a tool completes.
@@ -563,6 +582,32 @@ mod tests {
         assert_eq!(completion, 200);
         assert_eq!(total, 1200);
         assert_eq!(usage_state.get_tool_completion_tokens(), 0);
+    }
+
+    #[test]
+    fn test_usage_state_accumulate_aggregates_prompt_and_completion() {
+        let usage_state = UsageState::new();
+
+        // Multiple calls (as orchestration emits across planning/workers/synthesis)
+        usage_state.accumulate_usage(100, 50);
+        usage_state.accumulate_usage(400, 200);
+        usage_state.accumulate_usage(250, 75);
+
+        let (prompt, completion, total) = usage_state.get_final_usage();
+        assert_eq!(prompt, 750, "prompt should be the sum of all inputs");
+        assert_eq!(completion, 325, "completion should be the sum of all outputs");
+        assert_eq!(total, 1075);
+    }
+
+    #[test]
+    fn test_usage_state_accumulate_marks_initialized() {
+        let usage_state = UsageState::new();
+        // Before any usage, get_final_usage returns 0 — handler would skip aura.usage.
+        assert_eq!(usage_state.get_final_usage(), (0, 0, 0));
+
+        usage_state.accumulate_usage(500, 100);
+        let (prompt, _, _) = usage_state.get_final_usage();
+        assert!(prompt > 0, "handler uses prompt > 0 to gate aura.usage emission");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Orchestration mode was reporting `$0.00` / `0 tokens` on every request because `OrchestratorFactory::stream_with_timeout` handed the streaming handler a fresh `UsageState`. The handler gates `aura.usage` emission on `prompt > 0` (`aura-web-server/src/streaming/handlers.rs:402`), so the event was skipped entirely.
- This PR shares one `UsageState` between the inner `Orchestrator` and the streaming handler. Planning, worker, synthesis, and evaluation turns accumulate into it via a new `UsageState::accumulate_usage(prompt, completion)` method — paired with each existing `set_token_usage` call site — and `stream_with_timeout` returns that shared handle instead of a throwaway.
- `stream()` spawn logic is extracted into a private `spawn_orchestration_stream` helper parameterized by a `usage_state` handle; both trait methods now route through it.

Fixes #73.

## Validation

- 189-trial `o11y-bench` orchestration run (gpt-5.4, k=3) after applying the fix reports real cost (`$35.44`) and real tokens (`10.5M in / 608K out`) per trial, vs. `$0.00` / `0 tokens` before.
- `cargo test -p aura --lib`: 565/565 pass, including two new tests for additive aggregation and the `initialized` flag.
- `cargo clippy -p aura --all-targets --no-deps`: clean.
- `cargo build --release -p aura`: clean.

## Test plan

- [ ] CI green
- [ ] Manual: start web-server with `AURA_CUSTOM_EVENTS=true` and an orchestration config; confirm SSE stream emits `event: aura.usage` with non-zero token counts
- [ ] Manual: JSON (non-stream) request against orchestration config reports non-zero `usage.prompt_tokens` / `usage.completion_tokens`