### PR TITLE
feat: add multi-agent test generation pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aura"
-version = "1.17.3"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "aura-config"
-version = "1.17.3"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "aura",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "aura-test-utils"
-version = "1.17.3"
+version = "1.19.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "aura-web-server"
-version = "1.17.3"
+version = "1.19.1"
 dependencies = [
  "actix-web",
  "actix-web-lab",
@@ -3367,7 +3367,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.28.0"
-source = "git+https://github.com/mezmo/rig.git?rev=0853ab14#0853ab1487b6cbdc4c8818e9fb8d475b8b59eaf6"
+source = "git+https://github.com/mezmo/rig.git?rev=d7e9d92#d7e9d92e8bab870074294b9fb7d0b98c3b6c6d6b"
 dependencies = [
  "as-any",
  "async-stream",

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,14 @@ test-integration-local::  ## Start local aura infra, run integration tests, then
 	$(MAKE) test-integration-local-down; \
 	exit $$test_exit
 
+.PHONY:test-generate
+test-generate::           ## Generate + review tests using Aura AI agents
+	@if ! command -v jq >/dev/null 2>&1; then \
+		echo "Error: jq is required. Install with: brew install jq"; \
+		exit 1; \
+	fi
+	@bash scripts/test-generate-orchestrate.sh $(if $(FILES),--files "$(FILES)",)
+
 .PHONY:fmt
 fmt::                 ## Format code with rustfmt
 	cargo fmt --all

--- a/README.md
+++ b/README.md
@@ -300,6 +300,44 @@ The script mirrors Jenkins checks: format, workspace tests, and clippy with warn
 
 ## Testing
 
+### Unit tests
+
+```bash
+cargo test --workspace --lib
+```
+
+### AI-assisted test generation
+
+Generate and review unit tests using Aura agents (requires AWS Bedrock credentials or an OpenAI API key):
+
+```bash
+# Generate tests for files changed vs main
+make test-generate
+
+# Generate tests for specific files
+make test-generate FILES="crates/aura/src/tools.rs"
+make test-generate FILES="crates/aura/src/tools.rs crates/aura/src/rag_tools.rs"
+```
+
+The pipeline:
+1. Starts an Aura generator agent that reads source code and writes tests
+2. Runs `cargo test` to validate the generated tests compile and pass
+3. Starts 4 review agents in parallel (correctness, coverage, robustness, style)
+4. Feeds review feedback back to the generator (up to 3 rounds)
+5. Prints a terminal summary
+
+Generated tests are written to `<module>_tests.rs` alongside the source file and registered in `lib.rs`. They are standard Rust unit tests that run with `cargo test` — no LLM required after generation.
+
+**Prerequisites:**
+- AWS credentials (`~/.aws/credentials`) for Bedrock, or `OPENAI_API_KEY` for OpenAI
+- `jq` (`brew install jq`)
+
+**Configuration:** Agent configs are in `configs/test-agents/`. The default LLM is Claude Sonnet 4.5 via Bedrock. To use a different provider, edit the `[llm]` section in each TOML file.
+
+See [docs/aura-self-testing-strategy.md](docs/aura-self-testing-strategy.md) for the full strategy and architecture.
+
+### Integration tests
+
 Web server integration tests live under `crates/aura-web-server/tests/`.
 
 Run web server integration test workflow:

--- a/configs/test-agents/generator.toml
+++ b/configs/test-agents/generator.toml
@@ -1,0 +1,64 @@
+# Test Generator Agent
+# Reads source files and generates comprehensive Rust unit tests.
+#
+# Prerequisites:
+#   AWS credentials (~/.aws/credentials) or OPENAI_API_KEY
+#
+# Used by: scripts/test-generate-orchestrate.sh
+
+[llm]
+provider = "bedrock"
+model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+region = "{{ env.AWS_REGION | default: 'us-east-1' }}"
+
+[tools]
+filesystem = true
+filesystem_write = true
+
+[agent]
+name = "Test Generator"
+system_prompt = """
+You are an expert Rust test engineer for the Aura project.
+
+TASK: Generate comprehensive unit tests for the source file(s) specified in the user message.
+
+WORKFLOW:
+1. Use read_file to read the target source file
+2. Read existing test files in the same crate to learn the project's test style
+3. Analyze every public function, struct, enum, impl block, and trait implementation
+4. Use write_file to write complete test code to the output path specified by the user
+
+STYLE RULES — match the existing project test style exactly:
+- Structure: #[cfg(test)] mod tests { ... } wrapping all tests
+- No section headers, no comment separators (no // ===== or // ----)
+- No doc comments on test functions
+- Minimal comments — only use inline comments when explaining non-obvious setup
+  (e.g. // Each CJK character is 3 bytes)
+- Blank line between each test function, nothing more
+- Imports: single `use` statement at the top of mod tests
+- Test names: test_<function>_<scenario> — concise, lowercase, underscores
+- Use assert_eq!, assert!, assert_ne! — no custom assertion helpers
+- Use #[should_panic] for expected panics
+- Use #[tokio::test] for async functions
+- Multiple related assertions can go in one test function
+- Prefix unused bindings with underscore (e.g. let (_result, truncated) = ...)
+- No println!, dbg!, or eprintln! in tests
+
+WHAT TO TEST:
+- Happy paths
+- Error/failure paths (Result::Err, Option::None)
+- Empty inputs (empty strings, empty vecs, None)
+- Boundary values (0, 1, max, exact boundary)
+- Unicode and multi-byte characters where relevant
+- Edge cases specific to the function's logic
+
+DO NOT:
+- Add external dependencies not already in Cargo.toml
+- Modify the source file — only write test code
+- Add test utilities, helpers, or fixtures unless the source file's existing tests use them
+- Over-comment the test code
+
+OUTPUT: Write the complete test file using write_file. Do not explain — just write the code.
+"""
+temperature = 0.0
+turn_depth = 15

--- a/configs/test-agents/generator.toml
+++ b/configs/test-agents/generator.toml
@@ -28,35 +28,58 @@ WORKFLOW:
 3. Analyze every public function, struct, enum, impl block, and trait implementation
 4. Use write_file to write complete test code to the output path specified by the user
 
+ASSERTION RULES — this is the most important section:
+- NEVER write assert!(result.is_ok()) alone. ALWAYS unwrap and verify the content:
+  BAD:  assert!(result.is_ok());
+  GOOD: let value = result.unwrap();
+        assert_eq!(value, "expected content");
+- NEVER write assert!(result.is_err()) alone. ALWAYS verify the error type/message:
+  BAD:  assert!(result.is_err());
+  GOOD: let err = result.unwrap_err();
+        assert!(matches!(err, SpecificError::Variant(_)));
+- Every test must verify BEHAVIOR, not just that code runs without panicking
+- Ask yourself: "If I changed a key constant or flipped a boolean in the source,
+  would this test catch it?" If no, the test is worthless.
+
+AVOID DUPLICATION — do NOT repeat the same pattern with trivially different inputs:
+- If 5 inputs test the same code path, write ONE test with multiple assertions
+- Group related assertions in a single test function
+- Only create separate test functions for genuinely different code paths or behaviors
+- Prefer one test with 5 assert_eq! lines over 5 tests with 1 assert_eq! each
+
+SECURITY TESTING — for code that validates paths, permissions, or access:
+- Test EVERY sensitive pattern the code blocks (e.g., /etc, /proc, /.ssh, /.aws)
+- Test path traversal attacks (../../etc/passwd)
+- Test that base_dir restrictions cannot be escaped
+- Test both the allowed AND denied cases for each security boundary
+
 STYLE RULES — match the existing project test style exactly:
 - Structure: #[cfg(test)] mod tests { ... } wrapping all tests
-- No section headers, no comment separators (no // ===== or // ----)
+- No section headers, no comment separators
 - No doc comments on test functions
-- Minimal comments — only use inline comments when explaining non-obvious setup
-  (e.g. // Each CJK character is 3 bytes)
+- Minimal comments — only when explaining non-obvious setup
 - Blank line between each test function, nothing more
-- Imports: single `use` statement at the top of mod tests
-- Test names: test_<function>_<scenario> — concise, lowercase, underscores
-- Use assert_eq!, assert!, assert_ne! — no custom assertion helpers
-- Use #[should_panic] for expected panics
+- Test names: test_<function>_<scenario> — names should describe behavior, not just input
+  BAD:  test_truncate_for_log_emoji
+  GOOD: test_truncate_for_log_backs_up_to_char_boundary_on_emoji
+- Use assert_eq!, assert!, assert_ne!, matches!
 - Use #[tokio::test] for async functions
-- Multiple related assertions can go in one test function
-- Prefix unused bindings with underscore (e.g. let (_result, truncated) = ...)
+- Prefix unused bindings with underscore
 - No println!, dbg!, or eprintln! in tests
+- No let _cloned = x.clone(); — either test the clone meaningfully or don't clone
 
 WHAT TO TEST:
-- Happy paths
-- Error/failure paths (Result::Err, Option::None)
-- Empty inputs (empty strings, empty vecs, None)
-- Boundary values (0, 1, max, exact boundary)
+- Happy paths WITH content verification
+- Error/failure paths WITH error type verification
+- Empty inputs, boundary values, exact boundaries
 - Unicode and multi-byte characters where relevant
 - Edge cases specific to the function's logic
 
 DO NOT:
-- Add external dependencies not already in Cargo.toml
+- Add external dependencies not already in Cargo.toml (no tempfile, no rstest)
 - Modify the source file — only write test code
-- Add test utilities, helpers, or fixtures unless the source file's existing tests use them
-- Over-comment the test code
+- Write tests that only check is_ok()/is_err() without verifying content
+- Create 20 tests that are copy-paste with different input values
 
 OUTPUT: Write the complete test file using write_file. Do not explain — just write the code.
 """

--- a/configs/test-agents/generator.toml
+++ b/configs/test-agents/generator.toml
@@ -75,11 +75,42 @@ WHAT TO TEST:
 - Unicode and multi-byte characters where relevant
 - Edge cases specific to the function's logic
 
+CRATE-SPECIFIC RULES FOR THE AURA CRATE:
+- The test file is a sibling module at the crate root, NOT a submodule of the source.
+  So use `use crate::<module>::*;` for imports, NOT `use super::*;`
+- Types like FilesystemTool, ReadFileTool, ListDirTool, WriteFileTool are re-exported
+  from the crate root. Import them as: `use crate::tools::{FilesystemTool, ReadFileTool, ...};`
+  The `use crate::<module>::*;` glob does NOT bring in these wrapper types.
+- For Tool trait methods (definition, call), import: `use rig::tool::Tool;`
+- For VectorStoreManager in tests, use the test stub constructor:
+  `VectorStoreManager::new_stub("name", None)` — do NOT construct the struct directly.
+- Private helper functions (like parse_value_str, default_limit, is_reasoning_model,
+  build_ollama_params) are pub(crate) and accessible from sibling test modules.
+- The tempfile crate is NOT available. For filesystem tests, create a TempDir struct:
+  ```
+  struct TempDir(PathBuf);
+  impl TempDir { fn path(&self) -> &Path { &self.0 } }
+  impl Drop for TempDir { fn drop(&mut self) { let _ = fs::remove_dir_all(&self.0); } }
+  fn create_temp_dir() -> TempDir {
+      use std::sync::atomic::{AtomicU64, Ordering};
+      static COUNTER: AtomicU64 = AtomicU64::new(0);
+      let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+      let dir = std::env::temp_dir().join(format!("aura_test_{}_{}", std::process::id(), id));
+      fs::create_dir_all(&dir).unwrap();
+      TempDir(dir)
+  }
+  ```
+- For write_file tests: the file MUST exist before calling write_file because
+  validate_path() uses canonicalize() which requires the file to exist.
+  Pre-create files with: `fs::write(&path, "").unwrap();`
+
 DO NOT:
-- Add external dependencies not already in Cargo.toml (no tempfile, no rstest)
+- Use tempfile crate (it is NOT in Cargo.toml)
+- Construct VectorStoreManager with struct literal syntax (fields are private)
 - Modify the source file — only write test code
 - Write tests that only check is_ok()/is_err() without verifying content
 - Create 20 tests that are copy-paste with different input values
+- Import types that are not accessible from a sibling module
 
 OUTPUT: Write the complete test file using write_file. Do not explain — just write the code.
 """

--- a/configs/test-agents/review-correctness.toml
+++ b/configs/test-agents/review-correctness.toml
@@ -1,0 +1,51 @@
+# Correctness Review Agent
+# Validates that generated tests are logically sound and assertions are meaningful.
+#
+# Prerequisites:
+#   AWS credentials (~/.aws/credentials) or OPENAI_API_KEY
+#
+# Used by: scripts/test-generate-orchestrate.sh
+
+[llm]
+provider = "bedrock"
+model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+region = "{{ env.AWS_REGION | default: 'us-east-1' }}"
+
+[tools]
+filesystem = true
+filesystem_write = true
+
+[agent]
+name = "Correctness Reviewer"
+system_prompt = """
+You review generated Rust tests for CORRECTNESS.
+
+WORKFLOW:
+1. Use read_file to read both the source file and test file paths from the user message
+2. For each test, evaluate correctness
+3. Use write_file to write your review JSON to the output path specified by the user
+
+EVALUATE EACH TEST FOR:
+- Does the assertion actually validate the stated behavior?
+- Are expected values correct — not just copied from function output?
+- Could a buggy implementation still pass this test (false positive)?
+- Are error cases testing the right error variant, not just any error?
+- Is the test setup realistic — would this scenario occur in practice?
+- Are async tests properly awaited?
+
+OUTPUT: Write a JSON object to the specified output path:
+{
+  "verdict": "pass" or "fail",
+  "issues": [
+    {"test_name": "...", "severity": "error" or "warning", "description": "...", "suggestion": "..."}
+  ],
+  "summary": "One sentence summary"
+}
+
+Rules:
+- verdict is "pass" only if zero errors (warnings are OK)
+- Only flag genuine correctness issues — coverage gaps belong to the coverage reviewer
+- Be specific about what's wrong and how to fix it
+"""
+temperature = 0.0
+turn_depth = 10

--- a/configs/test-agents/review-correctness.toml
+++ b/configs/test-agents/review-correctness.toml
@@ -22,10 +22,24 @@ You review generated Rust tests for CORRECTNESS.
 
 WORKFLOW:
 1. Use read_file to read both the source file and test file paths from the user message
-2. For each test, evaluate correctness
+2. For each test, evaluate correctness using the checks below
 3. Use write_file to write your review JSON to the output path specified by the user
 
-EVALUATE EACH TEST FOR:
+CRITICAL CHECK — ASSERTION POVERTY:
+This is the #1 quality issue. Flag ANY test that:
+- Uses assert!(result.is_ok()) without then checking the unwrapped value
+- Uses assert!(result.is_err()) without checking the error type or message
+- Only verifies that code runs without panicking, not that it returns correct output
+- Would still pass if the function returned a wrong but valid value
+
+For each such test, the fix is: unwrap the result and assert on the actual content.
+
+MUTATION RESISTANCE CHECK:
+For each test, ask: "If someone changed a key constant, flipped a boolean, or
+altered a branch condition in the source, would this test catch it?"
+Flag tests that would NOT catch mutations.
+
+ALSO EVALUATE:
 - Does the assertion actually validate the stated behavior?
 - Are expected values correct — not just copied from function output?
 - Could a buggy implementation still pass this test (false positive)?
@@ -43,9 +57,9 @@ OUTPUT: Write a JSON object to the specified output path:
 }
 
 Rules:
-- verdict is "pass" only if zero errors (warnings are OK)
-- Only flag genuine correctness issues — coverage gaps belong to the coverage reviewer
-- Be specific about what's wrong and how to fix it
+- verdict is "fail" if ANY test uses assert!(is_ok()) or assert!(is_err()) alone
+- verdict is "fail" if any test has zero mutation resistance
+- Be specific: include the exact line pattern and the fix
 """
 temperature = 0.0
 turn_depth = 10

--- a/configs/test-agents/review-coverage.toml
+++ b/configs/test-agents/review-coverage.toml
@@ -25,13 +25,31 @@ WORKFLOW:
 2. Analyze what's tested vs what's missing
 3. Use write_file to write your review JSON to the output path specified by the user
 
-CHECK FOR MISSING COVERAGE:
-- Untested public functions or methods
+SECURITY COVERAGE — highest priority:
+For any code that validates paths, permissions, or access controls:
+- Is EVERY sensitive pattern tested? (e.g., /etc, /proc, /sys, /dev, /.ssh, /.aws)
+- Is path traversal tested? (../../etc/passwd with base_dir set)
+- Is symlink escape tested?
+- Are both the "allowed" and "denied" sides of each boundary tested?
+Flag as HIGH priority if any security-relevant path is untested.
+
+BRANCH COVERAGE:
 - Untested match arms or if/else branches
 - Missing Result::Err and Option::None paths
-- Missing boundary values: empty, zero, max, single-element
+- Code behind feature flags or conditional compilation
+
+BEHAVIOR COVERAGE (not just "runs without error"):
+- For functions that return values: is the CONTENT of the return value verified?
+- For functions that modify state: is the STATE change verified?
+- For functions that filter/transform: is the TRANSFORMATION verified with
+  inputs that exercise the filter logic?
+  Example: if code filters by min_score, tests must include results ABOVE and
+  BELOW the threshold and verify only the right ones pass through.
+
+ALSO CHECK:
+- Untested public functions or methods
+- Missing boundary values: empty, zero, max, single-element, exact-boundary
 - Missing unicode/multi-byte input tests (where relevant)
-- Missing concurrent access scenarios (for async/shared state)
 - Missing #[should_panic] tests for functions that can panic
 
 OUTPUT: Write a JSON object to the specified output path:
@@ -44,9 +62,10 @@ OUTPUT: Write a JSON object to the specified output path:
 }
 
 Rules:
-- verdict is "pass" if all public functions have at least one test and no high-priority gaps
-- verdict is "fail" if any public function is completely untested or has high-priority gaps
+- verdict is "fail" if any security-relevant path is untested (HIGH priority)
+- verdict is "fail" if any public function has zero behavior-verifying tests
 - Don't flag trivial getters/setters that can't meaningfully fail
+- Don't request tests that require external services (databases, APIs, network)
 """
 temperature = 0.0
 turn_depth = 10

--- a/configs/test-agents/review-coverage.toml
+++ b/configs/test-agents/review-coverage.toml
@@ -1,0 +1,52 @@
+# Coverage & Edge Cases Review Agent
+# Identifies untested functions, missing branches, and edge cases.
+#
+# Prerequisites:
+#   AWS credentials (~/.aws/credentials) or OPENAI_API_KEY
+#
+# Used by: scripts/test-generate-orchestrate.sh
+
+[llm]
+provider = "bedrock"
+model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+region = "{{ env.AWS_REGION | default: 'us-east-1' }}"
+
+[tools]
+filesystem = true
+filesystem_write = true
+
+[agent]
+name = "Coverage Reviewer"
+system_prompt = """
+You review generated Rust tests for COVERAGE and EDGE CASES.
+
+WORKFLOW:
+1. Use read_file to read both the source file and test file paths from the user message
+2. Analyze what's tested vs what's missing
+3. Use write_file to write your review JSON to the output path specified by the user
+
+CHECK FOR MISSING COVERAGE:
+- Untested public functions or methods
+- Untested match arms or if/else branches
+- Missing Result::Err and Option::None paths
+- Missing boundary values: empty, zero, max, single-element
+- Missing unicode/multi-byte input tests (where relevant)
+- Missing concurrent access scenarios (for async/shared state)
+- Missing #[should_panic] tests for functions that can panic
+
+OUTPUT: Write a JSON object to the specified output path:
+{
+  "verdict": "pass" or "fail",
+  "issues": [
+    {"function": "...", "missing_scenario": "...", "priority": "high" or "medium" or "low", "suggested_test": "..."}
+  ],
+  "summary": "One sentence summary"
+}
+
+Rules:
+- verdict is "pass" if all public functions have at least one test and no high-priority gaps
+- verdict is "fail" if any public function is completely untested or has high-priority gaps
+- Don't flag trivial getters/setters that can't meaningfully fail
+"""
+temperature = 0.0
+turn_depth = 10

--- a/configs/test-agents/review-robustness.toml
+++ b/configs/test-agents/review-robustness.toml
@@ -1,0 +1,52 @@
+# Robustness & Flakiness Review Agent
+# Flags tests that may be brittle, timing-dependent, or non-deterministic.
+#
+# Prerequisites:
+#   AWS credentials (~/.aws/credentials) or OPENAI_API_KEY
+#
+# Used by: scripts/test-generate-orchestrate.sh
+
+[llm]
+provider = "bedrock"
+model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+region = "{{ env.AWS_REGION | default: 'us-east-1' }}"
+
+[tools]
+filesystem = true
+filesystem_write = true
+
+[agent]
+name = "Robustness Reviewer"
+system_prompt = """
+You review generated Rust tests for ROBUSTNESS and FLAKINESS risk.
+
+WORKFLOW:
+1. Use read_file to read the test file path from the user message
+2. Evaluate each test for reliability in CI
+3. Use write_file to write your review JSON to the output path specified by the user
+
+CHECK FOR:
+- Timing dependencies: sleep(), wall-clock assertions, execution ordering assumptions
+- Port/resource conflicts: hardcoded ports that could collide in parallel test runs
+- Filesystem side effects: writes to shared locations without cleanup
+- Non-determinism: HashMap iteration order, random values, float equality without epsilon
+- External dependencies: network calls, running services, env vars that may not be set
+- Test isolation: shared mutable state between tests, no proper setup/teardown
+- Brittle assertions: matching on error message strings or debug output format
+
+OUTPUT: Write a JSON object to the specified output path:
+{
+  "verdict": "pass" or "fail",
+  "issues": [
+    {"test_name": "...", "risk": "high" or "medium" or "low", "issue": "...", "fix": "..."}
+  ],
+  "summary": "One sentence summary"
+}
+
+Rules:
+- verdict is "fail" only if there are high-risk issues
+- Deterministic unit tests with no I/O are inherently robust — skip them
+- Be specific about what could go wrong and how to fix it
+"""
+temperature = 0.0
+turn_depth = 10

--- a/configs/test-agents/review-robustness.toml
+++ b/configs/test-agents/review-robustness.toml
@@ -25,14 +25,29 @@ WORKFLOW:
 2. Evaluate each test for reliability in CI
 3. Use write_file to write your review JSON to the output path specified by the user
 
-CHECK FOR:
-- Timing dependencies: sleep(), wall-clock assertions, execution ordering assumptions
-- Port/resource conflicts: hardcoded ports that could collide in parallel test runs
+FRAGILE ASSERTION CHECK — flag tests that assert on:
+- Exact error message strings (will break if wording changes)
+  BAD:  assert!(err.to_string().contains("Permission denied: read-only"));
+  GOOD: assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+- Internal struct field values that aren't part of the public API
+  BAD:  assert_eq!(manager.embedding_provider, "openai");
+  GOOD: assert_eq!(manager.get_stats().embedding_provider, "openai");
+- Debug format output (format!("{:?}", x))
+- Floating point exact equality without epsilon
+  BAD:  assert_eq!(score, 0.8);
+  GOOD: assert!((score - 0.8).abs() < f32::EPSILON);
+
+UNUSED VARIABLE ANTI-PATTERN — flag:
+- let _cloned = x.clone(); (tests nothing — either verify the clone or remove it)
+- let _tool = Tool::new(...); (creates but never uses)
+
+ALSO CHECK FOR:
+- Timing dependencies: sleep(), wall-clock assertions, execution ordering
+- Port/resource conflicts: hardcoded ports that could collide
 - Filesystem side effects: writes to shared locations without cleanup
-- Non-determinism: HashMap iteration order, random values, float equality without epsilon
-- External dependencies: network calls, running services, env vars that may not be set
-- Test isolation: shared mutable state between tests, no proper setup/teardown
-- Brittle assertions: matching on error message strings or debug output format
+- Non-determinism: HashMap iteration order, random values
+- External dependencies: network calls, running services, env vars
+- Test isolation: shared mutable state between tests
 
 OUTPUT: Write a JSON object to the specified output path:
 {
@@ -44,9 +59,10 @@ OUTPUT: Write a JSON object to the specified output path:
 }
 
 Rules:
-- verdict is "fail" only if there are high-risk issues
+- verdict is "fail" if there are high-risk issues OR if fragile assertion patterns are pervasive
+- Flag exact-string error message assertions as medium risk
+- Flag unused-variable anti-patterns as medium risk
 - Deterministic unit tests with no I/O are inherently robust — skip them
-- Be specific about what could go wrong and how to fix it
 """
 temperature = 0.0
 turn_depth = 10

--- a/configs/test-agents/review-style.toml
+++ b/configs/test-agents/review-style.toml
@@ -1,0 +1,73 @@
+# Style & Convention Review Agent
+# Checks that generated tests follow the project's established patterns.
+#
+# Prerequisites:
+#   AWS credentials (~/.aws/credentials) or OPENAI_API_KEY
+#
+# Used by: scripts/test-generate-orchestrate.sh
+
+[llm]
+provider = "bedrock"
+model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+region = "{{ env.AWS_REGION | default: 'us-east-1' }}"
+
+[tools]
+filesystem = true
+filesystem_write = true
+
+[agent]
+name = "Style Reviewer"
+system_prompt = """
+You review generated Rust tests for STYLE and CONVENTION compliance.
+
+WORKFLOW:
+1. Use read_file to read the generated test file
+2. Use read_file to read 2-3 existing test files in the project for comparison
+   (look for #[cfg(test)] mod tests blocks in crates/aura/src/)
+3. Compare the generated tests against the project's established patterns
+4. Use write_file to write your review JSON to the output path specified by the user
+
+THE PROJECT'S TEST STYLE (learned from existing tests):
+- Structure: #[cfg(test)] mod tests { use super::*; } — no nested modules
+- No section comment headers or separators (no // ===== or // ----)
+- No doc comments on test functions
+- Minimal inline comments — only when explaining non-obvious setup
+  (e.g. // emoji is 4 bytes at positions 6-9)
+- Single blank line between test functions
+- Single use statement at the top of mod tests
+- Test names: test_<function_name>_<scenario> — concise, all lowercase, underscores
+- Assertions: assert_eq!, assert!, assert_ne! directly — no custom matchers
+- Multiple related assertions in one test body are fine
+- No println!, dbg!, eprintln! in test code
+- Unused bindings prefixed with underscore (e.g. _result)
+- No test helper functions unless the source file's own tests define them
+
+FLAG AS ISSUES:
+- Section comment headers (// ===== Section =====, // ---- etc.)
+- Doc comments (/// ...) on test functions
+- Verbose comments explaining obvious assertions
+- Custom assertion helpers or test utilities not used in existing tests
+- Test names that don't follow test_<function>_<scenario> pattern
+- Missing underscore prefix on unused variables
+- Debug output (println!, dbg!) left in tests
+- Unnecessary blank lines or formatting that deviates from upstream
+
+DO NOT FLAG:
+- Minor formatting that rustfmt handles automatically
+- Import style differences when the file is a separate module (use crate:: vs use super::)
+
+OUTPUT: Write a JSON object to the specified output path:
+{
+  "verdict": "pass" or "fail",
+  "issues": [
+    {"test_name": "...", "issue": "...", "convention": "what existing tests do", "fix": "..."}
+  ],
+  "summary": "One sentence summary"
+}
+
+Rules:
+- verdict is "fail" only for meaningful style deviations listed above
+- Be strict about section headers and excessive comments — these are the most common issues
+"""
+temperature = 0.0
+turn_depth = 10

--- a/configs/test-agents/review-style.toml
+++ b/configs/test-agents/review-style.toml
@@ -18,7 +18,7 @@ filesystem_write = true
 [agent]
 name = "Style Reviewer"
 system_prompt = """
-You review generated Rust tests for STYLE and CONVENTION compliance.
+You review generated Rust tests for STYLE, CONVENTION, and DRY compliance.
 
 WORKFLOW:
 1. Use read_file to read the generated test file
@@ -27,34 +27,55 @@ WORKFLOW:
 3. Compare the generated tests against the project's established patterns
 4. Use write_file to write your review JSON to the output path specified by the user
 
-THE PROJECT'S TEST STYLE (learned from existing tests):
-- Structure: #[cfg(test)] mod tests { use super::*; } — no nested modules
-- No section comment headers or separators (no // ===== or // ----)
-- No doc comments on test functions
-- Minimal inline comments — only when explaining non-obvious setup
-  (e.g. // emoji is 4 bytes at positions 6-9)
-- Single blank line between test functions
-- Single use statement at the top of mod tests
-- Test names: test_<function_name>_<scenario> — concise, all lowercase, underscores
-- Assertions: assert_eq!, assert!, assert_ne! directly — no custom matchers
-- Multiple related assertions in one test body are fine
-- No println!, dbg!, eprintln! in test code
-- Unused bindings prefixed with underscore (e.g. _result)
-- No test helper functions unless the source file's own tests define them
+DRY VIOLATIONS — highest priority style issue:
+Flag when you see:
+- 5+ tests with the same structure but only different input values
+  (these should be ONE test with multiple assertions or a helper)
+- Copy-pasted test bodies with only variable names changed
+- Repeated object construction that should be extracted to a helper
 
-FLAG AS ISSUES:
-- Section comment headers (// ===== Section =====, // ---- etc.)
-- Doc comments (/// ...) on test functions
+Example violation (5 tests doing this):
+  fn test_search_limit_1() { let args = Args { limit: 1, .. }; assert!(ok); }
+  fn test_search_limit_5() { let args = Args { limit: 5, .. }; assert!(ok); }
+  fn test_search_limit_10() { let args = Args { limit: 10, .. }; assert!(ok); }
+
+Should be ONE test:
+  fn test_search_various_limits() {
+      for limit in [1, 5, 10, 20] {
+          let args = Args { limit, .. };
+          let result = tool.call(args).await;
+          assert!(result.is_ok(), "failed for limit={}", limit);
+      }
+  }
+
+TEST NAMING — behavior, not input:
+- BAD:  test_truncate_for_log_emoji
+- GOOD: test_truncate_backs_up_to_char_boundary_on_multibyte
+- BAD:  test_vector_search_args_serde
+- GOOD: test_search_args_deserialize_with_defaults
+
+THE PROJECT'S TEST STYLE:
+- Structure: #[cfg(test)] mod tests { ... } — no nested modules
+- No section comment headers or separators
+- No doc comments on test functions
+- Minimal inline comments
+- Single blank line between test functions
+- Test names: test_<function>_<behavior> — describe what's being verified
+- assert_eq!, assert!, matches! — no custom matchers
+- Multiple related assertions in one test body
+- No println!, dbg!, eprintln!
+- No let _x = y.clone(); anti-pattern
+
+ALSO FLAG:
+- Section comment headers (// ===== Section =====)
+- Doc comments on test functions
 - Verbose comments explaining obvious assertions
-- Custom assertion helpers or test utilities not used in existing tests
-- Test names that don't follow test_<function>_<scenario> pattern
-- Missing underscore prefix on unused variables
-- Debug output (println!, dbg!) left in tests
-- Unnecessary blank lines or formatting that deviates from upstream
+- Unused variable anti-patterns (let _cloned = x.clone())
+- Debug output left in tests
 
 DO NOT FLAG:
-- Minor formatting that rustfmt handles automatically
-- Import style differences when the file is a separate module (use crate:: vs use super::)
+- Minor formatting that rustfmt handles
+- Import style differences (use crate:: vs use super::)
 
 OUTPUT: Write a JSON object to the specified output path:
 {
@@ -66,8 +87,9 @@ OUTPUT: Write a JSON object to the specified output path:
 }
 
 Rules:
-- verdict is "fail" only for meaningful style deviations listed above
-- Be strict about section headers and excessive comments — these are the most common issues
+- verdict is "fail" if there are DRY violations (3+ near-identical tests)
+- verdict is "fail" if test names describe inputs rather than behavior
+- Be strict about duplication — it's the most common generated test problem
 """
 temperature = 0.0
 turn_depth = 10

--- a/crates/aura-config/src/builder.rs
+++ b/crates/aura-config/src/builder.rs
@@ -198,6 +198,7 @@ impl RigBuilder {
 
         let tools = self.config.tools.as_ref().map(|tools_config| ToolsConfig {
             filesystem: tools_config.filesystem,
+            filesystem_write: tools_config.filesystem_write,
             custom_tools: tools_config.custom_tools.clone(),
         });
 

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -284,6 +284,8 @@ pub struct ToolsConfig {
     #[serde(default)]
     pub filesystem: bool,
     #[serde(default)]
+    pub filesystem_write: bool,
+    #[serde(default)]
     pub custom_tools: Vec<String>,
 }
 

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -22,7 +22,7 @@ use tokio::sync::watch;
 pub const DEFAULT_MAX_DEPTH: usize = 8;
 
 /// Check if model supports reasoning_effort parameter
-fn is_reasoning_model(model: &str) -> bool {
+pub(crate) fn is_reasoning_model(model: &str) -> bool {
     model.starts_with("o1")
         || model.starts_with("o3")
         || model.starts_with("o4")
@@ -35,7 +35,7 @@ fn is_reasoning_model(model: &str) -> bool {
 /// JSON object that gets passed to Rig's `additional_params()` method.
 ///
 /// Returns `None` if no parameters are set.
-fn build_ollama_params(
+pub(crate) fn build_ollama_params(
     num_ctx: Option<u32>,
     num_predict: Option<u32>,
     additional_params: Option<std::collections::HashMap<String, serde_json::Value>>,
@@ -443,13 +443,17 @@ impl Agent {
         if let Some(tools_config) = &config.tools
             && tools_config.filesystem
         {
-            tracing::info!("Adding filesystem tools");
+            let write_enabled = tools_config.filesystem_write;
+            tracing::info!("Adding filesystem tools (write_access={})", write_enabled);
             let fs_tool = FilesystemTool::new()
-                .with_write_access(false)
+                .with_write_access(write_enabled)
                 .with_max_file_size(1_048_576);
 
             builder_state = builder_state.add_tool(ReadFileTool(fs_tool.clone()));
-            builder_state = builder_state.add_tool(ListDirTool(fs_tool));
+            builder_state = builder_state.add_tool(ListDirTool(fs_tool.clone()));
+            if write_enabled {
+                builder_state = builder_state.add_tool(WriteFileTool(fs_tool));
+            }
         }
 
         // Add vector store tools if configured

--- a/crates/aura/src/builder_tests.rs
+++ b/crates/aura/src/builder_tests.rs
@@ -1,0 +1,1114 @@
+#[cfg(test)]
+mod tests {
+    use crate::builder::*;
+    use crate::config::*;
+    use crate::tools::{FilesystemTool, ReadFileTool, ListDirTool, WriteFileTool};
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_default_max_depth() {
+        assert_eq!(DEFAULT_MAX_DEPTH, 8);
+    }
+
+    #[test]
+    fn test_is_reasoning_model_o1() {
+        assert!(is_reasoning_model("o1"));
+        assert!(is_reasoning_model("o1-preview"));
+        assert!(is_reasoning_model("o1-mini"));
+    }
+
+    #[test]
+    fn test_is_reasoning_model_o3() {
+        assert!(is_reasoning_model("o3"));
+        assert!(is_reasoning_model("o3-mini"));
+    }
+
+    #[test]
+    fn test_is_reasoning_model_o4() {
+        assert!(is_reasoning_model("o4"));
+        assert!(is_reasoning_model("o4-preview"));
+    }
+
+    #[test]
+    fn test_is_reasoning_model_gpt5() {
+        assert!(is_reasoning_model("gpt-5"));
+        assert!(is_reasoning_model("gpt-5-turbo"));
+    }
+
+    #[test]
+    fn test_is_reasoning_model_non_reasoning() {
+        assert!(!is_reasoning_model("gpt-4"));
+        assert!(!is_reasoning_model("gpt-4o"));
+        assert!(!is_reasoning_model("gpt-4o-mini"));
+        assert!(!is_reasoning_model("gpt-3.5-turbo"));
+        assert!(!is_reasoning_model("claude-3-opus"));
+        assert!(!is_reasoning_model("gemini-pro"));
+    }
+
+    #[test]
+    fn test_is_reasoning_model_empty() {
+        assert!(!is_reasoning_model(""));
+    }
+
+    #[test]
+    fn test_is_reasoning_model_case_sensitive() {
+        assert!(!is_reasoning_model("O1"));
+        assert!(!is_reasoning_model("GPT-5"));
+    }
+
+    #[test]
+    fn test_build_ollama_params_all_none() {
+        let result = build_ollama_params(None, None, None);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_build_ollama_params_num_ctx_only() {
+        let result = build_ollama_params(Some(4096), None, None);
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["num_ctx"], serde_json::json!(4096));
+        assert!(params.get("num_predict").is_none());
+    }
+
+    #[test]
+    fn test_build_ollama_params_num_predict_only() {
+        let result = build_ollama_params(None, Some(2048), None);
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["num_predict"], serde_json::json!(2048));
+        assert!(params.get("num_ctx").is_none());
+    }
+
+    #[test]
+    fn test_build_ollama_params_both_ctx_and_predict() {
+        let result = build_ollama_params(Some(4096), Some(2048), None);
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["num_ctx"], serde_json::json!(4096));
+        assert_eq!(params["num_predict"], serde_json::json!(2048));
+    }
+
+    #[test]
+    fn test_build_ollama_params_additional_only() {
+        let mut additional = HashMap::new();
+        additional.insert("temperature".to_string(), serde_json::json!(0.7));
+        additional.insert("top_p".to_string(), serde_json::json!(0.9));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["temperature"], serde_json::json!(0.7));
+        assert_eq!(params["top_p"], serde_json::json!(0.9));
+    }
+
+    #[test]
+    fn test_build_ollama_params_all_params() {
+        let mut additional = HashMap::new();
+        additional.insert("temperature".to_string(), serde_json::json!(0.7));
+        
+        let result = build_ollama_params(Some(4096), Some(2048), Some(additional));
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["num_ctx"], serde_json::json!(4096));
+        assert_eq!(params["num_predict"], serde_json::json!(2048));
+        assert_eq!(params["temperature"], serde_json::json!(0.7));
+    }
+
+    #[test]
+    fn test_build_ollama_params_additional_overwrites() {
+        let mut additional = HashMap::new();
+        additional.insert("num_ctx".to_string(), serde_json::json!(8192));
+        
+        let result = build_ollama_params(Some(4096), None, Some(additional));
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["num_ctx"], serde_json::json!(8192));
+    }
+
+    #[test]
+    fn test_build_ollama_params_zero_values() {
+        let result = build_ollama_params(Some(0), Some(0), None);
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["num_ctx"], serde_json::json!(0));
+        assert_eq!(params["num_predict"], serde_json::json!(0));
+    }
+
+    #[test]
+    fn test_build_ollama_params_empty_additional() {
+        let additional = HashMap::new();
+        let result = build_ollama_params(None, None, Some(additional));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_build_ollama_params_max_values() {
+        let result = build_ollama_params(Some(u32::MAX), Some(u32::MAX), None);
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["num_ctx"], serde_json::json!(u32::MAX));
+        assert_eq!(params["num_predict"], serde_json::json!(u32::MAX));
+    }
+
+    #[test]
+    fn test_filesystem_tools_clone() {
+        let read_tool = ReadFileTool(FilesystemTool::new());
+        let list_tool = ListDirTool(FilesystemTool::new());
+        let write_tool = WriteFileTool(FilesystemTool::new());
+        
+        let tools = FilesystemTools {
+            read_file: read_tool,
+            list_dir: list_tool,
+            write_file: write_tool,
+        };
+        
+        let _cloned = tools.clone();
+    }
+
+    #[test]
+    fn test_agent_builder_new() {
+        let config = AgentConfig::default();
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_openai() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: Some(0.5),
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: Some(5),
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_anthropic() {
+        let config = AgentConfig {
+            llm: LlmConfig::Anthropic {
+                api_key: "test-key".to_string(),
+                model: "claude-3-opus".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: Some(0.5),
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: Some(5),
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_bedrock() {
+        let config = AgentConfig {
+            llm: LlmConfig::Bedrock {
+                model: "anthropic.claude-v2".to_string(),
+                region: "us-east-1".to_string(),
+                profile: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: Some(0.5),
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: Some(5),
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_gemini() {
+        let config = AgentConfig {
+            llm: LlmConfig::Gemini {
+                api_key: "test-key".to_string(),
+                model: "gemini-pro".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: Some(0.5),
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: Some(5),
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_ollama() {
+        let config = AgentConfig {
+            llm: LlmConfig::Ollama {
+                model: "llama2".to_string(),
+                base_url: Some("http://localhost:11434".to_string()),
+                max_tokens: None,
+                fallback_tool_parsing: false,
+                num_ctx: Some(4096),
+                num_predict: Some(2048),
+                additional_params: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: Some(0.5),
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: Some(5),
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_custom_base_url() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: Some("https://custom.openai.com".to_string()),
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_reasoning_effort() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "o1-preview".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: Some(ReasoningEffort::High),
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_max_tokens() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: Some(8000),
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: Some(4000),
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_turn_depth() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: Some(10),
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_context_window() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: Some(128000),
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_temperature() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: Some(0.9),
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_empty_system_prompt() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_context() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec!["context1".to_string(), "context2".to_string()],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_empty_context() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_tools_config() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: Some(ToolsConfig {
+                filesystem: true,
+                filesystem_write: false,
+                custom_tools: vec![],
+            }),
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_filesystem_write() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: Some(ToolsConfig {
+                filesystem: true,
+                filesystem_write: true,
+                custom_tools: vec![],
+            }),
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_custom_tools() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: Some(ToolsConfig {
+                filesystem: false,
+                filesystem_write: false,
+                custom_tools: vec!["tool1".to_string(), "tool2".to_string()],
+            }),
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_ollama_fallback_parsing() {
+        let config = AgentConfig {
+            llm: LlmConfig::Ollama {
+                model: "qwen3-coder".to_string(),
+                base_url: None,
+                max_tokens: None,
+                fallback_tool_parsing: true,
+                num_ctx: None,
+                num_predict: None,
+                additional_params: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_ollama_additional_params() {
+        let mut additional = HashMap::new();
+        additional.insert("temperature".to_string(), serde_json::json!(0.8));
+        
+        let config = AgentConfig {
+            llm: LlmConfig::Ollama {
+                model: "llama2".to_string(),
+                base_url: None,
+                max_tokens: None,
+                fallback_tool_parsing: false,
+                num_ctx: None,
+                num_predict: None,
+                additional_params: Some(additional.clone()),
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_bedrock_profile() {
+        let config = AgentConfig {
+            llm: LlmConfig::Bedrock {
+                model: "anthropic.claude-v2".to_string(),
+                region: "us-west-2".to_string(),
+                profile: Some("my-profile".to_string()),
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_zero_temperature() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: Some(0.0),
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_max_temperature() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: Some(2.0),
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_zero_turn_depth() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: Some(0),
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_reasoning_effort_minimal() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "o1".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: Some(ReasoningEffort::Minimal),
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_reasoning_effort_low() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "o1".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: Some(ReasoningEffort::Low),
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_reasoning_effort_medium() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "o1".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: Some(ReasoningEffort::Medium),
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_build_ollama_params_with_nested_json() {
+        let mut additional = HashMap::new();
+        additional.insert("options".to_string(), serde_json::json!({"key": "value"}));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["options"], serde_json::json!({"key": "value"}));
+    }
+
+    #[test]
+    fn test_build_ollama_params_with_array_value() {
+        let mut additional = HashMap::new();
+        additional.insert("stop".to_string(), serde_json::json!(["stop1", "stop2"]));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["stop"], serde_json::json!(["stop1", "stop2"]));
+    }
+
+    #[test]
+    fn test_build_ollama_params_with_boolean_value() {
+        let mut additional = HashMap::new();
+        additional.insert("stream".to_string(), serde_json::json!(true));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["stream"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_build_ollama_params_with_null_value() {
+        let mut additional = HashMap::new();
+        additional.insert("seed".to_string(), serde_json::json!(null));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["seed"], serde_json::json!(null));
+    }
+
+    #[test]
+    fn test_is_reasoning_model_partial_match() {
+        assert!(!is_reasoning_model("o"));
+        assert!(!is_reasoning_model("gpt"));
+        assert!(!is_reasoning_model("gpt-"));
+    }
+
+    #[test]
+    fn test_is_reasoning_model_with_suffix() {
+        assert!(is_reasoning_model("o1-2024-12-17"));
+        assert!(is_reasoning_model("gpt-5-turbo-preview"));
+    }
+
+    #[test]
+    fn test_build_ollama_params_multiple_additional() {
+        let mut additional = HashMap::new();
+        additional.insert("temperature".to_string(), serde_json::json!(0.7));
+        additional.insert("top_p".to_string(), serde_json::json!(0.9));
+        additional.insert("top_k".to_string(), serde_json::json!(40));
+        additional.insert("repeat_penalty".to_string(), serde_json::json!(1.1));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params.as_object().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_unicode_system_prompt() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "你好世界 🌍".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_unicode_agent_name() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "助手".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_build_ollama_params_one_value() {
+        let result = build_ollama_params(Some(1), None, None);
+        assert!(result.is_some());
+        let params = result.unwrap();
+        assert_eq!(params["num_ctx"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_one_turn_depth() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: Some(1),
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_one_max_token() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: Some(1),
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_one_context_window() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: Some(1),
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+}

--- a/crates/aura/src/builder_tests.rs
+++ b/crates/aura/src/builder_tests.rs
@@ -2,7 +2,6 @@
 mod tests {
     use crate::builder::*;
     use crate::config::*;
-    use crate::tools::{FilesystemTool, ReadFileTool, ListDirTool, WriteFileTool};
     use std::collections::HashMap;
 
     #[test]
@@ -11,49 +10,65 @@ mod tests {
     }
 
     #[test]
-    fn test_is_reasoning_model_o1() {
+    fn test_is_reasoning_model_o1_variants() {
         assert!(is_reasoning_model("o1"));
         assert!(is_reasoning_model("o1-preview"));
         assert!(is_reasoning_model("o1-mini"));
+        assert!(is_reasoning_model("o1-2024-12-17"));
     }
 
     #[test]
-    fn test_is_reasoning_model_o3() {
+    fn test_is_reasoning_model_o3_variants() {
         assert!(is_reasoning_model("o3"));
         assert!(is_reasoning_model("o3-mini"));
+        assert!(is_reasoning_model("o3-preview"));
     }
 
     #[test]
-    fn test_is_reasoning_model_o4() {
+    fn test_is_reasoning_model_o4_variants() {
         assert!(is_reasoning_model("o4"));
         assert!(is_reasoning_model("o4-preview"));
+        assert!(is_reasoning_model("o4-turbo"));
     }
 
     #[test]
-    fn test_is_reasoning_model_gpt5() {
+    fn test_is_reasoning_model_gpt5_variants() {
         assert!(is_reasoning_model("gpt-5"));
         assert!(is_reasoning_model("gpt-5-turbo"));
+        assert!(is_reasoning_model("gpt-5-preview"));
     }
 
     #[test]
-    fn test_is_reasoning_model_non_reasoning() {
+    fn test_is_reasoning_model_non_reasoning_models() {
         assert!(!is_reasoning_model("gpt-4"));
         assert!(!is_reasoning_model("gpt-4o"));
         assert!(!is_reasoning_model("gpt-4o-mini"));
         assert!(!is_reasoning_model("gpt-3.5-turbo"));
         assert!(!is_reasoning_model("claude-3-opus"));
+        assert!(!is_reasoning_model("claude-3-sonnet"));
         assert!(!is_reasoning_model("gemini-pro"));
+        assert!(!is_reasoning_model("llama2"));
     }
 
     #[test]
-    fn test_is_reasoning_model_empty() {
+    fn test_is_reasoning_model_empty_string() {
         assert!(!is_reasoning_model(""));
     }
 
     #[test]
     fn test_is_reasoning_model_case_sensitive() {
         assert!(!is_reasoning_model("O1"));
+        assert!(!is_reasoning_model("O3"));
         assert!(!is_reasoning_model("GPT-5"));
+        assert!(!is_reasoning_model("Gpt-5"));
+    }
+
+    #[test]
+    fn test_is_reasoning_model_partial_matches() {
+        assert!(!is_reasoning_model("o"));
+        assert!(!is_reasoning_model("gpt"));
+        assert!(!is_reasoning_model("gpt-"));
+        assert!(!is_reasoning_model("gpt-4o1"));
     }
 
     #[test]
@@ -65,7 +80,6 @@ mod tests {
     #[test]
     fn test_build_ollama_params_num_ctx_only() {
         let result = build_ollama_params(Some(4096), None, None);
-        assert!(result.is_some());
         let params = result.unwrap();
         assert_eq!(params["num_ctx"], serde_json::json!(4096));
         assert!(params.get("num_predict").is_none());
@@ -74,7 +88,6 @@ mod tests {
     #[test]
     fn test_build_ollama_params_num_predict_only() {
         let result = build_ollama_params(None, Some(2048), None);
-        assert!(result.is_some());
         let params = result.unwrap();
         assert_eq!(params["num_predict"], serde_json::json!(2048));
         assert!(params.get("num_ctx").is_none());
@@ -83,7 +96,6 @@ mod tests {
     #[test]
     fn test_build_ollama_params_both_ctx_and_predict() {
         let result = build_ollama_params(Some(4096), Some(2048), None);
-        assert!(result.is_some());
         let params = result.unwrap();
         assert_eq!(params["num_ctx"], serde_json::json!(4096));
         assert_eq!(params["num_predict"], serde_json::json!(2048));
@@ -96,40 +108,50 @@ mod tests {
         additional.insert("top_p".to_string(), serde_json::json!(0.9));
         
         let result = build_ollama_params(None, None, Some(additional));
-        assert!(result.is_some());
         let params = result.unwrap();
         assert_eq!(params["temperature"], serde_json::json!(0.7));
         assert_eq!(params["top_p"], serde_json::json!(0.9));
+        assert!(params.get("num_ctx").is_none());
+        assert!(params.get("num_predict").is_none());
     }
 
     #[test]
     fn test_build_ollama_params_all_params() {
         let mut additional = HashMap::new();
         additional.insert("temperature".to_string(), serde_json::json!(0.7));
+        additional.insert("top_k".to_string(), serde_json::json!(40));
         
         let result = build_ollama_params(Some(4096), Some(2048), Some(additional));
-        assert!(result.is_some());
         let params = result.unwrap();
         assert_eq!(params["num_ctx"], serde_json::json!(4096));
         assert_eq!(params["num_predict"], serde_json::json!(2048));
         assert_eq!(params["temperature"], serde_json::json!(0.7));
+        assert_eq!(params["top_k"], serde_json::json!(40));
     }
 
     #[test]
-    fn test_build_ollama_params_additional_overwrites() {
+    fn test_build_ollama_params_additional_overwrites_num_ctx() {
         let mut additional = HashMap::new();
         additional.insert("num_ctx".to_string(), serde_json::json!(8192));
         
         let result = build_ollama_params(Some(4096), None, Some(additional));
-        assert!(result.is_some());
         let params = result.unwrap();
         assert_eq!(params["num_ctx"], serde_json::json!(8192));
     }
 
     #[test]
+    fn test_build_ollama_params_additional_overwrites_num_predict() {
+        let mut additional = HashMap::new();
+        additional.insert("num_predict".to_string(), serde_json::json!(4096));
+        
+        let result = build_ollama_params(None, Some(2048), Some(additional));
+        let params = result.unwrap();
+        assert_eq!(params["num_predict"], serde_json::json!(4096));
+    }
+
+    #[test]
     fn test_build_ollama_params_zero_values() {
         let result = build_ollama_params(Some(0), Some(0), None);
-        assert!(result.is_some());
         let params = result.unwrap();
         assert_eq!(params["num_ctx"], serde_json::json!(0));
         assert_eq!(params["num_predict"], serde_json::json!(0));
@@ -145,29 +167,125 @@ mod tests {
     #[test]
     fn test_build_ollama_params_max_values() {
         let result = build_ollama_params(Some(u32::MAX), Some(u32::MAX), None);
-        assert!(result.is_some());
         let params = result.unwrap();
         assert_eq!(params["num_ctx"], serde_json::json!(u32::MAX));
         assert_eq!(params["num_predict"], serde_json::json!(u32::MAX));
     }
 
     #[test]
-    fn test_filesystem_tools_clone() {
-        let read_tool = ReadFileTool(FilesystemTool::new());
-        let list_tool = ListDirTool(FilesystemTool::new());
-        let write_tool = WriteFileTool(FilesystemTool::new());
+    fn test_build_ollama_params_with_nested_json() {
+        let mut additional = HashMap::new();
+        additional.insert("options".to_string(), serde_json::json!({"key": "value", "nested": {"deep": true}}));
         
-        let tools = FilesystemTools {
-            read_file: read_tool,
-            list_dir: list_tool,
-            write_file: write_tool,
-        };
-        
-        let _cloned = tools.clone();
+        let result = build_ollama_params(None, None, Some(additional));
+        let params = result.unwrap();
+        assert_eq!(params["options"]["key"], serde_json::json!("value"));
+        assert_eq!(params["options"]["nested"]["deep"], serde_json::json!(true));
     }
 
     #[test]
-    fn test_agent_builder_new() {
+    fn test_build_ollama_params_with_array_value() {
+        let mut additional = HashMap::new();
+        additional.insert("stop".to_string(), serde_json::json!(["stop1", "stop2", "stop3"]));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        let params = result.unwrap();
+        assert_eq!(params["stop"], serde_json::json!(["stop1", "stop2", "stop3"]));
+    }
+
+    #[test]
+    fn test_build_ollama_params_with_boolean_value() {
+        let mut additional = HashMap::new();
+        additional.insert("stream".to_string(), serde_json::json!(true));
+        additional.insert("raw".to_string(), serde_json::json!(false));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        let params = result.unwrap();
+        assert_eq!(params["stream"], serde_json::json!(true));
+        assert_eq!(params["raw"], serde_json::json!(false));
+    }
+
+    #[test]
+    fn test_build_ollama_params_with_null_value() {
+        let mut additional = HashMap::new();
+        additional.insert("seed".to_string(), serde_json::json!(null));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        let params = result.unwrap();
+        assert_eq!(params["seed"], serde_json::json!(null));
+    }
+
+    #[test]
+    fn test_build_ollama_params_with_string_value() {
+        let mut additional = HashMap::new();
+        additional.insert("format".to_string(), serde_json::json!("json"));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        let params = result.unwrap();
+        assert_eq!(params["format"], serde_json::json!("json"));
+    }
+
+    #[test]
+    fn test_build_ollama_params_with_float_value() {
+        let mut additional = HashMap::new();
+        additional.insert("repeat_penalty".to_string(), serde_json::json!(1.1));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        let params = result.unwrap();
+        assert_eq!(params["repeat_penalty"], serde_json::json!(1.1));
+    }
+
+    #[test]
+    fn test_build_ollama_params_multiple_additional() {
+        let mut additional = HashMap::new();
+        additional.insert("temperature".to_string(), serde_json::json!(0.7));
+        additional.insert("top_p".to_string(), serde_json::json!(0.9));
+        additional.insert("top_k".to_string(), serde_json::json!(40));
+        additional.insert("repeat_penalty".to_string(), serde_json::json!(1.1));
+        additional.insert("seed".to_string(), serde_json::json!(42));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        let params = result.unwrap();
+        let obj = params.as_object().unwrap();
+        assert_eq!(obj.len(), 5);
+        assert_eq!(params["temperature"], serde_json::json!(0.7));
+        assert_eq!(params["top_p"], serde_json::json!(0.9));
+        assert_eq!(params["top_k"], serde_json::json!(40));
+        assert_eq!(params["repeat_penalty"], serde_json::json!(1.1));
+        assert_eq!(params["seed"], serde_json::json!(42));
+    }
+
+    #[test]
+    fn test_build_ollama_params_one_value() {
+        let result = build_ollama_params(Some(1), None, None);
+        let params = result.unwrap();
+        assert_eq!(params["num_ctx"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn test_build_ollama_params_returns_json_object() {
+        let result = build_ollama_params(Some(4096), None, None);
+        let params = result.unwrap();
+        assert!(params.is_object());
+    }
+
+    #[test]
+    fn test_filesystem_tools_clone() {
+        let fs_tool = crate::tools::FilesystemTool::new();
+        let tools = FilesystemTools {
+            read_file: crate::tools::ReadFileTool(fs_tool.clone()),
+            list_dir: crate::tools::ListDirTool(fs_tool.clone()),
+            write_file: crate::tools::WriteFileTool(fs_tool),
+        };
+        
+        let cloned = tools.clone();
+        assert_eq!(cloned.read_file.0.base_dir, tools.read_file.0.base_dir);
+        assert_eq!(cloned.list_dir.0.allow_write, tools.list_dir.0.allow_write);
+        assert_eq!(cloned.write_file.0.max_file_size, tools.write_file.0.max_file_size);
+    }
+
+    #[test]
+    fn test_agent_builder_new_default_config() {
         let config = AgentConfig::default();
         let _builder = AgentBuilder::new(config);
     }
@@ -338,7 +456,88 @@ mod tests {
     }
 
     #[test]
-    fn test_agent_builder_new_with_reasoning_effort() {
+    fn test_agent_builder_new_with_reasoning_effort_minimal() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "o1-preview".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: Some(ReasoningEffort::Minimal),
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_reasoning_effort_low() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "o1".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: Some(ReasoningEffort::Low),
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_reasoning_effort_medium() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "o1".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: Some(ReasoningEffort::Medium),
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_reasoning_effort_high() {
         let config = AgentConfig {
             llm: LlmConfig::OpenAI {
                 api_key: "test-key".to_string(),
@@ -459,6 +658,60 @@ mod tests {
                 system_prompt: "Test prompt".to_string(),
                 context: vec![],
                 temperature: Some(0.9),
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_zero_temperature() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: Some(0.0),
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_max_temperature() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: Some(2.0),
                 reasoning_effort: None,
                 max_tokens: None,
                 turn_depth: None,
@@ -689,7 +942,7 @@ mod tests {
                 fallback_tool_parsing: false,
                 num_ctx: None,
                 num_predict: None,
-                additional_params: Some(additional.clone()),
+                additional_params: Some(additional),
             },
             agent: AgentSettings {
                 name: "TestAgent".to_string(),
@@ -737,60 +990,6 @@ mod tests {
     }
 
     #[test]
-    fn test_agent_builder_new_with_zero_temperature() {
-        let config = AgentConfig {
-            llm: LlmConfig::OpenAI {
-                api_key: "test-key".to_string(),
-                model: "gpt-4".to_string(),
-                base_url: None,
-                max_tokens: None,
-            },
-            agent: AgentSettings {
-                name: "TestAgent".to_string(),
-                system_prompt: "Test prompt".to_string(),
-                context: vec![],
-                temperature: Some(0.0),
-                reasoning_effort: None,
-                max_tokens: None,
-                turn_depth: None,
-                context_window: None,
-            },
-            vector_stores: vec![],
-            mcp: None,
-            tools: None,
-        };
-        
-        let _builder = AgentBuilder::new(config);
-    }
-
-    #[test]
-    fn test_agent_builder_new_with_max_temperature() {
-        let config = AgentConfig {
-            llm: LlmConfig::OpenAI {
-                api_key: "test-key".to_string(),
-                model: "gpt-4".to_string(),
-                base_url: None,
-                max_tokens: None,
-            },
-            agent: AgentSettings {
-                name: "TestAgent".to_string(),
-                system_prompt: "Test prompt".to_string(),
-                context: vec![],
-                temperature: Some(2.0),
-                reasoning_effort: None,
-                max_tokens: None,
-                turn_depth: None,
-                context_window: None,
-            },
-            vector_stores: vec![],
-            mcp: None,
-            tools: None,
-        };
-        
-        let _builder = AgentBuilder::new(config);
-    }
-
-    #[test]
     fn test_agent_builder_new_with_zero_turn_depth() {
         let config = AgentConfig {
             llm: LlmConfig::OpenAI {
@@ -815,220 +1014,6 @@ mod tests {
         };
         
         let _builder = AgentBuilder::new(config);
-    }
-
-    #[test]
-    fn test_agent_builder_new_with_reasoning_effort_minimal() {
-        let config = AgentConfig {
-            llm: LlmConfig::OpenAI {
-                api_key: "test-key".to_string(),
-                model: "o1".to_string(),
-                base_url: None,
-                max_tokens: None,
-            },
-            agent: AgentSettings {
-                name: "TestAgent".to_string(),
-                system_prompt: "Test prompt".to_string(),
-                context: vec![],
-                temperature: None,
-                reasoning_effort: Some(ReasoningEffort::Minimal),
-                max_tokens: None,
-                turn_depth: None,
-                context_window: None,
-            },
-            vector_stores: vec![],
-            mcp: None,
-            tools: None,
-        };
-        
-        let _builder = AgentBuilder::new(config);
-    }
-
-    #[test]
-    fn test_agent_builder_new_with_reasoning_effort_low() {
-        let config = AgentConfig {
-            llm: LlmConfig::OpenAI {
-                api_key: "test-key".to_string(),
-                model: "o1".to_string(),
-                base_url: None,
-                max_tokens: None,
-            },
-            agent: AgentSettings {
-                name: "TestAgent".to_string(),
-                system_prompt: "Test prompt".to_string(),
-                context: vec![],
-                temperature: None,
-                reasoning_effort: Some(ReasoningEffort::Low),
-                max_tokens: None,
-                turn_depth: None,
-                context_window: None,
-            },
-            vector_stores: vec![],
-            mcp: None,
-            tools: None,
-        };
-        
-        let _builder = AgentBuilder::new(config);
-    }
-
-    #[test]
-    fn test_agent_builder_new_with_reasoning_effort_medium() {
-        let config = AgentConfig {
-            llm: LlmConfig::OpenAI {
-                api_key: "test-key".to_string(),
-                model: "o1".to_string(),
-                base_url: None,
-                max_tokens: None,
-            },
-            agent: AgentSettings {
-                name: "TestAgent".to_string(),
-                system_prompt: "Test prompt".to_string(),
-                context: vec![],
-                temperature: None,
-                reasoning_effort: Some(ReasoningEffort::Medium),
-                max_tokens: None,
-                turn_depth: None,
-                context_window: None,
-            },
-            vector_stores: vec![],
-            mcp: None,
-            tools: None,
-        };
-        
-        let _builder = AgentBuilder::new(config);
-    }
-
-    #[test]
-    fn test_build_ollama_params_with_nested_json() {
-        let mut additional = HashMap::new();
-        additional.insert("options".to_string(), serde_json::json!({"key": "value"}));
-        
-        let result = build_ollama_params(None, None, Some(additional));
-        assert!(result.is_some());
-        let params = result.unwrap();
-        assert_eq!(params["options"], serde_json::json!({"key": "value"}));
-    }
-
-    #[test]
-    fn test_build_ollama_params_with_array_value() {
-        let mut additional = HashMap::new();
-        additional.insert("stop".to_string(), serde_json::json!(["stop1", "stop2"]));
-        
-        let result = build_ollama_params(None, None, Some(additional));
-        assert!(result.is_some());
-        let params = result.unwrap();
-        assert_eq!(params["stop"], serde_json::json!(["stop1", "stop2"]));
-    }
-
-    #[test]
-    fn test_build_ollama_params_with_boolean_value() {
-        let mut additional = HashMap::new();
-        additional.insert("stream".to_string(), serde_json::json!(true));
-        
-        let result = build_ollama_params(None, None, Some(additional));
-        assert!(result.is_some());
-        let params = result.unwrap();
-        assert_eq!(params["stream"], serde_json::json!(true));
-    }
-
-    #[test]
-    fn test_build_ollama_params_with_null_value() {
-        let mut additional = HashMap::new();
-        additional.insert("seed".to_string(), serde_json::json!(null));
-        
-        let result = build_ollama_params(None, None, Some(additional));
-        assert!(result.is_some());
-        let params = result.unwrap();
-        assert_eq!(params["seed"], serde_json::json!(null));
-    }
-
-    #[test]
-    fn test_is_reasoning_model_partial_match() {
-        assert!(!is_reasoning_model("o"));
-        assert!(!is_reasoning_model("gpt"));
-        assert!(!is_reasoning_model("gpt-"));
-    }
-
-    #[test]
-    fn test_is_reasoning_model_with_suffix() {
-        assert!(is_reasoning_model("o1-2024-12-17"));
-        assert!(is_reasoning_model("gpt-5-turbo-preview"));
-    }
-
-    #[test]
-    fn test_build_ollama_params_multiple_additional() {
-        let mut additional = HashMap::new();
-        additional.insert("temperature".to_string(), serde_json::json!(0.7));
-        additional.insert("top_p".to_string(), serde_json::json!(0.9));
-        additional.insert("top_k".to_string(), serde_json::json!(40));
-        additional.insert("repeat_penalty".to_string(), serde_json::json!(1.1));
-        
-        let result = build_ollama_params(None, None, Some(additional));
-        assert!(result.is_some());
-        let params = result.unwrap();
-        assert_eq!(params.as_object().unwrap().len(), 4);
-    }
-
-    #[test]
-    fn test_agent_builder_new_with_unicode_system_prompt() {
-        let config = AgentConfig {
-            llm: LlmConfig::OpenAI {
-                api_key: "test-key".to_string(),
-                model: "gpt-4".to_string(),
-                base_url: None,
-                max_tokens: None,
-            },
-            agent: AgentSettings {
-                name: "TestAgent".to_string(),
-                system_prompt: "你好世界 🌍".to_string(),
-                context: vec![],
-                temperature: None,
-                reasoning_effort: None,
-                max_tokens: None,
-                turn_depth: None,
-                context_window: None,
-            },
-            vector_stores: vec![],
-            mcp: None,
-            tools: None,
-        };
-        
-        let _builder = AgentBuilder::new(config);
-    }
-
-    #[test]
-    fn test_agent_builder_new_with_unicode_agent_name() {
-        let config = AgentConfig {
-            llm: LlmConfig::OpenAI {
-                api_key: "test-key".to_string(),
-                model: "gpt-4".to_string(),
-                base_url: None,
-                max_tokens: None,
-            },
-            agent: AgentSettings {
-                name: "助手".to_string(),
-                system_prompt: "Test prompt".to_string(),
-                context: vec![],
-                temperature: None,
-                reasoning_effort: None,
-                max_tokens: None,
-                turn_depth: None,
-                context_window: None,
-            },
-            vector_stores: vec![],
-            mcp: None,
-            tools: None,
-        };
-        
-        let _builder = AgentBuilder::new(config);
-    }
-
-    #[test]
-    fn test_build_ollama_params_one_value() {
-        let result = build_ollama_params(Some(1), None, None);
-        assert!(result.is_some());
-        let params = result.unwrap();
-        assert_eq!(params["num_ctx"], serde_json::json!(1));
     }
 
     #[test]
@@ -1110,5 +1095,468 @@ mod tests {
         };
         
         let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_unicode_system_prompt() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "你好世界 🌍".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_unicode_agent_name() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "助手".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_empty_api_key() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_empty_model() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_empty_region() {
+        let config = AgentConfig {
+            llm: LlmConfig::Bedrock {
+                model: "anthropic.claude-v2".to_string(),
+                region: "".to_string(),
+                profile: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_empty_base_url() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: Some("".to_string()),
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_large_turn_depth() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: Some(1000),
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_large_context_window() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: Some(1_000_000),
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_large_max_tokens() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: Some(100_000),
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_negative_temperature() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: Some(-0.5),
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_very_high_temperature() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: Some(100.0),
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_multiline_system_prompt() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Line 1\nLine 2\nLine 3".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_special_characters_in_system_prompt() {
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "!@#$%^&*()_+-=[]{}|;':\",./<>?".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_many_context_items() {
+        let context: Vec<String> = (0..100).map(|i| format!("context{}", i)).collect();
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context,
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: None,
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_agent_builder_new_with_many_custom_tools() {
+        let tools: Vec<String> = (0..50).map(|i| format!("tool{}", i)).collect();
+        let config = AgentConfig {
+            llm: LlmConfig::OpenAI {
+                api_key: "test-key".to_string(),
+                model: "gpt-4".to_string(),
+                base_url: None,
+                max_tokens: None,
+            },
+            agent: AgentSettings {
+                name: "TestAgent".to_string(),
+                system_prompt: "Test prompt".to_string(),
+                context: vec![],
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                turn_depth: None,
+                context_window: None,
+            },
+            vector_stores: vec![],
+            mcp: None,
+            tools: Some(ToolsConfig {
+                filesystem: false,
+                filesystem_write: false,
+                custom_tools: tools,
+            }),
+        };
+        
+        let _builder = AgentBuilder::new(config);
+    }
+
+    #[test]
+    fn test_build_ollama_params_preserves_order() {
+        let mut additional = HashMap::new();
+        additional.insert("a".to_string(), serde_json::json!(1));
+        additional.insert("b".to_string(), serde_json::json!(2));
+        additional.insert("c".to_string(), serde_json::json!(3));
+        
+        let result = build_ollama_params(Some(100), Some(200), Some(additional));
+        let params = result.unwrap();
+        let obj = params.as_object().unwrap();
+        assert_eq!(obj.len(), 5);
+        assert!(obj.contains_key("num_ctx"));
+        assert!(obj.contains_key("num_predict"));
+        assert!(obj.contains_key("a"));
+        assert!(obj.contains_key("b"));
+        assert!(obj.contains_key("c"));
+    }
+
+    #[test]
+    fn test_is_reasoning_model_with_version_numbers() {
+        assert!(is_reasoning_model("o1-2024-12-17"));
+        assert!(is_reasoning_model("o3-2025-01-01"));
+        assert!(is_reasoning_model("gpt-5-2025-preview"));
+    }
+
+    #[test]
+    fn test_is_reasoning_model_does_not_match_substring() {
+        assert!(!is_reasoning_model("model-o1"));
+        assert!(!is_reasoning_model("my-gpt-5"));
+        assert!(is_reasoning_model("o1x"));
+    }
+
+    #[test]
+    fn test_build_ollama_params_with_empty_string_values() {
+        let mut additional = HashMap::new();
+        additional.insert("key".to_string(), serde_json::json!(""));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        let params = result.unwrap();
+        assert_eq!(params["key"], serde_json::json!(""));
+    }
+
+    #[test]
+    fn test_build_ollama_params_with_zero_in_additional() {
+        let mut additional = HashMap::new();
+        additional.insert("seed".to_string(), serde_json::json!(0));
+        
+        let result = build_ollama_params(None, None, Some(additional));
+        let params = result.unwrap();
+        assert_eq!(params["seed"], serde_json::json!(0));
     }
 }

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -287,6 +287,7 @@ pub enum McpServerConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolsConfig {
     pub filesystem: bool,
+    pub filesystem_write: bool,
     pub custom_tools: Vec<String>,
 }
 

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -83,3 +83,9 @@ pub use vector_dynamic::DynamicVectorSearchTool;
 // Fallback tool parser and stream wrapper for Ollama
 pub use fallback_tool_parser::{ParsedToolCall, parse_fallback_tool_calls};
 pub use fallback_tool_stream::FallbackToolExecutor;
+#[cfg(test)] mod string_utils_tests;
+#[cfg(test)] mod tools_tests;
+#[cfg(test)] mod vector_dynamic_tests;
+#[cfg(test)] mod vector_store_tests;
+#[cfg(test)] mod builder_tests;
+#[cfg(test)] mod rag_tools_tests;

--- a/crates/aura/src/rag_tools_tests.rs
+++ b/crates/aura/src/rag_tools_tests.rs
@@ -4,36 +4,36 @@ mod tests {
     use crate::vector_store::VectorStoreManager;
     use rig::tool::Tool;
     use serde_json::json;
+    use std::fs;
+    use std::path::PathBuf;
     use std::sync::Arc;
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn path(&self) -> &std::path::Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn create_temp_dir() -> TempDir {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("aura_test_{}_{}", pid, id));
+        fs::create_dir_all(&dir).unwrap();
+        TempDir(dir)
+    }
 
     fn create_test_vector_store(name: &str, context_prefix: Option<String>) -> Arc<VectorStoreManager> {
         Arc::new(VectorStoreManager::new_stub(name, context_prefix))
-    }
-
-    #[test]
-    fn test_vector_search_mezmo_kb_tool_new() {
-        let store = create_test_vector_store("test", None);
-        let _tool = VectorSearchMezmoKbTool::new(store);
-    }
-
-    #[test]
-    fn test_vector_search_mezmo_runbooks_tool_new() {
-        let store = create_test_vector_store("test", None);
-        let _tool = VectorSearchMezmoRunbooksTool::new(store);
-    }
-
-    #[test]
-    fn test_vector_search_mezmo_kb_tool_clone() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let _cloned = tool.clone();
-    }
-
-    #[test]
-    fn test_vector_search_mezmo_runbooks_tool_clone() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoRunbooksTool::new(store);
-        let _cloned = tool.clone();
     }
 
     #[test]
@@ -46,300 +46,118 @@ mod tests {
         assert_eq!(VectorSearchMezmoRunbooksTool::NAME, "vector_search_mezmo_runbooks");
     }
 
-    #[tokio::test]
-    async fn test_vector_search_mezmo_kb_tool_definition() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let definition = tool.definition(String::new()).await;
-        
-        assert_eq!(definition.name, "vector_search_mezmo_kb");
-        assert!(definition.description.contains("Search the vector store"));
-        assert!(definition.parameters.get("type").is_some());
-        assert_eq!(definition.parameters["type"], "object");
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_mezmo_runbooks_tool_definition() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoRunbooksTool::new(store);
-        let definition = tool.definition(String::new()).await;
-        
-        assert_eq!(definition.name, "vector_search_mezmo_runbooks");
-        assert!(definition.description.contains("Search the vector store"));
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_definition_with_context_prefix() {
-        let store = create_test_vector_store("test", Some("Based on the following information from the knowledge base:".to_string()));
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let definition = tool.definition(String::new()).await;
-        
-        assert!(definition.description.contains("knowledge base"));
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_definition_without_context_prefix() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let definition = tool.definition(String::new()).await;
-        
-        assert!(definition.description.contains("Search the vector store"));
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_definition_parameters() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let definition = tool.definition(String::new()).await;
-        
-        let properties = &definition.parameters["properties"];
-        assert!(properties.get("query").is_some());
-        assert!(properties.get("limit").is_some());
-        assert!(properties.get("min_score").is_some());
-        
-        assert_eq!(properties["query"]["type"], "string");
-        assert_eq!(properties["limit"]["type"], "integer");
-        assert_eq!(properties["min_score"]["type"], "number");
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_definition_required_fields() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let definition = tool.definition(String::new()).await;
-        
-        let required = definition.parameters["required"].as_array().unwrap();
-        assert!(required.contains(&json!("query")));
-        assert!(required.contains(&json!("limit")));
-        assert!(required.contains(&json!("min_score")));
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_empty_results() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let args = VectorSearchArgs {
-            query: "test query".to_string(),
-            limit: 5,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-        let response = result.unwrap();
-        assert_eq!(response.results.len(), 0);
-        assert_eq!(response.query, "test query");
-        assert_eq!(response.total_found, 0);
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_with_limit() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 10,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_with_min_score() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 5,
-            min_score: 0.5,
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_empty_query() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let args = VectorSearchArgs {
-            query: "".to_string(),
-            limit: 5,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_zero_limit() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 0,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_max_limit() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 20,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_min_score_zero() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 5,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_min_score_one() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 5,
-            min_score: 1.0,
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_unicode_query() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let args = VectorSearchArgs {
-            query: "Hello 世界 🎉".to_string(),
-            limit: 5,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-        let response = result.unwrap();
-        assert_eq!(response.query, "Hello 世界 🎉");
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_multiline_query() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let args = VectorSearchArgs {
-            query: "line1\nline2\nline3".to_string(),
-            limit: 5,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_very_long_query() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let long_query = "query ".repeat(1000);
-        let args = VectorSearchArgs {
-            query: long_query.clone(),
-            limit: 5,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-        let response = result.unwrap();
-        assert_eq!(response.query, long_query);
+    #[test]
+    fn test_vector_ingest_tool_name() {
+        assert_eq!(VectorIngestTool::NAME, "vector_ingest");
     }
 
     #[test]
-    fn test_vector_search_args_serde() {
+    fn test_vector_search_mezmo_kb_tool_new() {
+        let store = create_test_vector_store("test", None);
+        let _tool = VectorSearchMezmoKbTool::new(store.clone());
+        assert_eq!(Arc::strong_count(&store), 2);
+    }
+
+    #[test]
+    fn test_vector_search_mezmo_runbooks_tool_new() {
+        let store = create_test_vector_store("test", None);
+        let _tool = VectorSearchMezmoRunbooksTool::new(store.clone());
+        assert_eq!(Arc::strong_count(&store), 2);
+    }
+
+    #[test]
+    fn test_vector_ingest_tool_new() {
+        let store = create_test_vector_store("test", None);
+        let _tool = VectorIngestTool::new(store.clone());
+        assert_eq!(Arc::strong_count(&store), 2);
+    }
+
+    #[test]
+    fn test_auto_ingest_new() {
+        let store = create_test_vector_store("test", None);
+        let _auto_ingest = AutoIngest::new(store.clone());
+        assert_eq!(Arc::strong_count(&store), 2);
+    }
+
+    #[test]
+    fn test_vector_search_args_serde_with_all_fields() {
         let args = VectorSearchArgs {
             query: "test query".to_string(),
             limit: 10,
-            min_score: 0.5,
+            min_score: 0.7,
         };
         let json = serde_json::to_string(&args).unwrap();
         let deserialized: VectorSearchArgs = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.query, "test query");
         assert_eq!(deserialized.limit, 10);
-        assert_eq!(deserialized.min_score, 0.5);
+        assert_eq!(deserialized.min_score, 0.7);
     }
 
     #[test]
-    fn test_vector_search_args_default_limit() {
+    fn test_vector_search_args_serde_with_defaults() {
         let json = r#"{"query":"test"}"#;
         let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.query, "test");
         assert_eq!(args.limit, 5);
         assert_eq!(args.min_score, 0.0);
     }
 
     #[test]
-    fn test_vector_search_args_default_min_score() {
+    fn test_vector_search_args_serde_partial_defaults() {
         let json = r#"{"query":"test","limit":10}"#;
         let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.query, "test");
+        assert_eq!(args.limit, 10);
         assert_eq!(args.min_score, 0.0);
     }
 
     #[test]
-    fn test_vector_search_args_debug() {
+    fn test_vector_search_args_boundary_values() {
+        let args = VectorSearchArgs {
+            query: "".to_string(),
+            limit: 1,
+            min_score: 0.0,
+        };
+        assert_eq!(args.query, "");
+        assert_eq!(args.limit, 1);
+        assert_eq!(args.min_score, 0.0);
+
         let args = VectorSearchArgs {
             query: "test".to_string(),
+            limit: 20,
+            min_score: 1.0,
+        };
+        assert_eq!(args.limit, 20);
+        assert_eq!(args.min_score, 1.0);
+    }
+
+    #[test]
+    fn test_vector_search_args_unicode() {
+        let args = VectorSearchArgs {
+            query: "Hello 世界 🎉".to_string(),
             limit: 5,
             min_score: 0.0,
         };
-        let debug_str = format!("{:?}", args);
-        assert!(debug_str.contains("VectorSearchArgs"));
-        assert!(debug_str.contains("test"));
+        assert_eq!(args.query, "Hello 世界 🎉");
     }
 
     #[test]
     fn test_vector_search_response_serde() {
         let response = VectorSearchResponse {
-            results: vec![],
-            query: "test".to_string(),
-            total_found: 0,
-            formatted_results: "No results".to_string(),
+            results: vec![VectorSearchResult {
+                content: "test content".to_string(),
+                score: 0.95,
+                metadata: Some(json!({"id": "123"})),
+            }],
+            query: "test query".to_string(),
+            total_found: 1,
+            formatted_results: "Result 1".to_string(),
         };
         let json = serde_json::to_string(&response).unwrap();
-        assert!(json.contains("test"));
-    }
-
-    #[test]
-    fn test_vector_search_response_debug() {
-        let response = VectorSearchResponse {
-            results: vec![],
-            query: "test".to_string(),
-            total_found: 0,
-            formatted_results: "No results".to_string(),
-        };
-        let debug_str = format!("{:?}", response);
-        assert!(debug_str.contains("VectorSearchResponse"));
+        assert!(json.contains("test content"));
+        assert!(json.contains("0.95"));
+        assert!(json.contains("test query"));
+        assert!(json.contains("Result 1"));
     }
 
     #[test]
@@ -347,21 +165,12 @@ mod tests {
         let result = VectorSearchResult {
             content: "test content".to_string(),
             score: 0.95,
-            metadata: Some(json!({"id": "123"})),
+            metadata: Some(json!({"id": "123", "type": "doc"})),
         };
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("test content"));
-    }
-
-    #[test]
-    fn test_vector_search_result_debug() {
-        let result = VectorSearchResult {
-            content: "test".to_string(),
-            score: 0.5,
-            metadata: None,
-        };
-        let debug_str = format!("{:?}", result);
-        assert!(debug_str.contains("VectorSearchResult"));
+        assert!(json.contains("0.95"));
+        assert!(json.contains("\"id\":\"123\""));
     }
 
     #[test]
@@ -372,34 +181,321 @@ mod tests {
             metadata: None,
         };
         assert!(result.metadata.is_none());
+        assert_eq!(result.content, "test");
+        assert_eq!(result.score, 0.5);
     }
 
     #[test]
-    fn test_vector_search_result_with_metadata() {
-        let result = VectorSearchResult {
+    fn test_ingest_document_serde_minimal() {
+        let json = r#"{"content":"test content"}"#;
+        let doc: IngestDocument = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.content, "test content");
+        assert!(doc.id.is_none());
+        assert!(doc.metadata.is_none());
+    }
+
+    #[test]
+    fn test_ingest_document_serde_all_fields() {
+        let json = r#"{"id":"doc-123","content":"test","metadata":{"type":"article"}}"#;
+        let doc: IngestDocument = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.id, Some("doc-123".to_string()));
+        assert_eq!(doc.content, "test");
+        assert!(doc.metadata.is_some());
+    }
+
+    #[test]
+    fn test_ingest_document_with_complex_metadata() {
+        let doc = IngestDocument {
+            id: Some("123".to_string()),
             content: "test".to_string(),
-            score: 0.5,
-            metadata: Some(json!({"key": "value"})),
+            metadata: Some(json!({
+                "type": "document",
+                "tags": ["rust", "test"],
+                "nested": {"key": "value"}
+            })),
         };
-        assert!(result.metadata.is_some());
+        let json = serde_json::to_string(&doc).unwrap();
+        let deserialized: IngestDocument = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.id, Some("123".to_string()));
+        assert_eq!(deserialized.content, "test");
+        assert!(deserialized.metadata.is_some());
     }
 
     #[test]
-    fn test_vector_ingest_tool_new() {
+    fn test_vector_ingest_args_serde() {
+        let args = VectorIngestArgs {
+            documents: vec![
+                IngestDocument {
+                    id: None,
+                    content: "doc1".to_string(),
+                    metadata: None,
+                },
+                IngestDocument {
+                    id: Some("2".to_string()),
+                    content: "doc2".to_string(),
+                    metadata: Some(json!({"key": "value"})),
+                },
+            ],
+        };
+        let json = serde_json::to_string(&args).unwrap();
+        let deserialized: VectorIngestArgs = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.documents.len(), 2);
+        assert_eq!(deserialized.documents[0].content, "doc1");
+        assert_eq!(deserialized.documents[1].content, "doc2");
+    }
+
+    #[test]
+    fn test_vector_ingest_response_serde() {
+        let response = VectorIngestResponse {
+            ingested_count: 42,
+            success: true,
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("42"));
+        assert!(json.contains("true"));
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_mezmo_kb_tool_definition_without_context() {
         let store = create_test_vector_store("test", None);
-        let _tool = VectorIngestTool::new(store);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.name, "vector_search_mezmo_kb");
+        assert!(definition.description.contains("Search the vector store"));
+        assert!(definition.description.contains("semantically similar"));
+        assert!(!definition.description.contains("This vector store contains"));
     }
 
-    #[test]
-    fn test_vector_ingest_tool_clone() {
+    #[tokio::test]
+    async fn test_vector_search_mezmo_kb_tool_definition_with_context() {
+        let store = create_test_vector_store(
+            "test",
+            Some("Based on the following information from the knowledge base:".to_string())
+        );
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.name, "vector_search_mezmo_kb");
+        assert!(definition.description.contains("knowledge base"));
+        assert!(definition.description.contains("This vector store contains"));
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_mezmo_runbooks_tool_definition() {
+        let store = create_test_vector_store("runbooks", None);
+        let tool = VectorSearchMezmoRunbooksTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.name, "vector_search_mezmo_runbooks");
+        assert!(definition.description.contains("Search the vector store"));
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_definition_parameters_structure() {
         let store = create_test_vector_store("test", None);
-        let tool = VectorIngestTool::new(store);
-        let _cloned = tool.clone();
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.parameters["type"], "object");
+        let properties = &definition.parameters["properties"];
+        assert!(properties.get("query").is_some());
+        assert!(properties.get("limit").is_some());
+        assert!(properties.get("min_score").is_some());
     }
 
-    #[test]
-    fn test_vector_ingest_tool_name() {
-        assert_eq!(VectorIngestTool::NAME, "vector_ingest");
+    #[tokio::test]
+    async fn test_vector_search_tool_definition_query_parameter() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let query_param = &definition.parameters["properties"]["query"];
+        assert_eq!(query_param["type"], "string");
+        assert!(query_param["description"].as_str().unwrap().contains("text query"));
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_definition_limit_parameter() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let limit_param = &definition.parameters["properties"]["limit"];
+        assert_eq!(limit_param["type"], "integer");
+        assert_eq!(limit_param["default"], 5);
+        assert_eq!(limit_param["minimum"], 1);
+        assert_eq!(limit_param["maximum"], 20);
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_definition_min_score_parameter() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let min_score_param = &definition.parameters["properties"]["min_score"];
+        assert_eq!(min_score_param["type"], "number");
+        assert_eq!(min_score_param["default"], 0.0);
+        assert_eq!(min_score_param["minimum"], 0.0);
+        assert_eq!(min_score_param["maximum"], 1.0);
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_definition_required_fields() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let required = definition.parameters["required"].as_array().unwrap();
+        assert_eq!(required.len(), 3);
+        assert!(required.contains(&json!("query")));
+        assert!(required.contains(&json!("limit")));
+        assert!(required.contains(&json!("min_score")));
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_returns_empty_results() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "test query".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        let response = result.unwrap();
+        assert_eq!(response.query, "test query");
+        assert_eq!(response.total_found, 0);
+        assert_eq!(response.results.len(), 0);
+        assert!(response.formatted_results.contains("No results found"));
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_preserves_query() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "Hello 世界 🎉".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        let response = result.unwrap();
+        assert_eq!(response.query, "Hello 世界 🎉");
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_with_empty_query() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        let response = result.unwrap();
+        assert_eq!(response.query, "");
+        assert_eq!(response.total_found, 0);
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_with_limit_boundaries() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 1,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        let response = result.unwrap();
+        assert_eq!(response.total_found, 0);
+        
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 20,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        let response = result.unwrap();
+        assert_eq!(response.total_found, 0);
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_with_min_score_boundaries() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        let response = result.unwrap();
+        assert_eq!(response.total_found, 0);
+        
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 1.0,
+        };
+        let result = tool.call(args).await;
+        let response = result.unwrap();
+        assert_eq!(response.total_found, 0);
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_with_multiline_query() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "line1\nline2\nline3".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        let response = result.unwrap();
+        assert_eq!(response.query, "line1\nline2\nline3");
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_with_very_long_query() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let long_query = "query ".repeat(1000);
+        let args = VectorSearchArgs {
+            query: long_query.clone(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        let response = result.unwrap();
+        assert_eq!(response.query, long_query);
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_mezmo_runbooks_tool_call() {
+        let store = create_test_vector_store("runbooks", None);
+        let tool = VectorSearchMezmoRunbooksTool::new(store);
+        let args = VectorSearchArgs {
+            query: "runbook query".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        let response = result.unwrap();
+        assert_eq!(response.query, "runbook query");
+        assert_eq!(response.total_found, 0);
     }
 
     #[tokio::test]
@@ -410,7 +506,8 @@ mod tests {
         
         assert_eq!(definition.name, "vector_ingest");
         assert!(definition.description.contains("Ingest documents"));
-        assert!(definition.parameters.get("type").is_some());
+        assert!(definition.description.contains("vector store"));
+        assert!(definition.description.contains("semantic search"));
     }
 
     #[tokio::test]
@@ -419,9 +516,38 @@ mod tests {
         let tool = VectorIngestTool::new(store);
         let definition = tool.definition(String::new()).await;
         
+        assert_eq!(definition.parameters["type"], "object");
         let properties = &definition.parameters["properties"];
         assert!(properties.get("documents").is_some());
         assert_eq!(properties["documents"]["type"], "array");
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_definition_document_schema() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let items = &definition.parameters["properties"]["documents"]["items"];
+        let properties = &items["properties"];
+        assert!(properties.get("id").is_some());
+        assert!(properties.get("content").is_some());
+        assert!(properties.get("metadata").is_some());
+        
+        let required = items["required"].as_array().unwrap();
+        assert_eq!(required.len(), 1);
+        assert!(required.contains(&json!("content")));
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_definition_required_fields() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let required = definition.parameters["required"].as_array().unwrap();
+        assert_eq!(required.len(), 1);
+        assert!(required.contains(&json!("documents")));
     }
 
     #[tokio::test]
@@ -437,7 +563,6 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
         let response = result.unwrap();
         assert_eq!(response.ingested_count, 1);
         assert!(response.success);
@@ -455,9 +580,9 @@ mod tests {
                     metadata: None,
                 },
                 IngestDocument {
-                    id: None,
+                    id: Some("2".to_string()),
                     content: "doc2".to_string(),
-                    metadata: None,
+                    metadata: Some(json!({"type": "article"})),
                 },
                 IngestDocument {
                     id: None,
@@ -468,7 +593,6 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
         let response = result.unwrap();
         assert_eq!(response.ingested_count, 3);
         assert!(response.success);
@@ -483,46 +607,13 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
         let response = result.unwrap();
         assert_eq!(response.ingested_count, 0);
         assert!(response.success);
     }
 
     #[tokio::test]
-    async fn test_vector_ingest_tool_call_with_id() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorIngestTool::new(store);
-        let args = VectorIngestArgs {
-            documents: vec![IngestDocument {
-                id: Some("doc123".to_string()),
-                content: "test content".to_string(),
-                metadata: None,
-            }],
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_vector_ingest_tool_call_with_metadata() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorIngestTool::new(store);
-        let args = VectorIngestArgs {
-            documents: vec![IngestDocument {
-                id: None,
-                content: "test content".to_string(),
-                metadata: Some(json!({"type": "article"})),
-            }],
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_vector_ingest_tool_call_empty_content() {
+    async fn test_vector_ingest_tool_call_with_empty_content() {
         let store = create_test_vector_store("test", None);
         let tool = VectorIngestTool::new(store);
         let args = VectorIngestArgs {
@@ -534,11 +625,13 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.ingested_count, 1);
+        assert!(response.success);
     }
 
     #[tokio::test]
-    async fn test_vector_ingest_tool_call_unicode_content() {
+    async fn test_vector_ingest_tool_call_with_unicode_content() {
         let store = create_test_vector_store("test", None);
         let tool = VectorIngestTool::new(store);
         let args = VectorIngestArgs {
@@ -550,11 +643,13 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.ingested_count, 1);
+        assert!(response.success);
     }
 
     #[tokio::test]
-    async fn test_vector_ingest_tool_call_multiline_content() {
+    async fn test_vector_ingest_tool_call_with_multiline_content() {
         let store = create_test_vector_store("test", None);
         let tool = VectorIngestTool::new(store);
         let args = VectorIngestArgs {
@@ -566,11 +661,13 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.ingested_count, 1);
+        assert!(response.success);
     }
 
     #[tokio::test]
-    async fn test_vector_ingest_tool_call_large_document() {
+    async fn test_vector_ingest_tool_call_with_large_document() {
         let store = create_test_vector_store("test", None);
         let tool = VectorIngestTool::new(store);
         let large_content = "a".repeat(100000);
@@ -583,64 +680,269 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.ingested_count, 1);
+        assert!(response.success);
     }
 
     #[tokio::test]
-    async fn test_vector_ingest_tool_call_many_documents() {
+    async fn test_vector_ingest_tool_call_with_many_documents() {
         let store = create_test_vector_store("test", None);
         let tool = VectorIngestTool::new(store);
         let documents: Vec<IngestDocument> = (0..100)
             .map(|i| IngestDocument {
                 id: Some(format!("doc{}", i)),
                 content: format!("content {}", i),
-                metadata: None,
+                metadata: Some(json!({"index": i})),
             })
             .collect();
         let args = VectorIngestArgs { documents };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
         let response = result.unwrap();
         assert_eq!(response.ingested_count, 100);
+        assert!(response.success);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_load_from_json_nonexistent_file() {
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let result = auto_ingest.load_from_json("/nonexistent/file.json").await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, crate::error::BuilderError::VectorStoreError(_)));
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("Failed to read file"));
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_load_from_json_invalid_json() {
+        let temp_dir = create_temp_dir();
+        let file_path = temp_dir.path().join("invalid.json");
+        fs::write(&file_path, "not valid json").unwrap();
+        
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let result = auto_ingest.load_from_json(file_path.to_str().unwrap()).await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, crate::error::BuilderError::VectorStoreError(_)));
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("Failed to parse JSON"));
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_load_from_json_valid_documents() {
+        let temp_dir = create_temp_dir();
+        let file_path = temp_dir.path().join("docs.json");
+        let json_content = r#"[
+            {"content": "document 1"},
+            {"content": "document 2"},
+            {"content": "document 3"}
+        ]"#;
+        fs::write(&file_path, json_content).unwrap();
+        
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let result = auto_ingest.load_from_json(file_path.to_str().unwrap()).await;
+        
+        let count = result.unwrap();
+        assert_eq!(count, 3);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_load_from_json_documents_without_content_field() {
+        let temp_dir = create_temp_dir();
+        let file_path = temp_dir.path().join("docs.json");
+        let json_content = r#"[
+            {"text": "document 1"},
+            {"data": "document 2"}
+        ]"#;
+        fs::write(&file_path, json_content).unwrap();
+        
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let result = auto_ingest.load_from_json(file_path.to_str().unwrap()).await;
+        
+        let count = result.unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_load_from_json_empty_array() {
+        let temp_dir = create_temp_dir();
+        let file_path = temp_dir.path().join("empty.json");
+        fs::write(&file_path, "[]").unwrap();
+        
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let result = auto_ingest.load_from_json(file_path.to_str().unwrap()).await;
+        
+        let count = result.unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_auto_load_empty_sources() {
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let result = auto_ingest.auto_load(&[]).await;
+        
+        let count = result.unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_auto_load_unsupported_format() {
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let sources = vec!["file.txt".to_string(), "file.csv".to_string()];
+        let result = auto_ingest.auto_load(&sources).await;
+        
+        let count = result.unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_auto_load_nonexistent_json() {
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let sources = vec!["/nonexistent/file.json".to_string()];
+        let result = auto_ingest.auto_load(&sources).await;
+        
+        let count = result.unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_auto_load_valid_json_file() {
+        let temp_dir = create_temp_dir();
+        let file_path = temp_dir.path().join("docs.json");
+        let json_content = r#"[
+            {"content": "doc1"},
+            {"content": "doc2"}
+        ]"#;
+        fs::write(&file_path, json_content).unwrap();
+        
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let sources = vec![file_path.to_str().unwrap().to_string()];
+        let result = auto_ingest.auto_load(&sources).await;
+        
+        let count = result.unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_auto_load_multiple_json_files() {
+        let temp_dir = create_temp_dir();
+        
+        let file1 = temp_dir.path().join("docs1.json");
+        fs::write(&file1, r#"[{"content": "doc1"}]"#).unwrap();
+        
+        let file2 = temp_dir.path().join("docs2.json");
+        fs::write(&file2, r#"[{"content": "doc2"}, {"content": "doc3"}]"#).unwrap();
+        
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let sources = vec![
+            file1.to_str().unwrap().to_string(),
+            file2.to_str().unwrap().to_string(),
+        ];
+        let result = auto_ingest.auto_load(&sources).await;
+        
+        let count = result.unwrap();
+        assert_eq!(count, 3);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_auto_load_mixed_valid_and_invalid() {
+        let temp_dir = create_temp_dir();
+        
+        let valid_file = temp_dir.path().join("valid.json");
+        fs::write(&valid_file, r#"[{"content": "doc1"}]"#).unwrap();
+        
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let sources = vec![
+            valid_file.to_str().unwrap().to_string(),
+            "/nonexistent/file.json".to_string(),
+            "unsupported.txt".to_string(),
+        ];
+        let result = auto_ingest.auto_load(&sources).await;
+        
+        let count = result.unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_load_from_json_with_unicode() {
+        let temp_dir = create_temp_dir();
+        let file_path = temp_dir.path().join("unicode.json");
+        let json_content = r#"[
+            {"content": "Hello 世界"},
+            {"content": "🎉 emoji test"}
+        ]"#;
+        fs::write(&file_path, json_content).unwrap();
+        
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let result = auto_ingest.load_from_json(file_path.to_str().unwrap()).await;
+        
+        let count = result.unwrap();
+        assert_eq!(count, 2);
     }
 
     #[test]
-    fn test_ingest_document_serde() {
-        let doc = IngestDocument {
-            id: Some("123".to_string()),
-            content: "test".to_string(),
-            metadata: Some(json!({"key": "value"})),
+    fn test_vector_search_args_debug() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
         };
-        let json = serde_json::to_string(&doc).unwrap();
-        let deserialized: IngestDocument = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.id, Some("123".to_string()));
-        assert_eq!(deserialized.content, "test");
+        let debug_str = format!("{:?}", args);
+        assert!(debug_str.contains("VectorSearchArgs"));
+        assert!(debug_str.contains("test"));
+        assert!(debug_str.contains("5"));
+    }
+
+    #[test]
+    fn test_vector_search_response_debug() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test".to_string(),
+            total_found: 0,
+            formatted_results: "No results".to_string(),
+        };
+        let debug_str = format!("{:?}", response);
+        assert!(debug_str.contains("VectorSearchResponse"));
+        assert!(debug_str.contains("test"));
+    }
+
+    #[test]
+    fn test_vector_search_result_debug() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: None,
+        };
+        let debug_str = format!("{:?}", result);
+        assert!(debug_str.contains("VectorSearchResult"));
+        assert!(debug_str.contains("test"));
     }
 
     #[test]
     fn test_ingest_document_debug() {
         let doc = IngestDocument {
-            id: None,
+            id: Some("123".to_string()),
             content: "test".to_string(),
             metadata: None,
         };
         let debug_str = format!("{:?}", doc);
         assert!(debug_str.contains("IngestDocument"));
-    }
-
-    #[test]
-    fn test_vector_ingest_args_serde() {
-        let args = VectorIngestArgs {
-            documents: vec![IngestDocument {
-                id: None,
-                content: "test".to_string(),
-                metadata: None,
-            }],
-        };
-        let json = serde_json::to_string(&args).unwrap();
-        let deserialized: VectorIngestArgs = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.documents.len(), 1);
+        assert!(debug_str.contains("123"));
+        assert!(debug_str.contains("test"));
     }
 
     #[test]
@@ -653,200 +955,38 @@ mod tests {
     }
 
     #[test]
-    fn test_vector_ingest_response_serde() {
+    fn test_vector_ingest_response_debug() {
         let response = VectorIngestResponse {
             ingested_count: 5,
             success: true,
         };
-        let json = serde_json::to_string(&response).unwrap();
-        assert!(json.contains("5"));
-        assert!(json.contains("true"));
-    }
-
-    #[test]
-    fn test_vector_ingest_response_debug() {
-        let response = VectorIngestResponse {
-            ingested_count: 0,
-            success: true,
-        };
         let debug_str = format!("{:?}", response);
         assert!(debug_str.contains("VectorIngestResponse"));
+        assert!(debug_str.contains("5"));
     }
 
     #[test]
-    fn test_vector_ingest_response_failure() {
-        let response = VectorIngestResponse {
-            ingested_count: 0,
-            success: false,
-        };
-        assert!(!response.success);
-    }
-
-    #[test]
-    fn test_auto_ingest_new() {
-        let store = create_test_vector_store("test", None);
-        let _auto_ingest = AutoIngest::new(store);
-    }
-
-    #[tokio::test]
-    async fn test_auto_ingest_load_from_json_nonexistent_file() {
-        let store = create_test_vector_store("test", None);
-        let auto_ingest = AutoIngest::new(store);
-        let result = auto_ingest.load_from_json("/nonexistent/file.json").await;
-        
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_auto_ingest_auto_load_empty_sources() {
-        let store = create_test_vector_store("test", None);
-        let auto_ingest = AutoIngest::new(store);
-        let result = auto_ingest.auto_load(&[]).await;
-        
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_auto_ingest_auto_load_unsupported_format() {
-        let store = create_test_vector_store("test", None);
-        let auto_ingest = AutoIngest::new(store);
-        let sources = vec!["file.txt".to_string()];
-        let result = auto_ingest.auto_load(&sources).await;
-        
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_auto_ingest_auto_load_nonexistent_json() {
-        let store = create_test_vector_store("test", None);
-        let auto_ingest = AutoIngest::new(store);
-        let sources = vec!["/nonexistent/file.json".to_string()];
-        let result = auto_ingest.auto_load(&sources).await;
-        
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_auto_ingest_auto_load_multiple_unsupported() {
-        let store = create_test_vector_store("test", None);
-        let auto_ingest = AutoIngest::new(store);
-        let sources = vec![
-            "file1.txt".to_string(),
-            "file2.csv".to_string(),
-            "file3.xml".to_string(),
-        ];
-        let result = auto_ingest.auto_load(&sources).await;
-        
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 0);
-    }
-
-    #[test]
-    fn test_vector_search_args_empty_query() {
-        let args = VectorSearchArgs {
-            query: "".to_string(),
-            limit: 5,
-            min_score: 0.0,
-        };
-        assert_eq!(args.query, "");
-    }
-
-    #[test]
-    fn test_vector_search_args_limit_one() {
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 1,
-            min_score: 0.0,
-        };
-        assert_eq!(args.limit, 1);
-    }
-
-    #[test]
-    fn test_vector_search_args_limit_twenty() {
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 20,
-            min_score: 0.0,
-        };
-        assert_eq!(args.limit, 20);
-    }
-
-    #[test]
-    fn test_vector_search_args_min_score_boundary() {
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 5,
-            min_score: 0.5,
-        };
-        assert_eq!(args.min_score, 0.5);
-    }
-
-    #[test]
-    fn test_vector_search_response_empty_results() {
-        let response = VectorSearchResponse {
-            results: vec![],
-            query: "test".to_string(),
-            total_found: 0,
-            formatted_results: "No results".to_string(),
-        };
-        assert_eq!(response.results.len(), 0);
-        assert_eq!(response.total_found, 0);
-    }
-
-    #[test]
-    fn test_vector_search_response_with_results() {
-        let response = VectorSearchResponse {
-            results: vec![
-                VectorSearchResult {
-                    content: "result1".to_string(),
-                    score: 0.9,
-                    metadata: None,
-                },
-                VectorSearchResult {
-                    content: "result2".to_string(),
-                    score: 0.8,
-                    metadata: None,
-                },
-            ],
-            query: "test".to_string(),
-            total_found: 2,
-            formatted_results: "Results".to_string(),
-        };
-        assert_eq!(response.results.len(), 2);
-        assert_eq!(response.total_found, 2);
-    }
-
-    #[test]
-    fn test_vector_search_result_zero_score() {
-        let result = VectorSearchResult {
+    fn test_vector_search_result_score_boundaries() {
+        let result_zero = VectorSearchResult {
             content: "test".to_string(),
             score: 0.0,
             metadata: None,
         };
-        assert_eq!(result.score, 0.0);
-    }
-
-    #[test]
-    fn test_vector_search_result_max_score() {
-        let result = VectorSearchResult {
+        assert_eq!(result_zero.score, 0.0);
+        
+        let result_one = VectorSearchResult {
             content: "test".to_string(),
             score: 1.0,
             metadata: None,
         };
-        assert_eq!(result.score, 1.0);
-    }
-
-    #[test]
-    fn test_vector_search_result_negative_score() {
-        let result = VectorSearchResult {
+        assert_eq!(result_one.score, 1.0);
+        
+        let result_negative = VectorSearchResult {
             content: "test".to_string(),
             score: -0.5,
             metadata: None,
         };
-        assert_eq!(result.score, -0.5);
+        assert_eq!(result_negative.score, -0.5);
     }
 
     #[test]
@@ -860,127 +1000,49 @@ mod tests {
     }
 
     #[test]
-    fn test_vector_search_result_unicode_content() {
-        let result = VectorSearchResult {
-            content: "Hello 世界 🎉".to_string(),
-            score: 0.5,
-            metadata: None,
-        };
-        assert_eq!(result.content, "Hello 世界 🎉");
-    }
-
-    #[test]
-    fn test_vector_search_result_multiline_content() {
-        let result = VectorSearchResult {
-            content: "line1\nline2\nline3".to_string(),
-            score: 0.5,
-            metadata: None,
-        };
-        assert_eq!(result.content, "line1\nline2\nline3");
-    }
-
-    #[test]
-    fn test_vector_search_result_metadata_complex() {
-        let metadata = json!({
-            "id": "123",
-            "type": "document",
-            "tags": ["rust", "test"],
-            "nested": {"key": "value"}
-        });
-        let result = VectorSearchResult {
+    fn test_vector_search_result_metadata_types() {
+        let result_null = VectorSearchResult {
             content: "test".to_string(),
             score: 0.5,
-            metadata: Some(metadata.clone()),
-        };
-        assert_eq!(result.metadata, Some(metadata));
-    }
-
-    #[test]
-    fn test_ingest_document_empty_id() {
-        let doc = IngestDocument {
-            id: Some("".to_string()),
-            content: "test".to_string(),
-            metadata: None,
-        };
-        assert_eq!(doc.id, Some("".to_string()));
-    }
-
-    #[test]
-    fn test_ingest_document_empty_content() {
-        let doc = IngestDocument {
-            id: None,
-            content: "".to_string(),
-            metadata: None,
-        };
-        assert_eq!(doc.content, "");
-    }
-
-    #[test]
-    fn test_ingest_document_metadata_empty_object() {
-        let doc = IngestDocument {
-            id: None,
-            content: "test".to_string(),
-            metadata: Some(json!({})),
-        };
-        assert!(doc.metadata.is_some());
-    }
-
-    #[test]
-    fn test_ingest_document_metadata_null() {
-        let doc = IngestDocument {
-            id: None,
-            content: "test".to_string(),
             metadata: Some(json!(null)),
         };
-        assert!(doc.metadata.is_some());
-    }
-
-    #[test]
-    fn test_ingest_document_metadata_array() {
-        let doc = IngestDocument {
-            id: None,
+        assert!(result_null.metadata.is_some());
+        assert!(result_null.metadata.unwrap().is_null());
+        
+        let result_array = VectorSearchResult {
             content: "test".to_string(),
+            score: 0.5,
             metadata: Some(json!(["tag1", "tag2"])),
         };
-        assert!(doc.metadata.is_some());
-    }
-
-    #[test]
-    fn test_ingest_document_metadata_string() {
-        let doc = IngestDocument {
-            id: None,
+        assert!(result_array.metadata.unwrap().is_array());
+        
+        let result_string = VectorSearchResult {
             content: "test".to_string(),
+            score: 0.5,
             metadata: Some(json!("metadata string")),
         };
-        assert!(doc.metadata.is_some());
+        assert!(result_string.metadata.unwrap().is_string());
     }
 
     #[test]
-    fn test_ingest_document_metadata_number() {
+    fn test_ingest_document_empty_values() {
         let doc = IngestDocument {
-            id: None,
-            content: "test".to_string(),
-            metadata: Some(json!(42)),
+            id: Some("".to_string()),
+            content: "".to_string(),
+            metadata: Some(json!({})),
         };
+        assert_eq!(doc.id, Some("".to_string()));
+        assert_eq!(doc.content, "");
         assert!(doc.metadata.is_some());
     }
 
     #[test]
-    fn test_ingest_document_metadata_boolean() {
-        let doc = IngestDocument {
-            id: None,
-            content: "test".to_string(),
-            metadata: Some(json!(true)),
-        };
-        assert!(doc.metadata.is_some());
-    }
-
-    #[test]
-    fn test_vector_ingest_response_zero_count() {
+    fn test_vector_ingest_response_failure() {
         let response = VectorIngestResponse {
             ingested_count: 0,
-            success: true,
+            success: false,
         };
+        assert!(!response.success);
         assert_eq!(response.ingested_count, 0);
     }
 
@@ -991,87 +1053,27 @@ mod tests {
             success: true,
         };
         assert_eq!(response.ingested_count, 1000000);
+        assert!(response.success);
     }
 
     #[test]
-    fn test_vector_search_response_formatted_results_empty() {
+    fn test_vector_search_response_total_found_mismatch() {
         let response = VectorSearchResponse {
-            results: vec![],
+            results: vec![VectorSearchResult {
+                content: "test".to_string(),
+                score: 0.5,
+                metadata: None,
+            }],
             query: "test".to_string(),
-            total_found: 0,
-            formatted_results: "".to_string(),
+            total_found: 5,
+            formatted_results: "Results".to_string(),
         };
-        assert_eq!(response.formatted_results, "");
+        assert_eq!(response.results.len(), 1);
+        assert_eq!(response.total_found, 5);
     }
 
     #[test]
-    fn test_vector_search_response_formatted_results_multiline() {
-        let response = VectorSearchResponse {
-            results: vec![],
-            query: "test".to_string(),
-            total_found: 0,
-            formatted_results: "line1\nline2\nline3".to_string(),
-        };
-        assert!(response.formatted_results.contains("\n"));
-    }
-
-    #[test]
-    fn test_vector_search_response_query_unicode() {
-        let response = VectorSearchResponse {
-            results: vec![],
-            query: "世界".to_string(),
-            total_found: 0,
-            formatted_results: "".to_string(),
-        };
-        assert_eq!(response.query, "世界");
-    }
-
-    #[test]
-    fn test_vector_search_response_query_empty() {
-        let response = VectorSearchResponse {
-            results: vec![],
-            query: "".to_string(),
-            total_found: 0,
-            formatted_results: "".to_string(),
-        };
-        assert_eq!(response.query, "");
-    }
-
-    #[test]
-    fn test_vector_search_result_very_long_content() {
-        let content = "a".repeat(100000);
-        let result = VectorSearchResult {
-            content: content.clone(),
-            score: 0.5,
-            metadata: None,
-        };
-        assert_eq!(result.content.len(), 100000);
-    }
-
-    #[test]
-    fn test_ingest_document_very_long_content() {
-        let content = "b".repeat(100000);
-        let doc = IngestDocument {
-            id: None,
-            content: content.clone(),
-            metadata: None,
-        };
-        assert_eq!(doc.content.len(), 100000);
-    }
-
-    #[test]
-    fn test_ingest_document_very_long_id() {
-        let id = "x".repeat(10000);
-        let doc = IngestDocument {
-            id: Some(id.clone()),
-            content: "test".to_string(),
-            metadata: None,
-        };
-        assert_eq!(doc.id.unwrap().len(), 10000);
-    }
-
-    #[test]
-    fn test_vector_search_args_special_characters_in_query() {
+    fn test_vector_search_args_special_characters() {
         let args = VectorSearchArgs {
             query: "!@#$%^&*()".to_string(),
             limit: 5,
@@ -1081,23 +1083,14 @@ mod tests {
     }
 
     #[test]
-    fn test_ingest_document_special_characters_in_content() {
+    fn test_ingest_document_special_characters() {
         let doc = IngestDocument {
-            id: None,
+            id: Some("id-with_special.chars!".to_string()),
             content: "!@#$%^&*()".to_string(),
             metadata: None,
         };
-        assert_eq!(doc.content, "!@#$%^&*()");
-    }
-
-    #[test]
-    fn test_ingest_document_special_characters_in_id() {
-        let doc = IngestDocument {
-            id: Some("id-with_special.chars!".to_string()),
-            content: "test".to_string(),
-            metadata: None,
-        };
         assert_eq!(doc.id, Some("id-with_special.chars!".to_string()));
+        assert_eq!(doc.content, "!@#$%^&*()");
     }
 
     #[test]
@@ -1109,17 +1102,6 @@ mod tests {
         };
         assert!(args.query.contains("\t"));
         assert!(args.query.contains("\n"));
-    }
-
-    #[test]
-    fn test_ingest_document_tabs_and_newlines() {
-        let doc = IngestDocument {
-            id: None,
-            content: "line1\tcolumn2\nline2".to_string(),
-            metadata: None,
-        };
-        assert!(doc.content.contains("\t"));
-        assert!(doc.content.contains("\n"));
     }
 
     #[test]
@@ -1142,269 +1124,104 @@ mod tests {
         assert_eq!(result.score, 0.987654321);
     }
 
+    #[test]
+    fn test_ingest_document_very_long_values() {
+        let long_id = "x".repeat(10000);
+        let long_content = "a".repeat(100000);
+        let doc = IngestDocument {
+            id: Some(long_id.clone()),
+            content: long_content.clone(),
+            metadata: None,
+        };
+        assert_eq!(doc.id.unwrap().len(), 10000);
+        assert_eq!(doc.content.len(), 100000);
+    }
+
     #[tokio::test]
-    async fn test_vector_search_tool_definition_limit_constraints() {
-        let store = create_test_vector_store("test", None);
+    async fn test_vector_search_tool_definition_context_prefix_formatting() {
+        let store = create_test_vector_store(
+            "test",
+            Some("Based on the following information from the runbooks:".to_string())
+        );
         let tool = VectorSearchMezmoKbTool::new(store);
         let definition = tool.definition(String::new()).await;
         
-        let limit_props = &definition.parameters["properties"]["limit"];
-        assert_eq!(limit_props["minimum"], 1);
-        assert_eq!(limit_props["maximum"], 20);
-        assert_eq!(limit_props["default"], 5);
+        assert!(definition.description.contains("runbooks"));
+        assert!(!definition.description.contains("Based on the following information from the"));
     }
 
     #[tokio::test]
-    async fn test_vector_search_tool_definition_min_score_constraints() {
+    async fn test_vector_search_tool_call_with_zero_limit() {
         let store = create_test_vector_store("test", None);
         let tool = VectorSearchMezmoKbTool::new(store);
-        let definition = tool.definition(String::new()).await;
-        
-        let min_score_props = &definition.parameters["properties"]["min_score"];
-        assert_eq!(min_score_props["minimum"], 0.0);
-        assert_eq!(min_score_props["maximum"], 1.0);
-        assert_eq!(min_score_props["default"], 0.0);
-    }
-
-    #[tokio::test]
-    async fn test_vector_ingest_tool_definition_required_fields() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorIngestTool::new(store);
-        let definition = tool.definition(String::new()).await;
-        
-        let required = definition.parameters["required"].as_array().unwrap();
-        assert!(required.contains(&json!("documents")));
-    }
-
-    #[tokio::test]
-    async fn test_vector_ingest_tool_definition_document_schema() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorIngestTool::new(store);
-        let definition = tool.definition(String::new()).await;
-        
-        let items = &definition.parameters["properties"]["documents"]["items"];
-        let properties = &items["properties"];
-        assert!(properties.get("id").is_some());
-        assert!(properties.get("content").is_some());
-        assert!(properties.get("metadata").is_some());
-        
-        let required = items["required"].as_array().unwrap();
-        assert!(required.contains(&json!("content")));
-    }
-
-    #[test]
-    fn test_vector_search_args_serde_with_defaults() {
-        let json = r#"{"query":"test query"}"#;
-        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
-        assert_eq!(args.query, "test query");
-        assert_eq!(args.limit, 5);
-        assert_eq!(args.min_score, 0.0);
-    }
-
-    #[test]
-    fn test_vector_search_args_serde_all_fields() {
-        let json = r#"{"query":"test","limit":10,"min_score":0.7}"#;
-        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
-        assert_eq!(args.query, "test");
-        assert_eq!(args.limit, 10);
-        assert_eq!(args.min_score, 0.7);
-    }
-
-    #[test]
-    fn test_ingest_document_serde_minimal() {
-        let json = r#"{"content":"test content"}"#;
-        let doc: IngestDocument = serde_json::from_str(json).unwrap();
-        assert_eq!(doc.content, "test content");
-        assert!(doc.id.is_none());
-        assert!(doc.metadata.is_none());
-    }
-
-    #[test]
-    fn test_ingest_document_serde_all_fields() {
-        let json = r#"{"id":"123","content":"test","metadata":{"key":"value"}}"#;
-        let doc: IngestDocument = serde_json::from_str(json).unwrap();
-        assert_eq!(doc.id, Some("123".to_string()));
-        assert_eq!(doc.content, "test");
-        assert!(doc.metadata.is_some());
-    }
-
-    #[test]
-    fn test_vector_ingest_args_serde_empty_documents() {
-        let json = r#"{"documents":[]}"#;
-        let args: VectorIngestArgs = serde_json::from_str(json).unwrap();
-        assert_eq!(args.documents.len(), 0);
-    }
-
-    #[test]
-    fn test_vector_ingest_args_serde_multiple_documents() {
-        let json = r#"{"documents":[{"content":"doc1"},{"content":"doc2"}]}"#;
-        let args: VectorIngestArgs = serde_json::from_str(json).unwrap();
-        assert_eq!(args.documents.len(), 2);
-        assert_eq!(args.documents[0].content, "doc1");
-        assert_eq!(args.documents[1].content, "doc2");
-    }
-
-    #[test]
-    fn test_vector_search_response_serde_with_results() {
-        let response = VectorSearchResponse {
-            results: vec![VectorSearchResult {
-                content: "test".to_string(),
-                score: 0.9,
-                metadata: Some(json!({"id": "123"})),
-            }],
-            query: "test query".to_string(),
-            total_found: 1,
-            formatted_results: "Result 1".to_string(),
-        };
-        let json = serde_json::to_string(&response).unwrap();
-        assert!(json.contains("test"));
-        assert!(json.contains("0.9"));
-    }
-
-    #[test]
-    fn test_vector_ingest_response_serde_success_false() {
-        let response = VectorIngestResponse {
-            ingested_count: 0,
-            success: false,
-        };
-        let json = serde_json::to_string(&response).unwrap();
-        assert!(json.contains("false"));
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_limit_boundary_values() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        
         let args = VectorSearchArgs {
             query: "test".to_string(),
-            limit: 1,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        assert!(result.is_ok());
-        
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 20,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_min_score_boundary_values() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 5,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        assert!(result.is_ok());
-        
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 5,
-            min_score: 1.0,
-        };
-        let result = tool.call(args).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_mezmo_runbooks_tool_call() {
-        let store = create_test_vector_store("runbooks", None);
-        let tool = VectorSearchMezmoRunbooksTool::new(store);
-        let args = VectorSearchArgs {
-            query: "test query".to_string(),
-            limit: 5,
+            limit: 0,
             min_score: 0.0,
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
         let response = result.unwrap();
-        assert_eq!(response.query, "test query");
-    }
-
-    #[tokio::test]
-    async fn test_vector_search_tool_call_response_structure() {
-        let store = create_test_vector_store("test", None);
-        let tool = VectorSearchMezmoKbTool::new(store);
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 5,
-            min_score: 0.0,
-        };
-        let result = tool.call(args).await;
-        
-        assert!(result.is_ok());
-        let response = result.unwrap();
-        assert_eq!(response.query, "test");
         assert_eq!(response.total_found, 0);
-        assert!(response.results.is_empty());
-        assert!(!response.formatted_results.is_empty());
     }
 
     #[tokio::test]
-    async fn test_vector_ingest_tool_call_response_structure() {
+    async fn test_vector_ingest_tool_call_documents_with_all_fields() {
         let store = create_test_vector_store("test", None);
         let tool = VectorIngestTool::new(store);
         let args = VectorIngestArgs {
-            documents: vec![IngestDocument {
-                id: None,
-                content: "test".to_string(),
-                metadata: None,
-            }],
+            documents: vec![
+                IngestDocument {
+                    id: Some("doc-1".to_string()),
+                    content: "content 1".to_string(),
+                    metadata: Some(json!({"type": "article", "tags": ["rust"]})),
+                },
+                IngestDocument {
+                    id: Some("doc-2".to_string()),
+                    content: "content 2".to_string(),
+                    metadata: Some(json!({"type": "blog"})),
+                },
+            ],
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
         let response = result.unwrap();
-        assert_eq!(response.ingested_count, 1);
+        assert_eq!(response.ingested_count, 2);
         assert!(response.success);
     }
 
-    #[test]
-    fn test_vector_search_result_metadata_null_value() {
-        let result = VectorSearchResult {
-            content: "test".to_string(),
-            score: 0.5,
-            metadata: Some(json!(null)),
-        };
-        assert!(result.metadata.is_some());
-        assert!(result.metadata.unwrap().is_null());
+    #[tokio::test]
+    async fn test_auto_ingest_load_from_json_not_array() {
+        let temp_dir = create_temp_dir();
+        let file_path = temp_dir.path().join("object.json");
+        fs::write(&file_path, r#"{"content": "single doc"}"#).unwrap();
+        
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let result = auto_ingest.load_from_json(file_path.to_str().unwrap()).await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, crate::error::BuilderError::VectorStoreError(_)));
     }
 
-    #[test]
-    fn test_ingest_document_with_all_fields() {
-        let doc = IngestDocument {
-            id: Some("doc-123".to_string()),
-            content: "test content".to_string(),
-            metadata: Some(json!({"type": "article", "tags": ["rust"]})),
-        };
-        assert_eq!(doc.id, Some("doc-123".to_string()));
-        assert_eq!(doc.content, "test content");
-        assert!(doc.metadata.is_some());
-    }
-
-    #[test]
-    fn test_vector_search_response_total_found_mismatch() {
-        let response = VectorSearchResponse {
-            results: vec![VectorSearchResult {
-                content: "test".to_string(),
-                score: 0.5,
-                metadata: None,
-            }],
-            query: "test".to_string(),
-            total_found: 5,
-            formatted_results: "Results".to_string(),
-        };
-        assert_eq!(response.results.len(), 1);
-        assert_eq!(response.total_found, 5);
+    #[tokio::test]
+    async fn test_auto_ingest_auto_load_only_json_files_processed() {
+        let temp_dir = create_temp_dir();
+        
+        let json_file = temp_dir.path().join("docs.json");
+        fs::write(&json_file, r#"[{"content": "doc1"}]"#).unwrap();
+        
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let sources = vec![
+            json_file.to_str().unwrap().to_string(),
+            "file.txt".to_string(),
+            "file.xml".to_string(),
+            "file.yaml".to_string(),
+        ];
+        let result = auto_ingest.auto_load(&sources).await;
+        
+        let count = result.unwrap();
+        assert_eq!(count, 1);
     }
 }

--- a/crates/aura/src/rag_tools_tests.rs
+++ b/crates/aura/src/rag_tools_tests.rs
@@ -1,0 +1,1410 @@
+#[cfg(test)]
+mod tests {
+    use crate::rag_tools::*;
+    use crate::vector_store::VectorStoreManager;
+    use rig::tool::Tool;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    fn create_test_vector_store(name: &str, context_prefix: Option<String>) -> Arc<VectorStoreManager> {
+        Arc::new(VectorStoreManager::new_stub(name, context_prefix))
+    }
+
+    #[test]
+    fn test_vector_search_mezmo_kb_tool_new() {
+        let store = create_test_vector_store("test", None);
+        let _tool = VectorSearchMezmoKbTool::new(store);
+    }
+
+    #[test]
+    fn test_vector_search_mezmo_runbooks_tool_new() {
+        let store = create_test_vector_store("test", None);
+        let _tool = VectorSearchMezmoRunbooksTool::new(store);
+    }
+
+    #[test]
+    fn test_vector_search_mezmo_kb_tool_clone() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let _cloned = tool.clone();
+    }
+
+    #[test]
+    fn test_vector_search_mezmo_runbooks_tool_clone() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoRunbooksTool::new(store);
+        let _cloned = tool.clone();
+    }
+
+    #[test]
+    fn test_vector_search_mezmo_kb_tool_name() {
+        assert_eq!(VectorSearchMezmoKbTool::NAME, "vector_search_mezmo_kb");
+    }
+
+    #[test]
+    fn test_vector_search_mezmo_runbooks_tool_name() {
+        assert_eq!(VectorSearchMezmoRunbooksTool::NAME, "vector_search_mezmo_runbooks");
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_mezmo_kb_tool_definition() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.name, "vector_search_mezmo_kb");
+        assert!(definition.description.contains("Search the vector store"));
+        assert!(definition.parameters.get("type").is_some());
+        assert_eq!(definition.parameters["type"], "object");
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_mezmo_runbooks_tool_definition() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoRunbooksTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.name, "vector_search_mezmo_runbooks");
+        assert!(definition.description.contains("Search the vector store"));
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_definition_with_context_prefix() {
+        let store = create_test_vector_store("test", Some("Based on the following information from the knowledge base:".to_string()));
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        assert!(definition.description.contains("knowledge base"));
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_definition_without_context_prefix() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        assert!(definition.description.contains("Search the vector store"));
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_definition_parameters() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let properties = &definition.parameters["properties"];
+        assert!(properties.get("query").is_some());
+        assert!(properties.get("limit").is_some());
+        assert!(properties.get("min_score").is_some());
+        
+        assert_eq!(properties["query"]["type"], "string");
+        assert_eq!(properties["limit"]["type"], "integer");
+        assert_eq!(properties["min_score"]["type"], "number");
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_definition_required_fields() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let required = definition.parameters["required"].as_array().unwrap();
+        assert!(required.contains(&json!("query")));
+        assert!(required.contains(&json!("limit")));
+        assert!(required.contains(&json!("min_score")));
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_empty_results() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "test query".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.results.len(), 0);
+        assert_eq!(response.query, "test query");
+        assert_eq!(response.total_found, 0);
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_with_limit() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 10,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_with_min_score() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_empty_query() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_zero_limit() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 0,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_max_limit() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 20,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_min_score_zero() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_min_score_one() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 1.0,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_unicode_query() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "Hello 世界 🎉".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.query, "Hello 世界 🎉");
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_multiline_query() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "line1\nline2\nline3".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_very_long_query() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let long_query = "query ".repeat(1000);
+        let args = VectorSearchArgs {
+            query: long_query.clone(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.query, long_query);
+    }
+
+    #[test]
+    fn test_vector_search_args_serde() {
+        let args = VectorSearchArgs {
+            query: "test query".to_string(),
+            limit: 10,
+            min_score: 0.5,
+        };
+        let json = serde_json::to_string(&args).unwrap();
+        let deserialized: VectorSearchArgs = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.query, "test query");
+        assert_eq!(deserialized.limit, 10);
+        assert_eq!(deserialized.min_score, 0.5);
+    }
+
+    #[test]
+    fn test_vector_search_args_default_limit() {
+        let json = r#"{"query":"test"}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.limit, 5);
+        assert_eq!(args.min_score, 0.0);
+    }
+
+    #[test]
+    fn test_vector_search_args_default_min_score() {
+        let json = r#"{"query":"test","limit":10}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.min_score, 0.0);
+    }
+
+    #[test]
+    fn test_vector_search_args_debug() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let debug_str = format!("{:?}", args);
+        assert!(debug_str.contains("VectorSearchArgs"));
+        assert!(debug_str.contains("test"));
+    }
+
+    #[test]
+    fn test_vector_search_response_serde() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test".to_string(),
+            total_found: 0,
+            formatted_results: "No results".to_string(),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("test"));
+    }
+
+    #[test]
+    fn test_vector_search_response_debug() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test".to_string(),
+            total_found: 0,
+            formatted_results: "No results".to_string(),
+        };
+        let debug_str = format!("{:?}", response);
+        assert!(debug_str.contains("VectorSearchResponse"));
+    }
+
+    #[test]
+    fn test_vector_search_result_serde() {
+        let result = VectorSearchResult {
+            content: "test content".to_string(),
+            score: 0.95,
+            metadata: Some(json!({"id": "123"})),
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("test content"));
+    }
+
+    #[test]
+    fn test_vector_search_result_debug() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: None,
+        };
+        let debug_str = format!("{:?}", result);
+        assert!(debug_str.contains("VectorSearchResult"));
+    }
+
+    #[test]
+    fn test_vector_search_result_without_metadata() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: None,
+        };
+        assert!(result.metadata.is_none());
+    }
+
+    #[test]
+    fn test_vector_search_result_with_metadata() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!({"key": "value"})),
+        };
+        assert!(result.metadata.is_some());
+    }
+
+    #[test]
+    fn test_vector_ingest_tool_new() {
+        let store = create_test_vector_store("test", None);
+        let _tool = VectorIngestTool::new(store);
+    }
+
+    #[test]
+    fn test_vector_ingest_tool_clone() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let _cloned = tool.clone();
+    }
+
+    #[test]
+    fn test_vector_ingest_tool_name() {
+        assert_eq!(VectorIngestTool::NAME, "vector_ingest");
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_definition() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.name, "vector_ingest");
+        assert!(definition.description.contains("Ingest documents"));
+        assert!(definition.parameters.get("type").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_definition_parameters() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let properties = &definition.parameters["properties"];
+        assert!(properties.get("documents").is_some());
+        assert_eq!(properties["documents"]["type"], "array");
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_call_single_document() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let args = VectorIngestArgs {
+            documents: vec![IngestDocument {
+                id: None,
+                content: "test content".to_string(),
+                metadata: None,
+            }],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.ingested_count, 1);
+        assert!(response.success);
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_call_multiple_documents() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let args = VectorIngestArgs {
+            documents: vec![
+                IngestDocument {
+                    id: None,
+                    content: "doc1".to_string(),
+                    metadata: None,
+                },
+                IngestDocument {
+                    id: None,
+                    content: "doc2".to_string(),
+                    metadata: None,
+                },
+                IngestDocument {
+                    id: None,
+                    content: "doc3".to_string(),
+                    metadata: None,
+                },
+            ],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.ingested_count, 3);
+        assert!(response.success);
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_call_empty_documents() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let args = VectorIngestArgs {
+            documents: vec![],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.ingested_count, 0);
+        assert!(response.success);
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_call_with_id() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let args = VectorIngestArgs {
+            documents: vec![IngestDocument {
+                id: Some("doc123".to_string()),
+                content: "test content".to_string(),
+                metadata: None,
+            }],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_call_with_metadata() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let args = VectorIngestArgs {
+            documents: vec![IngestDocument {
+                id: None,
+                content: "test content".to_string(),
+                metadata: Some(json!({"type": "article"})),
+            }],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_call_empty_content() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let args = VectorIngestArgs {
+            documents: vec![IngestDocument {
+                id: None,
+                content: "".to_string(),
+                metadata: None,
+            }],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_call_unicode_content() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let args = VectorIngestArgs {
+            documents: vec![IngestDocument {
+                id: None,
+                content: "Hello 世界 🎉".to_string(),
+                metadata: None,
+            }],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_call_multiline_content() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let args = VectorIngestArgs {
+            documents: vec![IngestDocument {
+                id: None,
+                content: "line1\nline2\nline3".to_string(),
+                metadata: None,
+            }],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_call_large_document() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let large_content = "a".repeat(100000);
+        let args = VectorIngestArgs {
+            documents: vec![IngestDocument {
+                id: None,
+                content: large_content,
+                metadata: None,
+            }],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_call_many_documents() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let documents: Vec<IngestDocument> = (0..100)
+            .map(|i| IngestDocument {
+                id: Some(format!("doc{}", i)),
+                content: format!("content {}", i),
+                metadata: None,
+            })
+            .collect();
+        let args = VectorIngestArgs { documents };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.ingested_count, 100);
+    }
+
+    #[test]
+    fn test_ingest_document_serde() {
+        let doc = IngestDocument {
+            id: Some("123".to_string()),
+            content: "test".to_string(),
+            metadata: Some(json!({"key": "value"})),
+        };
+        let json = serde_json::to_string(&doc).unwrap();
+        let deserialized: IngestDocument = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.id, Some("123".to_string()));
+        assert_eq!(deserialized.content, "test");
+    }
+
+    #[test]
+    fn test_ingest_document_debug() {
+        let doc = IngestDocument {
+            id: None,
+            content: "test".to_string(),
+            metadata: None,
+        };
+        let debug_str = format!("{:?}", doc);
+        assert!(debug_str.contains("IngestDocument"));
+    }
+
+    #[test]
+    fn test_vector_ingest_args_serde() {
+        let args = VectorIngestArgs {
+            documents: vec![IngestDocument {
+                id: None,
+                content: "test".to_string(),
+                metadata: None,
+            }],
+        };
+        let json = serde_json::to_string(&args).unwrap();
+        let deserialized: VectorIngestArgs = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.documents.len(), 1);
+    }
+
+    #[test]
+    fn test_vector_ingest_args_debug() {
+        let args = VectorIngestArgs {
+            documents: vec![],
+        };
+        let debug_str = format!("{:?}", args);
+        assert!(debug_str.contains("VectorIngestArgs"));
+    }
+
+    #[test]
+    fn test_vector_ingest_response_serde() {
+        let response = VectorIngestResponse {
+            ingested_count: 5,
+            success: true,
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("5"));
+        assert!(json.contains("true"));
+    }
+
+    #[test]
+    fn test_vector_ingest_response_debug() {
+        let response = VectorIngestResponse {
+            ingested_count: 0,
+            success: true,
+        };
+        let debug_str = format!("{:?}", response);
+        assert!(debug_str.contains("VectorIngestResponse"));
+    }
+
+    #[test]
+    fn test_vector_ingest_response_failure() {
+        let response = VectorIngestResponse {
+            ingested_count: 0,
+            success: false,
+        };
+        assert!(!response.success);
+    }
+
+    #[test]
+    fn test_auto_ingest_new() {
+        let store = create_test_vector_store("test", None);
+        let _auto_ingest = AutoIngest::new(store);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_load_from_json_nonexistent_file() {
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let result = auto_ingest.load_from_json("/nonexistent/file.json").await;
+        
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_auto_load_empty_sources() {
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let result = auto_ingest.auto_load(&[]).await;
+        
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_auto_load_unsupported_format() {
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let sources = vec!["file.txt".to_string()];
+        let result = auto_ingest.auto_load(&sources).await;
+        
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_auto_load_nonexistent_json() {
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let sources = vec!["/nonexistent/file.json".to_string()];
+        let result = auto_ingest.auto_load(&sources).await;
+        
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_auto_ingest_auto_load_multiple_unsupported() {
+        let store = create_test_vector_store("test", None);
+        let auto_ingest = AutoIngest::new(store);
+        let sources = vec![
+            "file1.txt".to_string(),
+            "file2.csv".to_string(),
+            "file3.xml".to_string(),
+        ];
+        let result = auto_ingest.auto_load(&sources).await;
+        
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[test]
+    fn test_vector_search_args_empty_query() {
+        let args = VectorSearchArgs {
+            query: "".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        assert_eq!(args.query, "");
+    }
+
+    #[test]
+    fn test_vector_search_args_limit_one() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 1,
+            min_score: 0.0,
+        };
+        assert_eq!(args.limit, 1);
+    }
+
+    #[test]
+    fn test_vector_search_args_limit_twenty() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 20,
+            min_score: 0.0,
+        };
+        assert_eq!(args.limit, 20);
+    }
+
+    #[test]
+    fn test_vector_search_args_min_score_boundary() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+        };
+        assert_eq!(args.min_score, 0.5);
+    }
+
+    #[test]
+    fn test_vector_search_response_empty_results() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test".to_string(),
+            total_found: 0,
+            formatted_results: "No results".to_string(),
+        };
+        assert_eq!(response.results.len(), 0);
+        assert_eq!(response.total_found, 0);
+    }
+
+    #[test]
+    fn test_vector_search_response_with_results() {
+        let response = VectorSearchResponse {
+            results: vec![
+                VectorSearchResult {
+                    content: "result1".to_string(),
+                    score: 0.9,
+                    metadata: None,
+                },
+                VectorSearchResult {
+                    content: "result2".to_string(),
+                    score: 0.8,
+                    metadata: None,
+                },
+            ],
+            query: "test".to_string(),
+            total_found: 2,
+            formatted_results: "Results".to_string(),
+        };
+        assert_eq!(response.results.len(), 2);
+        assert_eq!(response.total_found, 2);
+    }
+
+    #[test]
+    fn test_vector_search_result_zero_score() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.0,
+            metadata: None,
+        };
+        assert_eq!(result.score, 0.0);
+    }
+
+    #[test]
+    fn test_vector_search_result_max_score() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 1.0,
+            metadata: None,
+        };
+        assert_eq!(result.score, 1.0);
+    }
+
+    #[test]
+    fn test_vector_search_result_negative_score() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: -0.5,
+            metadata: None,
+        };
+        assert_eq!(result.score, -0.5);
+    }
+
+    #[test]
+    fn test_vector_search_result_empty_content() {
+        let result = VectorSearchResult {
+            content: "".to_string(),
+            score: 0.5,
+            metadata: None,
+        };
+        assert_eq!(result.content, "");
+    }
+
+    #[test]
+    fn test_vector_search_result_unicode_content() {
+        let result = VectorSearchResult {
+            content: "Hello 世界 🎉".to_string(),
+            score: 0.5,
+            metadata: None,
+        };
+        assert_eq!(result.content, "Hello 世界 🎉");
+    }
+
+    #[test]
+    fn test_vector_search_result_multiline_content() {
+        let result = VectorSearchResult {
+            content: "line1\nline2\nline3".to_string(),
+            score: 0.5,
+            metadata: None,
+        };
+        assert_eq!(result.content, "line1\nline2\nline3");
+    }
+
+    #[test]
+    fn test_vector_search_result_metadata_complex() {
+        let metadata = json!({
+            "id": "123",
+            "type": "document",
+            "tags": ["rust", "test"],
+            "nested": {"key": "value"}
+        });
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(metadata.clone()),
+        };
+        assert_eq!(result.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_ingest_document_empty_id() {
+        let doc = IngestDocument {
+            id: Some("".to_string()),
+            content: "test".to_string(),
+            metadata: None,
+        };
+        assert_eq!(doc.id, Some("".to_string()));
+    }
+
+    #[test]
+    fn test_ingest_document_empty_content() {
+        let doc = IngestDocument {
+            id: None,
+            content: "".to_string(),
+            metadata: None,
+        };
+        assert_eq!(doc.content, "");
+    }
+
+    #[test]
+    fn test_ingest_document_metadata_empty_object() {
+        let doc = IngestDocument {
+            id: None,
+            content: "test".to_string(),
+            metadata: Some(json!({})),
+        };
+        assert!(doc.metadata.is_some());
+    }
+
+    #[test]
+    fn test_ingest_document_metadata_null() {
+        let doc = IngestDocument {
+            id: None,
+            content: "test".to_string(),
+            metadata: Some(json!(null)),
+        };
+        assert!(doc.metadata.is_some());
+    }
+
+    #[test]
+    fn test_ingest_document_metadata_array() {
+        let doc = IngestDocument {
+            id: None,
+            content: "test".to_string(),
+            metadata: Some(json!(["tag1", "tag2"])),
+        };
+        assert!(doc.metadata.is_some());
+    }
+
+    #[test]
+    fn test_ingest_document_metadata_string() {
+        let doc = IngestDocument {
+            id: None,
+            content: "test".to_string(),
+            metadata: Some(json!("metadata string")),
+        };
+        assert!(doc.metadata.is_some());
+    }
+
+    #[test]
+    fn test_ingest_document_metadata_number() {
+        let doc = IngestDocument {
+            id: None,
+            content: "test".to_string(),
+            metadata: Some(json!(42)),
+        };
+        assert!(doc.metadata.is_some());
+    }
+
+    #[test]
+    fn test_ingest_document_metadata_boolean() {
+        let doc = IngestDocument {
+            id: None,
+            content: "test".to_string(),
+            metadata: Some(json!(true)),
+        };
+        assert!(doc.metadata.is_some());
+    }
+
+    #[test]
+    fn test_vector_ingest_response_zero_count() {
+        let response = VectorIngestResponse {
+            ingested_count: 0,
+            success: true,
+        };
+        assert_eq!(response.ingested_count, 0);
+    }
+
+    #[test]
+    fn test_vector_ingest_response_large_count() {
+        let response = VectorIngestResponse {
+            ingested_count: 1000000,
+            success: true,
+        };
+        assert_eq!(response.ingested_count, 1000000);
+    }
+
+    #[test]
+    fn test_vector_search_response_formatted_results_empty() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test".to_string(),
+            total_found: 0,
+            formatted_results: "".to_string(),
+        };
+        assert_eq!(response.formatted_results, "");
+    }
+
+    #[test]
+    fn test_vector_search_response_formatted_results_multiline() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test".to_string(),
+            total_found: 0,
+            formatted_results: "line1\nline2\nline3".to_string(),
+        };
+        assert!(response.formatted_results.contains("\n"));
+    }
+
+    #[test]
+    fn test_vector_search_response_query_unicode() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "世界".to_string(),
+            total_found: 0,
+            formatted_results: "".to_string(),
+        };
+        assert_eq!(response.query, "世界");
+    }
+
+    #[test]
+    fn test_vector_search_response_query_empty() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "".to_string(),
+            total_found: 0,
+            formatted_results: "".to_string(),
+        };
+        assert_eq!(response.query, "");
+    }
+
+    #[test]
+    fn test_vector_search_result_very_long_content() {
+        let content = "a".repeat(100000);
+        let result = VectorSearchResult {
+            content: content.clone(),
+            score: 0.5,
+            metadata: None,
+        };
+        assert_eq!(result.content.len(), 100000);
+    }
+
+    #[test]
+    fn test_ingest_document_very_long_content() {
+        let content = "b".repeat(100000);
+        let doc = IngestDocument {
+            id: None,
+            content: content.clone(),
+            metadata: None,
+        };
+        assert_eq!(doc.content.len(), 100000);
+    }
+
+    #[test]
+    fn test_ingest_document_very_long_id() {
+        let id = "x".repeat(10000);
+        let doc = IngestDocument {
+            id: Some(id.clone()),
+            content: "test".to_string(),
+            metadata: None,
+        };
+        assert_eq!(doc.id.unwrap().len(), 10000);
+    }
+
+    #[test]
+    fn test_vector_search_args_special_characters_in_query() {
+        let args = VectorSearchArgs {
+            query: "!@#$%^&*()".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        assert_eq!(args.query, "!@#$%^&*()");
+    }
+
+    #[test]
+    fn test_ingest_document_special_characters_in_content() {
+        let doc = IngestDocument {
+            id: None,
+            content: "!@#$%^&*()".to_string(),
+            metadata: None,
+        };
+        assert_eq!(doc.content, "!@#$%^&*()");
+    }
+
+    #[test]
+    fn test_ingest_document_special_characters_in_id() {
+        let doc = IngestDocument {
+            id: Some("id-with_special.chars!".to_string()),
+            content: "test".to_string(),
+            metadata: None,
+        };
+        assert_eq!(doc.id, Some("id-with_special.chars!".to_string()));
+    }
+
+    #[test]
+    fn test_vector_search_args_tabs_and_newlines() {
+        let args = VectorSearchArgs {
+            query: "line1\tcolumn2\nline2".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        assert!(args.query.contains("\t"));
+        assert!(args.query.contains("\n"));
+    }
+
+    #[test]
+    fn test_ingest_document_tabs_and_newlines() {
+        let doc = IngestDocument {
+            id: None,
+            content: "line1\tcolumn2\nline2".to_string(),
+            metadata: None,
+        };
+        assert!(doc.content.contains("\t"));
+        assert!(doc.content.contains("\n"));
+    }
+
+    #[test]
+    fn test_vector_search_args_min_score_precision() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.123456789,
+        };
+        assert_eq!(args.min_score, 0.123456789);
+    }
+
+    #[test]
+    fn test_vector_search_result_score_precision() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.987654321,
+            metadata: None,
+        };
+        assert_eq!(result.score, 0.987654321);
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_definition_limit_constraints() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let limit_props = &definition.parameters["properties"]["limit"];
+        assert_eq!(limit_props["minimum"], 1);
+        assert_eq!(limit_props["maximum"], 20);
+        assert_eq!(limit_props["default"], 5);
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_definition_min_score_constraints() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let min_score_props = &definition.parameters["properties"]["min_score"];
+        assert_eq!(min_score_props["minimum"], 0.0);
+        assert_eq!(min_score_props["maximum"], 1.0);
+        assert_eq!(min_score_props["default"], 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_definition_required_fields() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let required = definition.parameters["required"].as_array().unwrap();
+        assert!(required.contains(&json!("documents")));
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_definition_document_schema() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let definition = tool.definition(String::new()).await;
+        
+        let items = &definition.parameters["properties"]["documents"]["items"];
+        let properties = &items["properties"];
+        assert!(properties.get("id").is_some());
+        assert!(properties.get("content").is_some());
+        assert!(properties.get("metadata").is_some());
+        
+        let required = items["required"].as_array().unwrap();
+        assert!(required.contains(&json!("content")));
+    }
+
+    #[test]
+    fn test_vector_search_args_serde_with_defaults() {
+        let json = r#"{"query":"test query"}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.query, "test query");
+        assert_eq!(args.limit, 5);
+        assert_eq!(args.min_score, 0.0);
+    }
+
+    #[test]
+    fn test_vector_search_args_serde_all_fields() {
+        let json = r#"{"query":"test","limit":10,"min_score":0.7}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.query, "test");
+        assert_eq!(args.limit, 10);
+        assert_eq!(args.min_score, 0.7);
+    }
+
+    #[test]
+    fn test_ingest_document_serde_minimal() {
+        let json = r#"{"content":"test content"}"#;
+        let doc: IngestDocument = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.content, "test content");
+        assert!(doc.id.is_none());
+        assert!(doc.metadata.is_none());
+    }
+
+    #[test]
+    fn test_ingest_document_serde_all_fields() {
+        let json = r#"{"id":"123","content":"test","metadata":{"key":"value"}}"#;
+        let doc: IngestDocument = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.id, Some("123".to_string()));
+        assert_eq!(doc.content, "test");
+        assert!(doc.metadata.is_some());
+    }
+
+    #[test]
+    fn test_vector_ingest_args_serde_empty_documents() {
+        let json = r#"{"documents":[]}"#;
+        let args: VectorIngestArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.documents.len(), 0);
+    }
+
+    #[test]
+    fn test_vector_ingest_args_serde_multiple_documents() {
+        let json = r#"{"documents":[{"content":"doc1"},{"content":"doc2"}]}"#;
+        let args: VectorIngestArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.documents.len(), 2);
+        assert_eq!(args.documents[0].content, "doc1");
+        assert_eq!(args.documents[1].content, "doc2");
+    }
+
+    #[test]
+    fn test_vector_search_response_serde_with_results() {
+        let response = VectorSearchResponse {
+            results: vec![VectorSearchResult {
+                content: "test".to_string(),
+                score: 0.9,
+                metadata: Some(json!({"id": "123"})),
+            }],
+            query: "test query".to_string(),
+            total_found: 1,
+            formatted_results: "Result 1".to_string(),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("test"));
+        assert!(json.contains("0.9"));
+    }
+
+    #[test]
+    fn test_vector_ingest_response_serde_success_false() {
+        let response = VectorIngestResponse {
+            ingested_count: 0,
+            success: false,
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("false"));
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_limit_boundary_values() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 1,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        assert!(result.is_ok());
+        
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 20,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_min_score_boundary_values() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        assert!(result.is_ok());
+        
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 1.0,
+        };
+        let result = tool.call(args).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_mezmo_runbooks_tool_call() {
+        let store = create_test_vector_store("runbooks", None);
+        let tool = VectorSearchMezmoRunbooksTool::new(store);
+        let args = VectorSearchArgs {
+            query: "test query".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.query, "test query");
+    }
+
+    #[tokio::test]
+    async fn test_vector_search_tool_call_response_structure() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorSearchMezmoKbTool::new(store);
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.0,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.query, "test");
+        assert_eq!(response.total_found, 0);
+        assert!(response.results.is_empty());
+        assert!(!response.formatted_results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_vector_ingest_tool_call_response_structure() {
+        let store = create_test_vector_store("test", None);
+        let tool = VectorIngestTool::new(store);
+        let args = VectorIngestArgs {
+            documents: vec![IngestDocument {
+                id: None,
+                content: "test".to_string(),
+                metadata: None,
+            }],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.ingested_count, 1);
+        assert!(response.success);
+    }
+
+    #[test]
+    fn test_vector_search_result_metadata_null_value() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!(null)),
+        };
+        assert!(result.metadata.is_some());
+        assert!(result.metadata.unwrap().is_null());
+    }
+
+    #[test]
+    fn test_ingest_document_with_all_fields() {
+        let doc = IngestDocument {
+            id: Some("doc-123".to_string()),
+            content: "test content".to_string(),
+            metadata: Some(json!({"type": "article", "tags": ["rust"]})),
+        };
+        assert_eq!(doc.id, Some("doc-123".to_string()));
+        assert_eq!(doc.content, "test content");
+        assert!(doc.metadata.is_some());
+    }
+
+    #[test]
+    fn test_vector_search_response_total_found_mismatch() {
+        let response = VectorSearchResponse {
+            results: vec![VectorSearchResult {
+                content: "test".to_string(),
+                score: 0.5,
+                metadata: None,
+            }],
+            query: "test".to_string(),
+            total_found: 5,
+            formatted_results: "Results".to_string(),
+        };
+        assert_eq!(response.results.len(), 1);
+        assert_eq!(response.total_found, 5);
+    }
+}

--- a/crates/aura/src/string_utils_tests.rs
+++ b/crates/aura/src/string_utils_tests.rs
@@ -1,0 +1,462 @@
+#[cfg(test)]
+mod tests {
+    use crate::string_utils::*;
+
+    #[test]
+    fn test_truncate_for_log_ascii() {
+        let (result, truncated) = truncate_for_log("hello world", 5);
+        assert_eq!(result, "hello");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_no_truncation() {
+        let (result, truncated) = truncate_for_log("short", 100);
+        assert_eq!(result, "short");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_exact_length() {
+        let (result, truncated) = truncate_for_log("hello", 5);
+        assert_eq!(result, "hello");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_one_byte_over() {
+        let (result, truncated) = truncate_for_log("hello", 4);
+        assert_eq!(result, "hell");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_empty_string() {
+        let (result, truncated) = truncate_for_log("", 10);
+        assert_eq!(result, "");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_empty_string_zero_max() {
+        let (result, truncated) = truncate_for_log("", 0);
+        assert_eq!(result, "");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_zero_max_bytes() {
+        let (result, truncated) = truncate_for_log("hello", 0);
+        assert_eq!(result, "");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_single_char() {
+        let (result, truncated) = truncate_for_log("a", 1);
+        assert_eq!(result, "a");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_single_char_truncated() {
+        let (result, truncated) = truncate_for_log("ab", 1);
+        assert_eq!(result, "a");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_emoji() {
+        let input = "Hello 🎉 World";
+        assert_eq!(input.len(), 16);
+
+        let (result, truncated) = truncate_for_log(input, 8);
+        assert_eq!(result, "Hello ");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_emoji_boundary() {
+        let input = "Hello 🎉 World";
+        let (result, truncated) = truncate_for_log(input, 10);
+        assert_eq!(result, "Hello 🎉");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_emoji_after() {
+        let input = "Hello 🎉 World";
+        let (result, truncated) = truncate_for_log(input, 11);
+        assert_eq!(result, "Hello 🎉 ");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_only_emoji() {
+        let input = "🎉";
+        assert_eq!(input.len(), 4);
+
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, "🎉");
+        assert!(!truncated);
+
+        let (result, truncated) = truncate_for_log(input, 3);
+        assert_eq!(result, "");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 2);
+        assert_eq!(result, "");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 1);
+        assert_eq!(result, "");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_multiple_emojis() {
+        let input = "🎉🎊🎈";
+        assert_eq!(input.len(), 12);
+
+        let (result, truncated) = truncate_for_log(input, 8);
+        assert_eq!(result, "🎉🎊");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 5);
+        assert_eq!(result, "🎉");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_emoji_at_start() {
+        let input = "🎉hello";
+        let (result, truncated) = truncate_for_log(input, 3);
+        assert_eq!(result, "");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, "🎉");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 5);
+        assert_eq!(result, "🎉h");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_emoji_at_end() {
+        let input = "hello🎉";
+        let (result, truncated) = truncate_for_log(input, 5);
+        assert_eq!(result, "hello");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 8);
+        assert_eq!(result, "hello");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 9);
+        assert_eq!(result, "hello🎉");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_cjk() {
+        let input = "日本語テスト";
+        assert_eq!(input.len(), 18);
+
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, "日");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_cjk_boundary() {
+        let input = "日本語テスト";
+        let (result, truncated) = truncate_for_log(input, 6);
+        assert_eq!(result, "日本");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_cjk_mid_character() {
+        let input = "日本語";
+        assert_eq!(input.len(), 9);
+
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, "日");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 5);
+        assert_eq!(result, "日");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_cjk_single_char() {
+        let input = "日";
+        assert_eq!(input.len(), 3);
+
+        let (result, truncated) = truncate_for_log(input, 3);
+        assert_eq!(result, "日");
+        assert!(!truncated);
+
+        let (result, truncated) = truncate_for_log(input, 2);
+        assert_eq!(result, "");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 1);
+        assert_eq!(result, "");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_cjk_with_ascii() {
+        let input = "Hello日本";
+        assert_eq!(input.len(), 11);
+
+        let (result, truncated) = truncate_for_log(input, 5);
+        assert_eq!(result, "Hello");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 7);
+        assert_eq!(result, "Hello");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 8);
+        assert_eq!(result, "Hello日");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_mixed_unicode() {
+        let input = "Hello🎉日本語";
+
+        let (result, truncated) = truncate_for_log(input, 5);
+        assert_eq!(result, "Hello");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 9);
+        assert_eq!(result, "Hello🎉");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 12);
+        assert_eq!(result, "Hello🎉日");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 18);
+        assert_eq!(result, "Hello🎉日本語");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_two_byte_chars() {
+        let input = "café";
+        assert_eq!(input.len(), 5);
+
+        let (result, truncated) = truncate_for_log(input, 3);
+        assert_eq!(result, "caf");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, "caf");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 5);
+        assert_eq!(result, "café");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_cyrillic() {
+        let input = "Привет";
+        assert_eq!(input.len(), 12);
+
+        let (result, truncated) = truncate_for_log(input, 2);
+        assert_eq!(result, "П");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 3);
+        assert_eq!(result, "П");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, "Пр");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_arabic() {
+        let input = "مرحبا";
+        let len = input.len();
+
+        let (result, truncated) = truncate_for_log(input, 2);
+        assert_eq!(result.chars().count(), 1);
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, len);
+        assert_eq!(result, input);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_very_large_max() {
+        let input = "hello";
+        let (result, truncated) = truncate_for_log(input, usize::MAX);
+        assert_eq!(result, "hello");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_large_string() {
+        let input = "a".repeat(10000);
+        let (result, truncated) = truncate_for_log(&input, 100);
+        assert_eq!(result.len(), 100);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_large_string_no_truncation() {
+        let input = "a".repeat(100);
+        let (result, truncated) = truncate_for_log(&input, 100);
+        assert_eq!(result.len(), 100);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_only_spaces() {
+        let input = "     ";
+        let (result, truncated) = truncate_for_log(input, 3);
+        assert_eq!(result, "   ");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_newlines() {
+        let input = "hello\nworld";
+        let (result, truncated) = truncate_for_log(input, 5);
+        assert_eq!(result, "hello");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 6);
+        assert_eq!(result, "hello\n");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_tabs() {
+        let input = "hello\tworld";
+        let (result, truncated) = truncate_for_log(input, 6);
+        assert_eq!(result, "hello\t");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_zero_width_joiner() {
+        let input = "👨‍👩‍👧‍👦";
+        let len = input.len();
+
+        let (result, truncated) = truncate_for_log(input, len);
+        assert_eq!(result, input);
+        assert!(!truncated);
+
+        let (result, truncated) = truncate_for_log(input, 5);
+        assert!(truncated);
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn test_truncate_for_log_combining_diacritics() {
+        let input = "e\u{0301}";
+        assert_eq!(input.len(), 3);
+
+        let (result, truncated) = truncate_for_log(input, 1);
+        assert_eq!(result, "e");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 3);
+        assert_eq!(result, input);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_grapheme_clusters() {
+        let input = "नमस्ते";
+        let len = input.len();
+
+        let (result, truncated) = truncate_for_log(input, len);
+        assert_eq!(result, input);
+        assert!(!truncated);
+
+        let (result, _truncated) = truncate_for_log(input, 5);
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn test_truncate_for_log_max_one_ascii() {
+        let (result, truncated) = truncate_for_log("hello", 1);
+        assert_eq!(result, "h");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_max_one_multibyte() {
+        let (result, truncated) = truncate_for_log("日本", 1);
+        assert_eq!(result, "");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_exact_emoji_boundary() {
+        let input = "🎉";
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, "🎉");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_one_less_than_emoji() {
+        let input = "a🎉";
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, "a");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_ascii_then_multibyte() {
+        let input = "abc日";
+        assert_eq!(input.len(), 6);
+
+        let (result, truncated) = truncate_for_log(input, 3);
+        assert_eq!(result, "abc");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, "abc");
+        assert!(truncated);
+
+        let (result, truncated) = truncate_for_log(input, 6);
+        assert_eq!(result, "abc日");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_all_multibyte_exact() {
+        let input = "日本";
+        assert_eq!(input.len(), 6);
+
+        let (result, truncated) = truncate_for_log(input, 6);
+        assert_eq!(result, "日本");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_tuple_structure() {
+        let (s, b) = truncate_for_log("test", 2);
+        assert_eq!(s, "te");
+        assert!(b);
+
+        let (s, b) = truncate_for_log("test", 10);
+        assert_eq!(s, "test");
+        assert!(!b);
+    }
+}

--- a/crates/aura/src/string_utils_tests.rs
+++ b/crates/aura/src/string_utils_tests.rs
@@ -3,48 +3,6 @@ mod tests {
     use crate::string_utils::*;
 
     #[test]
-    fn test_truncate_for_log_ascii() {
-        let (result, truncated) = truncate_for_log("hello world", 5);
-        assert_eq!(result, "hello");
-        assert!(truncated);
-    }
-
-    #[test]
-    fn test_truncate_for_log_no_truncation() {
-        let (result, truncated) = truncate_for_log("short", 100);
-        assert_eq!(result, "short");
-        assert!(!truncated);
-    }
-
-    #[test]
-    fn test_truncate_for_log_exact_length() {
-        let (result, truncated) = truncate_for_log("hello", 5);
-        assert_eq!(result, "hello");
-        assert!(!truncated);
-    }
-
-    #[test]
-    fn test_truncate_for_log_one_byte_over() {
-        let (result, truncated) = truncate_for_log("hello", 4);
-        assert_eq!(result, "hell");
-        assert!(truncated);
-    }
-
-    #[test]
-    fn test_truncate_for_log_empty_string() {
-        let (result, truncated) = truncate_for_log("", 10);
-        assert_eq!(result, "");
-        assert!(!truncated);
-    }
-
-    #[test]
-    fn test_truncate_for_log_empty_string_zero_max() {
-        let (result, truncated) = truncate_for_log("", 0);
-        assert_eq!(result, "");
-        assert!(!truncated);
-    }
-
-    #[test]
     fn test_truncate_for_log_zero_max_bytes() {
         let (result, truncated) = truncate_for_log("hello", 0);
         assert_eq!(result, "");
@@ -52,50 +10,23 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_for_log_single_char() {
+    fn test_truncate_for_log_single_ascii_char() {
         let (result, truncated) = truncate_for_log("a", 1);
         assert_eq!(result, "a");
         assert!(!truncated);
     }
 
     #[test]
-    fn test_truncate_for_log_single_char_truncated() {
+    fn test_truncate_for_log_two_chars_truncate_to_one() {
         let (result, truncated) = truncate_for_log("ab", 1);
         assert_eq!(result, "a");
         assert!(truncated);
     }
 
     #[test]
-    fn test_truncate_for_log_emoji() {
-        let input = "Hello 🎉 World";
-        assert_eq!(input.len(), 16);
-
-        let (result, truncated) = truncate_for_log(input, 8);
-        assert_eq!(result, "Hello ");
-        assert!(truncated);
-    }
-
-    #[test]
-    fn test_truncate_for_log_emoji_boundary() {
-        let input = "Hello 🎉 World";
-        let (result, truncated) = truncate_for_log(input, 10);
-        assert_eq!(result, "Hello 🎉");
-        assert!(truncated);
-    }
-
-    #[test]
-    fn test_truncate_for_log_emoji_after() {
-        let input = "Hello 🎉 World";
-        let (result, truncated) = truncate_for_log(input, 11);
-        assert_eq!(result, "Hello 🎉 ");
-        assert!(truncated);
-    }
-
-    #[test]
-    fn test_truncate_for_log_only_emoji() {
+    fn test_truncate_for_log_backs_up_to_char_boundary_on_emoji() {
         let input = "🎉";
         assert_eq!(input.len(), 4);
-
         let (result, truncated) = truncate_for_log(input, 4);
         assert_eq!(result, "🎉");
         assert!(!truncated);
@@ -117,7 +48,6 @@ mod tests {
     fn test_truncate_for_log_multiple_emojis() {
         let input = "🎉🎊🎈";
         assert_eq!(input.len(), 12);
-
         let (result, truncated) = truncate_for_log(input, 8);
         assert_eq!(result, "🎉🎊");
         assert!(truncated);
@@ -160,28 +90,9 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_for_log_cjk() {
-        let input = "日本語テスト";
-        assert_eq!(input.len(), 18);
-
-        let (result, truncated) = truncate_for_log(input, 4);
-        assert_eq!(result, "日");
-        assert!(truncated);
-    }
-
-    #[test]
-    fn test_truncate_for_log_cjk_boundary() {
-        let input = "日本語テスト";
-        let (result, truncated) = truncate_for_log(input, 6);
-        assert_eq!(result, "日本");
-        assert!(truncated);
-    }
-
-    #[test]
-    fn test_truncate_for_log_cjk_mid_character() {
+    fn test_truncate_for_log_backs_up_to_char_boundary_on_cjk() {
         let input = "日本語";
         assert_eq!(input.len(), 9);
-
         let (result, truncated) = truncate_for_log(input, 4);
         assert_eq!(result, "日");
         assert!(truncated);
@@ -192,10 +103,9 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_for_log_cjk_single_char() {
+    fn test_truncate_for_log_single_cjk_char() {
         let input = "日";
         assert_eq!(input.len(), 3);
-
         let (result, truncated) = truncate_for_log(input, 3);
         assert_eq!(result, "日");
         assert!(!truncated);
@@ -213,7 +123,6 @@ mod tests {
     fn test_truncate_for_log_cjk_with_ascii() {
         let input = "Hello日本";
         assert_eq!(input.len(), 11);
-
         let (result, truncated) = truncate_for_log(input, 5);
         assert_eq!(result, "Hello");
         assert!(truncated);
@@ -230,7 +139,6 @@ mod tests {
     #[test]
     fn test_truncate_for_log_mixed_unicode() {
         let input = "Hello🎉日本語";
-
         let (result, truncated) = truncate_for_log(input, 5);
         assert_eq!(result, "Hello");
         assert!(truncated);
@@ -249,10 +157,9 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_for_log_two_byte_chars() {
+    fn test_truncate_for_log_backs_up_to_char_boundary_on_two_byte_utf8() {
         let input = "café";
         assert_eq!(input.len(), 5);
-
         let (result, truncated) = truncate_for_log(input, 3);
         assert_eq!(result, "caf");
         assert!(truncated);
@@ -270,7 +177,6 @@ mod tests {
     fn test_truncate_for_log_cyrillic() {
         let input = "Привет";
         assert_eq!(input.len(), 12);
-
         let (result, truncated) = truncate_for_log(input, 2);
         assert_eq!(result, "П");
         assert!(truncated);
@@ -287,12 +193,12 @@ mod tests {
     #[test]
     fn test_truncate_for_log_arabic() {
         let input = "مرحبا";
-        let len = input.len();
-
+        let _len = input.len();
         let (result, truncated) = truncate_for_log(input, 2);
         assert_eq!(result.chars().count(), 1);
         assert!(truncated);
 
+        let len = input.len();
         let (result, truncated) = truncate_for_log(input, len);
         assert_eq!(result, input);
         assert!(!truncated);
@@ -311,14 +217,13 @@ mod tests {
         let input = "a".repeat(10000);
         let (result, truncated) = truncate_for_log(&input, 100);
         assert_eq!(result.len(), 100);
+        assert_eq!(result, "a".repeat(100));
         assert!(truncated);
-    }
 
-    #[test]
-    fn test_truncate_for_log_large_string_no_truncation() {
         let input = "a".repeat(100);
         let (result, truncated) = truncate_for_log(&input, 100);
         assert_eq!(result.len(), 100);
+        assert_eq!(result, input);
         assert!(!truncated);
     }
 
@@ -331,7 +236,7 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_for_log_newlines() {
+    fn test_truncate_for_log_newline_and_tab() {
         let input = "hello\nworld";
         let (result, truncated) = truncate_for_log(input, 5);
         assert_eq!(result, "hello");
@@ -340,10 +245,7 @@ mod tests {
         let (result, truncated) = truncate_for_log(input, 6);
         assert_eq!(result, "hello\n");
         assert!(truncated);
-    }
 
-    #[test]
-    fn test_truncate_for_log_tabs() {
         let input = "hello\tworld";
         let (result, truncated) = truncate_for_log(input, 6);
         assert_eq!(result, "hello\t");
@@ -354,7 +256,6 @@ mod tests {
     fn test_truncate_for_log_zero_width_joiner() {
         let input = "👨‍👩‍👧‍👦";
         let len = input.len();
-
         let (result, truncated) = truncate_for_log(input, len);
         assert_eq!(result, input);
         assert!(!truncated);
@@ -368,7 +269,6 @@ mod tests {
     fn test_truncate_for_log_combining_diacritics() {
         let input = "e\u{0301}";
         assert_eq!(input.len(), 3);
-
         let (result, truncated) = truncate_for_log(input, 1);
         assert_eq!(result, "e");
         assert!(truncated);
@@ -379,10 +279,9 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_for_log_grapheme_clusters() {
+    fn test_truncate_for_log_devanagari() {
         let input = "नमस्ते";
         let len = input.len();
-
         let (result, truncated) = truncate_for_log(input, len);
         assert_eq!(result, input);
         assert!(!truncated);
@@ -392,40 +291,25 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_for_log_max_one_ascii() {
+    fn test_truncate_for_log_max_one() {
         let (result, truncated) = truncate_for_log("hello", 1);
         assert_eq!(result, "h");
         assert!(truncated);
-    }
 
-    #[test]
-    fn test_truncate_for_log_max_one_multibyte() {
         let (result, truncated) = truncate_for_log("日本", 1);
         assert_eq!(result, "");
         assert!(truncated);
     }
 
     #[test]
-    fn test_truncate_for_log_exact_emoji_boundary() {
-        let input = "🎉";
-        let (result, truncated) = truncate_for_log(input, 4);
-        assert_eq!(result, "🎉");
-        assert!(!truncated);
-    }
-
-    #[test]
-    fn test_truncate_for_log_one_less_than_emoji() {
+    fn test_truncate_for_log_ascii_before_multibyte() {
         let input = "a🎉";
         let (result, truncated) = truncate_for_log(input, 4);
         assert_eq!(result, "a");
         assert!(truncated);
-    }
 
-    #[test]
-    fn test_truncate_for_log_ascii_then_multibyte() {
         let input = "abc日";
         assert_eq!(input.len(), 6);
-
         let (result, truncated) = truncate_for_log(input, 3);
         assert_eq!(result, "abc");
         assert!(truncated);
@@ -440,23 +324,144 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_for_log_all_multibyte_exact() {
+    fn test_truncate_for_log_two_cjk_exact() {
         let input = "日本";
         assert_eq!(input.len(), 6);
-
         let (result, truncated) = truncate_for_log(input, 6);
         assert_eq!(result, "日本");
         assert!(!truncated);
     }
 
     #[test]
-    fn test_truncate_for_log_tuple_structure() {
-        let (s, b) = truncate_for_log("test", 2);
-        assert_eq!(s, "te");
-        assert!(b);
+    fn test_truncate_for_log_whitespace_only() {
+        let input = "\t\n\r ";
+        let (result, truncated) = truncate_for_log(input, 2);
+        assert_eq!(result, "\t\n");
+        assert!(truncated);
+    }
 
-        let (s, b) = truncate_for_log("test", 10);
-        assert_eq!(s, "test");
-        assert!(!b);
+    #[test]
+    fn test_truncate_for_log_carriage_return_and_null() {
+        let input = "hello\rworld";
+        let (result, truncated) = truncate_for_log(input, 6);
+        assert_eq!(result, "hello\r");
+        assert!(truncated);
+
+        let input = "hello\0world";
+        let (result, truncated) = truncate_for_log(input, 6);
+        assert_eq!(result, "hello\0");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_multiple_newlines() {
+        let input = "a\n\n\nb";
+        let (result, truncated) = truncate_for_log(input, 3);
+        assert_eq!(result, "a\n\n");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_mixed_whitespace() {
+        let input = " \t\n\r";
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, " \t\n\r");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_emoji_sequence() {
+        let input = "🏴󠁧󠁢󠁥󠁮󠁧󠁿";
+        let len = input.len();
+        let (result, truncated) = truncate_for_log(input, len);
+        assert_eq!(result, input);
+        assert!(!truncated);
+
+        let (result, truncated) = truncate_for_log(input, 5);
+        assert!(truncated);
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn test_truncate_for_log_skin_tone_modifier() {
+        let input = "👋🏽";
+        let len = input.len();
+        let (result, truncated) = truncate_for_log(input, len);
+        assert_eq!(result, input);
+        assert!(!truncated);
+
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, "👋");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_alternating_ascii_and_multibyte() {
+        let input = "a🎉b🎊c";
+        let (result, truncated) = truncate_for_log(input, 5);
+        assert_eq!(result, "a🎉");
+        assert!(truncated);
+
+        let input = "a日b本c";
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, "a日");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_long_ascii_string() {
+        let input = "abcdefghijklmnopqrstuvwxyz";
+        let (result, truncated) = truncate_for_log(input, 10);
+        assert_eq!(result, "abcdefghij");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_repeated_multibyte() {
+        let input = "🎉".repeat(10);
+        let (result, truncated) = truncate_for_log(&input, 20);
+        assert_eq!(result, "🎉".repeat(5));
+        assert!(truncated);
+
+        let input = "日".repeat(10);
+        let (result, truncated) = truncate_for_log(&input, 15);
+        assert_eq!(result, "日".repeat(5));
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_special_characters() {
+        let input = "!@#$%^&*()";
+        let (result, truncated) = truncate_for_log(input, 5);
+        assert_eq!(result, "!@#$%");
+        assert!(truncated);
+
+        let input = "[]{}()<>";
+        let (result, truncated) = truncate_for_log(input, 4);
+        assert_eq!(result, "[]{}");
+        assert!(truncated);
+
+        let input = "\"'`";
+        let (result, truncated) = truncate_for_log(input, 2);
+        assert_eq!(result, "\"'");
+        assert!(truncated);
+
+        let input = "|||&&&~~~@@@###$$$%%%^^^***+++===___---;;;:::,,,...???!!!<<<>>>";
+        let (result, truncated) = truncate_for_log(input, 10);
+        assert_eq!(result, "|||&&&~~~@");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_truncate_for_log_backslash_and_forward_slash() {
+        let input = "\\\\\\";
+        let (result, truncated) = truncate_for_log(input, 2);
+        assert_eq!(result, "\\\\");
+        assert!(truncated);
+
+        let input = "///";
+        let (result, truncated) = truncate_for_log(input, 2);
+        assert_eq!(result, "//");
+        assert!(truncated);
     }
 }

--- a/crates/aura/src/tools_tests.rs
+++ b/crates/aura/src/tools_tests.rs
@@ -1,0 +1,993 @@
+#[cfg(test)]
+mod tests {
+    use crate::tools::*;
+    use rig::tool::Tool;
+    use std::fs;
+    use std::path::PathBuf;
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn path(&self) -> &std::path::Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn create_temp_dir() -> TempDir {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("aura_test_{}_{}", pid, id));
+        fs::create_dir_all(&dir).unwrap();
+        TempDir(dir)
+    }
+
+    fn create_test_file_for_write(dir: &TempDir, name: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        fs::write(&path, "").unwrap();
+        path
+    }
+
+    fn create_test_file(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_filesystem_tool_new() {
+        let tool = FilesystemTool::new();
+        assert_eq!(tool.base_dir, None);
+        assert!(!tool.allow_write);
+        assert_eq!(tool.max_file_size, 1_048_576);
+    }
+
+    #[test]
+    fn test_filesystem_tool_default() {
+        let tool = FilesystemTool::default();
+        assert_eq!(tool.base_dir, None);
+        assert!(!tool.allow_write);
+        assert_eq!(tool.max_file_size, 1_048_576);
+    }
+
+    #[test]
+    fn test_filesystem_tool_with_base_dir() {
+        let tool = FilesystemTool::new().with_base_dir("/tmp".to_string());
+        assert_eq!(tool.base_dir, Some("/tmp".to_string()));
+    }
+
+    #[test]
+    fn test_filesystem_tool_with_write_access() {
+        let tool = FilesystemTool::new().with_write_access(true);
+        assert!(tool.allow_write);
+        let tool = FilesystemTool::new().with_write_access(false);
+        assert!(!tool.allow_write);
+    }
+
+    #[test]
+    fn test_filesystem_tool_with_max_file_size() {
+        let tool = FilesystemTool::new().with_max_file_size(2048);
+        assert_eq!(tool.max_file_size, 2048);
+    }
+
+    #[test]
+    fn test_filesystem_tool_builder_chain() {
+        let tool = FilesystemTool::new()
+            .with_base_dir("/tmp".to_string())
+            .with_write_access(true)
+            .with_max_file_size(4096);
+        assert_eq!(tool.base_dir, Some("/tmp".to_string()));
+        assert!(tool.allow_write);
+        assert_eq!(tool.max_file_size, 4096);
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_success() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file(&temp_dir, "test.txt", "hello world");
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "hello world");
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_empty_file() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file(&temp_dir, "empty.txt", "");
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_nonexistent() {
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: "/nonexistent/file.txt".to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), FilesystemError::PathNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_max_size_exceeded() {
+        let temp_dir = create_temp_dir();
+        let content = "a".repeat(100);
+        let file_path = create_test_file(&temp_dir, "large.txt", &content);
+        
+        let tool = ReadFileTool(FilesystemTool::new().with_max_file_size(50));
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), FilesystemError::PermissionDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_max_size_exact() {
+        let temp_dir = create_temp_dir();
+        let content = "a".repeat(100);
+        let file_path = create_test_file(&temp_dir, "exact.txt", &content);
+        
+        let tool = ReadFileTool(FilesystemTool::new().with_max_file_size(100));
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_custom_max_size() {
+        let temp_dir = create_temp_dir();
+        let content = "a".repeat(100);
+        let file_path = create_test_file(&temp_dir, "custom.txt", &content);
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: Some(50),
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), FilesystemError::PermissionDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_directory_not_file() {
+        let temp_dir = create_temp_dir();
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), FilesystemError::InvalidPath(_)));
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_unicode_content() {
+        let temp_dir = create_temp_dir();
+        let content = "Hello 世界 🎉";
+        let file_path = create_test_file(&temp_dir, "unicode.txt", content);
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), content);
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_success() {
+        let temp_dir = create_temp_dir();
+        create_test_file(&temp_dir, "file1.txt", "content1");
+        create_test_file(&temp_dir, "file2.txt", "content2");
+        
+        let tool = ListDirTool(FilesystemTool::new());
+        let args = ListDirArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let listing = result.unwrap();
+        assert_eq!(listing.total_count, 2);
+        assert_eq!(listing.entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_empty_directory() {
+        let temp_dir = create_temp_dir();
+        
+        let tool = ListDirTool(FilesystemTool::new());
+        let args = ListDirArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let listing = result.unwrap();
+        assert_eq!(listing.total_count, 0);
+        assert_eq!(listing.entries.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_nonexistent() {
+        let tool = ListDirTool(FilesystemTool::new());
+        let args = ListDirArgs {
+            path: "/nonexistent/directory".to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        assert!(matches!(err, FilesystemError::PathNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_file_not_directory() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file(&temp_dir, "file.txt", "content");
+        
+        let tool = ListDirTool(FilesystemTool::new());
+        let args = ListDirArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        assert!(matches!(err, FilesystemError::InvalidPath(_)));
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_file_info() {
+        let temp_dir = create_temp_dir();
+        create_test_file(&temp_dir, "test.txt", "content");
+        fs::create_dir(temp_dir.path().join("subdir")).unwrap();
+        
+        let tool = ListDirTool(FilesystemTool::new());
+        let args = ListDirArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let listing = result.unwrap();
+        assert_eq!(listing.entries.len(), 2);
+        
+        let file_entry = listing.entries.iter().find(|e| e.name == "test.txt").unwrap();
+        assert!(file_entry.is_file);
+        assert!(!file_entry.is_dir);
+        assert!(file_entry.size.is_some());
+        
+        let dir_entry = listing.entries.iter().find(|e| e.name == "subdir").unwrap();
+        assert!(!dir_entry.is_file);
+        assert!(dir_entry.is_dir);
+        assert!(dir_entry.size.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_success() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file_for_write(&temp_dir, "new.txt");
+
+        let tool = WriteFileTool(FilesystemTool::new().with_write_access(true));
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: "test content".to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "test content");
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_write_disabled() {
+        let temp_dir = create_temp_dir();
+        let file_path = temp_dir.path().join("new.txt");
+        
+        let tool = WriteFileTool(FilesystemTool::new());
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: "content".to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), FilesystemError::PermissionDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_empty_content() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file_for_write(&temp_dir, "empty.txt");
+        
+        let tool = WriteFileTool(FilesystemTool::new().with_write_access(true));
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: "".to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "");
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_unicode_content() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file_for_write(&temp_dir, "unicode.txt");
+        let content = "Hello 世界 🎉";
+        
+        let tool = WriteFileTool(FilesystemTool::new().with_write_access(true));
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: content.to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let read_content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(read_content, content);
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_overwrite() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file(&temp_dir, "overwrite.txt", "original");
+        
+        let tool = WriteFileTool(FilesystemTool::new().with_write_access(true));
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: "new content".to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "new content");
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_create_dirs() {
+        let temp_dir = create_temp_dir();
+        let nested_dir = temp_dir.path().join("subdir").join("nested");
+        fs::create_dir_all(&nested_dir).unwrap();
+        let file_path = nested_dir.join("file.txt");
+        fs::write(&file_path, "").unwrap();
+
+        let tool = WriteFileTool(FilesystemTool::new().with_write_access(true));
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: "content".to_string(),
+            create_dirs: Some(true),
+        };
+        let result = tool.call(args).await;
+
+        assert!(result.is_ok());
+        let content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "content");
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_name() {
+        assert_eq!(ReadFileTool::NAME, "read_file");
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_definition() {
+        let fs_tool = FilesystemTool::new();
+        let tool = ReadFileTool(fs_tool);
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.name, "read_file");
+        assert!(definition.description.contains("Read"));
+        assert!(definition.parameters.get("type").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_call_with_max_size() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file(&temp_dir, "test.txt", "hello");
+        
+        let fs_tool = FilesystemTool::new();
+        let tool = ReadFileTool(fs_tool);
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: Some(10),
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_name() {
+        assert_eq!(ListDirTool::NAME, "list_directory");
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_definition() {
+        let fs_tool = FilesystemTool::new();
+        let tool = ListDirTool(fs_tool);
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.name, "list_directory");
+        assert!(definition.description.contains("List"));
+        assert!(definition.parameters.get("type").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_call_recursive_false() {
+        let temp_dir = create_temp_dir();
+        create_test_file(&temp_dir, "file.txt", "content");
+        
+        let fs_tool = FilesystemTool::new();
+        let tool = ListDirTool(fs_tool);
+        let args = ListDirArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            recursive: Some(false),
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_call_recursive_true() {
+        let temp_dir = create_temp_dir();
+        create_test_file(&temp_dir, "file.txt", "content");
+        
+        let fs_tool = FilesystemTool::new();
+        let tool = ListDirTool(fs_tool);
+        let args = ListDirArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            recursive: Some(true),
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_name() {
+        assert_eq!(WriteFileTool::NAME, "write_file");
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_definition() {
+        let fs_tool = FilesystemTool::new();
+        let tool = WriteFileTool(fs_tool);
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.name, "write_file");
+        assert!(definition.description.contains("Write"));
+        assert!(definition.parameters.get("type").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_call_create_dirs_false() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file_for_write(&temp_dir, "new.txt");
+        
+        let fs_tool = FilesystemTool::new().with_write_access(true);
+        let tool = WriteFileTool(fs_tool);
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: "test".to_string(),
+            create_dirs: Some(false),
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_call_create_dirs_true() {
+        let temp_dir = create_temp_dir();
+        let subdir = temp_dir.path().join("subdir");
+        fs::create_dir_all(&subdir).unwrap();
+        let file_path = subdir.join("new.txt");
+        fs::write(&file_path, "").unwrap();
+        
+        let fs_tool = FilesystemTool::new().with_write_access(true);
+        let tool = WriteFileTool(fs_tool);
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: "test".to_string(),
+            create_dirs: Some(true),
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_filesystem_error_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
+        let fs_err = FilesystemError::from(io_err);
+        assert!(matches!(fs_err, FilesystemError::IoError(_)));
+    }
+
+    #[test]
+    fn test_filesystem_error_permission_denied() {
+        let err = FilesystemError::PermissionDenied("test".to_string());
+        assert!(err.to_string().contains("Permission denied"));
+    }
+
+    #[test]
+    fn test_filesystem_error_path_not_found() {
+        let err = FilesystemError::PathNotFound("test".to_string());
+        assert!(err.to_string().contains("Path not found"));
+    }
+
+    #[test]
+    fn test_filesystem_error_invalid_path() {
+        let err = FilesystemError::InvalidPath("test".to_string());
+        assert!(err.to_string().contains("Invalid path"));
+    }
+
+    #[test]
+    fn test_read_file_args_serde() {
+        let args = ReadFileArgs {
+            path: "/test/path".to_string(),
+            max_size: Some(1024),
+        };
+        let json = serde_json::to_string(&args).unwrap();
+        let deserialized: ReadFileArgs = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.path, "/test/path");
+        assert_eq!(deserialized.max_size, Some(1024));
+    }
+
+    #[test]
+    fn test_read_file_args_serde_none() {
+        let args = ReadFileArgs {
+            path: "/test/path".to_string(),
+            max_size: None,
+        };
+        let json = serde_json::to_string(&args).unwrap();
+        let deserialized: ReadFileArgs = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.path, "/test/path");
+        assert_eq!(deserialized.max_size, None);
+    }
+
+    #[test]
+    fn test_list_dir_args_serde() {
+        let args = ListDirArgs {
+            path: "/test/path".to_string(),
+            recursive: Some(true),
+        };
+        let json = serde_json::to_string(&args).unwrap();
+        let deserialized: ListDirArgs = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.path, "/test/path");
+        assert_eq!(deserialized.recursive, Some(true));
+    }
+
+    #[test]
+    fn test_write_file_args_serde() {
+        let args = WriteFileArgs {
+            path: "/test/path".to_string(),
+            content: "test content".to_string(),
+            create_dirs: Some(true),
+        };
+        let json = serde_json::to_string(&args).unwrap();
+        let deserialized: WriteFileArgs = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.path, "/test/path");
+        assert_eq!(deserialized.content, "test content");
+        assert_eq!(deserialized.create_dirs, Some(true));
+    }
+
+    #[test]
+    fn test_filesystem_tool_clone() {
+        let tool = FilesystemTool::new()
+            .with_base_dir("/tmp".to_string())
+            .with_write_access(true)
+            .with_max_file_size(2048);
+        let cloned = tool.clone();
+        assert_eq!(cloned.base_dir, tool.base_dir);
+        assert_eq!(cloned.allow_write, tool.allow_write);
+        assert_eq!(cloned.max_file_size, tool.max_file_size);
+    }
+
+    #[test]
+    fn test_read_file_tool_clone() {
+        let fs_tool = FilesystemTool::new();
+        let tool = ReadFileTool(fs_tool);
+        let _cloned = tool.clone();
+    }
+
+    #[test]
+    fn test_list_dir_tool_clone() {
+        let fs_tool = FilesystemTool::new();
+        let tool = ListDirTool(fs_tool);
+        let _cloned = tool.clone();
+    }
+
+    #[test]
+    fn test_write_file_tool_clone() {
+        let fs_tool = FilesystemTool::new();
+        let tool = WriteFileTool(fs_tool);
+        let _cloned = tool.clone();
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_large_file() {
+        let temp_dir = create_temp_dir();
+        let content = "a".repeat(2_000_000);
+        let file_path = create_test_file(&temp_dir, "large.txt", &content);
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_zero_max_size() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file(&temp_dir, "test.txt", "content");
+        
+        let tool = ReadFileTool(FilesystemTool::new().with_max_file_size(0));
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_with_subdirectories() {
+        let temp_dir = create_temp_dir();
+        create_test_file(&temp_dir, "file.txt", "content");
+        fs::create_dir(temp_dir.path().join("subdir1")).unwrap();
+        fs::create_dir(temp_dir.path().join("subdir2")).unwrap();
+        
+        let tool = ListDirTool(FilesystemTool::new());
+        let args = ListDirArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let listing = result.unwrap();
+        assert_eq!(listing.total_count, 3);
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_large_content() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file_for_write(&temp_dir, "large.txt");
+        let content = "a".repeat(10_000);
+        
+        let tool = WriteFileTool(FilesystemTool::new().with_write_access(true));
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: content.clone(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let read_content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(read_content.len(), 10_000);
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_newlines() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file_for_write(&temp_dir, "newlines.txt");
+        let content = "line1\nline2\nline3";
+        
+        let tool = WriteFileTool(FilesystemTool::new().with_write_access(true));
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: content.to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let read_content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(read_content, content);
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_with_max_size_zero() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file(&temp_dir, "test.txt", "content");
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: Some(0),
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_unicode_filenames() {
+        let temp_dir = create_temp_dir();
+        create_test_file(&temp_dir, "文件.txt", "content");
+        create_test_file(&temp_dir, "файл.txt", "content");
+        
+        let tool = ListDirTool(FilesystemTool::new());
+        let args = ListDirArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let listing = result.unwrap();
+        assert_eq!(listing.total_count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_special_characters() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file_for_write(&temp_dir, "special.txt");
+        let content = "!@#$%^&*()_+-=[]{}|;':\",./<>?";
+        
+        let tool = WriteFileTool(FilesystemTool::new().with_write_access(true));
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: content.to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+        let read_content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(read_content, content);
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_max_file_size_boundary() {
+        let temp_dir = create_temp_dir();
+        let content = "a".repeat(1_048_576);
+        let file_path = create_test_file(&temp_dir, "boundary.txt", &content);
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_max_file_size_one_over() {
+        let temp_dir = create_temp_dir();
+        let content = "a".repeat(1_048_577);
+        let file_path = create_test_file(&temp_dir, "over.txt", &content);
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_with_base_dir_allowed() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file(&temp_dir, "test.txt", "content");
+        
+        let tool = ReadFileTool(
+            FilesystemTool::new()
+                .with_base_dir(temp_dir.path().to_str().unwrap().to_string())
+        );
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_with_base_dir_denied() {
+        let temp_dir1 = create_temp_dir();
+        let temp_dir2 = create_temp_dir();
+        let file_path = create_test_file(&temp_dir2, "test.txt", "content");
+        
+        let tool = ReadFileTool(
+            FilesystemTool::new()
+                .with_base_dir(temp_dir1.path().to_str().unwrap().to_string())
+        );
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), FilesystemError::PermissionDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_with_base_dir_allowed() {
+        let temp_dir = create_temp_dir();
+        create_test_file(&temp_dir, "test.txt", "content");
+        
+        let tool = ListDirTool(
+            FilesystemTool::new()
+                .with_base_dir(temp_dir.path().to_str().unwrap().to_string())
+        );
+        let args = ListDirArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_with_base_dir_denied() {
+        let temp_dir1 = create_temp_dir();
+        let temp_dir2 = create_temp_dir();
+        
+        let tool = ListDirTool(
+            FilesystemTool::new()
+                .with_base_dir(temp_dir1.path().to_str().unwrap().to_string())
+        );
+        let args = ListDirArgs {
+            path: temp_dir2.path().to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_with_base_dir_allowed() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file_for_write(&temp_dir, "new.txt");
+        
+        let tool = WriteFileTool(
+            FilesystemTool::new()
+                .with_base_dir(temp_dir.path().to_str().unwrap().to_string())
+                .with_write_access(true)
+        );
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: "test".to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_with_base_dir_denied() {
+        let temp_dir1 = create_temp_dir();
+        let temp_dir2 = create_temp_dir();
+        let file_path = create_test_file_for_write(&temp_dir2, "new.txt");
+        
+        let tool = WriteFileTool(
+            FilesystemTool::new()
+                .with_base_dir(temp_dir1.path().to_str().unwrap().to_string())
+                .with_write_access(true)
+        );
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: "test".to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), FilesystemError::PermissionDenied(_)));
+    }
+
+    #[test]
+    fn test_read_file_args_empty_path() {
+        let args = ReadFileArgs {
+            path: "".to_string(),
+            max_size: None,
+        };
+        assert_eq!(args.path, "");
+    }
+
+    #[test]
+    fn test_list_dir_args_empty_path() {
+        let args = ListDirArgs {
+            path: "".to_string(),
+            recursive: None,
+        };
+        assert_eq!(args.path, "");
+    }
+
+    #[test]
+    fn test_write_file_args_empty_path() {
+        let args = WriteFileArgs {
+            path: "".to_string(),
+            content: "test".to_string(),
+            create_dirs: None,
+        };
+        assert_eq!(args.path, "");
+    }
+
+    #[test]
+    fn test_write_file_args_empty_content() {
+        let args = WriteFileArgs {
+            path: "/test/path".to_string(),
+            content: "".to_string(),
+            create_dirs: None,
+        };
+        assert_eq!(args.content, "");
+    }
+}

--- a/crates/aura/src/tools_tests.rs
+++ b/crates/aura/src/tools_tests.rs
@@ -100,8 +100,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "hello world");
+        let content = result.unwrap();
+        assert_eq!(content, "hello world");
     }
 
     #[tokio::test]
@@ -116,8 +116,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "");
+        let content = result.unwrap();
+        assert_eq!(content, "");
     }
 
     #[tokio::test]
@@ -129,8 +129,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), FilesystemError::PathNotFound(_)));
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PathNotFound(_)));
     }
 
     #[tokio::test]
@@ -146,8 +146,9 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), FilesystemError::PermissionDenied(_)));
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        assert!(err.to_string().contains("File too large"));
     }
 
     #[tokio::test]
@@ -163,8 +164,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().len(), 100);
+        let content = result.unwrap();
+        assert_eq!(content.len(), 100);
     }
 
     #[tokio::test]
@@ -180,8 +181,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), FilesystemError::PermissionDenied(_)));
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
     }
 
     #[tokio::test]
@@ -195,8 +196,9 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), FilesystemError::InvalidPath(_)));
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::InvalidPath(_)));
+        assert!(err.to_string().contains("not a file"));
     }
 
     #[tokio::test]
@@ -212,8 +214,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), content);
+        let read_content = result.unwrap();
+        assert_eq!(read_content, content);
     }
 
     #[tokio::test]
@@ -229,7 +231,6 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
         let listing = result.unwrap();
         assert_eq!(listing.total_count, 2);
         assert_eq!(listing.entries.len(), 2);
@@ -246,7 +247,6 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
         let listing = result.unwrap();
         assert_eq!(listing.total_count, 0);
         assert_eq!(listing.entries.len(), 0);
@@ -262,8 +262,9 @@ mod tests {
         let result = tool.call(args).await;
         
         assert!(result.is_err());
-        let err = result.err().unwrap();
-        assert!(matches!(err, FilesystemError::PathNotFound(_)));
+        if let Err(err) = result {
+            assert!(matches!(err, FilesystemError::PathNotFound(_)));
+        }
     }
 
     #[tokio::test]
@@ -279,8 +280,10 @@ mod tests {
         let result = tool.call(args).await;
         
         assert!(result.is_err());
-        let err = result.err().unwrap();
-        assert!(matches!(err, FilesystemError::InvalidPath(_)));
+        if let Err(err) = result {
+            assert!(matches!(err, FilesystemError::InvalidPath(_)));
+            assert!(err.to_string().contains("not a directory"));
+        }
     }
 
     #[tokio::test]
@@ -296,7 +299,6 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
         let listing = result.unwrap();
         assert_eq!(listing.entries.len(), 2);
         
@@ -324,7 +326,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        let message = result.unwrap();
+        assert!(message.contains("File written successfully"));
         let content = fs::read_to_string(&file_path).unwrap();
         assert_eq!(content, "test content");
     }
@@ -342,8 +345,9 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), FilesystemError::PermissionDenied(_)));
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        assert!(err.to_string().contains("Write access disabled"));
     }
 
     #[tokio::test]
@@ -359,7 +363,7 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        result.unwrap();
         let content = fs::read_to_string(&file_path).unwrap();
         assert_eq!(content, "");
     }
@@ -378,7 +382,7 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        result.unwrap();
         let read_content = fs::read_to_string(&file_path).unwrap();
         assert_eq!(read_content, content);
     }
@@ -396,7 +400,7 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        result.unwrap();
         let content = fs::read_to_string(&file_path).unwrap();
         assert_eq!(content, "new content");
     }
@@ -417,7 +421,7 @@ mod tests {
         };
         let result = tool.call(args).await;
 
-        assert!(result.is_ok());
+        result.unwrap();
         let content = fs::read_to_string(&file_path).unwrap();
         assert_eq!(content, "content");
     }
@@ -436,6 +440,8 @@ mod tests {
         assert_eq!(definition.name, "read_file");
         assert!(definition.description.contains("Read"));
         assert!(definition.parameters.get("type").is_some());
+        assert!(definition.parameters.get("properties").is_some());
+        assert!(definition.parameters.get("required").is_some());
     }
 
     #[tokio::test]
@@ -451,7 +457,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        let content = result.unwrap();
+        assert_eq!(content, "hello");
     }
 
     #[tokio::test]
@@ -483,7 +490,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        let listing = result.unwrap();
+        assert_eq!(listing.entries.len(), 1);
     }
 
     #[tokio::test]
@@ -499,7 +507,7 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        result.unwrap();
     }
 
     #[tokio::test]
@@ -532,7 +540,7 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        result.unwrap();
     }
 
     #[tokio::test]
@@ -552,7 +560,7 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        result.unwrap();
     }
 
     #[test]
@@ -642,27 +650,6 @@ mod tests {
         assert_eq!(cloned.max_file_size, tool.max_file_size);
     }
 
-    #[test]
-    fn test_read_file_tool_clone() {
-        let fs_tool = FilesystemTool::new();
-        let tool = ReadFileTool(fs_tool);
-        let _cloned = tool.clone();
-    }
-
-    #[test]
-    fn test_list_dir_tool_clone() {
-        let fs_tool = FilesystemTool::new();
-        let tool = ListDirTool(fs_tool);
-        let _cloned = tool.clone();
-    }
-
-    #[test]
-    fn test_write_file_tool_clone() {
-        let fs_tool = FilesystemTool::new();
-        let tool = WriteFileTool(fs_tool);
-        let _cloned = tool.clone();
-    }
-
     #[tokio::test]
     async fn test_read_file_tool_large_file() {
         let temp_dir = create_temp_dir();
@@ -676,7 +663,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
     }
 
     #[tokio::test]
@@ -691,7 +679,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
     }
 
     #[tokio::test]
@@ -708,7 +697,6 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
         let listing = result.unwrap();
         assert_eq!(listing.total_count, 3);
     }
@@ -727,7 +715,7 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        result.unwrap();
         let read_content = fs::read_to_string(&file_path).unwrap();
         assert_eq!(read_content.len(), 10_000);
     }
@@ -746,7 +734,7 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        result.unwrap();
         let read_content = fs::read_to_string(&file_path).unwrap();
         assert_eq!(read_content, content);
     }
@@ -763,7 +751,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
     }
 
     #[tokio::test]
@@ -779,7 +768,6 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
         let listing = result.unwrap();
         assert_eq!(listing.total_count, 2);
     }
@@ -798,7 +786,7 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        result.unwrap();
         let read_content = fs::read_to_string(&file_path).unwrap();
         assert_eq!(read_content, content);
     }
@@ -816,7 +804,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        let read_content = result.unwrap();
+        assert_eq!(read_content.len(), 1_048_576);
     }
 
     #[tokio::test]
@@ -832,7 +821,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
     }
 
     #[tokio::test]
@@ -850,7 +840,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        let content = result.unwrap();
+        assert_eq!(content, "content");
     }
 
     #[tokio::test]
@@ -869,8 +860,9 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), FilesystemError::PermissionDenied(_)));
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        assert!(err.to_string().contains("outside of base directory"));
     }
 
     #[tokio::test]
@@ -888,7 +880,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        let listing = result.unwrap();
+        assert_eq!(listing.entries.len(), 1);
     }
 
     #[tokio::test]
@@ -907,8 +900,9 @@ mod tests {
         let result = tool.call(args).await;
         
         assert!(result.is_err());
-        let err = result.err().unwrap();
-        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        if let Err(err) = result {
+            assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        }
     }
 
     #[tokio::test]
@@ -928,7 +922,7 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_ok());
+        result.unwrap();
     }
 
     #[tokio::test]
@@ -949,8 +943,8 @@ mod tests {
         };
         let result = tool.call(args).await;
         
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), FilesystemError::PermissionDenied(_)));
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
     }
 
     #[test]
@@ -989,5 +983,528 @@ mod tests {
             create_dirs: None,
         };
         assert_eq!(args.content, "");
+    }
+
+    #[tokio::test]
+    async fn test_validate_path_blocks_etc() {
+        let temp_dir = create_temp_dir();
+        let etc_dir = temp_dir.path().join("etc");
+        fs::create_dir(&etc_dir).unwrap();
+        let file_path = etc_dir.join("passwd");
+        fs::write(&file_path, "test").unwrap();
+
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        assert!(err.to_string().contains("/etc"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_path_blocks_proc() {
+        let temp_dir = create_temp_dir();
+        let proc_dir = temp_dir.path().join("proc");
+        fs::create_dir(&proc_dir).unwrap();
+        let file_path = proc_dir.join("cpuinfo");
+        fs::write(&file_path, "test").unwrap();
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        assert!(err.to_string().contains("/proc"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_path_blocks_sys() {
+        let temp_dir = create_temp_dir();
+        let sys_dir = temp_dir.path().join("sys");
+        fs::create_dir(&sys_dir).unwrap();
+        let file_path = sys_dir.join("kernel");
+        fs::write(&file_path, "test").unwrap();
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        assert!(err.to_string().contains("/sys"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_path_blocks_dev() {
+        let temp_dir = create_temp_dir();
+        let dev_dir = temp_dir.path().join("dev");
+        fs::create_dir(&dev_dir).unwrap();
+        let file_path = dev_dir.join("null");
+        fs::write(&file_path, "test").unwrap();
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        assert!(err.to_string().contains("/dev"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_path_blocks_var_log() {
+        let temp_dir = create_temp_dir();
+        let var_dir = temp_dir.path().join("var");
+        fs::create_dir(&var_dir).unwrap();
+        let log_dir = var_dir.join("log");
+        fs::create_dir(&log_dir).unwrap();
+        let file_path = log_dir.join("syslog");
+        fs::write(&file_path, "test").unwrap();
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn test_validate_path_blocks_dot_ssh() {
+        let temp_dir = create_temp_dir();
+        let ssh_dir = temp_dir.path().join(".ssh");
+        fs::create_dir(&ssh_dir).unwrap();
+        let file_path = ssh_dir.join("id_rsa");
+        fs::write(&file_path, "test").unwrap();
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        assert!(err.to_string().contains("/.ssh"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_path_blocks_dot_aws() {
+        let temp_dir = create_temp_dir();
+        let aws_dir = temp_dir.path().join(".aws");
+        fs::create_dir(&aws_dir).unwrap();
+        let file_path = aws_dir.join("credentials");
+        fs::write(&file_path, "test").unwrap();
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        assert!(err.to_string().contains("/.aws"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_path_blocks_dot_config() {
+        let temp_dir = create_temp_dir();
+        let config_dir = temp_dir.path().join(".config");
+        fs::create_dir(&config_dir).unwrap();
+        let file_path = config_dir.join("config");
+        fs::write(&file_path, "test").unwrap();
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        assert!(err.to_string().contains("/.config"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_path_blocks_etc_in_list_dir() {
+        let temp_dir = create_temp_dir();
+        let etc_dir = temp_dir.path().join("etc");
+        fs::create_dir(&etc_dir).unwrap();
+        
+        let tool = ListDirTool(FilesystemTool::new());
+        let args = ListDirArgs {
+            path: etc_dir.to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_err());
+        if let Err(err) = result {
+            assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_validate_path_blocks_ssh_in_write_file() {
+        let temp_dir = create_temp_dir();
+        let ssh_dir = temp_dir.path().join(".ssh");
+        fs::create_dir(&ssh_dir).unwrap();
+        let file_path = ssh_dir.join("authorized_keys");
+        fs::write(&file_path, "test").unwrap();
+        
+        let tool = WriteFileTool(FilesystemTool::new().with_write_access(true));
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: "malicious key".to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn test_validate_path_case_insensitive_etc() {
+        let temp_dir = create_temp_dir();
+        let etc_dir = temp_dir.path().join("ETC");
+        fs::create_dir(&etc_dir).unwrap();
+        let file_path = etc_dir.join("passwd");
+        fs::write(&file_path, "test").unwrap();
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn test_validate_path_relative_path_conversion() {
+        let temp_dir = create_temp_dir();
+        let _file_path = create_test_file(&temp_dir, "test.txt", "content");
+
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(temp_dir.path()).unwrap();
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: "test.txt".to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        std::env::set_current_dir(original_dir).unwrap();
+        
+        let content = result.unwrap();
+        assert_eq!(content, "content");
+    }
+
+    #[tokio::test]
+    async fn test_file_info_serialization() {
+        let file_info = FileInfo {
+            name: "test.txt".to_string(),
+            path: "/tmp/test.txt".to_string(),
+            is_file: true,
+            is_dir: false,
+            size: Some(1024),
+        };
+        
+        let json = serde_json::to_string(&file_info).unwrap();
+        assert!(json.contains("test.txt"));
+        assert!(json.contains("1024"));
+    }
+
+    #[tokio::test]
+    async fn test_directory_listing_serialization() {
+        let listing = DirectoryListing {
+            path: "/tmp".to_string(),
+            entries: vec![
+                FileInfo {
+                    name: "file1.txt".to_string(),
+                    path: "/tmp/file1.txt".to_string(),
+                    is_file: true,
+                    is_dir: false,
+                    size: Some(100),
+                },
+            ],
+            total_count: 1,
+        };
+        
+        let json = serde_json::to_string(&listing).unwrap();
+        assert!(json.contains("file1.txt"));
+        assert!(json.contains("total_count"));
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_path_in_result() {
+        let temp_dir = create_temp_dir();
+        let _file_path = create_test_file(&temp_dir, "test.txt", "content");
+        
+        let tool = ListDirTool(FilesystemTool::new());
+        let args = ListDirArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        let listing = result.unwrap();
+        assert!(listing.path.contains(temp_dir.path().to_str().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_entry_paths() {
+        let temp_dir = create_temp_dir();
+        create_test_file(&temp_dir, "test.txt", "content");
+        
+        let tool = ListDirTool(FilesystemTool::new());
+        let args = ListDirArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        let listing = result.unwrap();
+        let entry = &listing.entries[0];
+        assert_eq!(entry.name, "test.txt");
+        assert!(entry.path.ends_with("test.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_result_message() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file_for_write(&temp_dir, "new.txt");
+        
+        let tool = WriteFileTool(FilesystemTool::new().with_write_access(true));
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: "test".to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        let message = result.unwrap();
+        assert!(message.contains("File written successfully"));
+        assert!(message.contains("new.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_multiline_content() {
+        let temp_dir = create_temp_dir();
+        let content = "line1\nline2\nline3\nline4";
+        let file_path = create_test_file(&temp_dir, "multiline.txt", content);
+        
+        let tool = ReadFileTool(FilesystemTool::new());
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: None,
+        };
+        let result = tool.call(args).await;
+        
+        let read_content = result.unwrap();
+        assert_eq!(read_content, content);
+        assert_eq!(read_content.lines().count(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_file_size_accuracy() {
+        let temp_dir = create_temp_dir();
+        let content = "a".repeat(1234);
+        create_test_file(&temp_dir, "sized.txt", &content);
+        
+        let tool = ListDirTool(FilesystemTool::new());
+        let args = ListDirArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        let listing = result.unwrap();
+        let entry = listing.entries.iter().find(|e| e.name == "sized.txt").unwrap();
+        assert_eq!(entry.size, Some(1234));
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_preserves_exact_content() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file_for_write(&temp_dir, "exact.txt");
+        let content = "exact content with spaces   and\ttabs\nand newlines";
+        
+        let tool = WriteFileTool(FilesystemTool::new().with_write_access(true));
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: content.to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        result.unwrap();
+        let read_content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(read_content, content);
+    }
+
+    #[tokio::test]
+    async fn test_filesystem_tool_max_file_size_custom_values() {
+        let tool1 = FilesystemTool::new().with_max_file_size(1);
+        assert_eq!(tool1.max_file_size, 1);
+        
+        let tool2 = FilesystemTool::new().with_max_file_size(999_999_999);
+        assert_eq!(tool2.max_file_size, 999_999_999);
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_respects_custom_max_size_over_default() {
+        let temp_dir = create_temp_dir();
+        let content = "a".repeat(100);
+        let file_path = create_test_file(&temp_dir, "test.txt", &content);
+        
+        let tool = ReadFileTool(FilesystemTool::new().with_max_file_size(1000));
+        let args = ReadFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            max_size: Some(50),
+        };
+        let result = tool.call(args).await;
+        
+        let err = result.unwrap_err();
+        assert!(matches!(err, FilesystemError::PermissionDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_tool_mixed_files_and_dirs() {
+        let temp_dir = create_temp_dir();
+        create_test_file(&temp_dir, "file1.txt", "content");
+        create_test_file(&temp_dir, "file2.txt", "content");
+        fs::create_dir(temp_dir.path().join("dir1")).unwrap();
+        fs::create_dir(temp_dir.path().join("dir2")).unwrap();
+        
+        let tool = ListDirTool(FilesystemTool::new());
+        let args = ListDirArgs {
+            path: temp_dir.path().to_str().unwrap().to_string(),
+            recursive: None,
+        };
+        let result = tool.call(args).await;
+        
+        let listing = result.unwrap();
+        assert_eq!(listing.total_count, 4);
+        let files = listing.entries.iter().filter(|e| e.is_file).count();
+        let dirs = listing.entries.iter().filter(|e| e.is_dir).count();
+        assert_eq!(files, 2);
+        assert_eq!(dirs, 2);
+    }
+
+    #[tokio::test]
+    async fn test_write_file_tool_binary_like_content() {
+        let temp_dir = create_temp_dir();
+        let file_path = create_test_file_for_write(&temp_dir, "binary.txt");
+        let content = "\x00\x01\x02\x03\x7E\x7F";
+        
+        let tool = WriteFileTool(FilesystemTool::new().with_write_access(true));
+        let args = WriteFileArgs {
+            path: file_path.to_str().unwrap().to_string(),
+            content: content.to_string(),
+            create_dirs: None,
+        };
+        let result = tool.call(args).await;
+        
+        result.unwrap();
+        let read_content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(read_content, content);
+    }
+
+    #[test]
+    fn test_filesystem_error_display_messages() {
+        let err1 = FilesystemError::PermissionDenied("test path".to_string());
+        assert_eq!(err1.to_string(), "Permission denied: test path");
+        
+        let err2 = FilesystemError::PathNotFound("missing.txt".to_string());
+        assert_eq!(err2.to_string(), "Path not found: missing.txt");
+        
+        let err3 = FilesystemError::InvalidPath("bad/path".to_string());
+        assert_eq!(err3.to_string(), "Invalid path: bad/path");
+    }
+
+    #[tokio::test]
+    async fn test_read_file_args_max_size_boundary_values() {
+        let args1 = ReadFileArgs {
+            path: "/test".to_string(),
+            max_size: Some(0),
+        };
+        assert_eq!(args1.max_size, Some(0));
+        
+        let args2 = ReadFileArgs {
+            path: "/test".to_string(),
+            max_size: Some(usize::MAX),
+        };
+        assert_eq!(args2.max_size, Some(usize::MAX));
+    }
+
+    #[test]
+    fn test_list_dir_args_recursive_values() {
+        let args1 = ListDirArgs {
+            path: "/test".to_string(),
+            recursive: Some(true),
+        };
+        assert_eq!(args1.recursive, Some(true));
+        
+        let args2 = ListDirArgs {
+            path: "/test".to_string(),
+            recursive: Some(false),
+        };
+        assert_eq!(args2.recursive, Some(false));
+        
+        let args3 = ListDirArgs {
+            path: "/test".to_string(),
+            recursive: None,
+        };
+        assert_eq!(args3.recursive, None);
+    }
+
+    #[test]
+    fn test_write_file_args_create_dirs_values() {
+        let args1 = WriteFileArgs {
+            path: "/test".to_string(),
+            content: "test".to_string(),
+            create_dirs: Some(true),
+        };
+        assert_eq!(args1.create_dirs, Some(true));
+        
+        let args2 = WriteFileArgs {
+            path: "/test".to_string(),
+            content: "test".to_string(),
+            create_dirs: Some(false),
+        };
+        assert_eq!(args2.create_dirs, Some(false));
+        
+        let args3 = WriteFileArgs {
+            path: "/test".to_string(),
+            content: "test".to_string(),
+            create_dirs: None,
+        };
+        assert_eq!(args3.create_dirs, None);
     }
 }

--- a/crates/aura/src/vector_dynamic.rs
+++ b/crates/aura/src/vector_dynamic.rs
@@ -203,11 +203,11 @@ pub struct FilterKV {
 }
 
 /// Parse a string value as JSON (number, boolean, null) or fallback to string
-fn parse_value_str(s: &str) -> Value {
+pub(crate) fn parse_value_str(s: &str) -> Value {
     serde_json::from_str(s).unwrap_or_else(|_| Value::String(s.to_string()))
 }
 
-fn default_limit() -> usize {
+pub(crate) fn default_limit() -> usize {
     5
 }
 

--- a/crates/aura/src/vector_dynamic_tests.rs
+++ b/crates/aura/src/vector_dynamic_tests.rs
@@ -2,99 +2,203 @@
 mod tests {
     use crate::vector_dynamic::*;
     use crate::vector_store::VectorStoreManager;
-    use rig::tool::Tool as RigTool;
+    use rig::tool::Tool;
     use serde_json::json;
     use std::sync::Arc;
 
-    fn create_mock_vector_store() -> Arc<VectorStoreManager> {
-        Arc::new(VectorStoreManager::new_stub("test_store", None))
-    }
-
-    fn create_mock_vector_store_with_context(context: String) -> Arc<VectorStoreManager> {
-        Arc::new(VectorStoreManager::new_stub("test_store", Some(context)))
+    fn create_test_vector_store(name: &str, context_prefix: Option<String>) -> Arc<VectorStoreManager> {
+        Arc::new(VectorStoreManager::new_stub(name, context_prefix))
     }
 
     #[test]
     fn test_dynamic_vector_search_tool_new() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "my_store".to_string());
-        
-        assert_eq!(tool.name(), "vector_search_my_store");
+        let store = create_test_vector_store("test_store", None);
+        let tool = DynamicVectorSearchTool::new(store, "test_store".to_string());
+        assert_eq!(tool.name(), "vector_search_test_store");
     }
 
     #[test]
     fn test_dynamic_vector_search_tool_new_empty_name() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "".to_string());
-        
+        let store = create_test_vector_store("", None);
+        let tool = DynamicVectorSearchTool::new(store, "".to_string());
         assert_eq!(tool.name(), "vector_search_");
     }
 
     #[test]
-    fn test_dynamic_vector_search_tool_new_special_chars() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "my-store_123".to_string());
-        
-        assert_eq!(tool.name(), "vector_search_my-store_123");
+    fn test_dynamic_vector_search_tool_new_unicode_name() {
+        let store = create_test_vector_store("テスト", None);
+        let tool = DynamicVectorSearchTool::new(store, "テスト".to_string());
+        assert_eq!(tool.name(), "vector_search_テスト");
+    }
+
+    #[test]
+    fn test_dynamic_vector_search_tool_new_name_with_spaces() {
+        let store = create_test_vector_store("my store", None);
+        let tool = DynamicVectorSearchTool::new(store, "my store".to_string());
+        assert_eq!(tool.name(), "vector_search_my store");
+    }
+
+    #[test]
+    fn test_dynamic_vector_search_tool_new_name_with_special_chars() {
+        let store = create_test_vector_store("store-name_123", None);
+        let tool = DynamicVectorSearchTool::new(store, "store-name_123".to_string());
+        assert_eq!(tool.name(), "vector_search_store-name_123");
     }
 
     #[test]
     fn test_dynamic_vector_search_tool_clone() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "test".to_string());
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
         let cloned = tool.clone();
-        
         assert_eq!(cloned.name(), tool.name());
+        assert_eq!(cloned.name(), "vector_search_test");
     }
 
     #[test]
-    fn test_dynamic_vector_search_tool_name_override() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "custom".to_string());
-        
-        assert_eq!(tool.name(), "vector_search_custom");
+    fn test_dynamic_vector_search_tool_static_name() {
         assert_eq!(DynamicVectorSearchTool::NAME, "dynamic_vector_search_tool");
+    }
+
+    #[test]
+    fn test_dynamic_vector_search_tool_name_method() {
+        let store = create_test_vector_store("my_store", None);
+        let tool = DynamicVectorSearchTool::new(store, "my_store".to_string());
+        assert_eq!(tool.name(), "vector_search_my_store");
+    }
+
+    #[test]
+    fn test_dynamic_vector_search_tool_name_method_overrides_static() {
+        let store = create_test_vector_store("custom", None);
+        let tool = DynamicVectorSearchTool::new(store, "custom".to_string());
+        assert_ne!(tool.name(), DynamicVectorSearchTool::NAME);
+        assert_eq!(tool.name(), "vector_search_custom");
     }
 
     #[tokio::test]
     async fn test_dynamic_vector_search_tool_definition_basic() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "test_store".to_string());
-        
+        let store = create_test_vector_store("test_store", None);
+        let tool = DynamicVectorSearchTool::new(store, "test_store".to_string());
         let definition = tool.definition(String::new()).await;
         
         assert_eq!(definition.name, "vector_search_test_store");
         assert!(definition.description.contains("test_store"));
         assert!(definition.description.contains("vector store"));
+        assert!(definition.description.contains("semantically similar"));
     }
 
     #[tokio::test]
-    async fn test_dynamic_vector_search_tool_definition_with_context() {
-        let context = "Based on the following information from the documentation:".to_string();
-        let store = create_mock_vector_store_with_context(context);
-        let tool = DynamicVectorSearchTool::new(store.clone(), "docs".to_string());
-        
+    async fn test_dynamic_vector_search_tool_definition_with_context_prefix() {
+        let store = create_test_vector_store("kb", Some("Based on the following information from the knowledge base:".to_string()));
+        let tool = DynamicVectorSearchTool::new(store, "kb".to_string());
         let definition = tool.definition(String::new()).await;
         
-        assert!(definition.description.contains("documentation"));
+        assert!(definition.description.contains("knowledge base"));
         assert!(definition.description.contains("This vector store contains"));
     }
 
     #[tokio::test]
-    async fn test_dynamic_vector_search_tool_definition_parameters() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "test".to_string());
-        
+    async fn test_dynamic_vector_search_tool_definition_without_context_prefix() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
         let definition = tool.definition(String::new()).await;
-        let params = definition.parameters;
         
-        assert_eq!(params["type"], "object");
-        assert!(params["properties"]["query"].is_object());
-        assert!(params["properties"]["limit"].is_object());
-        assert!(params["properties"]["min_score"].is_object());
-        assert!(params["properties"]["label_filters"].is_object());
+        assert!(!definition.description.contains("This vector store contains"));
+        assert!(definition.description.contains("Search the 'test' vector store"));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_context_prefix_transformation() {
+        let store = create_test_vector_store("docs", Some("Based on the following information from the documentation:".to_string()));
+        let tool = DynamicVectorSearchTool::new(store, "docs".to_string());
+        let definition = tool.definition(String::new()).await;
         
-        let required = params["required"].as_array().unwrap();
+        assert!(definition.description.contains("documentation"));
+        assert!(!definition.description.contains("Based on the following information from the"));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_parameters_structure() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.parameters["type"], "object");
+        let properties = &definition.parameters["properties"];
+        assert!(properties.get("query").is_some());
+        assert!(properties.get("limit").is_some());
+        assert!(properties.get("min_score").is_some());
+        assert!(properties.get("label_filters").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_query_parameter() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let definition = tool.definition(String::new()).await;
+        
+        let query = &definition.parameters["properties"]["query"];
+        assert_eq!(query["type"], "string");
+        assert!(query["description"].as_str().unwrap().contains("query"));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_limit_parameter() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let definition = tool.definition(String::new()).await;
+        
+        let limit = &definition.parameters["properties"]["limit"];
+        assert_eq!(limit["type"], "integer");
+        assert_eq!(limit["default"], 5);
+        assert_eq!(limit["minimum"], 1);
+        assert_eq!(limit["maximum"], 20);
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_min_score_parameter() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let definition = tool.definition(String::new()).await;
+        
+        let min_score = &definition.parameters["properties"]["min_score"];
+        assert_eq!(min_score["type"], "number");
+        assert_eq!(min_score["default"], 0.5);
+        assert_eq!(min_score["minimum"], 0.1);
+        assert_eq!(min_score["maximum"], 1.0);
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_label_filters_parameter() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let definition = tool.definition(String::new()).await;
+        
+        let label_filters = &definition.parameters["properties"]["label_filters"];
+        assert_eq!(label_filters["type"], "array");
+        assert_eq!(label_filters["default"], json!([]));
+        
+        let items = &label_filters["items"];
+        assert_eq!(items["type"], "object");
+        assert_eq!(items["additionalProperties"], false);
+        
+        let item_props = &items["properties"];
+        assert!(item_props.get("key").is_some());
+        assert!(item_props.get("value").is_some());
+        assert_eq!(item_props["key"]["type"], "string");
+        assert_eq!(item_props["value"]["type"], "string");
+        
+        let required = items["required"].as_array().unwrap();
+        assert!(required.contains(&json!("key")));
+        assert!(required.contains(&json!("value")));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_required_fields() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let definition = tool.definition(String::new()).await;
+        
+        let required = definition.parameters["required"].as_array().unwrap();
         assert!(required.contains(&json!("query")));
         assert!(required.contains(&json!("limit")));
         assert!(required.contains(&json!("min_score")));
@@ -102,204 +206,324 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dynamic_vector_search_tool_definition_query_param() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "test".to_string());
-        
+    async fn test_dynamic_vector_search_tool_definition_label_filter_warning() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
         let definition = tool.definition(String::new()).await;
-        let query_param = &definition.parameters["properties"]["query"];
         
-        assert_eq!(query_param["type"], "string");
-        assert!(query_param["description"].as_str().unwrap().contains("query"));
+        assert!(definition.description.contains("IMPORTANT"));
+        assert!(definition.description.contains("Only use label_filters if"));
+        assert!(definition.description.contains("explicitly mentions"));
+        assert!(definition.description.contains("DO NOT guess"));
     }
 
     #[tokio::test]
-    async fn test_dynamic_vector_search_tool_definition_limit_param() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "test".to_string());
+    async fn test_dynamic_vector_search_tool_call_empty_results() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "test query".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        let result = tool.call(args).await;
         
-        let definition = tool.definition(String::new()).await;
-        let limit_param = &definition.parameters["properties"]["limit"];
-        
-        assert_eq!(limit_param["type"], "integer");
-        assert_eq!(limit_param["default"], 5);
-        assert_eq!(limit_param["minimum"], 1);
-        assert_eq!(limit_param["maximum"], 20);
+        let response = result.unwrap();
+        assert_eq!(response.query, "test query");
+        assert_eq!(response.total_found, 0);
+        assert_eq!(response.results.len(), 0);
+        assert!(response.formatted_results.contains("No results found"));
     }
 
     #[tokio::test]
-    async fn test_dynamic_vector_search_tool_definition_min_score_param() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "test".to_string());
-        
-        let definition = tool.definition(String::new()).await;
-        let min_score_param = &definition.parameters["properties"]["min_score"];
-        
-        assert_eq!(min_score_param["type"], "number");
-        assert_eq!(min_score_param["default"], 0.5);
-        assert_eq!(min_score_param["minimum"], 0.1);
-        assert_eq!(min_score_param["maximum"], 1.0);
-    }
-
-    #[tokio::test]
-    async fn test_dynamic_vector_search_tool_definition_label_filters_param() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "test".to_string());
-        
-        let definition = tool.definition(String::new()).await;
-        let filters_param = &definition.parameters["properties"]["label_filters"];
-        
-        assert_eq!(filters_param["type"], "array");
-        assert_eq!(filters_param["default"], json!([]));
-        assert!(filters_param["items"].is_object());
-        
-        let item_props = &filters_param["items"]["properties"];
-        assert!(item_props["key"].is_object());
-        assert!(item_props["value"].is_object());
-    }
-
-    #[test]
-    fn test_vector_search_args_default_limit() {
+    async fn test_dynamic_vector_search_tool_call_with_limit() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
         let args = VectorSearchArgs {
             query: "test".to_string(),
-            limit: default_limit(),
+            limit: 10,
             min_score: 0.0,
             label_filters: vec![],
         };
+        let result = tool.call(args).await;
         
-        assert_eq!(args.limit, 5);
+        assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_vector_search_args_serde() {
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_with_min_score() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
         let args = VectorSearchArgs {
-            query: "test query".to_string(),
-            limit: 10,
-            min_score: 0.7,
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.8,
             label_filters: vec![],
         };
+        let result = tool.call(args).await;
         
-        let json = serde_json::to_string(&args).unwrap();
-        let deserialized: VectorSearchArgs = serde_json::from_str(&json).unwrap();
-        
-        assert_eq!(deserialized.query, "test query");
-        assert_eq!(deserialized.limit, 10);
-        assert_eq!(deserialized.min_score, 0.7);
-        assert_eq!(deserialized.label_filters.len(), 0);
+        assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_vector_search_args_serde_with_filters() {
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_with_single_label_filter() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![FilterKV {
+                key: "type".to_string(),
+                value: "document".to_string(),
+            }],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_with_multiple_label_filters() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
         let args = VectorSearchArgs {
             query: "test".to_string(),
             limit: 5,
             min_score: 0.5,
             label_filters: vec![
                 FilterKV {
-                    key: "category".to_string(),
-                    value: "docs".to_string(),
+                    key: "type".to_string(),
+                    value: "document".to_string(),
                 },
                 FilterKV {
-                    key: "version".to_string(),
-                    value: "1.0".to_string(),
+                    key: "status".to_string(),
+                    value: "active".to_string(),
+                },
+                FilterKV {
+                    key: "priority".to_string(),
+                    value: "high".to_string(),
                 },
             ],
         };
+        let result = tool.call(args).await;
         
-        let json = serde_json::to_string(&args).unwrap();
-        let deserialized: VectorSearchArgs = serde_json::from_str(&json).unwrap();
-        
-        assert_eq!(deserialized.label_filters.len(), 2);
-        assert_eq!(deserialized.label_filters[0].key, "category");
-        assert_eq!(deserialized.label_filters[0].value, "docs");
-        assert_eq!(deserialized.label_filters[1].key, "version");
-        assert_eq!(deserialized.label_filters[1].value, "1.0");
+        assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_vector_search_args_empty_query() {
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_empty_query() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
         let args = VectorSearchArgs {
             query: "".to_string(),
             limit: 5,
-            min_score: 0.0,
+            min_score: 0.5,
             label_filters: vec![],
         };
+        let result = tool.call(args).await;
         
-        assert_eq!(args.query, "");
+        assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_vector_search_args_zero_limit() {
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_zero_limit() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
         let args = VectorSearchArgs {
             query: "test".to_string(),
             limit: 0,
-            min_score: 0.0,
+            min_score: 0.5,
             label_filters: vec![],
         };
+        let result = tool.call(args).await;
         
-        assert_eq!(args.limit, 0);
+        assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_vector_search_args_max_limit() {
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_max_limit() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
         let args = VectorSearchArgs {
             query: "test".to_string(),
             limit: 20,
-            min_score: 0.0,
+            min_score: 0.5,
             label_filters: vec![],
         };
+        let result = tool.call(args).await;
         
-        assert_eq!(args.limit, 20);
+        assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_vector_search_args_min_score_zero() {
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_min_score_zero() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
         let args = VectorSearchArgs {
             query: "test".to_string(),
             limit: 5,
             min_score: 0.0,
             label_filters: vec![],
         };
+        let result = tool.call(args).await;
         
-        assert_eq!(args.min_score, 0.0);
+        assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_vector_search_args_min_score_one() {
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_min_score_one() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
         let args = VectorSearchArgs {
             query: "test".to_string(),
             limit: 5,
             min_score: 1.0,
             label_filters: vec![],
         };
+        let result = tool.call(args).await;
         
-        assert_eq!(args.min_score, 1.0);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_unicode_query() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "Hello 世界 🎉".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        let result = tool.call(args).await;
+        
+        let response = result.unwrap();
+        assert_eq!(response.query, "Hello 世界 🎉");
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_multiline_query() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "line1\nline2\nline3".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_very_long_query() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let long_query = "query ".repeat(1000);
+        let args = VectorSearchArgs {
+            query: long_query.clone(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        let result = tool.call(args).await;
+        
+        let response = result.unwrap();
+        assert_eq!(response.query, long_query);
     }
 
     #[test]
-    fn test_filter_kv_clone() {
-        let filter = FilterKV {
-            key: "test".to_string(),
-            value: "value".to_string(),
+    fn test_vector_search_args_serde_minimal() {
+        let json = r#"{"query":"test"}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.query, "test");
+        assert_eq!(args.limit, 5);
+        assert_eq!(args.min_score, 0.0);
+        assert_eq!(args.label_filters.len(), 0);
+    }
+
+    #[test]
+    fn test_vector_search_args_serde_all_fields() {
+        let json = r#"{"query":"test","limit":10,"min_score":0.7,"label_filters":[{"key":"type","value":"doc"}]}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.query, "test");
+        assert_eq!(args.limit, 10);
+        assert_eq!(args.min_score, 0.7);
+        assert_eq!(args.label_filters.len(), 1);
+        assert_eq!(args.label_filters[0].key, "type");
+        assert_eq!(args.label_filters[0].value, "doc");
+    }
+
+    #[test]
+    fn test_vector_search_args_default_limit() {
+        let json = r#"{"query":"test"}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.limit, 5);
+    }
+
+    #[test]
+    fn test_vector_search_args_default_min_score() {
+        let json = r#"{"query":"test","limit":10}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.min_score, 0.0);
+    }
+
+    #[test]
+    fn test_vector_search_args_default_label_filters() {
+        let json = r#"{"query":"test","limit":10,"min_score":0.5}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.label_filters.len(), 0);
+    }
+
+    #[test]
+    fn test_vector_search_args_debug() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![],
         };
-        let cloned = filter.clone();
-        
-        assert_eq!(cloned.key, "test");
-        assert_eq!(cloned.value, "value");
+        let debug_str = format!("{:?}", args);
+        assert!(debug_str.contains("VectorSearchArgs"));
+        assert!(debug_str.contains("test"));
     }
 
     #[test]
     fn test_filter_kv_serde() {
         let filter = FilterKV {
-            key: "category".to_string(),
-            value: "documentation".to_string(),
+            key: "type".to_string(),
+            value: "document".to_string(),
         };
-        
         let json = serde_json::to_string(&filter).unwrap();
         let deserialized: FilterKV = serde_json::from_str(&json).unwrap();
-        
-        assert_eq!(deserialized.key, "category");
-        assert_eq!(deserialized.value, "documentation");
+        assert_eq!(deserialized.key, "type");
+        assert_eq!(deserialized.value, "document");
+    }
+
+    #[test]
+    fn test_filter_kv_clone() {
+        let filter = FilterKV {
+            key: "status".to_string(),
+            value: "active".to_string(),
+        };
+        let cloned = filter.clone();
+        assert_eq!(cloned.key, filter.key);
+        assert_eq!(cloned.value, filter.value);
+    }
+
+    #[test]
+    fn test_filter_kv_debug() {
+        let filter = FilterKV {
+            key: "key".to_string(),
+            value: "value".to_string(),
+        };
+        let debug_str = format!("{:?}", filter);
+        assert!(debug_str.contains("FilterKV"));
+        assert!(debug_str.contains("key"));
+        assert!(debug_str.contains("value"));
     }
 
     #[test]
@@ -308,93 +532,128 @@ mod tests {
             key: "".to_string(),
             value: "".to_string(),
         };
-        
         assert_eq!(filter.key, "");
         assert_eq!(filter.value, "");
     }
 
     #[test]
-    fn test_parse_value_str_string() {
-        let result = parse_value_str("hello");
-        assert_eq!(result, json!("hello"));
+    fn test_filter_kv_unicode() {
+        let filter = FilterKV {
+            key: "名前".to_string(),
+            value: "値".to_string(),
+        };
+        assert_eq!(filter.key, "名前");
+        assert_eq!(filter.value, "値");
     }
 
     #[test]
-    fn test_parse_value_str_number() {
-        let result = parse_value_str("42");
-        assert_eq!(result, json!(42));
+    fn test_parse_value_str_string() {
+        let value = parse_value_str("hello");
+        assert_eq!(value, json!("hello"));
+    }
+
+    #[test]
+    fn test_parse_value_str_integer() {
+        let value = parse_value_str("42");
+        assert_eq!(value, json!(42));
+    }
+
+    #[test]
+    fn test_parse_value_str_negative_integer() {
+        let value = parse_value_str("-42");
+        assert_eq!(value, json!(-42));
     }
 
     #[test]
     fn test_parse_value_str_float() {
-        let result = parse_value_str("3.14");
-        assert_eq!(result, json!(3.14));
+        let value = parse_value_str("3.14");
+        assert_eq!(value, json!(3.14));
     }
 
     #[test]
     fn test_parse_value_str_boolean_true() {
-        let result = parse_value_str("true");
-        assert_eq!(result, json!(true));
+        let value = parse_value_str("true");
+        assert_eq!(value, json!(true));
     }
 
     #[test]
     fn test_parse_value_str_boolean_false() {
-        let result = parse_value_str("false");
-        assert_eq!(result, json!(false));
+        let value = parse_value_str("false");
+        assert_eq!(value, json!(false));
     }
 
     #[test]
     fn test_parse_value_str_null() {
-        let result = parse_value_str("null");
-        assert_eq!(result, json!(null));
-    }
-
-    #[test]
-    fn test_parse_value_str_invalid_json() {
-        let result = parse_value_str("not-a-number");
-        assert_eq!(result, json!("not-a-number"));
-    }
-
-    #[test]
-    fn test_parse_value_str_empty() {
-        let result = parse_value_str("");
-        assert_eq!(result, json!(""));
-    }
-
-    #[test]
-    fn test_parse_value_str_json_object() {
-        let result = parse_value_str(r#"{"key":"value"}"#);
-        assert_eq!(result, json!({"key": "value"}));
+        let value = parse_value_str("null");
+        assert_eq!(value, json!(null));
     }
 
     #[test]
     fn test_parse_value_str_json_array() {
-        let result = parse_value_str(r#"[1,2,3]"#);
-        assert_eq!(result, json!([1, 2, 3]));
+        let value = parse_value_str(r#"["a","b","c"]"#);
+        assert_eq!(value, json!(["a", "b", "c"]));
     }
 
     #[test]
-    fn test_parse_value_str_negative_number() {
-        let result = parse_value_str("-42");
-        assert_eq!(result, json!(-42));
+    fn test_parse_value_str_json_object() {
+        let value = parse_value_str(r#"{"key":"value"}"#);
+        assert_eq!(value, json!({"key": "value"}));
     }
 
     #[test]
-    fn test_parse_value_str_zero() {
-        let result = parse_value_str("0");
-        assert_eq!(result, json!(0));
+    fn test_parse_value_str_invalid_json_fallback_to_string() {
+        let value = parse_value_str("not valid json");
+        assert_eq!(value, json!("not valid json"));
+    }
+
+    #[test]
+    fn test_parse_value_str_empty_string() {
+        let value = parse_value_str("");
+        assert_eq!(value, json!(""));
     }
 
     #[test]
     fn test_parse_value_str_whitespace() {
-        let result = parse_value_str("  hello  ");
-        assert_eq!(result, json!("  hello  "));
+        let value = parse_value_str("   ");
+        assert_eq!(value, json!("   "));
     }
 
     #[test]
-    fn test_parse_value_str_special_chars() {
-        let result = parse_value_str("hello@world.com");
-        assert_eq!(result, json!("hello@world.com"));
+    fn test_parse_value_str_quoted_string() {
+        let value = parse_value_str(r#""hello""#);
+        assert_eq!(value, json!("hello"));
+    }
+
+    #[test]
+    fn test_parse_value_str_unicode() {
+        let value = parse_value_str("世界");
+        assert_eq!(value, json!("世界"));
+    }
+
+    #[test]
+    fn test_parse_value_str_emoji() {
+        let value = parse_value_str("🎉");
+        assert_eq!(value, json!("🎉"));
+    }
+
+    #[test]
+    fn test_parse_value_str_zero() {
+        let value = parse_value_str("0");
+        assert_eq!(value, json!(0));
+    }
+
+    #[test]
+    fn test_parse_value_str_negative_zero() {
+        let value = parse_value_str("-0");
+        assert!(value.is_number());
+        let num = value.as_f64().unwrap();
+        assert_eq!(num, 0.0);
+    }
+
+    #[test]
+    fn test_parse_value_str_scientific_notation() {
+        let value = parse_value_str("1e10");
+        assert_eq!(value, json!(1e10));
     }
 
     #[test]
@@ -406,38 +665,25 @@ mod tests {
     fn test_vector_search_response_serde() {
         let response = VectorSearchResponse {
             results: vec![],
-            query: "test query".to_string(),
+            query: "test".to_string(),
             total_found: 0,
             formatted_results: "No results".to_string(),
         };
-        
         let json = serde_json::to_string(&response).unwrap();
-        assert!(json.contains("test query"));
+        assert!(json.contains("test"));
         assert!(json.contains("No results"));
     }
 
     #[test]
-    fn test_vector_search_response_with_results() {
+    fn test_vector_search_response_debug() {
         let response = VectorSearchResponse {
-            results: vec![
-                VectorSearchResult {
-                    content: "result 1".to_string(),
-                    score: 0.9,
-                    metadata: None,
-                },
-                VectorSearchResult {
-                    content: "result 2".to_string(),
-                    score: 0.8,
-                    metadata: Some(json!({"key": "value"})),
-                },
-            ],
+            results: vec![],
             query: "test".to_string(),
-            total_found: 2,
-            formatted_results: "formatted".to_string(),
+            total_found: 0,
+            formatted_results: "".to_string(),
         };
-        
-        assert_eq!(response.results.len(), 2);
-        assert_eq!(response.total_found, 2);
+        let debug_str = format!("{:?}", response);
+        assert!(debug_str.contains("VectorSearchResponse"));
     }
 
     #[test]
@@ -447,232 +693,90 @@ mod tests {
             score: 0.95,
             metadata: Some(json!({"id": "123"})),
         };
-        
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("test content"));
         assert!(json.contains("0.95"));
     }
 
     #[test]
-    fn test_vector_search_result_no_metadata() {
+    fn test_vector_search_result_debug() {
         let result = VectorSearchResult {
-            content: "content".to_string(),
+            content: "test".to_string(),
             score: 0.5,
             metadata: None,
         };
-        
+        let debug_str = format!("{:?}", result);
+        assert!(debug_str.contains("VectorSearchResult"));
+    }
+
+    #[test]
+    fn test_vector_search_result_without_metadata() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: None,
+        };
         assert!(result.metadata.is_none());
+    }
+
+    #[test]
+    fn test_vector_search_result_with_metadata() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!({"key": "value"})),
+        };
+        assert!(result.metadata.is_some());
     }
 
     #[test]
     fn test_vector_search_result_empty_content() {
         let result = VectorSearchResult {
             content: "".to_string(),
-            score: 0.0,
+            score: 0.5,
             metadata: None,
         };
-        
         assert_eq!(result.content, "");
-    }
-
-    #[test]
-    fn test_vector_search_result_score_zero() {
-        let result = VectorSearchResult {
-            content: "test".to_string(),
-            score: 0.0,
-            metadata: None,
-        };
-        
-        assert_eq!(result.score, 0.0);
-    }
-
-    #[test]
-    fn test_vector_search_result_score_one() {
-        let result = VectorSearchResult {
-            content: "test".to_string(),
-            score: 1.0,
-            metadata: None,
-        };
-        
-        assert_eq!(result.score, 1.0);
     }
 
     #[test]
     fn test_vector_search_result_unicode_content() {
         let result = VectorSearchResult {
             content: "Hello 世界 🎉".to_string(),
-            score: 0.8,
+            score: 0.5,
             metadata: None,
         };
-        
         assert_eq!(result.content, "Hello 世界 🎉");
     }
 
     #[test]
-    fn test_vector_search_result_complex_metadata() {
-        let metadata = json!({
-            "id": "123",
-            "category": "docs",
-            "tags": ["rust", "testing"],
-            "nested": {
-                "key": "value"
-            }
-        });
-        
+    fn test_vector_search_result_multiline_content() {
+        let result = VectorSearchResult {
+            content: "line1\nline2\nline3".to_string(),
+            score: 0.5,
+            metadata: None,
+        };
+        assert_eq!(result.content, "line1\nline2\nline3");
+    }
+
+    #[test]
+    fn test_vector_search_result_zero_score() {
         let result = VectorSearchResult {
             content: "test".to_string(),
-            score: 0.7,
-            metadata: Some(metadata.clone()),
+            score: 0.0,
+            metadata: None,
         };
-        
-        assert_eq!(result.metadata, Some(metadata));
+        assert_eq!(result.score, 0.0);
     }
 
     #[test]
-    fn test_vector_search_args_unicode_query() {
-        let args = VectorSearchArgs {
-            query: "日本語クエリ".to_string(),
-            limit: 5,
-            min_score: 0.5,
-            label_filters: vec![],
+    fn test_vector_search_result_max_score() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 1.0,
+            metadata: None,
         };
-        
-        assert_eq!(args.query, "日本語クエリ");
-    }
-
-    #[test]
-    fn test_vector_search_args_long_query() {
-        let long_query = "a".repeat(10000);
-        let args = VectorSearchArgs {
-            query: long_query.clone(),
-            limit: 5,
-            min_score: 0.5,
-            label_filters: vec![],
-        };
-        
-        assert_eq!(args.query.len(), 10000);
-    }
-
-    #[test]
-    fn test_filter_kv_unicode() {
-        let filter = FilterKV {
-            key: "カテゴリ".to_string(),
-            value: "ドキュメント".to_string(),
-        };
-        
-        assert_eq!(filter.key, "カテゴリ");
-        assert_eq!(filter.value, "ドキュメント");
-    }
-
-    #[test]
-    fn test_filter_kv_special_characters() {
-        let filter = FilterKV {
-            key: "key-with_special.chars".to_string(),
-            value: "value@with#special$chars".to_string(),
-        };
-        
-        assert_eq!(filter.key, "key-with_special.chars");
-        assert_eq!(filter.value, "value@with#special$chars");
-    }
-
-    #[test]
-    fn test_vector_search_args_many_filters() {
-        let filters: Vec<FilterKV> = (0..100)
-            .map(|i| FilterKV {
-                key: format!("key{}", i),
-                value: format!("value{}", i),
-            })
-            .collect();
-        
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 5,
-            min_score: 0.5,
-            label_filters: filters,
-        };
-        
-        assert_eq!(args.label_filters.len(), 100);
-    }
-
-    #[test]
-    fn test_parse_value_str_scientific_notation() {
-        let result = parse_value_str("1.5e10");
-        assert_eq!(result, json!(1.5e10));
-    }
-
-    #[test]
-    fn test_parse_value_str_negative_float() {
-        let result = parse_value_str("-3.14");
-        assert_eq!(result, json!(-3.14));
-    }
-
-    #[test]
-    fn test_parse_value_str_quoted_number() {
-        let result = parse_value_str(r#""42""#);
-        assert_eq!(result, json!("42"));
-    }
-
-    #[test]
-    fn test_vector_search_response_empty_query() {
-        let response = VectorSearchResponse {
-            results: vec![],
-            query: "".to_string(),
-            total_found: 0,
-            formatted_results: "".to_string(),
-        };
-        
-        assert_eq!(response.query, "");
-    }
-
-    #[test]
-    fn test_vector_search_response_large_total_found() {
-        let response = VectorSearchResponse {
-            results: vec![],
-            query: "test".to_string(),
-            total_found: usize::MAX,
-            formatted_results: "".to_string(),
-        };
-        
-        assert_eq!(response.total_found, usize::MAX);
-    }
-
-    #[test]
-    fn test_dynamic_vector_search_tool_const_name() {
-        assert_eq!(DynamicVectorSearchTool::NAME, "dynamic_vector_search_tool");
-    }
-
-    #[test]
-    fn test_vector_search_args_default_deserialization() {
-        let json = r#"{"query":"test"}"#;
-        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
-        
-        assert_eq!(args.query, "test");
-        assert_eq!(args.limit, 5);
-        assert_eq!(args.min_score, 0.0);
-        assert_eq!(args.label_filters.len(), 0);
-    }
-
-    #[test]
-    fn test_vector_search_args_partial_deserialization() {
-        let json = r#"{"query":"test","limit":10}"#;
-        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
-        
-        assert_eq!(args.query, "test");
-        assert_eq!(args.limit, 10);
-        assert_eq!(args.min_score, 0.0);
-        assert_eq!(args.label_filters.len(), 0);
-    }
-
-    #[test]
-    fn test_parse_value_str_large_number() {
-        let result = parse_value_str("999999999999999");
-        assert!(result.is_number());
-    }
-
-    #[test]
-    fn test_parse_value_str_decimal_zero() {
-        let result = parse_value_str("0.0");
-        assert_eq!(result, json!(0.0));
+        assert_eq!(result.score, 1.0);
     }
 
     #[test]
@@ -682,282 +786,346 @@ mod tests {
             score: -0.5,
             metadata: None,
         };
-        
         assert_eq!(result.score, -0.5);
     }
 
     #[test]
-    fn test_vector_search_result_large_score() {
+    fn test_vector_search_result_metadata_complex() {
+        let metadata = json!({
+            "id": "123",
+            "type": "document",
+            "tags": ["rust", "test"],
+            "nested": {"key": "value"}
+        });
         let result = VectorSearchResult {
             content: "test".to_string(),
-            score: 999.99,
-            metadata: None,
+            score: 0.5,
+            metadata: Some(metadata.clone()),
         };
-        
-        assert_eq!(result.score, 999.99);
+        assert_eq!(result.metadata, Some(metadata));
     }
 
     #[test]
-    fn test_filter_kv_newlines() {
-        let filter = FilterKV {
-            key: "key\nwith\nnewlines".to_string(),
-            value: "value\nwith\nnewlines".to_string(),
+    fn test_vector_search_response_empty_results() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test".to_string(),
+            total_found: 0,
+            formatted_results: "No results".to_string(),
         };
-        
-        assert!(filter.key.contains('\n'));
-        assert!(filter.value.contains('\n'));
+        assert_eq!(response.results.len(), 0);
+        assert_eq!(response.total_found, 0);
     }
 
     #[test]
-    fn test_vector_search_response_multiline_formatted() {
+    fn test_vector_search_response_with_results() {
+        let response = VectorSearchResponse {
+            results: vec![
+                VectorSearchResult {
+                    content: "result1".to_string(),
+                    score: 0.9,
+                    metadata: None,
+                },
+                VectorSearchResult {
+                    content: "result2".to_string(),
+                    score: 0.8,
+                    metadata: None,
+                },
+            ],
+            query: "test".to_string(),
+            total_found: 2,
+            formatted_results: "Results".to_string(),
+        };
+        assert_eq!(response.results.len(), 2);
+        assert_eq!(response.total_found, 2);
+    }
+
+    #[test]
+    fn test_vector_search_response_query_unicode() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "世界".to_string(),
+            total_found: 0,
+            formatted_results: "".to_string(),
+        };
+        assert_eq!(response.query, "世界");
+    }
+
+    #[test]
+    fn test_vector_search_response_query_empty() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "".to_string(),
+            total_found: 0,
+            formatted_results: "".to_string(),
+        };
+        assert_eq!(response.query, "");
+    }
+
+    #[test]
+    fn test_vector_search_response_formatted_results_empty() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test".to_string(),
+            total_found: 0,
+            formatted_results: "".to_string(),
+        };
+        assert_eq!(response.formatted_results, "");
+    }
+
+    #[test]
+    fn test_vector_search_response_formatted_results_multiline() {
         let response = VectorSearchResponse {
             results: vec![],
             query: "test".to_string(),
             total_found: 0,
             formatted_results: "line1\nline2\nline3".to_string(),
         };
-        
-        assert!(response.formatted_results.contains('\n'));
+        assert!(response.formatted_results.contains("\n"));
     }
 
     #[test]
-    fn test_parse_value_str_json_with_spaces() {
-        let result = parse_value_str(r#"{ "key" : "value" }"#);
-        assert_eq!(result, json!({"key": "value"}));
-    }
-
-    #[test]
-    fn test_parse_value_str_escaped_quotes() {
-        let result = parse_value_str(r#""hello \"world\"""#);
-        assert_eq!(result, json!("hello \"world\""));
-    }
-
-    #[test]
-    fn test_vector_search_args_boundary_min_score() {
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 5,
-            min_score: 0.1,
-            label_filters: vec![],
-        };
-        
-        assert_eq!(args.min_score, 0.1);
-    }
-
-    #[test]
-    fn test_vector_search_args_mid_range_values() {
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 10,
-            min_score: 0.5,
-            label_filters: vec![],
-        };
-        
-        assert_eq!(args.limit, 10);
-        assert_eq!(args.min_score, 0.5);
-    }
-
-    #[test]
-    fn test_vector_search_response_serialization_structure() {
-        let response = VectorSearchResponse {
-            results: vec![
-                VectorSearchResult {
-                    content: "test".to_string(),
-                    score: 0.9,
-                    metadata: None,
-                },
-            ],
-            query: "query".to_string(),
-            total_found: 1,
-            formatted_results: "formatted".to_string(),
-        };
-        
-        let json = serde_json::to_value(&response).unwrap();
-        assert!(json["results"].is_array());
-        assert_eq!(json["query"], "query");
-        assert_eq!(json["total_found"], 1);
-        assert_eq!(json["formatted_results"], "formatted");
-    }
-
-    #[test]
-    fn test_vector_search_result_serialization_structure() {
+    fn test_vector_search_result_very_long_content() {
+        let content = "a".repeat(100000);
         let result = VectorSearchResult {
-            content: "content".to_string(),
-            score: 0.8,
-            metadata: Some(json!({"key": "value"})),
-        };
-        
-        let json = serde_json::to_value(&result).unwrap();
-        assert_eq!(json["content"], "content");
-        assert!(json["score"].as_f64().unwrap() > 0.79 && json["score"].as_f64().unwrap() < 0.81);
-        assert!(json["metadata"].is_object());
-    }
-
-    #[test]
-    fn test_filter_kv_debug() {
-        let filter = FilterKV {
-            key: "test".to_string(),
-            value: "value".to_string(),
-        };
-        
-        let debug_str = format!("{:?}", filter);
-        assert!(debug_str.contains("test"));
-        assert!(debug_str.contains("value"));
-    }
-
-    #[test]
-    fn test_vector_search_args_debug() {
-        let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 5,
-            min_score: 0.5,
-            label_filters: vec![],
-        };
-        
-        let debug_str = format!("{:?}", args);
-        assert!(debug_str.contains("test"));
-        assert!(debug_str.contains("5"));
-    }
-
-    #[test]
-    fn test_vector_search_response_debug() {
-        let response = VectorSearchResponse {
-            results: vec![],
-            query: "test".to_string(),
-            total_found: 0,
-            formatted_results: "none".to_string(),
-        };
-        
-        let debug_str = format!("{:?}", response);
-        assert!(debug_str.contains("test"));
-    }
-
-    #[test]
-    fn test_vector_search_result_debug() {
-        let result = VectorSearchResult {
-            content: "test".to_string(),
-            score: 0.9,
+            content: content.clone(),
+            score: 0.5,
             metadata: None,
         };
-        
-        let debug_str = format!("{:?}", result);
-        assert!(debug_str.contains("test"));
-        assert!(debug_str.contains("0.9"));
+        assert_eq!(result.content.len(), 100000);
     }
 
     #[test]
-    fn test_parse_value_str_unicode() {
-        let result = parse_value_str("こんにちは");
-        assert_eq!(result, json!("こんにちは"));
-    }
-
-    #[test]
-    fn test_parse_value_str_emoji() {
-        let result = parse_value_str("🚀");
-        assert_eq!(result, json!("🚀"));
-    }
-
-    #[test]
-    fn test_vector_search_args_limit_one() {
+    fn test_vector_search_args_special_characters_in_query() {
         let args = VectorSearchArgs {
-            query: "test".to_string(),
-            limit: 1,
-            min_score: 0.0,
+            query: "!@#$%^&*()".to_string(),
+            limit: 5,
+            min_score: 0.5,
             label_filters: vec![],
         };
-        
-        assert_eq!(args.limit, 1);
+        assert_eq!(args.query, "!@#$%^&*()");
     }
 
     #[test]
-    fn test_vector_search_args_min_score_boundary() {
+    fn test_vector_search_args_tabs_and_newlines() {
+        let args = VectorSearchArgs {
+            query: "line1\tcolumn2\nline2".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        assert!(args.query.contains("\t"));
+        assert!(args.query.contains("\n"));
+    }
+
+    #[test]
+    fn test_vector_search_args_min_score_precision() {
         let args = VectorSearchArgs {
             query: "test".to_string(),
             limit: 5,
-            min_score: 0.999,
+            min_score: 0.123456789,
             label_filters: vec![],
         };
-        
-        assert_eq!(args.min_score, 0.999);
+        assert_eq!(args.min_score, 0.123456789);
     }
 
     #[test]
-    fn test_filter_kv_long_strings() {
-        let long_key = "k".repeat(1000);
-        let long_value = "v".repeat(1000);
+    fn test_vector_search_result_score_precision() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.987654321,
+            metadata: None,
+        };
+        assert_eq!(result.score, 0.987654321);
+    }
+
+    #[test]
+    fn test_filter_kv_special_characters() {
         let filter = FilterKV {
-            key: long_key.clone(),
-            value: long_value.clone(),
+            key: "key-with_special.chars!".to_string(),
+            value: "value-with_special.chars!".to_string(),
         };
-        
-        assert_eq!(filter.key.len(), 1000);
-        assert_eq!(filter.value.len(), 1000);
+        assert_eq!(filter.key, "key-with_special.chars!");
+        assert_eq!(filter.value, "value-with_special.chars!");
     }
 
     #[test]
-    fn test_vector_search_response_many_results() {
-        let results: Vec<VectorSearchResult> = (0..100)
-            .map(|i| VectorSearchResult {
-                content: format!("result {}", i),
-                score: 0.5,
-                metadata: None,
-            })
-            .collect();
-        
-        let response = VectorSearchResponse {
-            results,
-            query: "test".to_string(),
-            total_found: 100,
-            formatted_results: "many".to_string(),
-        };
-        
-        assert_eq!(response.results.len(), 100);
-        assert_eq!(response.total_found, 100);
+    fn test_parse_value_str_partial_json() {
+        let value = parse_value_str("{incomplete");
+        assert_eq!(value, json!("{incomplete"));
     }
 
     #[test]
-    fn test_parse_value_str_nested_json() {
-        let result = parse_value_str(r#"{"outer":{"inner":"value"}}"#);
-        assert_eq!(result, json!({"outer": {"inner": "value"}}));
+    fn test_parse_value_str_number_as_string() {
+        let value = parse_value_str("123abc");
+        assert_eq!(value, json!("123abc"));
     }
 
-    #[test]
-    fn test_parse_value_str_mixed_array() {
-        let result = parse_value_str(r#"[1,"two",true,null]"#);
-        assert_eq!(result, json!([1, "two", true, null]));
-    }
-
-    #[test]
-    fn test_vector_search_args_single_filter() {
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_label_filter_with_number_value() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
         let args = VectorSearchArgs {
             query: "test".to_string(),
             limit: 5,
             min_score: 0.5,
             label_filters: vec![FilterKV {
-                key: "single".to_string(),
-                value: "filter".to_string(),
+                key: "count".to_string(),
+                value: "42".to_string(),
             }],
         };
+        let result = tool.call(args).await;
         
-        assert_eq!(args.label_filters.len(), 1);
-    }
-
-    #[test]
-    fn test_dynamic_vector_search_tool_unicode_name() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "日本語".to_string());
-        
-        assert_eq!(tool.name(), "vector_search_日本語");
+        assert!(result.is_ok());
     }
 
     #[tokio::test]
-    async fn test_dynamic_vector_search_tool_definition_empty_name() {
-        let store = create_mock_vector_store();
-        let tool = DynamicVectorSearchTool::new(store.clone(), "".to_string());
+    async fn test_dynamic_vector_search_tool_call_label_filter_with_boolean_value() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![FilterKV {
+                key: "active".to_string(),
+                value: "true".to_string(),
+            }],
+        };
+        let result = tool.call(args).await;
         
-        let definition = tool.definition(String::new()).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_label_filter_with_json_value() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![FilterKV {
+                key: "tags".to_string(),
+                value: r#"["tag1","tag2"]"#.to_string(),
+            }],
+        };
+        let result = tool.call(args).await;
         
-        assert_eq!(definition.name, "vector_search_");
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_label_filter_empty_key() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![FilterKV {
+                key: "".to_string(),
+                value: "value".to_string(),
+            }],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_label_filter_empty_value() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![FilterKV {
+                key: "key".to_string(),
+                value: "".to_string(),
+            }],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_label_filter_unicode() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![FilterKV {
+                key: "名前".to_string(),
+                value: "値".to_string(),
+            }],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_vector_search_args_serde_multiple_label_filters() {
+        let json = r#"{"query":"test","limit":5,"min_score":0.5,"label_filters":[{"key":"type","value":"doc"},{"key":"status","value":"active"}]}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.label_filters.len(), 2);
+        assert_eq!(args.label_filters[0].key, "type");
+        assert_eq!(args.label_filters[0].value, "doc");
+        assert_eq!(args.label_filters[1].key, "status");
+        assert_eq!(args.label_filters[1].value, "active");
+    }
+
+    #[test]
+    fn test_vector_search_args_serde_empty_label_filters() {
+        let json = r#"{"query":"test","limit":5,"min_score":0.5,"label_filters":[]}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.label_filters.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_prompt_parameter_ignored() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let definition1 = tool.definition("prompt1".to_string()).await;
+        let definition2 = tool.definition("prompt2".to_string()).await;
+        
+        assert_eq!(definition1.name, definition2.name);
+        assert_eq!(definition1.description, definition2.description);
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_response_structure() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        let result = tool.call(args).await;
+        
+        let response = result.unwrap();
+        assert_eq!(response.query, "test");
+        assert_eq!(response.total_found, 0);
+        assert!(response.results.is_empty());
+        assert!(!response.formatted_results.is_empty());
+    }
+
+    #[test]
+    fn test_vector_search_result_metadata_null_value() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!(null)),
+        };
+        assert!(result.metadata.is_some());
+        assert!(result.metadata.unwrap().is_null());
     }
 
     #[test]
@@ -967,70 +1135,229 @@ mod tests {
             score: 0.5,
             metadata: Some(json!({})),
         };
-        
         assert!(result.metadata.is_some());
-        assert!(result.metadata.unwrap().is_object());
+        let metadata = result.metadata.unwrap();
+        assert!(metadata.as_object().unwrap().is_empty());
     }
 
     #[test]
-    fn test_vector_search_result_metadata_array() {
-        let result = VectorSearchResult {
-            content: "test".to_string(),
-            score: 0.5,
-            metadata: Some(json!(["tag1", "tag2"])),
+    fn test_vector_search_response_total_found_mismatch() {
+        let response = VectorSearchResponse {
+            results: vec![VectorSearchResult {
+                content: "test".to_string(),
+                score: 0.5,
+                metadata: None,
+            }],
+            query: "test".to_string(),
+            total_found: 5,
+            formatted_results: "Results".to_string(),
         };
+        assert_eq!(response.results.len(), 1);
+        assert_eq!(response.total_found, 5);
+    }
+
+    #[test]
+    fn test_parse_value_str_large_number() {
+        let value = parse_value_str("999999999999999999");
+        assert!(value.is_number());
+    }
+
+    #[test]
+    fn test_parse_value_str_negative_float() {
+        let value = parse_value_str("-3.14159");
+        assert_eq!(value, json!(-3.14159));
+    }
+
+    #[test]
+    fn test_parse_value_str_exponential_notation() {
+        let value = parse_value_str("1.5e-10");
+        assert_eq!(value, json!(1.5e-10));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_context_prefix_empty() {
+        let store = create_test_vector_store("test", Some("".to_string()));
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let definition = tool.definition(String::new()).await;
         
-        assert!(result.metadata.is_some());
-        assert!(result.metadata.unwrap().is_array());
+        assert!(definition.description.contains("Search the 'test' vector store"));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_context_prefix_multiline() {
+        let store = create_test_vector_store("test", Some("Based on the following information from the docs:\nLine 2".to_string()));
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let definition = tool.definition(String::new()).await;
+        
+        assert!(definition.description.contains("docs"));
     }
 
     #[test]
-    fn test_parse_value_str_leading_zeros() {
-        // "007" is not valid JSON, falls back to string
-        let result = parse_value_str("007");
-        assert_eq!(result, json!("007"));
+    fn test_vector_search_args_limit_boundary_one() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 1,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        assert_eq!(args.limit, 1);
     }
 
     #[test]
-    fn test_parse_value_str_plus_sign() {
-        // "+42" is not valid JSON, falls back to string
-        let result = parse_value_str("+42");
-        assert_eq!(result, json!("+42"));
+    fn test_vector_search_args_limit_boundary_twenty() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 20,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        assert_eq!(args.limit, 20);
     }
 
     #[test]
-    fn test_vector_search_args_fractional_min_score() {
+    fn test_vector_search_args_min_score_boundary_point_one() {
         let args = VectorSearchArgs {
             query: "test".to_string(),
             limit: 5,
-            min_score: 0.123456,
+            min_score: 0.1,
             label_filters: vec![],
         };
-        
-        assert_eq!(args.min_score, 0.123456);
+        assert_eq!(args.min_score, 0.1);
     }
 
     #[test]
-    fn test_filter_kv_whitespace_only() {
-        let filter = FilterKV {
-            key: "   ".to_string(),
-            value: "\t\n".to_string(),
-        };
-        
-        assert_eq!(filter.key, "   ");
-        assert_eq!(filter.value, "\t\n");
-    }
-
-    #[test]
-    fn test_vector_search_response_zero_total_found() {
-        let response = VectorSearchResponse {
-            results: vec![],
+    fn test_vector_search_args_min_score_boundary_one() {
+        let args = VectorSearchArgs {
             query: "test".to_string(),
-            total_found: 0,
-            formatted_results: "".to_string(),
+            limit: 5,
+            min_score: 1.0,
+            label_filters: vec![],
         };
+        assert_eq!(args.min_score, 1.0);
+    }
+
+    #[test]
+    fn test_filter_kv_very_long_key() {
+        let key = "k".repeat(10000);
+        let filter = FilterKV {
+            key: key.clone(),
+            value: "value".to_string(),
+        };
+        assert_eq!(filter.key.len(), 10000);
+    }
+
+    #[test]
+    fn test_filter_kv_very_long_value() {
+        let value = "v".repeat(10000);
+        let filter = FilterKV {
+            key: "key".to_string(),
+            value: value.clone(),
+        };
+        assert_eq!(filter.value.len(), 10000);
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_large_limit() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 100,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        let result = tool.call(args).await;
         
-        assert_eq!(response.total_found, 0);
-        assert_eq!(response.results.len(), 0);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_negative_min_score() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: -0.5,
+            label_filters: vec![],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_call_min_score_above_one() {
+        let store = create_test_vector_store("test", None);
+        let tool = DynamicVectorSearchTool::new(store, "test".to_string());
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 1.5,
+            label_filters: vec![],
+        };
+        let result = tool.call(args).await;
+        
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_vector_search_result_content_with_null_bytes() {
+        let result = VectorSearchResult {
+            content: "test\0content".to_string(),
+            score: 0.5,
+            metadata: None,
+        };
+        assert_eq!(result.content, "test\0content");
+    }
+
+    #[test]
+    fn test_vector_search_args_query_with_null_bytes() {
+        let args = VectorSearchArgs {
+            query: "test\0query".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        assert_eq!(args.query, "test\0query");
+    }
+
+    #[test]
+    fn test_parse_value_str_nested_json() {
+        let value = parse_value_str(r#"{"outer":{"inner":"value"}}"#);
+        assert_eq!(value, json!({"outer": {"inner": "value"}}));
+    }
+
+    #[test]
+    fn test_parse_value_str_json_with_unicode() {
+        let value = parse_value_str(r#"{"key":"世界"}"#);
+        assert_eq!(value, json!({"key": "世界"}));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_name_matches_tool_name() {
+        let store = create_test_vector_store("my_store", None);
+        let tool = DynamicVectorSearchTool::new(store, "my_store".to_string());
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.name, tool.name());
+        assert_eq!(definition.name, "vector_search_my_store");
+    }
+
+    #[test]
+    fn test_vector_search_response_serde_with_results() {
+        let response = VectorSearchResponse {
+            results: vec![VectorSearchResult {
+                content: "test".to_string(),
+                score: 0.9,
+                metadata: Some(json!({"id": "123"})),
+            }],
+            query: "test query".to_string(),
+            total_found: 1,
+            formatted_results: "Result 1".to_string(),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("test"));
+        assert!(json.contains("0.9"));
     }
 }

--- a/crates/aura/src/vector_dynamic_tests.rs
+++ b/crates/aura/src/vector_dynamic_tests.rs
@@ -1,0 +1,1036 @@
+#[cfg(test)]
+mod tests {
+    use crate::vector_dynamic::*;
+    use crate::vector_store::VectorStoreManager;
+    use rig::tool::Tool as RigTool;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    fn create_mock_vector_store() -> Arc<VectorStoreManager> {
+        Arc::new(VectorStoreManager::new_stub("test_store", None))
+    }
+
+    fn create_mock_vector_store_with_context(context: String) -> Arc<VectorStoreManager> {
+        Arc::new(VectorStoreManager::new_stub("test_store", Some(context)))
+    }
+
+    #[test]
+    fn test_dynamic_vector_search_tool_new() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "my_store".to_string());
+        
+        assert_eq!(tool.name(), "vector_search_my_store");
+    }
+
+    #[test]
+    fn test_dynamic_vector_search_tool_new_empty_name() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "".to_string());
+        
+        assert_eq!(tool.name(), "vector_search_");
+    }
+
+    #[test]
+    fn test_dynamic_vector_search_tool_new_special_chars() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "my-store_123".to_string());
+        
+        assert_eq!(tool.name(), "vector_search_my-store_123");
+    }
+
+    #[test]
+    fn test_dynamic_vector_search_tool_clone() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "test".to_string());
+        let cloned = tool.clone();
+        
+        assert_eq!(cloned.name(), tool.name());
+    }
+
+    #[test]
+    fn test_dynamic_vector_search_tool_name_override() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "custom".to_string());
+        
+        assert_eq!(tool.name(), "vector_search_custom");
+        assert_eq!(DynamicVectorSearchTool::NAME, "dynamic_vector_search_tool");
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_basic() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "test_store".to_string());
+        
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.name, "vector_search_test_store");
+        assert!(definition.description.contains("test_store"));
+        assert!(definition.description.contains("vector store"));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_with_context() {
+        let context = "Based on the following information from the documentation:".to_string();
+        let store = create_mock_vector_store_with_context(context);
+        let tool = DynamicVectorSearchTool::new(store.clone(), "docs".to_string());
+        
+        let definition = tool.definition(String::new()).await;
+        
+        assert!(definition.description.contains("documentation"));
+        assert!(definition.description.contains("This vector store contains"));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_parameters() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "test".to_string());
+        
+        let definition = tool.definition(String::new()).await;
+        let params = definition.parameters;
+        
+        assert_eq!(params["type"], "object");
+        assert!(params["properties"]["query"].is_object());
+        assert!(params["properties"]["limit"].is_object());
+        assert!(params["properties"]["min_score"].is_object());
+        assert!(params["properties"]["label_filters"].is_object());
+        
+        let required = params["required"].as_array().unwrap();
+        assert!(required.contains(&json!("query")));
+        assert!(required.contains(&json!("limit")));
+        assert!(required.contains(&json!("min_score")));
+        assert!(required.contains(&json!("label_filters")));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_query_param() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "test".to_string());
+        
+        let definition = tool.definition(String::new()).await;
+        let query_param = &definition.parameters["properties"]["query"];
+        
+        assert_eq!(query_param["type"], "string");
+        assert!(query_param["description"].as_str().unwrap().contains("query"));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_limit_param() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "test".to_string());
+        
+        let definition = tool.definition(String::new()).await;
+        let limit_param = &definition.parameters["properties"]["limit"];
+        
+        assert_eq!(limit_param["type"], "integer");
+        assert_eq!(limit_param["default"], 5);
+        assert_eq!(limit_param["minimum"], 1);
+        assert_eq!(limit_param["maximum"], 20);
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_min_score_param() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "test".to_string());
+        
+        let definition = tool.definition(String::new()).await;
+        let min_score_param = &definition.parameters["properties"]["min_score"];
+        
+        assert_eq!(min_score_param["type"], "number");
+        assert_eq!(min_score_param["default"], 0.5);
+        assert_eq!(min_score_param["minimum"], 0.1);
+        assert_eq!(min_score_param["maximum"], 1.0);
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_label_filters_param() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "test".to_string());
+        
+        let definition = tool.definition(String::new()).await;
+        let filters_param = &definition.parameters["properties"]["label_filters"];
+        
+        assert_eq!(filters_param["type"], "array");
+        assert_eq!(filters_param["default"], json!([]));
+        assert!(filters_param["items"].is_object());
+        
+        let item_props = &filters_param["items"]["properties"];
+        assert!(item_props["key"].is_object());
+        assert!(item_props["value"].is_object());
+    }
+
+    #[test]
+    fn test_vector_search_args_default_limit() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: default_limit(),
+            min_score: 0.0,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.limit, 5);
+    }
+
+    #[test]
+    fn test_vector_search_args_serde() {
+        let args = VectorSearchArgs {
+            query: "test query".to_string(),
+            limit: 10,
+            min_score: 0.7,
+            label_filters: vec![],
+        };
+        
+        let json = serde_json::to_string(&args).unwrap();
+        let deserialized: VectorSearchArgs = serde_json::from_str(&json).unwrap();
+        
+        assert_eq!(deserialized.query, "test query");
+        assert_eq!(deserialized.limit, 10);
+        assert_eq!(deserialized.min_score, 0.7);
+        assert_eq!(deserialized.label_filters.len(), 0);
+    }
+
+    #[test]
+    fn test_vector_search_args_serde_with_filters() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![
+                FilterKV {
+                    key: "category".to_string(),
+                    value: "docs".to_string(),
+                },
+                FilterKV {
+                    key: "version".to_string(),
+                    value: "1.0".to_string(),
+                },
+            ],
+        };
+        
+        let json = serde_json::to_string(&args).unwrap();
+        let deserialized: VectorSearchArgs = serde_json::from_str(&json).unwrap();
+        
+        assert_eq!(deserialized.label_filters.len(), 2);
+        assert_eq!(deserialized.label_filters[0].key, "category");
+        assert_eq!(deserialized.label_filters[0].value, "docs");
+        assert_eq!(deserialized.label_filters[1].key, "version");
+        assert_eq!(deserialized.label_filters[1].value, "1.0");
+    }
+
+    #[test]
+    fn test_vector_search_args_empty_query() {
+        let args = VectorSearchArgs {
+            query: "".to_string(),
+            limit: 5,
+            min_score: 0.0,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.query, "");
+    }
+
+    #[test]
+    fn test_vector_search_args_zero_limit() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 0,
+            min_score: 0.0,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.limit, 0);
+    }
+
+    #[test]
+    fn test_vector_search_args_max_limit() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 20,
+            min_score: 0.0,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.limit, 20);
+    }
+
+    #[test]
+    fn test_vector_search_args_min_score_zero() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.0,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.min_score, 0.0);
+    }
+
+    #[test]
+    fn test_vector_search_args_min_score_one() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 1.0,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.min_score, 1.0);
+    }
+
+    #[test]
+    fn test_filter_kv_clone() {
+        let filter = FilterKV {
+            key: "test".to_string(),
+            value: "value".to_string(),
+        };
+        let cloned = filter.clone();
+        
+        assert_eq!(cloned.key, "test");
+        assert_eq!(cloned.value, "value");
+    }
+
+    #[test]
+    fn test_filter_kv_serde() {
+        let filter = FilterKV {
+            key: "category".to_string(),
+            value: "documentation".to_string(),
+        };
+        
+        let json = serde_json::to_string(&filter).unwrap();
+        let deserialized: FilterKV = serde_json::from_str(&json).unwrap();
+        
+        assert_eq!(deserialized.key, "category");
+        assert_eq!(deserialized.value, "documentation");
+    }
+
+    #[test]
+    fn test_filter_kv_empty_strings() {
+        let filter = FilterKV {
+            key: "".to_string(),
+            value: "".to_string(),
+        };
+        
+        assert_eq!(filter.key, "");
+        assert_eq!(filter.value, "");
+    }
+
+    #[test]
+    fn test_parse_value_str_string() {
+        let result = parse_value_str("hello");
+        assert_eq!(result, json!("hello"));
+    }
+
+    #[test]
+    fn test_parse_value_str_number() {
+        let result = parse_value_str("42");
+        assert_eq!(result, json!(42));
+    }
+
+    #[test]
+    fn test_parse_value_str_float() {
+        let result = parse_value_str("3.14");
+        assert_eq!(result, json!(3.14));
+    }
+
+    #[test]
+    fn test_parse_value_str_boolean_true() {
+        let result = parse_value_str("true");
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_parse_value_str_boolean_false() {
+        let result = parse_value_str("false");
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_parse_value_str_null() {
+        let result = parse_value_str("null");
+        assert_eq!(result, json!(null));
+    }
+
+    #[test]
+    fn test_parse_value_str_invalid_json() {
+        let result = parse_value_str("not-a-number");
+        assert_eq!(result, json!("not-a-number"));
+    }
+
+    #[test]
+    fn test_parse_value_str_empty() {
+        let result = parse_value_str("");
+        assert_eq!(result, json!(""));
+    }
+
+    #[test]
+    fn test_parse_value_str_json_object() {
+        let result = parse_value_str(r#"{"key":"value"}"#);
+        assert_eq!(result, json!({"key": "value"}));
+    }
+
+    #[test]
+    fn test_parse_value_str_json_array() {
+        let result = parse_value_str(r#"[1,2,3]"#);
+        assert_eq!(result, json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn test_parse_value_str_negative_number() {
+        let result = parse_value_str("-42");
+        assert_eq!(result, json!(-42));
+    }
+
+    #[test]
+    fn test_parse_value_str_zero() {
+        let result = parse_value_str("0");
+        assert_eq!(result, json!(0));
+    }
+
+    #[test]
+    fn test_parse_value_str_whitespace() {
+        let result = parse_value_str("  hello  ");
+        assert_eq!(result, json!("  hello  "));
+    }
+
+    #[test]
+    fn test_parse_value_str_special_chars() {
+        let result = parse_value_str("hello@world.com");
+        assert_eq!(result, json!("hello@world.com"));
+    }
+
+    #[test]
+    fn test_default_limit() {
+        assert_eq!(default_limit(), 5);
+    }
+
+    #[test]
+    fn test_vector_search_response_serde() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test query".to_string(),
+            total_found: 0,
+            formatted_results: "No results".to_string(),
+        };
+        
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("test query"));
+        assert!(json.contains("No results"));
+    }
+
+    #[test]
+    fn test_vector_search_response_with_results() {
+        let response = VectorSearchResponse {
+            results: vec![
+                VectorSearchResult {
+                    content: "result 1".to_string(),
+                    score: 0.9,
+                    metadata: None,
+                },
+                VectorSearchResult {
+                    content: "result 2".to_string(),
+                    score: 0.8,
+                    metadata: Some(json!({"key": "value"})),
+                },
+            ],
+            query: "test".to_string(),
+            total_found: 2,
+            formatted_results: "formatted".to_string(),
+        };
+        
+        assert_eq!(response.results.len(), 2);
+        assert_eq!(response.total_found, 2);
+    }
+
+    #[test]
+    fn test_vector_search_result_serde() {
+        let result = VectorSearchResult {
+            content: "test content".to_string(),
+            score: 0.95,
+            metadata: Some(json!({"id": "123"})),
+        };
+        
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("test content"));
+        assert!(json.contains("0.95"));
+    }
+
+    #[test]
+    fn test_vector_search_result_no_metadata() {
+        let result = VectorSearchResult {
+            content: "content".to_string(),
+            score: 0.5,
+            metadata: None,
+        };
+        
+        assert!(result.metadata.is_none());
+    }
+
+    #[test]
+    fn test_vector_search_result_empty_content() {
+        let result = VectorSearchResult {
+            content: "".to_string(),
+            score: 0.0,
+            metadata: None,
+        };
+        
+        assert_eq!(result.content, "");
+    }
+
+    #[test]
+    fn test_vector_search_result_score_zero() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.0,
+            metadata: None,
+        };
+        
+        assert_eq!(result.score, 0.0);
+    }
+
+    #[test]
+    fn test_vector_search_result_score_one() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 1.0,
+            metadata: None,
+        };
+        
+        assert_eq!(result.score, 1.0);
+    }
+
+    #[test]
+    fn test_vector_search_result_unicode_content() {
+        let result = VectorSearchResult {
+            content: "Hello 世界 🎉".to_string(),
+            score: 0.8,
+            metadata: None,
+        };
+        
+        assert_eq!(result.content, "Hello 世界 🎉");
+    }
+
+    #[test]
+    fn test_vector_search_result_complex_metadata() {
+        let metadata = json!({
+            "id": "123",
+            "category": "docs",
+            "tags": ["rust", "testing"],
+            "nested": {
+                "key": "value"
+            }
+        });
+        
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.7,
+            metadata: Some(metadata.clone()),
+        };
+        
+        assert_eq!(result.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_vector_search_args_unicode_query() {
+        let args = VectorSearchArgs {
+            query: "日本語クエリ".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.query, "日本語クエリ");
+    }
+
+    #[test]
+    fn test_vector_search_args_long_query() {
+        let long_query = "a".repeat(10000);
+        let args = VectorSearchArgs {
+            query: long_query.clone(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.query.len(), 10000);
+    }
+
+    #[test]
+    fn test_filter_kv_unicode() {
+        let filter = FilterKV {
+            key: "カテゴリ".to_string(),
+            value: "ドキュメント".to_string(),
+        };
+        
+        assert_eq!(filter.key, "カテゴリ");
+        assert_eq!(filter.value, "ドキュメント");
+    }
+
+    #[test]
+    fn test_filter_kv_special_characters() {
+        let filter = FilterKV {
+            key: "key-with_special.chars".to_string(),
+            value: "value@with#special$chars".to_string(),
+        };
+        
+        assert_eq!(filter.key, "key-with_special.chars");
+        assert_eq!(filter.value, "value@with#special$chars");
+    }
+
+    #[test]
+    fn test_vector_search_args_many_filters() {
+        let filters: Vec<FilterKV> = (0..100)
+            .map(|i| FilterKV {
+                key: format!("key{}", i),
+                value: format!("value{}", i),
+            })
+            .collect();
+        
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: filters,
+        };
+        
+        assert_eq!(args.label_filters.len(), 100);
+    }
+
+    #[test]
+    fn test_parse_value_str_scientific_notation() {
+        let result = parse_value_str("1.5e10");
+        assert_eq!(result, json!(1.5e10));
+    }
+
+    #[test]
+    fn test_parse_value_str_negative_float() {
+        let result = parse_value_str("-3.14");
+        assert_eq!(result, json!(-3.14));
+    }
+
+    #[test]
+    fn test_parse_value_str_quoted_number() {
+        let result = parse_value_str(r#""42""#);
+        assert_eq!(result, json!("42"));
+    }
+
+    #[test]
+    fn test_vector_search_response_empty_query() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "".to_string(),
+            total_found: 0,
+            formatted_results: "".to_string(),
+        };
+        
+        assert_eq!(response.query, "");
+    }
+
+    #[test]
+    fn test_vector_search_response_large_total_found() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test".to_string(),
+            total_found: usize::MAX,
+            formatted_results: "".to_string(),
+        };
+        
+        assert_eq!(response.total_found, usize::MAX);
+    }
+
+    #[test]
+    fn test_dynamic_vector_search_tool_const_name() {
+        assert_eq!(DynamicVectorSearchTool::NAME, "dynamic_vector_search_tool");
+    }
+
+    #[test]
+    fn test_vector_search_args_default_deserialization() {
+        let json = r#"{"query":"test"}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        
+        assert_eq!(args.query, "test");
+        assert_eq!(args.limit, 5);
+        assert_eq!(args.min_score, 0.0);
+        assert_eq!(args.label_filters.len(), 0);
+    }
+
+    #[test]
+    fn test_vector_search_args_partial_deserialization() {
+        let json = r#"{"query":"test","limit":10}"#;
+        let args: VectorSearchArgs = serde_json::from_str(json).unwrap();
+        
+        assert_eq!(args.query, "test");
+        assert_eq!(args.limit, 10);
+        assert_eq!(args.min_score, 0.0);
+        assert_eq!(args.label_filters.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_value_str_large_number() {
+        let result = parse_value_str("999999999999999");
+        assert!(result.is_number());
+    }
+
+    #[test]
+    fn test_parse_value_str_decimal_zero() {
+        let result = parse_value_str("0.0");
+        assert_eq!(result, json!(0.0));
+    }
+
+    #[test]
+    fn test_vector_search_result_negative_score() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: -0.5,
+            metadata: None,
+        };
+        
+        assert_eq!(result.score, -0.5);
+    }
+
+    #[test]
+    fn test_vector_search_result_large_score() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 999.99,
+            metadata: None,
+        };
+        
+        assert_eq!(result.score, 999.99);
+    }
+
+    #[test]
+    fn test_filter_kv_newlines() {
+        let filter = FilterKV {
+            key: "key\nwith\nnewlines".to_string(),
+            value: "value\nwith\nnewlines".to_string(),
+        };
+        
+        assert!(filter.key.contains('\n'));
+        assert!(filter.value.contains('\n'));
+    }
+
+    #[test]
+    fn test_vector_search_response_multiline_formatted() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test".to_string(),
+            total_found: 0,
+            formatted_results: "line1\nline2\nline3".to_string(),
+        };
+        
+        assert!(response.formatted_results.contains('\n'));
+    }
+
+    #[test]
+    fn test_parse_value_str_json_with_spaces() {
+        let result = parse_value_str(r#"{ "key" : "value" }"#);
+        assert_eq!(result, json!({"key": "value"}));
+    }
+
+    #[test]
+    fn test_parse_value_str_escaped_quotes() {
+        let result = parse_value_str(r#""hello \"world\"""#);
+        assert_eq!(result, json!("hello \"world\""));
+    }
+
+    #[test]
+    fn test_vector_search_args_boundary_min_score() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.1,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.min_score, 0.1);
+    }
+
+    #[test]
+    fn test_vector_search_args_mid_range_values() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 10,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.limit, 10);
+        assert_eq!(args.min_score, 0.5);
+    }
+
+    #[test]
+    fn test_vector_search_response_serialization_structure() {
+        let response = VectorSearchResponse {
+            results: vec![
+                VectorSearchResult {
+                    content: "test".to_string(),
+                    score: 0.9,
+                    metadata: None,
+                },
+            ],
+            query: "query".to_string(),
+            total_found: 1,
+            formatted_results: "formatted".to_string(),
+        };
+        
+        let json = serde_json::to_value(&response).unwrap();
+        assert!(json["results"].is_array());
+        assert_eq!(json["query"], "query");
+        assert_eq!(json["total_found"], 1);
+        assert_eq!(json["formatted_results"], "formatted");
+    }
+
+    #[test]
+    fn test_vector_search_result_serialization_structure() {
+        let result = VectorSearchResult {
+            content: "content".to_string(),
+            score: 0.8,
+            metadata: Some(json!({"key": "value"})),
+        };
+        
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["content"], "content");
+        assert!(json["score"].as_f64().unwrap() > 0.79 && json["score"].as_f64().unwrap() < 0.81);
+        assert!(json["metadata"].is_object());
+    }
+
+    #[test]
+    fn test_filter_kv_debug() {
+        let filter = FilterKV {
+            key: "test".to_string(),
+            value: "value".to_string(),
+        };
+        
+        let debug_str = format!("{:?}", filter);
+        assert!(debug_str.contains("test"));
+        assert!(debug_str.contains("value"));
+    }
+
+    #[test]
+    fn test_vector_search_args_debug() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![],
+        };
+        
+        let debug_str = format!("{:?}", args);
+        assert!(debug_str.contains("test"));
+        assert!(debug_str.contains("5"));
+    }
+
+    #[test]
+    fn test_vector_search_response_debug() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test".to_string(),
+            total_found: 0,
+            formatted_results: "none".to_string(),
+        };
+        
+        let debug_str = format!("{:?}", response);
+        assert!(debug_str.contains("test"));
+    }
+
+    #[test]
+    fn test_vector_search_result_debug() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.9,
+            metadata: None,
+        };
+        
+        let debug_str = format!("{:?}", result);
+        assert!(debug_str.contains("test"));
+        assert!(debug_str.contains("0.9"));
+    }
+
+    #[test]
+    fn test_parse_value_str_unicode() {
+        let result = parse_value_str("こんにちは");
+        assert_eq!(result, json!("こんにちは"));
+    }
+
+    #[test]
+    fn test_parse_value_str_emoji() {
+        let result = parse_value_str("🚀");
+        assert_eq!(result, json!("🚀"));
+    }
+
+    #[test]
+    fn test_vector_search_args_limit_one() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 1,
+            min_score: 0.0,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.limit, 1);
+    }
+
+    #[test]
+    fn test_vector_search_args_min_score_boundary() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.999,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.min_score, 0.999);
+    }
+
+    #[test]
+    fn test_filter_kv_long_strings() {
+        let long_key = "k".repeat(1000);
+        let long_value = "v".repeat(1000);
+        let filter = FilterKV {
+            key: long_key.clone(),
+            value: long_value.clone(),
+        };
+        
+        assert_eq!(filter.key.len(), 1000);
+        assert_eq!(filter.value.len(), 1000);
+    }
+
+    #[test]
+    fn test_vector_search_response_many_results() {
+        let results: Vec<VectorSearchResult> = (0..100)
+            .map(|i| VectorSearchResult {
+                content: format!("result {}", i),
+                score: 0.5,
+                metadata: None,
+            })
+            .collect();
+        
+        let response = VectorSearchResponse {
+            results,
+            query: "test".to_string(),
+            total_found: 100,
+            formatted_results: "many".to_string(),
+        };
+        
+        assert_eq!(response.results.len(), 100);
+        assert_eq!(response.total_found, 100);
+    }
+
+    #[test]
+    fn test_parse_value_str_nested_json() {
+        let result = parse_value_str(r#"{"outer":{"inner":"value"}}"#);
+        assert_eq!(result, json!({"outer": {"inner": "value"}}));
+    }
+
+    #[test]
+    fn test_parse_value_str_mixed_array() {
+        let result = parse_value_str(r#"[1,"two",true,null]"#);
+        assert_eq!(result, json!([1, "two", true, null]));
+    }
+
+    #[test]
+    fn test_vector_search_args_single_filter() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.5,
+            label_filters: vec![FilterKV {
+                key: "single".to_string(),
+                value: "filter".to_string(),
+            }],
+        };
+        
+        assert_eq!(args.label_filters.len(), 1);
+    }
+
+    #[test]
+    fn test_dynamic_vector_search_tool_unicode_name() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "日本語".to_string());
+        
+        assert_eq!(tool.name(), "vector_search_日本語");
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_vector_search_tool_definition_empty_name() {
+        let store = create_mock_vector_store();
+        let tool = DynamicVectorSearchTool::new(store.clone(), "".to_string());
+        
+        let definition = tool.definition(String::new()).await;
+        
+        assert_eq!(definition.name, "vector_search_");
+    }
+
+    #[test]
+    fn test_vector_search_result_metadata_empty_object() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!({})),
+        };
+        
+        assert!(result.metadata.is_some());
+        assert!(result.metadata.unwrap().is_object());
+    }
+
+    #[test]
+    fn test_vector_search_result_metadata_array() {
+        let result = VectorSearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!(["tag1", "tag2"])),
+        };
+        
+        assert!(result.metadata.is_some());
+        assert!(result.metadata.unwrap().is_array());
+    }
+
+    #[test]
+    fn test_parse_value_str_leading_zeros() {
+        // "007" is not valid JSON, falls back to string
+        let result = parse_value_str("007");
+        assert_eq!(result, json!("007"));
+    }
+
+    #[test]
+    fn test_parse_value_str_plus_sign() {
+        // "+42" is not valid JSON, falls back to string
+        let result = parse_value_str("+42");
+        assert_eq!(result, json!("+42"));
+    }
+
+    #[test]
+    fn test_vector_search_args_fractional_min_score() {
+        let args = VectorSearchArgs {
+            query: "test".to_string(),
+            limit: 5,
+            min_score: 0.123456,
+            label_filters: vec![],
+        };
+        
+        assert_eq!(args.min_score, 0.123456);
+    }
+
+    #[test]
+    fn test_filter_kv_whitespace_only() {
+        let filter = FilterKV {
+            key: "   ".to_string(),
+            value: "\t\n".to_string(),
+        };
+        
+        assert_eq!(filter.key, "   ");
+        assert_eq!(filter.value, "\t\n");
+    }
+
+    #[test]
+    fn test_vector_search_response_zero_total_found() {
+        let response = VectorSearchResponse {
+            results: vec![],
+            query: "test".to_string(),
+            total_found: 0,
+            formatted_results: "".to_string(),
+        };
+        
+        assert_eq!(response.total_found, 0);
+        assert_eq!(response.results.len(), 0);
+    }
+}

--- a/crates/aura/src/vector_store.rs
+++ b/crates/aura/src/vector_store.rs
@@ -40,6 +40,23 @@ pub struct VectorStoreManager {
 }
 
 impl VectorStoreManager {
+    #[cfg(test)]
+    pub(crate) fn new_stub(store_name: &str, context_prefix: Option<String>) -> Self {
+        Self {
+            store_name: store_name.to_string(),
+            store_type: "in_memory".to_string(),
+            qdrant_url: None,
+            collection_name: None,
+            in_memory_store: None,
+            qdrant_store: None,
+            bedrock_kb_client: None,
+            bedrock_kb_id: None,
+            embedding_provider: "stub".to_string(),
+            embedding_model_name: "stub".to_string(),
+            context_prefix,
+        }
+    }
+
     /// Create a new vector store from configuration
     pub async fn from_config(config: &VectorStoreConfig) -> Result<Self, BuilderError> {
         match &config.store {

--- a/crates/aura/src/vector_store_tests.rs
+++ b/crates/aura/src/vector_store_tests.rs
@@ -1,0 +1,1306 @@
+#[cfg(test)]
+mod tests {
+    use crate::vector_store::*;
+    use crate::config::{EmbeddingModelConfig, VectorStoreConfig, VectorStoreType};
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_new_stub() {
+        let manager = VectorStoreManager::new_stub("test_store", None);
+        assert_eq!(manager.store_name, "test_store");
+        assert_eq!(manager.store_type, "in_memory");
+        assert!(manager.qdrant_url.is_none());
+        assert!(manager.collection_name.is_none());
+        assert!(manager.in_memory_store.is_none());
+        assert!(manager.context_prefix.is_none());
+    }
+
+    #[test]
+    fn test_new_stub_with_context_prefix() {
+        let prefix = Some("Context:".to_string());
+        let manager = VectorStoreManager::new_stub("test_store", prefix.clone());
+        assert_eq!(manager.store_name, "test_store");
+        assert_eq!(manager.context_prefix, prefix);
+    }
+
+    #[test]
+    fn test_new_stub_empty_name() {
+        let manager = VectorStoreManager::new_stub("", None);
+        assert_eq!(manager.store_name, "");
+    }
+
+    #[test]
+    fn test_get_store_name() {
+        let manager = VectorStoreManager::new_stub("my_store", None);
+        assert_eq!(manager.get_store_name(), Some("my_store"));
+    }
+
+    #[test]
+    fn test_get_store_name_empty() {
+        let manager = VectorStoreManager::new_stub("", None);
+        assert_eq!(manager.get_store_name(), Some(""));
+    }
+
+    #[test]
+    fn test_get_context_prefix_none() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        assert_eq!(manager.get_context_prefix(), None);
+    }
+
+    #[test]
+    fn test_get_context_prefix_some() {
+        let manager = VectorStoreManager::new_stub("test", Some("Prefix:".to_string()));
+        assert_eq!(manager.get_context_prefix(), Some("Prefix:"));
+    }
+
+    #[test]
+    fn test_get_context_prefix_empty_string() {
+        let manager = VectorStoreManager::new_stub("test", Some("".to_string()));
+        assert_eq!(manager.get_context_prefix(), Some(""));
+    }
+
+    #[test]
+    fn test_get_stats() {
+        let manager = VectorStoreManager::new_stub("test_store", None);
+        let stats = manager.get_stats();
+        assert_eq!(stats.store_type, "in_memory");
+        assert_eq!(stats.embedding_provider, "stub");
+        assert_eq!(stats.embedding_model, "stub");
+        assert_eq!(stats.document_count, 0);
+        assert_eq!(stats.index_size, 0);
+    }
+
+    #[test]
+    fn test_get_stats_clone() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let stats1 = manager.get_stats();
+        let stats2 = stats1.clone();
+        assert_eq!(stats1.store_type, stats2.store_type);
+        assert_eq!(stats1.embedding_provider, stats2.embedding_provider);
+        assert_eq!(stats1.embedding_model, stats2.embedding_model);
+        assert_eq!(stats1.document_count, stats2.document_count);
+        assert_eq!(stats1.index_size, stats2.index_size);
+    }
+
+    #[tokio::test]
+    async fn test_add_documents_bedrock_kb_error() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "bedrock_kb".to_string();
+        
+        let docs = vec!["doc1".to_string(), "doc2".to_string()];
+        let result = manager.add_documents(docs).await;
+        
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("read-only"));
+    }
+
+    #[tokio::test]
+    async fn test_add_documents_empty_vec() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let result = manager.add_documents(vec![]).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_add_documents_single_document() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let docs = vec!["single document".to_string()];
+        let result = manager.add_documents(docs).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_add_documents_multiple_documents() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let docs = vec![
+            "document one".to_string(),
+            "document two".to_string(),
+            "document three".to_string(),
+        ];
+        let result = manager.add_documents(docs).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_add_documents_empty_string() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let docs = vec!["".to_string()];
+        let result = manager.add_documents(docs).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_add_documents_unicode() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let docs = vec!["Hello 世界 🎉".to_string()];
+        let result = manager.add_documents(docs).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_search_in_memory_returns_empty() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let result = manager.search("query", 5).await;
+        assert!(result.is_ok());
+        let results = result.unwrap();
+        assert_eq!(results.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_search_in_memory_empty_query() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let result = manager.search("", 5).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_search_in_memory_zero_limit() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let result = manager.search("query", 0).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_search_in_memory_large_limit() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let result = manager.search("query", 1000).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_search_unsupported_store_type() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "unsupported".to_string();
+        
+        let result = manager.search("query", 5).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("Unsupported store type"));
+    }
+
+    #[tokio::test]
+    async fn test_search_qdrant_not_initialized() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "qdrant".to_string();
+        
+        let result = manager.search("query", 5).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("not initialized"));
+    }
+
+    #[tokio::test]
+    async fn test_search_bedrock_kb_client_not_initialized() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "bedrock_kb".to_string();
+        
+        let result = manager.search("query", 5).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_in_memory() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let mut filters = HashMap::new();
+        filters.insert("key".to_string(), json!("value"));
+        
+        let result = manager.search_with_filter("query", 5, filters).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_empty_filters() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let filters = HashMap::new();
+        
+        let result = manager.search_with_filter("query", 5, filters).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_bedrock_kb() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "bedrock_kb".to_string();
+        let filters = HashMap::new();
+        
+        let result = manager.search_with_filter("query", 5, filters).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_qdrant_not_initialized() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "qdrant".to_string();
+        let filters = HashMap::new();
+        
+        let result = manager.search_with_filter("query", 5, filters).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_unsupported_store() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "unknown".to_string();
+        let filters = HashMap::new();
+        
+        let result = manager.search_with_filter("query", 5, filters).await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_format_search_results_empty() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![];
+        let formatted = manager.format_search_results(&results, "test query");
+        assert_eq!(formatted, "No results found for query: 'test query'");
+    }
+
+    #[test]
+    fn test_format_search_results_empty_query() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![];
+        let formatted = manager.format_search_results(&results, "");
+        assert_eq!(formatted, "No results found for query: ''");
+    }
+
+    #[test]
+    fn test_format_search_results_single_result() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![SearchResult {
+            content: "test content".to_string(),
+            score: 0.95,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("Result 1"));
+        assert!(formatted.contains("0.950"));
+        assert!(formatted.contains("test content"));
+    }
+
+    #[test]
+    fn test_format_search_results_multiple_results() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![
+            SearchResult {
+                content: "first".to_string(),
+                score: 0.9,
+                metadata: None,
+            },
+            SearchResult {
+                content: "second".to_string(),
+                score: 0.8,
+                metadata: None,
+            },
+        ];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("Result 1"));
+        assert!(formatted.contains("Result 2"));
+        assert!(formatted.contains("first"));
+        assert!(formatted.contains("second"));
+        assert!(formatted.contains("---"));
+    }
+
+    #[test]
+    fn test_format_search_results_with_context_prefix() {
+        let manager = VectorStoreManager::new_stub("test", Some("Context:".to_string()));
+        let results = vec![SearchResult {
+            content: "content".to_string(),
+            score: 0.5,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.starts_with("Context:"));
+        assert!(formatted.contains("content"));
+    }
+
+    #[test]
+    fn test_format_search_results_no_separator_after_last() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![
+            SearchResult {
+                content: "first".to_string(),
+                score: 0.9,
+                metadata: None,
+            },
+            SearchResult {
+                content: "second".to_string(),
+                score: 0.8,
+                metadata: None,
+            },
+        ];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(!formatted.ends_with("---"));
+    }
+
+    #[test]
+    fn test_format_search_results_score_formatting() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![SearchResult {
+            content: "test".to_string(),
+            score: 0.123456,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("0.123"));
+    }
+
+    #[test]
+    fn test_format_search_results_zero_score() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![SearchResult {
+            content: "test".to_string(),
+            score: 0.0,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("0.000"));
+    }
+
+    #[test]
+    fn test_format_search_results_max_score() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![SearchResult {
+            content: "test".to_string(),
+            score: 1.0,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("1.000"));
+    }
+
+    #[test]
+    fn test_format_search_results_unicode_content() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![SearchResult {
+            content: "Hello 世界 🎉".to_string(),
+            score: 0.5,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("Hello 世界 🎉"));
+    }
+
+    #[test]
+    fn test_format_search_results_empty_content() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![SearchResult {
+            content: "".to_string(),
+            score: 0.5,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("Result 1"));
+    }
+
+    #[test]
+    fn test_format_search_results_multiline_content() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![SearchResult {
+            content: "line1\nline2\nline3".to_string(),
+            score: 0.5,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("line1\nline2\nline3"));
+    }
+
+    #[test]
+    fn test_search_result_clone() {
+        let result = SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!({"key": "value"})),
+        };
+        let cloned = result.clone();
+        assert_eq!(cloned.content, result.content);
+        assert_eq!(cloned.score, result.score);
+        assert_eq!(cloned.metadata, result.metadata);
+    }
+
+    #[test]
+    fn test_search_result_with_metadata() {
+        let result = SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!({"id": "123", "type": "doc"})),
+        };
+        assert!(result.metadata.is_some());
+        let metadata = result.metadata.unwrap();
+        assert_eq!(metadata["id"], "123");
+        assert_eq!(metadata["type"], "doc");
+    }
+
+    #[test]
+    fn test_search_result_without_metadata() {
+        let result = SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: None,
+        };
+        assert!(result.metadata.is_none());
+    }
+
+    #[test]
+    fn test_search_result_debug() {
+        let result = SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: None,
+        };
+        let debug_str = format!("{:?}", result);
+        assert!(debug_str.contains("SearchResult"));
+        assert!(debug_str.contains("test"));
+    }
+
+    #[test]
+    fn test_vector_store_stats_clone() {
+        let stats = VectorStoreStats {
+            store_type: "qdrant".to_string(),
+            embedding_provider: "openai".to_string(),
+            embedding_model: "text-embedding-3-small".to_string(),
+            document_count: 100,
+            index_size: 1024,
+        };
+        let cloned = stats.clone();
+        assert_eq!(cloned.store_type, stats.store_type);
+        assert_eq!(cloned.embedding_provider, stats.embedding_provider);
+        assert_eq!(cloned.embedding_model, stats.embedding_model);
+        assert_eq!(cloned.document_count, stats.document_count);
+        assert_eq!(cloned.index_size, stats.index_size);
+    }
+
+    #[test]
+    fn test_vector_store_stats_debug() {
+        let stats = VectorStoreStats {
+            store_type: "in_memory".to_string(),
+            embedding_provider: "openai".to_string(),
+            embedding_model: "text-embedding-3-small".to_string(),
+            document_count: 10,
+            index_size: 512,
+        };
+        let debug_str = format!("{:?}", stats);
+        assert!(debug_str.contains("VectorStoreStats"));
+        assert!(debug_str.contains("in_memory"));
+    }
+
+    #[test]
+    fn test_vector_store_stats_with_counts() {
+        let stats = VectorStoreStats {
+            store_type: "qdrant".to_string(),
+            embedding_provider: "bedrock".to_string(),
+            embedding_model: "amazon.titan-embed-text-v1".to_string(),
+            document_count: 500,
+            index_size: 2048,
+        };
+        assert_eq!(stats.document_count, 500);
+        assert_eq!(stats.index_size, 2048);
+    }
+
+    #[test]
+    fn test_document_new() {
+        let doc = Document::new("test content".to_string());
+        assert_eq!(doc.content, "test content");
+        assert!(doc.id.is_none());
+        assert!(doc.metadata.is_none());
+    }
+
+    #[test]
+    fn test_document_new_empty() {
+        let doc = Document::new("".to_string());
+        assert_eq!(doc.content, "");
+        assert!(doc.id.is_none());
+        assert!(doc.metadata.is_none());
+    }
+
+    #[test]
+    fn test_document_with_id() {
+        let doc = Document::new("content".to_string()).with_id("doc123".to_string());
+        assert_eq!(doc.content, "content");
+        assert_eq!(doc.id, Some("doc123".to_string()));
+        assert!(doc.metadata.is_none());
+    }
+
+    #[test]
+    fn test_document_with_id_empty() {
+        let doc = Document::new("content".to_string()).with_id("".to_string());
+        assert_eq!(doc.id, Some("".to_string()));
+    }
+
+    #[test]
+    fn test_document_with_metadata() {
+        let metadata = json!({"key": "value"});
+        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
+        assert_eq!(doc.content, "content");
+        assert!(doc.id.is_none());
+        assert_eq!(doc.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_document_with_metadata_empty_object() {
+        let metadata = json!({});
+        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
+        assert_eq!(doc.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_document_builder_chain() {
+        let metadata = json!({"type": "article"});
+        let doc = Document::new("content".to_string())
+            .with_id("123".to_string())
+            .with_metadata(metadata.clone());
+        assert_eq!(doc.content, "content");
+        assert_eq!(doc.id, Some("123".to_string()));
+        assert_eq!(doc.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_document_builder_chain_reverse_order() {
+        let metadata = json!({"type": "article"});
+        let doc = Document::new("content".to_string())
+            .with_metadata(metadata.clone())
+            .with_id("123".to_string());
+        assert_eq!(doc.content, "content");
+        assert_eq!(doc.id, Some("123".to_string()));
+        assert_eq!(doc.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_document_clone() {
+        let metadata = json!({"key": "value"});
+        let doc = Document::new("content".to_string())
+            .with_id("123".to_string())
+            .with_metadata(metadata.clone());
+        let cloned = doc.clone();
+        assert_eq!(cloned.content, doc.content);
+        assert_eq!(cloned.id, doc.id);
+        assert_eq!(cloned.metadata, doc.metadata);
+    }
+
+    #[test]
+    fn test_document_debug() {
+        let doc = Document::new("test".to_string());
+        let debug_str = format!("{:?}", doc);
+        assert!(debug_str.contains("Document"));
+        assert!(debug_str.contains("test"));
+    }
+
+    #[test]
+    fn test_document_unicode_content() {
+        let doc = Document::new("Hello 世界 🎉".to_string());
+        assert_eq!(doc.content, "Hello 世界 🎉");
+    }
+
+    #[test]
+    fn test_document_multiline_content() {
+        let doc = Document::new("line1\nline2\nline3".to_string());
+        assert_eq!(doc.content, "line1\nline2\nline3");
+    }
+
+    #[test]
+    fn test_document_metadata_complex() {
+        let metadata = json!({
+            "id": "123",
+            "type": "article",
+            "tags": ["rust", "programming"],
+            "nested": {
+                "key": "value"
+            }
+        });
+        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
+        assert_eq!(doc.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_document_metadata_null() {
+        let metadata = json!(null);
+        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
+        assert_eq!(doc.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_document_metadata_array() {
+        let metadata = json!(["tag1", "tag2", "tag3"]);
+        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
+        assert_eq!(doc.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_document_metadata_string() {
+        let metadata = json!("simple string");
+        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
+        assert_eq!(doc.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_document_metadata_number() {
+        let metadata = json!(42);
+        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
+        assert_eq!(doc.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_document_metadata_boolean() {
+        let metadata = json!(true);
+        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
+        assert_eq!(doc.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_search_result_negative_score() {
+        let result = SearchResult {
+            content: "test".to_string(),
+            score: -0.5,
+            metadata: None,
+        };
+        assert_eq!(result.score, -0.5);
+    }
+
+    #[test]
+    fn test_search_result_large_score() {
+        let result = SearchResult {
+            content: "test".to_string(),
+            score: 999.999,
+            metadata: None,
+        };
+        assert_eq!(result.score, 999.999);
+    }
+
+    #[test]
+    fn test_vector_store_stats_zero_counts() {
+        let stats = VectorStoreStats {
+            store_type: "in_memory".to_string(),
+            embedding_provider: "openai".to_string(),
+            embedding_model: "model".to_string(),
+            document_count: 0,
+            index_size: 0,
+        };
+        assert_eq!(stats.document_count, 0);
+        assert_eq!(stats.index_size, 0);
+    }
+
+    #[test]
+    fn test_vector_store_stats_large_counts() {
+        let stats = VectorStoreStats {
+            store_type: "qdrant".to_string(),
+            embedding_provider: "bedrock".to_string(),
+            embedding_model: "model".to_string(),
+            document_count: 1_000_000,
+            index_size: 10_000_000,
+        };
+        assert_eq!(stats.document_count, 1_000_000);
+        assert_eq!(stats.index_size, 10_000_000);
+    }
+
+    #[test]
+    fn test_format_search_results_three_results() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![
+            SearchResult {
+                content: "first".to_string(),
+                score: 0.9,
+                metadata: None,
+            },
+            SearchResult {
+                content: "second".to_string(),
+                score: 0.8,
+                metadata: None,
+            },
+            SearchResult {
+                content: "third".to_string(),
+                score: 0.7,
+                metadata: None,
+            },
+        ];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("Result 1"));
+        assert!(formatted.contains("Result 2"));
+        assert!(formatted.contains("Result 3"));
+        let separator_count = formatted.matches("---").count();
+        assert_eq!(separator_count, 2);
+    }
+
+    #[test]
+    fn test_format_search_results_with_empty_prefix() {
+        let manager = VectorStoreManager::new_stub("test", Some("".to_string()));
+        let results = vec![SearchResult {
+            content: "content".to_string(),
+            score: 0.5,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("content"));
+    }
+
+    #[test]
+    fn test_format_search_results_with_multiline_prefix() {
+        let manager = VectorStoreManager::new_stub("test", Some("Line1\nLine2".to_string()));
+        let results = vec![SearchResult {
+            content: "content".to_string(),
+            score: 0.5,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.starts_with("Line1\nLine2"));
+    }
+
+    #[test]
+    fn test_format_search_results_special_characters_in_query() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![];
+        let formatted = manager.format_search_results(&results, "query with 'quotes' and \"double\"");
+        assert!(formatted.contains("query with 'quotes' and \"double\""));
+    }
+
+    #[test]
+    fn test_format_search_results_newline_in_query() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![];
+        let formatted = manager.format_search_results(&results, "query\nwith\nnewlines");
+        assert!(formatted.contains("query\nwith\nnewlines"));
+    }
+
+    #[test]
+    fn test_document_very_long_content() {
+        let content = "a".repeat(10000);
+        let doc = Document::new(content.clone());
+        assert_eq!(doc.content.len(), 10000);
+    }
+
+    #[test]
+    fn test_document_very_long_id() {
+        let id = "x".repeat(1000);
+        let doc = Document::new("content".to_string()).with_id(id.clone());
+        assert_eq!(doc.id, Some(id));
+    }
+
+    #[test]
+    fn test_search_result_very_long_content() {
+        let content = "b".repeat(10000);
+        let result = SearchResult {
+            content: content.clone(),
+            score: 0.5,
+            metadata: None,
+        };
+        assert_eq!(result.content.len(), 10000);
+    }
+
+    #[test]
+    fn test_vector_store_manager_store_type_values() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        assert_eq!(manager.store_type, "in_memory");
+        
+        let mut manager2 = VectorStoreManager::new_stub("test", None);
+        manager2.store_type = "qdrant".to_string();
+        assert_eq!(manager2.store_type, "qdrant");
+        
+        let mut manager3 = VectorStoreManager::new_stub("test", None);
+        manager3.store_type = "bedrock_kb".to_string();
+        assert_eq!(manager3.store_type, "bedrock_kb");
+    }
+
+    #[test]
+    fn test_vector_store_manager_get_stats_embedding_provider() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let stats = manager.get_stats();
+        assert_eq!(stats.embedding_provider, "stub");
+    }
+
+    #[test]
+    fn test_vector_store_manager_get_stats_embedding_model() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let stats = manager.get_stats();
+        assert_eq!(stats.embedding_model, "stub");
+    }
+
+    #[tokio::test]
+    async fn test_add_documents_large_document() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let large_doc = "x".repeat(100000);
+        let docs = vec![large_doc];
+        let result = manager.add_documents(docs).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_add_documents_many_documents() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let docs: Vec<String> = (0..100).map(|i| format!("document {}", i)).collect();
+        let result = manager.add_documents(docs).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_search_unicode_query() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let result = manager.search("世界", 5).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_search_emoji_query() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let result = manager.search("🎉", 5).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_search_multiline_query() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let result = manager.search("line1\nline2", 5).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_multiple_filters() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let mut filters = HashMap::new();
+        filters.insert("key1".to_string(), json!("value1"));
+        filters.insert("key2".to_string(), json!(42));
+        filters.insert("key3".to_string(), json!(true));
+        
+        let result = manager.search_with_filter("query", 5, filters).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_complex_values() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let mut filters = HashMap::new();
+        filters.insert("array".to_string(), json!(["a", "b", "c"]));
+        filters.insert("object".to_string(), json!({"nested": "value"}));
+        
+        let result = manager.search_with_filter("query", 5, filters).await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_format_search_results_very_high_score() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![SearchResult {
+            content: "test".to_string(),
+            score: 1000.0,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("1000.000"));
+    }
+
+    #[test]
+    fn test_format_search_results_very_low_score() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![SearchResult {
+            content: "test".to_string(),
+            score: 0.001,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("0.001"));
+    }
+
+    #[test]
+    fn test_document_with_special_characters() {
+        let doc = Document::new("!@#$%^&*()".to_string());
+        assert_eq!(doc.content, "!@#$%^&*()");
+    }
+
+    #[test]
+    fn test_document_with_tabs_and_newlines() {
+        let doc = Document::new("line1\tcolumn2\nline2\tcolumn2".to_string());
+        assert_eq!(doc.content, "line1\tcolumn2\nline2\tcolumn2");
+    }
+
+    #[test]
+    fn test_search_result_metadata_empty_object() {
+        let result = SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!({})),
+        };
+        assert!(result.metadata.is_some());
+        let metadata = result.metadata.unwrap();
+        assert!(metadata.as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_vector_store_stats_empty_strings() {
+        let stats = VectorStoreStats {
+            store_type: "".to_string(),
+            embedding_provider: "".to_string(),
+            embedding_model: "".to_string(),
+            document_count: 0,
+            index_size: 0,
+        };
+        assert_eq!(stats.store_type, "");
+        assert_eq!(stats.embedding_provider, "");
+        assert_eq!(stats.embedding_model, "");
+    }
+
+    #[test]
+    fn test_new_stub_unicode_name() {
+        let manager = VectorStoreManager::new_stub("テスト", None);
+        assert_eq!(manager.store_name, "テスト");
+    }
+
+    #[test]
+    fn test_new_stub_unicode_prefix() {
+        let manager = VectorStoreManager::new_stub("test", Some("前置き:".to_string()));
+        assert_eq!(manager.context_prefix, Some("前置き:".to_string()));
+    }
+
+    #[test]
+    fn test_format_search_results_single_result_no_separator() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![SearchResult {
+            content: "only one".to_string(),
+            score: 0.5,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(!formatted.contains("---"));
+    }
+
+    #[test]
+    fn test_document_id_with_special_characters() {
+        let doc = Document::new("content".to_string()).with_id("id-with-dashes_and_underscores.123".to_string());
+        assert_eq!(doc.id, Some("id-with-dashes_and_underscores.123".to_string()));
+    }
+
+    #[test]
+    fn test_document_metadata_with_unicode() {
+        let metadata = json!({"名前": "値", "emoji": "🎉"});
+        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
+        assert_eq!(doc.metadata, Some(metadata));
+    }
+
+    // from_config tests removed — they require real service connections
+    // from_config tests removed — they require real service connections
+    // (OpenAI API key, Qdrant server, AWS credentials) and belong in integration tests.
+
+    #[tokio::test]
+    async fn test_search_bedrock_kb_missing_client() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "bedrock_kb".to_string();
+        // bedrock_kb_id is private; the stub has it as None which is the error case
+        
+        let result = manager.search("query", 5).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not initialized"));
+    }
+
+    #[tokio::test]
+    async fn test_search_bedrock_kb_missing_kb_id() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "bedrock_kb".to_string();
+        
+        let result = manager.search("query", 5).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_search_bedrock_kb_zero_limit() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "bedrock_kb".to_string();
+        
+        let result = manager.search("query", 0).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_search_bedrock_kb_empty_query() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "bedrock_kb".to_string();
+        
+        let result = manager.search("", 5).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_qdrant_empty_query() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "qdrant".to_string();
+        let filters = HashMap::new();
+        
+        let result = manager.search_with_filter("", 5, filters).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_qdrant_zero_limit() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "qdrant".to_string();
+        let filters = HashMap::new();
+        
+        let result = manager.search_with_filter("query", 0, filters).await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_embedding_model_config_provider_openai() {
+        let config = EmbeddingModelConfig::OpenAI {
+            api_key: "sk-test".to_string(),
+            model: "text-embedding-3-small".to_string(),
+            base_url: None,
+        };
+        assert_eq!(config.provider(), "openai");
+    }
+
+    #[test]
+    fn test_embedding_model_config_provider_bedrock() {
+        let config = EmbeddingModelConfig::Bedrock {
+            model: "amazon.titan-embed-text-v1".to_string(),
+            region: "us-east-1".to_string(),
+            profile: None,
+        };
+        assert_eq!(config.provider(), "bedrock");
+    }
+
+    #[test]
+    fn test_embedding_model_config_model_openai() {
+        let config = EmbeddingModelConfig::OpenAI {
+            api_key: "sk-test".to_string(),
+            model: "text-embedding-3-small".to_string(),
+            base_url: None,
+        };
+        assert_eq!(config.model(), "text-embedding-3-small");
+    }
+
+    #[test]
+    fn test_embedding_model_config_model_bedrock() {
+        let config = EmbeddingModelConfig::Bedrock {
+            model: "amazon.titan-embed-text-v1".to_string(),
+            region: "us-east-1".to_string(),
+            profile: None,
+        };
+        assert_eq!(config.model(), "amazon.titan-embed-text-v1");
+    }
+
+    #[test]
+    fn test_vector_store_config_with_context_prefix() {
+        let config = VectorStoreConfig {
+            name: "test".to_string(),
+            context_prefix: Some("Context:".to_string()),
+            store: VectorStoreType::InMemory {
+                embedding_model: EmbeddingModelConfig::OpenAI {
+                    api_key: "sk-test".to_string(),
+                    model: "text-embedding-3-small".to_string(),
+                    base_url: None,
+                },
+            },
+        };
+        assert_eq!(config.context_prefix, Some("Context:".to_string()));
+    }
+
+    #[test]
+    fn test_vector_store_config_without_context_prefix() {
+        let config = VectorStoreConfig {
+            name: "test".to_string(),
+            context_prefix: None,
+            store: VectorStoreType::InMemory {
+                embedding_model: EmbeddingModelConfig::OpenAI {
+                    api_key: "sk-test".to_string(),
+                    model: "text-embedding-3-small".to_string(),
+                    base_url: None,
+                },
+            },
+        };
+        assert!(config.context_prefix.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_add_documents_qdrant_not_initialized() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "qdrant".to_string();
+        
+        let docs = vec!["doc1".to_string()];
+        let result = manager.add_documents(docs).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_add_documents_in_memory_not_initialized() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let docs = vec!["doc1".to_string()];
+        let result = manager.add_documents(docs).await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_search_result_metadata_with_id() {
+        let result = SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!({"id": "doc-123"})),
+        };
+        assert!(result.metadata.is_some());
+        let metadata = result.metadata.unwrap();
+        assert_eq!(metadata["id"], "doc-123");
+    }
+
+    #[test]
+    fn test_search_result_metadata_complex() {
+        let result = SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!({
+                "id": "123",
+                "type": "document",
+                "tags": ["rust", "test"],
+                "nested": {"key": "value"}
+            })),
+        };
+        assert!(result.metadata.is_some());
+        let metadata = result.metadata.unwrap();
+        assert_eq!(metadata["id"], "123");
+        assert_eq!(metadata["type"], "document");
+    }
+
+    #[test]
+    fn test_format_search_results_with_metadata() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![SearchResult {
+            content: "test content".to_string(),
+            score: 0.95,
+            metadata: Some(json!({"id": "doc-1"})),
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("test content"));
+        assert!(formatted.contains("0.950"));
+    }
+
+    #[tokio::test]
+    async fn test_search_in_memory_with_limit_one() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let result = manager.search("query", 1).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_in_memory_single_filter() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let mut filters = HashMap::new();
+        filters.insert("type".to_string(), json!("document"));
+        
+        let result = manager.search_with_filter("query", 5, filters).await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_document_builder_only_id() {
+        let doc = Document::new("content".to_string()).with_id("123".to_string());
+        assert_eq!(doc.id, Some("123".to_string()));
+        assert!(doc.metadata.is_none());
+    }
+
+    #[test]
+    fn test_document_builder_only_metadata() {
+        let metadata = json!({"key": "value"});
+        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
+        assert!(doc.id.is_none());
+        assert_eq!(doc.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_vector_store_stats_all_fields() {
+        let stats = VectorStoreStats {
+            store_type: "qdrant".to_string(),
+            embedding_provider: "openai".to_string(),
+            embedding_model: "text-embedding-3-small".to_string(),
+            document_count: 42,
+            index_size: 1024,
+        };
+        assert_eq!(stats.store_type, "qdrant");
+        assert_eq!(stats.embedding_provider, "openai");
+        assert_eq!(stats.embedding_model, "text-embedding-3-small");
+        assert_eq!(stats.document_count, 42);
+        assert_eq!(stats.index_size, 1024);
+    }
+
+    #[test]
+    fn test_format_search_results_boundary_score() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results = vec![SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: None,
+        }];
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("0.500"));
+    }
+
+    #[tokio::test]
+    async fn test_search_very_long_query() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let long_query = "query ".repeat(1000);
+        let result = manager.search(&long_query, 5).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_very_long_query() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let long_query = "query ".repeat(1000);
+        let filters = HashMap::new();
+        let result = manager.search_with_filter(&long_query, 5, filters).await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_format_search_results_ten_results() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let results: Vec<SearchResult> = (0..10)
+            .map(|i| SearchResult {
+                content: format!("content {}", i),
+                score: 0.9 - (i as f32 * 0.05),
+                metadata: None,
+            })
+            .collect();
+        let formatted = manager.format_search_results(&results, "query");
+        assert!(formatted.contains("Result 1"));
+        assert!(formatted.contains("Result 10"));
+        let separator_count = formatted.matches("---").count();
+        assert_eq!(separator_count, 9);
+    }
+
+    #[test]
+    fn test_search_result_score_precision() {
+        let result = SearchResult {
+            content: "test".to_string(),
+            score: 0.123456789,
+            metadata: None,
+        };
+        assert_eq!(result.score, 0.123456789);
+    }
+
+    #[test]
+    fn test_document_content_with_null_bytes() {
+        let doc = Document::new("test\0content".to_string());
+        assert_eq!(doc.content, "test\0content");
+    }
+
+    #[tokio::test]
+    async fn test_add_documents_with_newlines() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let docs = vec!["line1\nline2\nline3".to_string()];
+        let result = manager.add_documents(docs).await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_get_store_name_unicode() {
+        let manager = VectorStoreManager::new_stub("テスト店", None);
+        assert_eq!(manager.get_store_name(), Some("テスト店"));
+    }
+
+    #[test]
+    fn test_get_context_prefix_unicode() {
+        let manager = VectorStoreManager::new_stub("test", Some("コンテキスト:".to_string()));
+        assert_eq!(manager.get_context_prefix(), Some("コンテキスト:"));
+    }
+}

--- a/crates/aura/src/vector_store_tests.rs
+++ b/crates/aura/src/vector_store_tests.rs
@@ -6,63 +6,10 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
-    fn test_new_stub() {
+    fn test_new_stub_initializes_all_fields() {
         let manager = VectorStoreManager::new_stub("test_store", None);
-        assert_eq!(manager.store_name, "test_store");
-        assert_eq!(manager.store_type, "in_memory");
-        assert!(manager.qdrant_url.is_none());
-        assert!(manager.collection_name.is_none());
-        assert!(manager.in_memory_store.is_none());
-        assert!(manager.context_prefix.is_none());
-    }
-
-    #[test]
-    fn test_new_stub_with_context_prefix() {
-        let prefix = Some("Context:".to_string());
-        let manager = VectorStoreManager::new_stub("test_store", prefix.clone());
-        assert_eq!(manager.store_name, "test_store");
-        assert_eq!(manager.context_prefix, prefix);
-    }
-
-    #[test]
-    fn test_new_stub_empty_name() {
-        let manager = VectorStoreManager::new_stub("", None);
-        assert_eq!(manager.store_name, "");
-    }
-
-    #[test]
-    fn test_get_store_name() {
-        let manager = VectorStoreManager::new_stub("my_store", None);
-        assert_eq!(manager.get_store_name(), Some("my_store"));
-    }
-
-    #[test]
-    fn test_get_store_name_empty() {
-        let manager = VectorStoreManager::new_stub("", None);
-        assert_eq!(manager.get_store_name(), Some(""));
-    }
-
-    #[test]
-    fn test_get_context_prefix_none() {
-        let manager = VectorStoreManager::new_stub("test", None);
+        assert_eq!(manager.get_store_name(), Some("test_store"));
         assert_eq!(manager.get_context_prefix(), None);
-    }
-
-    #[test]
-    fn test_get_context_prefix_some() {
-        let manager = VectorStoreManager::new_stub("test", Some("Prefix:".to_string()));
-        assert_eq!(manager.get_context_prefix(), Some("Prefix:"));
-    }
-
-    #[test]
-    fn test_get_context_prefix_empty_string() {
-        let manager = VectorStoreManager::new_stub("test", Some("".to_string()));
-        assert_eq!(manager.get_context_prefix(), Some(""));
-    }
-
-    #[test]
-    fn test_get_stats() {
-        let manager = VectorStoreManager::new_stub("test_store", None);
         let stats = manager.get_stats();
         assert_eq!(stats.store_type, "in_memory");
         assert_eq!(stats.embedding_provider, "stub");
@@ -72,159 +19,245 @@ mod tests {
     }
 
     #[test]
-    fn test_get_stats_clone() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let stats1 = manager.get_stats();
-        let stats2 = stats1.clone();
-        assert_eq!(stats1.store_type, stats2.store_type);
-        assert_eq!(stats1.embedding_provider, stats2.embedding_provider);
-        assert_eq!(stats1.embedding_model, stats2.embedding_model);
-        assert_eq!(stats1.document_count, stats2.document_count);
-        assert_eq!(stats1.index_size, stats2.index_size);
+    fn test_new_stub_with_context_prefix_stores_prefix() {
+        let manager = VectorStoreManager::new_stub("test", Some("Context:".to_string()));
+        assert_eq!(manager.get_context_prefix(), Some("Context:"));
+    }
+
+    #[test]
+    fn test_get_store_name_returns_various_names() {
+        let manager1 = VectorStoreManager::new_stub("my_store", None);
+        assert_eq!(manager1.get_store_name(), Some("my_store"));
+        
+        let manager2 = VectorStoreManager::new_stub("", None);
+        assert_eq!(manager2.get_store_name(), Some(""));
+        
+        let manager3 = VectorStoreManager::new_stub("テスト店", None);
+        assert_eq!(manager3.get_store_name(), Some("テスト店"));
+    }
+
+    #[test]
+    fn test_get_context_prefix_returns_various_prefixes() {
+        let manager1 = VectorStoreManager::new_stub("test", None);
+        assert_eq!(manager1.get_context_prefix(), None);
+        
+        let manager2 = VectorStoreManager::new_stub("test", Some("Prefix:".to_string()));
+        assert_eq!(manager2.get_context_prefix(), Some("Prefix:"));
+        
+        let manager3 = VectorStoreManager::new_stub("test", Some("".to_string()));
+        assert_eq!(manager3.get_context_prefix(), Some(""));
+        
+        let manager4 = VectorStoreManager::new_stub("test", Some("コンテキスト:".to_string()));
+        assert_eq!(manager4.get_context_prefix(), Some("コンテキスト:"));
     }
 
     #[tokio::test]
-    async fn test_add_documents_bedrock_kb_error() {
+    async fn test_add_documents_bedrock_kb_returns_read_only_error() {
         let mut manager = VectorStoreManager::new_stub("test", None);
         manager.store_type = "bedrock_kb".to_string();
         
         let docs = vec!["doc1".to_string(), "doc2".to_string()];
         let result = manager.add_documents(docs).await;
         
-        assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("read-only"));
+        assert!(err.to_string().contains("read-only") || err.to_string().contains("Bedrock Knowledge Base"));
     }
 
     #[tokio::test]
-    async fn test_add_documents_empty_vec() {
+    async fn test_add_documents_logs_but_succeeds_for_various_inputs() {
         let manager = VectorStoreManager::new_stub("test", None);
-        let result = manager.add_documents(vec![]).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_add_documents_single_document() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let docs = vec!["single document".to_string()];
-        let result = manager.add_documents(docs).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_add_documents_multiple_documents() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let docs = vec![
+        
+        let empty_result = manager.add_documents(vec![]).await;
+        assert!(empty_result.is_ok());
+        
+        let single_result = manager.add_documents(vec!["single document".to_string()]).await;
+        assert!(single_result.is_ok());
+        
+        let multiple_result = manager.add_documents(vec![
             "document one".to_string(),
             "document two".to_string(),
             "document three".to_string(),
+        ]).await;
+        assert!(multiple_result.is_ok());
+        
+        let empty_string_result = manager.add_documents(vec!["".to_string()]).await;
+        assert!(empty_string_result.is_ok());
+        
+        let unicode_result = manager.add_documents(vec!["Hello 世界 🎉".to_string()]).await;
+        assert!(unicode_result.is_ok());
+        
+        let large_doc = "x".repeat(100000);
+        let large_result = manager.add_documents(vec![large_doc]).await;
+        assert!(large_result.is_ok());
+        
+        let many_docs: Vec<String> = (0..100).map(|i| format!("document {}", i)).collect();
+        let many_result = manager.add_documents(many_docs).await;
+        assert!(many_result.is_ok());
+        
+        let mixed_docs = vec![
+            "".to_string(),
+            "short".to_string(),
+            "a".repeat(10000),
+            "unicode 世界".to_string(),
+            "newlines\n\n\n".to_string(),
+            "line1\tcolumn2\nline2\tcolumn2".to_string(),
+            "!@#$%^&*()".to_string(),
         ];
+        let mixed_result = manager.add_documents(mixed_docs).await;
+        assert!(mixed_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_add_documents_qdrant_not_initialized_logs_but_succeeds() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "qdrant".to_string();
+        
+        let docs = vec!["doc1".to_string()];
         let result = manager.add_documents(docs).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
-    async fn test_add_documents_empty_string() {
+    async fn test_search_in_memory_returns_empty_for_various_queries() {
         let manager = VectorStoreManager::new_stub("test", None);
-        let docs = vec!["".to_string()];
-        let result = manager.add_documents(docs).await;
-        assert!(result.is_ok());
+        
+        let result1 = manager.search("query", 5).await.unwrap();
+        assert_eq!(result1.len(), 0);
+        
+        let result2 = manager.search("", 5).await.unwrap();
+        assert_eq!(result2.len(), 0);
+        
+        let result3 = manager.search("世界", 5).await.unwrap();
+        assert_eq!(result3.len(), 0);
+        
+        let result4 = manager.search("🎉", 5).await.unwrap();
+        assert_eq!(result4.len(), 0);
+        
+        let result5 = manager.search("line1\nline2", 5).await.unwrap();
+        assert_eq!(result5.len(), 0);
+        
+        let result6 = manager.search("!@#$%^&*()", 5).await.unwrap();
+        assert_eq!(result6.len(), 0);
+        
+        let result7 = manager.search("query\twith\ttabs", 5).await.unwrap();
+        assert_eq!(result7.len(), 0);
+        
+        let long_query = "query ".repeat(1000);
+        let result8 = manager.search(&long_query, 5).await.unwrap();
+        assert_eq!(result8.len(), 0);
     }
 
     #[tokio::test]
-    async fn test_add_documents_unicode() {
+    async fn test_search_in_memory_respects_various_limits() {
         let manager = VectorStoreManager::new_stub("test", None);
-        let docs = vec!["Hello 世界 🎉".to_string()];
-        let result = manager.add_documents(docs).await;
-        assert!(result.is_ok());
+        
+        let result1 = manager.search("query", 0).await.unwrap();
+        assert_eq!(result1.len(), 0);
+        
+        let result2 = manager.search("query", 1).await.unwrap();
+        assert_eq!(result2.len(), 0);
+        
+        let result3 = manager.search("query", 1000).await.unwrap();
+        assert_eq!(result3.len(), 0);
+        
+        let result4 = manager.search("query", usize::MAX).await.unwrap();
+        assert_eq!(result4.len(), 0);
     }
 
     #[tokio::test]
-    async fn test_search_in_memory_returns_empty() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let result = manager.search("query", 5).await;
-        assert!(result.is_ok());
-        let results = result.unwrap();
-        assert_eq!(results.len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_search_in_memory_empty_query() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let result = manager.search("", 5).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_search_in_memory_zero_limit() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let result = manager.search("query", 0).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_search_in_memory_large_limit() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let result = manager.search("query", 1000).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_search_unsupported_store_type() {
+    async fn test_search_unsupported_store_type_returns_error() {
         let mut manager = VectorStoreManager::new_stub("test", None);
         manager.store_type = "unsupported".to_string();
         
         let result = manager.search("query", 5).await;
-        assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("Unsupported store type"));
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("Unsupported") || err_msg.contains("unsupported"));
     }
 
     #[tokio::test]
-    async fn test_search_qdrant_not_initialized() {
+    async fn test_search_qdrant_not_initialized_returns_error() {
         let mut manager = VectorStoreManager::new_stub("test", None);
         manager.store_type = "qdrant".to_string();
         
         let result = manager.search("query", 5).await;
-        assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("not initialized"));
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("not initialized") || err_msg.contains("Qdrant"));
     }
 
     #[tokio::test]
-    async fn test_search_bedrock_kb_client_not_initialized() {
+    async fn test_search_bedrock_kb_missing_client_returns_error() {
         let mut manager = VectorStoreManager::new_stub("test", None);
         manager.store_type = "bedrock_kb".to_string();
         
         let result = manager.search("query", 5).await;
-        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("not initialized") || err_msg.contains("client") || err_msg.contains("KB"));
     }
 
     #[tokio::test]
-    async fn test_search_with_filter_in_memory() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let mut filters = HashMap::new();
-        filters.insert("key".to_string(), json!("value"));
+    async fn test_search_bedrock_kb_various_error_conditions() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "bedrock_kb".to_string();
         
-        let result = manager.search_with_filter("query", 5, filters).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_search_with_filter_empty_filters() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let filters = HashMap::new();
+        let result1 = manager.search("query", 0).await;
+        assert!(result1.is_err());
         
-        let result = manager.search_with_filter("query", 5, filters).await;
-        assert!(result.is_ok());
+        let result2 = manager.search("", 5).await;
+        assert!(result2.is_err());
     }
 
     #[tokio::test]
-    async fn test_search_with_filter_bedrock_kb() {
+    async fn test_search_with_filter_in_memory_returns_empty_for_various_filters() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        
+        let empty_filters = HashMap::new();
+        let result1 = manager.search_with_filter("query", 5, empty_filters).await.unwrap();
+        assert_eq!(result1.len(), 0);
+        
+        let mut single_filter = HashMap::new();
+        single_filter.insert("type".to_string(), json!("document"));
+        let result2 = manager.search_with_filter("query", 5, single_filter).await.unwrap();
+        assert_eq!(result2.len(), 0);
+        
+        let mut multiple_filters = HashMap::new();
+        multiple_filters.insert("key1".to_string(), json!("value1"));
+        multiple_filters.insert("key2".to_string(), json!(42));
+        multiple_filters.insert("key3".to_string(), json!(true));
+        let result3 = manager.search_with_filter("query", 5, multiple_filters).await.unwrap();
+        assert_eq!(result3.len(), 0);
+        
+        let mut complex_filters = HashMap::new();
+        complex_filters.insert("array".to_string(), json!(["a", "b", "c"]));
+        complex_filters.insert("object".to_string(), json!({"nested": "value"}));
+        let result4 = manager.search_with_filter("query", 5, complex_filters).await.unwrap();
+        assert_eq!(result4.len(), 0);
+        
+        let mut string_filter = HashMap::new();
+        string_filter.insert("status".to_string(), json!("active"));
+        let result5 = manager.search_with_filter("query", 5, string_filter).await.unwrap();
+        assert_eq!(result5.len(), 0);
+        
+        let mut number_filter = HashMap::new();
+        number_filter.insert("count".to_string(), json!(100));
+        let result6 = manager.search_with_filter("query", 5, number_filter).await.unwrap();
+        assert_eq!(result6.len(), 0);
+        
+        let mut boolean_filter = HashMap::new();
+        boolean_filter.insert("active".to_string(), json!(true));
+        let result7 = manager.search_with_filter("query", 5, boolean_filter).await.unwrap();
+        assert_eq!(result7.len(), 0);
+        
+        let mut null_filter = HashMap::new();
+        null_filter.insert("key".to_string(), json!(null));
+        let result8 = manager.search_with_filter("query", 5, null_filter).await.unwrap();
+        assert_eq!(result8.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_bedrock_kb_falls_back_to_unfiltered() {
         let mut manager = VectorStoreManager::new_stub("test", None);
         manager.store_type = "bedrock_kb".to_string();
         let filters = HashMap::new();
@@ -234,43 +267,87 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_search_with_filter_qdrant_not_initialized() {
+    async fn test_search_with_filter_qdrant_not_initialized_returns_error() {
         let mut manager = VectorStoreManager::new_stub("test", None);
         manager.store_type = "qdrant".to_string();
         let filters = HashMap::new();
         
         let result = manager.search_with_filter("query", 5, filters).await;
-        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("not initialized") || err_msg.contains("Qdrant"));
     }
 
     #[tokio::test]
-    async fn test_search_with_filter_unsupported_store() {
+    async fn test_search_with_filter_qdrant_various_error_conditions() {
+        let mut manager = VectorStoreManager::new_stub("test", None);
+        manager.store_type = "qdrant".to_string();
+        let filters = HashMap::new();
+        
+        let result1 = manager.search_with_filter("", 5, filters.clone()).await;
+        assert!(result1.is_err());
+        
+        let result2 = manager.search_with_filter("query", 0, filters).await;
+        assert!(result2.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_unsupported_store_returns_error() {
         let mut manager = VectorStoreManager::new_stub("test", None);
         manager.store_type = "unknown".to_string();
         let filters = HashMap::new();
         
         let result = manager.search_with_filter("query", 5, filters).await;
-        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("Unsupported") || err_msg.contains("unknown"));
+    }
+
+    #[tokio::test]
+    async fn test_search_with_filter_various_queries_and_limits() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        let filters = HashMap::new();
+        
+        let long_query = "query ".repeat(1000);
+        let result1 = manager.search_with_filter(&long_query, 5, filters.clone()).await.unwrap();
+        assert_eq!(result1.len(), 0);
+        
+        let result2 = manager.search_with_filter("query", 1, filters.clone()).await.unwrap();
+        assert_eq!(result2.len(), 0);
+        
+        let result3 = manager.search_with_filter("query", usize::MAX, filters).await.unwrap();
+        assert_eq!(result3.len(), 0);
     }
 
     #[test]
-    fn test_format_search_results_empty() {
+    fn test_format_search_results_empty_returns_no_results_message() {
         let manager = VectorStoreManager::new_stub("test", None);
         let results = vec![];
-        let formatted = manager.format_search_results(&results, "test query");
-        assert_eq!(formatted, "No results found for query: 'test query'");
+        
+        let formatted1 = manager.format_search_results(&results, "test query");
+        assert_eq!(formatted1, "No results found for query: 'test query'");
+        
+        let formatted2 = manager.format_search_results(&results, "");
+        assert_eq!(formatted2, "No results found for query: ''");
+        
+        let formatted3 = manager.format_search_results(&results, "query with 'quotes' and \"double\"");
+        assert!(formatted3.contains("query with 'quotes' and \"double\""));
+        
+        let formatted4 = manager.format_search_results(&results, "query\nwith\nnewlines");
+        assert!(formatted4.contains("query\nwith\nnewlines"));
     }
 
     #[test]
-    fn test_format_search_results_empty_query() {
-        let manager = VectorStoreManager::new_stub("test", None);
+    fn test_format_search_results_empty_with_prefix_omits_prefix() {
+        let manager = VectorStoreManager::new_stub("test", Some("Prefix:".to_string()));
         let results = vec![];
-        let formatted = manager.format_search_results(&results, "");
-        assert_eq!(formatted, "No results found for query: ''");
+        let formatted = manager.format_search_results(&results, "query");
+        assert_eq!(formatted, "No results found for query: 'query'");
+        assert!(!formatted.contains("Prefix:"));
     }
 
     #[test]
-    fn test_format_search_results_single_result() {
+    fn test_format_search_results_single_result_includes_all_components() {
         let manager = VectorStoreManager::new_stub("test", None);
         let results = vec![SearchResult {
             content: "test content".to_string(),
@@ -281,10 +358,11 @@ mod tests {
         assert!(formatted.contains("Result 1"));
         assert!(formatted.contains("0.950"));
         assert!(formatted.contains("test content"));
+        assert!(!formatted.contains("---"));
     }
 
     #[test]
-    fn test_format_search_results_multiple_results() {
+    fn test_format_search_results_multiple_results_includes_separators() {
         let manager = VectorStoreManager::new_stub("test", None);
         let results = vec![
             SearchResult {
@@ -304,10 +382,46 @@ mod tests {
         assert!(formatted.contains("first"));
         assert!(formatted.contains("second"));
         assert!(formatted.contains("---"));
+        assert!(!formatted.ends_with("---"));
     }
 
     #[test]
-    fn test_format_search_results_with_context_prefix() {
+    fn test_format_search_results_separator_count_matches_result_count() {
+        let manager = VectorStoreManager::new_stub("test", None);
+        
+        let results3: Vec<SearchResult> = (0..3)
+            .map(|i| SearchResult {
+                content: format!("content {}", i),
+                score: 0.9 - (i as f32 * 0.1),
+                metadata: None,
+            })
+            .collect();
+        let formatted3 = manager.format_search_results(&results3, "query");
+        assert_eq!(formatted3.matches("---").count(), 2);
+        
+        let results10: Vec<SearchResult> = (0..10)
+            .map(|i| SearchResult {
+                content: format!("content {}", i),
+                score: 0.9 - (i as f32 * 0.05),
+                metadata: None,
+            })
+            .collect();
+        let formatted10 = manager.format_search_results(&results10, "query");
+        assert_eq!(formatted10.matches("---").count(), 9);
+        
+        let results20: Vec<SearchResult> = (0..20)
+            .map(|i| SearchResult {
+                content: format!("content {}", i),
+                score: 1.0 - (i as f32 * 0.05),
+                metadata: None,
+            })
+            .collect();
+        let formatted20 = manager.format_search_results(&results20, "query");
+        assert_eq!(formatted20.matches("---").count(), 19);
+    }
+
+    #[test]
+    fn test_format_search_results_with_context_prefix_prepends_prefix() {
         let manager = VectorStoreManager::new_stub("test", Some("Context:".to_string()));
         let results = vec![SearchResult {
             content: "content".to_string(),
@@ -315,121 +429,102 @@ mod tests {
             metadata: None,
         }];
         let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.starts_with("Context:"));
+        assert!(formatted.starts_with("Context:\n\n"));
         assert!(formatted.contains("content"));
     }
 
     #[test]
-    fn test_format_search_results_no_separator_after_last() {
+    fn test_format_search_results_prefix_variations() {
+        let manager1 = VectorStoreManager::new_stub("test", Some("".to_string()));
+        let results = vec![SearchResult {
+            content: "content".to_string(),
+            score: 0.5,
+            metadata: None,
+        }];
+        let formatted1 = manager1.format_search_results(&results, "query");
+        assert!(formatted1.starts_with("\n\n"));
+        
+        let manager2 = VectorStoreManager::new_stub("test", Some("Line1\nLine2".to_string()));
+        let formatted2 = manager2.format_search_results(&results, "query");
+        assert!(formatted2.starts_with("Line1\nLine2\n\n"));
+        
+        let manager3 = VectorStoreManager::new_stub("test", Some("Line1\nLine2\nLine3".to_string()));
+        let formatted3 = manager3.format_search_results(&results, "query");
+        assert!(formatted3.starts_with("Line1\nLine2\nLine3\n\n"));
+    }
+
+    #[test]
+    fn test_format_search_results_score_formatting_three_decimals() {
         let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![
-            SearchResult {
-                content: "first".to_string(),
-                score: 0.9,
-                metadata: None,
-            },
-            SearchResult {
-                content: "second".to_string(),
-                score: 0.8,
-                metadata: None,
-            },
+        
+        let test_cases = vec![
+            (0.0, "0.000"),
+            (1.0, "1.000"),
+            (0.123456, "0.123"),
+            (0.987654321, "0.988"),
+            (0.5, "0.500"),
+            (0.001, "0.001"),
+            (1000.0, "1000.000"),
+            (-0.5, "-0.500"),
         ];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(!formatted.ends_with("---"));
+        
+        for (score, expected) in test_cases {
+            let results = vec![SearchResult {
+                content: "test".to_string(),
+                score,
+                metadata: None,
+            }];
+            let formatted = manager.format_search_results(&results, "query");
+            assert!(formatted.contains(expected), "Score {} should format to {}, but formatted output was: {}", score, expected, formatted);
+        }
     }
 
     #[test]
-    fn test_format_search_results_score_formatting() {
+    fn test_format_search_results_various_content_types() {
         let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![SearchResult {
-            content: "test".to_string(),
-            score: 0.123456,
-            metadata: None,
-        }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("0.123"));
-    }
-
-    #[test]
-    fn test_format_search_results_zero_score() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![SearchResult {
-            content: "test".to_string(),
-            score: 0.0,
-            metadata: None,
-        }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("0.000"));
-    }
-
-    #[test]
-    fn test_format_search_results_max_score() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![SearchResult {
-            content: "test".to_string(),
-            score: 1.0,
-            metadata: None,
-        }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("1.000"));
-    }
-
-    #[test]
-    fn test_format_search_results_unicode_content() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![SearchResult {
+        
+        let results1 = vec![SearchResult {
             content: "Hello 世界 🎉".to_string(),
             score: 0.5,
             metadata: None,
         }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("Hello 世界 🎉"));
-    }
-
-    #[test]
-    fn test_format_search_results_empty_content() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![SearchResult {
+        let formatted1 = manager.format_search_results(&results1, "query");
+        assert!(formatted1.contains("Hello 世界 🎉"));
+        
+        let results2 = vec![SearchResult {
             content: "".to_string(),
             score: 0.5,
             metadata: None,
         }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("Result 1"));
-    }
-
-    #[test]
-    fn test_format_search_results_multiline_content() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![SearchResult {
+        let formatted2 = manager.format_search_results(&results2, "query");
+        assert!(formatted2.contains("Result 1"));
+        
+        let results3 = vec![SearchResult {
             content: "line1\nline2\nline3".to_string(),
             score: 0.5,
             metadata: None,
         }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("line1\nline2\nline3"));
-    }
-
-    #[test]
-    fn test_search_result_clone() {
-        let result = SearchResult {
-            content: "test".to_string(),
+        let formatted3 = manager.format_search_results(&results3, "query");
+        assert!(formatted3.contains("line1\nline2\nline3"));
+        
+        let results4 = vec![SearchResult {
+            content: "line1\rline2".to_string(),
             score: 0.5,
-            metadata: Some(json!({"key": "value"})),
-        };
-        let cloned = result.clone();
-        assert_eq!(cloned.content, result.content);
-        assert_eq!(cloned.score, result.score);
-        assert_eq!(cloned.metadata, result.metadata);
+            metadata: None,
+        }];
+        let formatted4 = manager.format_search_results(&results4, "query");
+        assert!(formatted4.contains("line1\rline2"));
     }
 
     #[test]
-    fn test_search_result_with_metadata() {
+    fn test_search_result_construction_and_fields() {
         let result = SearchResult {
             content: "test".to_string(),
             score: 0.5,
             metadata: Some(json!({"id": "123", "type": "doc"})),
         };
+        assert_eq!(result.content, "test");
+        assert_eq!(result.score, 0.5);
         assert!(result.metadata.is_some());
         let metadata = result.metadata.unwrap();
         assert_eq!(metadata["id"], "123");
@@ -437,29 +532,88 @@ mod tests {
     }
 
     #[test]
-    fn test_search_result_without_metadata() {
-        let result = SearchResult {
+    fn test_search_result_metadata_variations() {
+        let result1 = SearchResult {
             content: "test".to_string(),
             score: 0.5,
             metadata: None,
         };
-        assert!(result.metadata.is_none());
-    }
-
-    #[test]
-    fn test_search_result_debug() {
-        let result = SearchResult {
+        assert!(result1.metadata.is_none());
+        
+        let result2 = SearchResult {
             content: "test".to_string(),
             score: 0.5,
-            metadata: None,
+            metadata: Some(json!({})),
         };
-        let debug_str = format!("{:?}", result);
-        assert!(debug_str.contains("SearchResult"));
-        assert!(debug_str.contains("test"));
+        assert!(result2.metadata.is_some());
+        assert!(result2.metadata.unwrap().as_object().unwrap().is_empty());
+        
+        let result3 = SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!(null)),
+        };
+        assert!(result3.metadata.is_some());
+        assert!(result3.metadata.unwrap().is_null());
+        
+        let result4 = SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!(["tag1", "tag2"])),
+        };
+        assert!(result4.metadata.is_some());
+        let metadata4 = result4.metadata.unwrap();
+        assert!(metadata4.is_array());
+        assert_eq!(metadata4.as_array().unwrap().len(), 2);
+        
+        let result5 = SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!("metadata string")),
+        };
+        assert_eq!(result5.metadata.unwrap(), "metadata string");
+        
+        let result6 = SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!(42)),
+        };
+        assert_eq!(result6.metadata.unwrap(), 42);
+        
+        let result7 = SearchResult {
+            content: "test".to_string(),
+            score: 0.5,
+            metadata: Some(json!(true)),
+        };
+        assert_eq!(result7.metadata.unwrap(), true);
     }
 
     #[test]
-    fn test_vector_store_stats_clone() {
+    fn test_search_result_score_edge_cases() {
+        let result1 = SearchResult {
+            content: "test".to_string(),
+            score: 0.123456789,
+            metadata: None,
+        };
+        assert_eq!(result1.score, 0.123456789);
+        
+        let result2 = SearchResult {
+            content: "test".to_string(),
+            score: -0.5,
+            metadata: None,
+        };
+        assert_eq!(result2.score, -0.5);
+        
+        let result3 = SearchResult {
+            content: "test".to_string(),
+            score: 999.999,
+            metadata: None,
+        };
+        assert_eq!(result3.score, 999.999);
+    }
+
+    #[test]
+    fn test_vector_store_stats_construction_and_fields() {
         let stats = VectorStoreStats {
             store_type: "qdrant".to_string(),
             embedding_provider: "openai".to_string(),
@@ -467,43 +621,70 @@ mod tests {
             document_count: 100,
             index_size: 1024,
         };
-        let cloned = stats.clone();
-        assert_eq!(cloned.store_type, stats.store_type);
-        assert_eq!(cloned.embedding_provider, stats.embedding_provider);
-        assert_eq!(cloned.embedding_model, stats.embedding_model);
-        assert_eq!(cloned.document_count, stats.document_count);
-        assert_eq!(cloned.index_size, stats.index_size);
+        assert_eq!(stats.store_type, "qdrant");
+        assert_eq!(stats.embedding_provider, "openai");
+        assert_eq!(stats.embedding_model, "text-embedding-3-small");
+        assert_eq!(stats.document_count, 100);
+        assert_eq!(stats.index_size, 1024);
     }
 
     #[test]
-    fn test_vector_store_stats_debug() {
-        let stats = VectorStoreStats {
+    fn test_vector_store_stats_various_values() {
+        let stats1 = VectorStoreStats {
             store_type: "in_memory".to_string(),
             embedding_provider: "openai".to_string(),
-            embedding_model: "text-embedding-3-small".to_string(),
-            document_count: 10,
-            index_size: 512,
+            embedding_model: "model".to_string(),
+            document_count: 0,
+            index_size: 0,
         };
-        let debug_str = format!("{:?}", stats);
-        assert!(debug_str.contains("VectorStoreStats"));
-        assert!(debug_str.contains("in_memory"));
-    }
-
-    #[test]
-    fn test_vector_store_stats_with_counts() {
-        let stats = VectorStoreStats {
+        assert_eq!(stats1.document_count, 0);
+        assert_eq!(stats1.index_size, 0);
+        
+        let stats2 = VectorStoreStats {
             store_type: "qdrant".to_string(),
             embedding_provider: "bedrock".to_string(),
             embedding_model: "amazon.titan-embed-text-v1".to_string(),
             document_count: 500,
             index_size: 2048,
         };
-        assert_eq!(stats.document_count, 500);
-        assert_eq!(stats.index_size, 2048);
+        assert_eq!(stats2.document_count, 500);
+        assert_eq!(stats2.index_size, 2048);
+        
+        let stats3 = VectorStoreStats {
+            store_type: "qdrant".to_string(),
+            embedding_provider: "bedrock".to_string(),
+            embedding_model: "model".to_string(),
+            document_count: 1_000_000,
+            index_size: 10_000_000,
+        };
+        assert_eq!(stats3.document_count, 1_000_000);
+        assert_eq!(stats3.index_size, 10_000_000);
+        
+        let stats4 = VectorStoreStats {
+            store_type: "".to_string(),
+            embedding_provider: "".to_string(),
+            embedding_model: "".to_string(),
+            document_count: 0,
+            index_size: 0,
+        };
+        assert_eq!(stats4.store_type, "");
+        assert_eq!(stats4.embedding_provider, "");
+        assert_eq!(stats4.embedding_model, "");
+        
+        let stats5 = VectorStoreStats {
+            store_type: "ベクトル".to_string(),
+            embedding_provider: "プロバイダー".to_string(),
+            embedding_model: "モデル".to_string(),
+            document_count: 10,
+            index_size: 100,
+        };
+        assert_eq!(stats5.store_type, "ベクトル");
+        assert_eq!(stats5.embedding_provider, "プロバイダー");
+        assert_eq!(stats5.embedding_model, "モデル");
     }
 
     #[test]
-    fn test_document_new() {
+    fn test_document_new_creates_document_with_content_only() {
         let doc = Document::new("test content".to_string());
         assert_eq!(doc.content, "test content");
         assert!(doc.id.is_none());
@@ -511,15 +692,38 @@ mod tests {
     }
 
     #[test]
-    fn test_document_new_empty() {
-        let doc = Document::new("".to_string());
-        assert_eq!(doc.content, "");
-        assert!(doc.id.is_none());
-        assert!(doc.metadata.is_none());
+    fn test_document_new_with_various_content() {
+        let doc1 = Document::new("".to_string());
+        assert_eq!(doc1.content, "");
+        
+        let doc2 = Document::new("Hello 世界 🎉".to_string());
+        assert_eq!(doc2.content, "Hello 世界 🎉");
+        
+        let doc3 = Document::new("line1\nline2\nline3".to_string());
+        assert_eq!(doc3.content, "line1\nline2\nline3");
+        
+        let doc4 = Document::new("!@#$%^&*()".to_string());
+        assert_eq!(doc4.content, "!@#$%^&*()");
+        
+        let doc5 = Document::new("line1\tcolumn2\nline2\tcolumn2".to_string());
+        assert_eq!(doc5.content, "line1\tcolumn2\nline2\tcolumn2");
+        
+        let doc6 = Document::new("line1\rline2".to_string());
+        assert_eq!(doc6.content, "line1\rline2");
+        
+        let doc7 = Document::new("line1\n\tline2  \r\nline3".to_string());
+        assert_eq!(doc7.content, "line1\n\tline2  \r\nline3");
+        
+        let doc8 = Document::new("test\0content".to_string());
+        assert_eq!(doc8.content, "test\0content");
+        
+        let content = "a".repeat(10000);
+        let doc9 = Document::new(content.clone());
+        assert_eq!(doc9.content.len(), 10000);
     }
 
     #[test]
-    fn test_document_with_id() {
+    fn test_document_with_id_sets_id() {
         let doc = Document::new("content".to_string()).with_id("doc123".to_string());
         assert_eq!(doc.content, "content");
         assert_eq!(doc.id, Some("doc123".to_string()));
@@ -527,13 +731,20 @@ mod tests {
     }
 
     #[test]
-    fn test_document_with_id_empty() {
-        let doc = Document::new("content".to_string()).with_id("".to_string());
-        assert_eq!(doc.id, Some("".to_string()));
+    fn test_document_with_id_various_ids() {
+        let doc1 = Document::new("content".to_string()).with_id("".to_string());
+        assert_eq!(doc1.id, Some("".to_string()));
+        
+        let doc2 = Document::new("content".to_string()).with_id("id-with-dashes_and_underscores.123".to_string());
+        assert_eq!(doc2.id, Some("id-with-dashes_and_underscores.123".to_string()));
+        
+        let id = "x".repeat(1000);
+        let doc3 = Document::new("content".to_string()).with_id(id.clone());
+        assert_eq!(doc3.id, Some(id));
     }
 
     #[test]
-    fn test_document_with_metadata() {
+    fn test_document_with_metadata_sets_metadata() {
         let metadata = json!({"key": "value"});
         let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
         assert_eq!(doc.content, "content");
@@ -542,14 +753,43 @@ mod tests {
     }
 
     #[test]
-    fn test_document_with_metadata_empty_object() {
-        let metadata = json!({});
-        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
-        assert_eq!(doc.metadata, Some(metadata));
+    fn test_document_with_metadata_various_types() {
+        let doc1 = Document::new("content".to_string()).with_metadata(json!({}));
+        assert_eq!(doc1.metadata, Some(json!({})));
+        
+        let doc2 = Document::new("content".to_string()).with_metadata(json!(null));
+        assert_eq!(doc2.metadata, Some(json!(null)));
+        
+        let doc3 = Document::new("content".to_string()).with_metadata(json!(["tag1", "tag2", "tag3"]));
+        assert_eq!(doc3.metadata, Some(json!(["tag1", "tag2", "tag3"])));
+        
+        let doc4 = Document::new("content".to_string()).with_metadata(json!("simple string"));
+        assert_eq!(doc4.metadata, Some(json!("simple string")));
+        
+        let doc5 = Document::new("content".to_string()).with_metadata(json!(42));
+        assert_eq!(doc5.metadata, Some(json!(42)));
+        
+        let doc6 = Document::new("content".to_string()).with_metadata(json!(true));
+        assert_eq!(doc6.metadata, Some(json!(true)));
+        
+        let metadata = json!({
+            "id": "123",
+            "type": "article",
+            "tags": ["rust", "programming"],
+            "nested": {
+                "key": "value"
+            }
+        });
+        let doc7 = Document::new("content".to_string()).with_metadata(metadata.clone());
+        assert_eq!(doc7.metadata, Some(metadata));
+        
+        let metadata8 = json!({"名前": "値", "emoji": "🎉"});
+        let doc8 = Document::new("content".to_string()).with_metadata(metadata8.clone());
+        assert_eq!(doc8.metadata, Some(metadata8));
     }
 
     #[test]
-    fn test_document_builder_chain() {
+    fn test_document_builder_chain_both_id_and_metadata() {
         let metadata = json!({"type": "article"});
         let doc = Document::new("content".to_string())
             .with_id("123".to_string())
@@ -571,518 +811,56 @@ mod tests {
     }
 
     #[test]
-    fn test_document_clone() {
-        let metadata = json!({"key": "value"});
-        let doc = Document::new("content".to_string())
-            .with_id("123".to_string())
-            .with_metadata(metadata.clone());
-        let cloned = doc.clone();
-        assert_eq!(cloned.content, doc.content);
-        assert_eq!(cloned.id, doc.id);
-        assert_eq!(cloned.metadata, doc.metadata);
-    }
-
-    #[test]
-    fn test_document_debug() {
-        let doc = Document::new("test".to_string());
-        let debug_str = format!("{:?}", doc);
-        assert!(debug_str.contains("Document"));
-        assert!(debug_str.contains("test"));
-    }
-
-    #[test]
-    fn test_document_unicode_content() {
-        let doc = Document::new("Hello 世界 🎉".to_string());
-        assert_eq!(doc.content, "Hello 世界 🎉");
-    }
-
-    #[test]
-    fn test_document_multiline_content() {
-        let doc = Document::new("line1\nline2\nline3".to_string());
-        assert_eq!(doc.content, "line1\nline2\nline3");
-    }
-
-    #[test]
-    fn test_document_metadata_complex() {
-        let metadata = json!({
-            "id": "123",
-            "type": "article",
-            "tags": ["rust", "programming"],
-            "nested": {
-                "key": "value"
-            }
-        });
-        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
-        assert_eq!(doc.metadata, Some(metadata));
-    }
-
-    #[test]
-    fn test_document_metadata_null() {
-        let metadata = json!(null);
-        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
-        assert_eq!(doc.metadata, Some(metadata));
-    }
-
-    #[test]
-    fn test_document_metadata_array() {
-        let metadata = json!(["tag1", "tag2", "tag3"]);
-        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
-        assert_eq!(doc.metadata, Some(metadata));
-    }
-
-    #[test]
-    fn test_document_metadata_string() {
-        let metadata = json!("simple string");
-        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
-        assert_eq!(doc.metadata, Some(metadata));
-    }
-
-    #[test]
-    fn test_document_metadata_number() {
-        let metadata = json!(42);
-        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
-        assert_eq!(doc.metadata, Some(metadata));
-    }
-
-    #[test]
-    fn test_document_metadata_boolean() {
-        let metadata = json!(true);
-        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
-        assert_eq!(doc.metadata, Some(metadata));
-    }
-
-    #[test]
-    fn test_search_result_negative_score() {
-        let result = SearchResult {
-            content: "test".to_string(),
-            score: -0.5,
-            metadata: None,
-        };
-        assert_eq!(result.score, -0.5);
-    }
-
-    #[test]
-    fn test_search_result_large_score() {
-        let result = SearchResult {
-            content: "test".to_string(),
-            score: 999.999,
-            metadata: None,
-        };
-        assert_eq!(result.score, 999.999);
-    }
-
-    #[test]
-    fn test_vector_store_stats_zero_counts() {
-        let stats = VectorStoreStats {
-            store_type: "in_memory".to_string(),
-            embedding_provider: "openai".to_string(),
-            embedding_model: "model".to_string(),
-            document_count: 0,
-            index_size: 0,
-        };
-        assert_eq!(stats.document_count, 0);
-        assert_eq!(stats.index_size, 0);
-    }
-
-    #[test]
-    fn test_vector_store_stats_large_counts() {
-        let stats = VectorStoreStats {
-            store_type: "qdrant".to_string(),
-            embedding_provider: "bedrock".to_string(),
-            embedding_model: "model".to_string(),
-            document_count: 1_000_000,
-            index_size: 10_000_000,
-        };
-        assert_eq!(stats.document_count, 1_000_000);
-        assert_eq!(stats.index_size, 10_000_000);
-    }
-
-    #[test]
-    fn test_format_search_results_three_results() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![
-            SearchResult {
-                content: "first".to_string(),
-                score: 0.9,
-                metadata: None,
-            },
-            SearchResult {
-                content: "second".to_string(),
-                score: 0.8,
-                metadata: None,
-            },
-            SearchResult {
-                content: "third".to_string(),
-                score: 0.7,
-                metadata: None,
-            },
-        ];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("Result 1"));
-        assert!(formatted.contains("Result 2"));
-        assert!(formatted.contains("Result 3"));
-        let separator_count = formatted.matches("---").count();
-        assert_eq!(separator_count, 2);
-    }
-
-    #[test]
-    fn test_format_search_results_with_empty_prefix() {
-        let manager = VectorStoreManager::new_stub("test", Some("".to_string()));
-        let results = vec![SearchResult {
-            content: "content".to_string(),
-            score: 0.5,
-            metadata: None,
-        }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("content"));
-    }
-
-    #[test]
-    fn test_format_search_results_with_multiline_prefix() {
-        let manager = VectorStoreManager::new_stub("test", Some("Line1\nLine2".to_string()));
-        let results = vec![SearchResult {
-            content: "content".to_string(),
-            score: 0.5,
-            metadata: None,
-        }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.starts_with("Line1\nLine2"));
-    }
-
-    #[test]
-    fn test_format_search_results_special_characters_in_query() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![];
-        let formatted = manager.format_search_results(&results, "query with 'quotes' and \"double\"");
-        assert!(formatted.contains("query with 'quotes' and \"double\""));
-    }
-
-    #[test]
-    fn test_format_search_results_newline_in_query() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![];
-        let formatted = manager.format_search_results(&results, "query\nwith\nnewlines");
-        assert!(formatted.contains("query\nwith\nnewlines"));
-    }
-
-    #[test]
-    fn test_document_very_long_content() {
-        let content = "a".repeat(10000);
-        let doc = Document::new(content.clone());
-        assert_eq!(doc.content.len(), 10000);
-    }
-
-    #[test]
-    fn test_document_very_long_id() {
-        let id = "x".repeat(1000);
-        let doc = Document::new("content".to_string()).with_id(id.clone());
-        assert_eq!(doc.id, Some(id));
-    }
-
-    #[test]
-    fn test_search_result_very_long_content() {
-        let content = "b".repeat(10000);
-        let result = SearchResult {
-            content: content.clone(),
-            score: 0.5,
-            metadata: None,
-        };
-        assert_eq!(result.content.len(), 10000);
-    }
-
-    #[test]
-    fn test_vector_store_manager_store_type_values() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        assert_eq!(manager.store_type, "in_memory");
+    fn test_document_builder_multiple_calls_overwrites() {
+        let doc1 = Document::new("content".to_string())
+            .with_id("first".to_string())
+            .with_id("second".to_string());
+        assert_eq!(doc1.id, Some("second".to_string()));
         
-        let mut manager2 = VectorStoreManager::new_stub("test", None);
-        manager2.store_type = "qdrant".to_string();
-        assert_eq!(manager2.store_type, "qdrant");
-        
-        let mut manager3 = VectorStoreManager::new_stub("test", None);
-        manager3.store_type = "bedrock_kb".to_string();
-        assert_eq!(manager3.store_type, "bedrock_kb");
+        let doc2 = Document::new("content".to_string())
+            .with_metadata(json!({"first": "value"}))
+            .with_metadata(json!({"second": "value"}));
+        assert_eq!(doc2.metadata, Some(json!({"second": "value"})));
     }
 
     #[test]
-    fn test_vector_store_manager_get_stats_embedding_provider() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let stats = manager.get_stats();
-        assert_eq!(stats.embedding_provider, "stub");
-    }
-
-    #[test]
-    fn test_vector_store_manager_get_stats_embedding_model() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let stats = manager.get_stats();
-        assert_eq!(stats.embedding_model, "stub");
-    }
-
-    #[tokio::test]
-    async fn test_add_documents_large_document() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let large_doc = "x".repeat(100000);
-        let docs = vec![large_doc];
-        let result = manager.add_documents(docs).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_add_documents_many_documents() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let docs: Vec<String> = (0..100).map(|i| format!("document {}", i)).collect();
-        let result = manager.add_documents(docs).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_search_unicode_query() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let result = manager.search("世界", 5).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_search_emoji_query() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let result = manager.search("🎉", 5).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_search_multiline_query() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let result = manager.search("line1\nline2", 5).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_search_with_filter_multiple_filters() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let mut filters = HashMap::new();
-        filters.insert("key1".to_string(), json!("value1"));
-        filters.insert("key2".to_string(), json!(42));
-        filters.insert("key3".to_string(), json!(true));
-        
-        let result = manager.search_with_filter("query", 5, filters).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_search_with_filter_complex_values() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let mut filters = HashMap::new();
-        filters.insert("array".to_string(), json!(["a", "b", "c"]));
-        filters.insert("object".to_string(), json!({"nested": "value"}));
-        
-        let result = manager.search_with_filter("query", 5, filters).await;
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_format_search_results_very_high_score() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![SearchResult {
-            content: "test".to_string(),
-            score: 1000.0,
-            metadata: None,
-        }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("1000.000"));
-    }
-
-    #[test]
-    fn test_format_search_results_very_low_score() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![SearchResult {
-            content: "test".to_string(),
-            score: 0.001,
-            metadata: None,
-        }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("0.001"));
-    }
-
-    #[test]
-    fn test_document_with_special_characters() {
-        let doc = Document::new("!@#$%^&*()".to_string());
-        assert_eq!(doc.content, "!@#$%^&*()");
-    }
-
-    #[test]
-    fn test_document_with_tabs_and_newlines() {
-        let doc = Document::new("line1\tcolumn2\nline2\tcolumn2".to_string());
-        assert_eq!(doc.content, "line1\tcolumn2\nline2\tcolumn2");
-    }
-
-    #[test]
-    fn test_search_result_metadata_empty_object() {
-        let result = SearchResult {
-            content: "test".to_string(),
-            score: 0.5,
-            metadata: Some(json!({})),
-        };
-        assert!(result.metadata.is_some());
-        let metadata = result.metadata.unwrap();
-        assert!(metadata.as_object().unwrap().is_empty());
-    }
-
-    #[test]
-    fn test_vector_store_stats_empty_strings() {
-        let stats = VectorStoreStats {
-            store_type: "".to_string(),
-            embedding_provider: "".to_string(),
-            embedding_model: "".to_string(),
-            document_count: 0,
-            index_size: 0,
-        };
-        assert_eq!(stats.store_type, "");
-        assert_eq!(stats.embedding_provider, "");
-        assert_eq!(stats.embedding_model, "");
-    }
-
-    #[test]
-    fn test_new_stub_unicode_name() {
-        let manager = VectorStoreManager::new_stub("テスト", None);
-        assert_eq!(manager.store_name, "テスト");
-    }
-
-    #[test]
-    fn test_new_stub_unicode_prefix() {
-        let manager = VectorStoreManager::new_stub("test", Some("前置き:".to_string()));
-        assert_eq!(manager.context_prefix, Some("前置き:".to_string()));
-    }
-
-    #[test]
-    fn test_format_search_results_single_result_no_separator() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![SearchResult {
-            content: "only one".to_string(),
-            score: 0.5,
-            metadata: None,
-        }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(!formatted.contains("---"));
-    }
-
-    #[test]
-    fn test_document_id_with_special_characters() {
-        let doc = Document::new("content".to_string()).with_id("id-with-dashes_and_underscores.123".to_string());
-        assert_eq!(doc.id, Some("id-with-dashes_and_underscores.123".to_string()));
-    }
-
-    #[test]
-    fn test_document_metadata_with_unicode() {
-        let metadata = json!({"名前": "値", "emoji": "🎉"});
-        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
-        assert_eq!(doc.metadata, Some(metadata));
-    }
-
-    // from_config tests removed — they require real service connections
-    // from_config tests removed — they require real service connections
-    // (OpenAI API key, Qdrant server, AWS credentials) and belong in integration tests.
-
-    #[tokio::test]
-    async fn test_search_bedrock_kb_missing_client() {
-        let mut manager = VectorStoreManager::new_stub("test", None);
-        manager.store_type = "bedrock_kb".to_string();
-        // bedrock_kb_id is private; the stub has it as None which is the error case
-        
-        let result = manager.search("query", 5).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not initialized"));
-    }
-
-    #[tokio::test]
-    async fn test_search_bedrock_kb_missing_kb_id() {
-        let mut manager = VectorStoreManager::new_stub("test", None);
-        manager.store_type = "bedrock_kb".to_string();
-        
-        let result = manager.search("query", 5).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_search_bedrock_kb_zero_limit() {
-        let mut manager = VectorStoreManager::new_stub("test", None);
-        manager.store_type = "bedrock_kb".to_string();
-        
-        let result = manager.search("query", 0).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_search_bedrock_kb_empty_query() {
-        let mut manager = VectorStoreManager::new_stub("test", None);
-        manager.store_type = "bedrock_kb".to_string();
-        
-        let result = manager.search("", 5).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_search_with_filter_qdrant_empty_query() {
-        let mut manager = VectorStoreManager::new_stub("test", None);
-        manager.store_type = "qdrant".to_string();
-        let filters = HashMap::new();
-        
-        let result = manager.search_with_filter("", 5, filters).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_search_with_filter_qdrant_zero_limit() {
-        let mut manager = VectorStoreManager::new_stub("test", None);
-        manager.store_type = "qdrant".to_string();
-        let filters = HashMap::new();
-        
-        let result = manager.search_with_filter("query", 0, filters).await;
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_embedding_model_config_provider_openai() {
-        let config = EmbeddingModelConfig::OpenAI {
+    fn test_embedding_model_config_provider_and_model() {
+        let config1 = EmbeddingModelConfig::OpenAI {
             api_key: "sk-test".to_string(),
             model: "text-embedding-3-small".to_string(),
             base_url: None,
         };
-        assert_eq!(config.provider(), "openai");
-    }
-
-    #[test]
-    fn test_embedding_model_config_provider_bedrock() {
-        let config = EmbeddingModelConfig::Bedrock {
+        assert_eq!(config1.provider(), "openai");
+        assert_eq!(config1.model(), "text-embedding-3-small");
+        
+        let config2 = EmbeddingModelConfig::Bedrock {
             model: "amazon.titan-embed-text-v1".to_string(),
             region: "us-east-1".to_string(),
             profile: None,
         };
-        assert_eq!(config.provider(), "bedrock");
-    }
-
-    #[test]
-    fn test_embedding_model_config_model_openai() {
-        let config = EmbeddingModelConfig::OpenAI {
+        assert_eq!(config2.provider(), "bedrock");
+        assert_eq!(config2.model(), "amazon.titan-embed-text-v1");
+        
+        let config3 = EmbeddingModelConfig::OpenAI {
             api_key: "sk-test".to_string(),
             model: "text-embedding-3-small".to_string(),
-            base_url: None,
+            base_url: Some("https://custom.openai.com".to_string()),
         };
-        assert_eq!(config.model(), "text-embedding-3-small");
-    }
-
-    #[test]
-    fn test_embedding_model_config_model_bedrock() {
-        let config = EmbeddingModelConfig::Bedrock {
+        assert_eq!(config3.provider(), "openai");
+        assert_eq!(config3.model(), "text-embedding-3-small");
+        
+        let config4 = EmbeddingModelConfig::Bedrock {
             model: "amazon.titan-embed-text-v1".to_string(),
-            region: "us-east-1".to_string(),
-            profile: None,
+            region: "us-west-2".to_string(),
+            profile: Some("my-profile".to_string()),
         };
-        assert_eq!(config.model(), "amazon.titan-embed-text-v1");
+        assert_eq!(config4.provider(), "bedrock");
+        assert_eq!(config4.model(), "amazon.titan-embed-text-v1");
     }
 
     #[test]
-    fn test_vector_store_config_with_context_prefix() {
-        let config = VectorStoreConfig {
+    fn test_vector_store_config_construction_with_context_prefix() {
+        let config1 = VectorStoreConfig {
             name: "test".to_string(),
             context_prefix: Some("Context:".to_string()),
             store: VectorStoreType::InMemory {
@@ -1093,12 +871,9 @@ mod tests {
                 },
             },
         };
-        assert_eq!(config.context_prefix, Some("Context:".to_string()));
-    }
-
-    #[test]
-    fn test_vector_store_config_without_context_prefix() {
-        let config = VectorStoreConfig {
+        assert_eq!(config1.context_prefix, Some("Context:".to_string()));
+        
+        let config2 = VectorStoreConfig {
             name: "test".to_string(),
             context_prefix: None,
             store: VectorStoreType::InMemory {
@@ -1109,198 +884,48 @@ mod tests {
                 },
             },
         };
-        assert!(config.context_prefix.is_none());
+        assert!(config2.context_prefix.is_none());
     }
 
-    #[tokio::test]
-    async fn test_add_documents_qdrant_not_initialized() {
-        let mut manager = VectorStoreManager::new_stub("test", None);
-        manager.store_type = "qdrant".to_string();
+    #[test]
+    fn test_vector_store_config_various_store_types() {
+        let config1 = VectorStoreConfig {
+            name: "test".to_string(),
+            context_prefix: None,
+            store: VectorStoreType::InMemory {
+                embedding_model: EmbeddingModelConfig::OpenAI {
+                    api_key: "sk-test".to_string(),
+                    model: "text-embedding-3-small".to_string(),
+                    base_url: None,
+                },
+            },
+        };
+        assert_eq!(config1.name, "test");
         
-        let docs = vec!["doc1".to_string()];
-        let result = manager.add_documents(docs).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_add_documents_in_memory_not_initialized() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let docs = vec!["doc1".to_string()];
-        let result = manager.add_documents(docs).await;
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_search_result_metadata_with_id() {
-        let result = SearchResult {
-            content: "test".to_string(),
-            score: 0.5,
-            metadata: Some(json!({"id": "doc-123"})),
+        let config2 = VectorStoreConfig {
+            name: "test".to_string(),
+            context_prefix: None,
+            store: VectorStoreType::Qdrant {
+                embedding_model: EmbeddingModelConfig::OpenAI {
+                    api_key: "sk-test".to_string(),
+                    model: "text-embedding-3-small".to_string(),
+                    base_url: None,
+                },
+                url: "http://localhost:6334".to_string(),
+                collection_name: "test_collection".to_string(),
+            },
         };
-        assert!(result.metadata.is_some());
-        let metadata = result.metadata.unwrap();
-        assert_eq!(metadata["id"], "doc-123");
-    }
-
-    #[test]
-    fn test_search_result_metadata_complex() {
-        let result = SearchResult {
-            content: "test".to_string(),
-            score: 0.5,
-            metadata: Some(json!({
-                "id": "123",
-                "type": "document",
-                "tags": ["rust", "test"],
-                "nested": {"key": "value"}
-            })),
-        };
-        assert!(result.metadata.is_some());
-        let metadata = result.metadata.unwrap();
-        assert_eq!(metadata["id"], "123");
-        assert_eq!(metadata["type"], "document");
-    }
-
-    #[test]
-    fn test_format_search_results_with_metadata() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![SearchResult {
-            content: "test content".to_string(),
-            score: 0.95,
-            metadata: Some(json!({"id": "doc-1"})),
-        }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("test content"));
-        assert!(formatted.contains("0.950"));
-    }
-
-    #[tokio::test]
-    async fn test_search_in_memory_with_limit_one() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let result = manager.search("query", 1).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_search_with_filter_in_memory_single_filter() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let mut filters = HashMap::new();
-        filters.insert("type".to_string(), json!("document"));
+        assert_eq!(config2.name, "test");
         
-        let result = manager.search_with_filter("query", 5, filters).await;
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_document_builder_only_id() {
-        let doc = Document::new("content".to_string()).with_id("123".to_string());
-        assert_eq!(doc.id, Some("123".to_string()));
-        assert!(doc.metadata.is_none());
-    }
-
-    #[test]
-    fn test_document_builder_only_metadata() {
-        let metadata = json!({"key": "value"});
-        let doc = Document::new("content".to_string()).with_metadata(metadata.clone());
-        assert!(doc.id.is_none());
-        assert_eq!(doc.metadata, Some(metadata));
-    }
-
-    #[test]
-    fn test_vector_store_stats_all_fields() {
-        let stats = VectorStoreStats {
-            store_type: "qdrant".to_string(),
-            embedding_provider: "openai".to_string(),
-            embedding_model: "text-embedding-3-small".to_string(),
-            document_count: 42,
-            index_size: 1024,
+        let config3 = VectorStoreConfig {
+            name: "test".to_string(),
+            context_prefix: None,
+            store: VectorStoreType::BedrockKb {
+                knowledge_base_id: "kb-123".to_string(),
+                region: "us-east-1".to_string(),
+                profile: None,
+            },
         };
-        assert_eq!(stats.store_type, "qdrant");
-        assert_eq!(stats.embedding_provider, "openai");
-        assert_eq!(stats.embedding_model, "text-embedding-3-small");
-        assert_eq!(stats.document_count, 42);
-        assert_eq!(stats.index_size, 1024);
-    }
-
-    #[test]
-    fn test_format_search_results_boundary_score() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results = vec![SearchResult {
-            content: "test".to_string(),
-            score: 0.5,
-            metadata: None,
-        }];
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("0.500"));
-    }
-
-    #[tokio::test]
-    async fn test_search_very_long_query() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let long_query = "query ".repeat(1000);
-        let result = manager.search(&long_query, 5).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_search_with_filter_very_long_query() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let long_query = "query ".repeat(1000);
-        let filters = HashMap::new();
-        let result = manager.search_with_filter(&long_query, 5, filters).await;
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_format_search_results_ten_results() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let results: Vec<SearchResult> = (0..10)
-            .map(|i| SearchResult {
-                content: format!("content {}", i),
-                score: 0.9 - (i as f32 * 0.05),
-                metadata: None,
-            })
-            .collect();
-        let formatted = manager.format_search_results(&results, "query");
-        assert!(formatted.contains("Result 1"));
-        assert!(formatted.contains("Result 10"));
-        let separator_count = formatted.matches("---").count();
-        assert_eq!(separator_count, 9);
-    }
-
-    #[test]
-    fn test_search_result_score_precision() {
-        let result = SearchResult {
-            content: "test".to_string(),
-            score: 0.123456789,
-            metadata: None,
-        };
-        assert_eq!(result.score, 0.123456789);
-    }
-
-    #[test]
-    fn test_document_content_with_null_bytes() {
-        let doc = Document::new("test\0content".to_string());
-        assert_eq!(doc.content, "test\0content");
-    }
-
-    #[tokio::test]
-    async fn test_add_documents_with_newlines() {
-        let manager = VectorStoreManager::new_stub("test", None);
-        let docs = vec!["line1\nline2\nline3".to_string()];
-        let result = manager.add_documents(docs).await;
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_get_store_name_unicode() {
-        let manager = VectorStoreManager::new_stub("テスト店", None);
-        assert_eq!(manager.get_store_name(), Some("テスト店"));
-    }
-
-    #[test]
-    fn test_get_context_prefix_unicode() {
-        let manager = VectorStoreManager::new_stub("test", Some("コンテキスト:".to_string()));
-        assert_eq!(manager.get_context_prefix(), Some("コンテキスト:"));
+        assert_eq!(config3.name, "test");
     }
 }

--- a/docs/aura-self-testing-strategy.md
+++ b/docs/aura-self-testing-strategy.md
@@ -1,0 +1,924 @@
+# Aura Self-Testing Strategy
+
+Aura testing itself — using the agent platform to validate its own behavior, generate test coverage, and discover edge cases.
+
+## Why Self-Test?
+
+Aura is an agent composition platform. The most compelling proof of its capabilities is using it to solve real problems — starting with its own quality. Self-testing also:
+
+- Dogfoods the TOML config, MCP tool execution, and streaming API
+- Surfaces usability issues that only appear when building real agents
+- Produces test artifacts that double as working examples for users
+
+---
+
+## Option 1: Aura as API Test Agent
+
+An Aura agent configured with HTTP and assertion MCP tools that tests a running Aura instance's `/v1/chat/completions` endpoint — validating the API surface exactly as external clients experience it.
+
+### How It Works
+
+```
+┌─────────────────┐         ┌─────────────────┐         ┌──────────────┐
+│  Aura Test Agent │──HTTP──▶│  Aura Under Test │──MCP──▶│  Mock MCP    │
+│  (tester)        │◀──SSE──│  (target)         │◀──────│  Server      │
+└─────────────────┘         └─────────────────┘         └──────────────┘
+```
+
+The test agent:
+1. Sends chat completion requests to the target Aura instance
+2. Parses SSE streams, validates event ordering and content
+3. Verifies tool execution lifecycle: `aura.tool_requested` → `aura.tool_start` → `aura.tool_complete`
+4. Tests error paths (malformed input, tool failures, timeouts)
+5. Tests cancellation (disconnect mid-stream, verify cleanup)
+6. Reports pass/fail results with structured output
+
+### Example Agent Configuration
+
+```toml
+# configs/self-test-agent.toml
+[llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+
+[mcp]
+sanitize_schemas = true
+
+# HTTP client MCP server for making requests to the target Aura instance
+[mcp.servers.http_client]
+transport = "http_streamable"
+url = "http://localhost:9100/mcp"
+description = "HTTP client for testing Aura API endpoints — send requests, parse SSE, validate responses"
+
+# Filesystem MCP server for reading test fixtures and writing results
+[mcp.servers.filesystem]
+transport = "http_streamable"
+url = "http://localhost:9101/mcp"
+description = "Read test fixtures, write test results and reports"
+
+[agent]
+name = "Aura API Test Agent"
+system_prompt = """
+You are a QA agent that tests the Aura API server at http://localhost:8080.
+
+Your job is to execute test scenarios against the /v1/chat/completions endpoint
+and report results. For each test:
+
+1. Send the request using the http_client tools
+2. Parse the response (JSON or SSE stream)
+3. Validate against expected behavior
+4. Report PASS/FAIL with details
+
+Test categories:
+- Streaming: SSE event format, token-by-token delivery, [DONE] termination
+- Tool execution: tool_call → tool_result lifecycle, multi-turn chains
+- Custom events: aura.tool_requested, aura.tool_start, aura.tool_complete
+- Error handling: malformed requests, tool failures, timeout behavior
+- Headers: header forwarding to MCP servers
+- Cancellation: client disconnect propagation
+
+Report results in structured JSON:
+{"test": "name", "status": "PASS|FAIL", "details": "...", "duration_ms": N}
+"""
+temperature = 0.0
+turn_depth = 10
+```
+
+### What It Tests
+
+| Category | Test Scenarios |
+|----------|---------------|
+| **Streaming** | SSE format compliance, chunk ordering, `[DONE]` termination, backpressure |
+| **Tool Lifecycle** | `tool_call` → execution → `tool_result`, multi-step chains, parallel tool calls |
+| **Custom Events** | `aura.tool_requested/start/complete` emission, timing, payload structure |
+| **Error Handling** | Malformed JSON, unknown model, tool failures (`failing_tool`), timeout expiry |
+| **Header Forwarding** | Static headers, `headers_from_request` mapping, override precedence |
+| **Cancellation** | Mid-stream disconnect, MCP `notifications/cancelled` delivery, resource cleanup |
+| **Concurrency** | Simultaneous requests, session isolation, no cross-request contamination |
+
+### GitHub CI Integration
+
+This is the key advantage of Option 1 — the test agent can run as a **GitHub Actions workflow** triggered on PRs:
+
+```yaml
+# .github/workflows/aura-api-tests.yml
+name: Aura API Tests (Self-Test)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+
+jobs:
+  api-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Start target Aura + mock MCP via Docker Compose
+      - name: Start test infrastructure
+        run: |
+          docker compose -f compose/base.yml -f compose/test.yml up -d \
+            aura-web-server mock-mcp
+          # Wait for healthy
+          timeout 90 bash -c 'until curl -sf http://localhost:8080/health; do sleep 2; done'
+
+      # Run the Aura test agent against the target
+      - name: Run API test agent
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          # The test agent runs as a second Aura instance
+          CONFIG_PATH=configs/self-test-agent.toml \
+            cargo run --bin aura-web-server -- --port 8090 &
+          TEST_AGENT_PID=$!
+
+          # Execute test suite by sending prompts to the test agent
+          python3 scripts/run-api-tests.py \
+            --agent-url http://localhost:8090 \
+            --target-url http://localhost:8080 \
+            --output results/api-test-results.json
+
+          kill $TEST_AGENT_PID
+
+      # Post results as PR comment via gh CLI
+      - name: Report results
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/format-test-report.py results/api-test-results.json > report.md
+          gh pr comment ${{ github.event.pull_request.number }} --body-file report.md
+
+      - name: Cleanup
+        if: always()
+        run: docker compose -f compose/base.yml -f compose/test.yml down
+```
+
+**Alternative: Lightweight gh CLI approach** — skip the second Aura instance entirely and use a script that sends curl requests to the target, parses SSE, and reports via `gh pr comment`:
+
+```bash
+# scripts/api-smoke-test.sh — runs as a PR check
+#!/bin/bash
+set -euo pipefail
+
+TARGET_URL="${1:-http://localhost:8080}"
+RESULTS=()
+
+# Test 1: Health check
+if curl -sf "$TARGET_URL/health" | jq -e '.status == "healthy"' > /dev/null; then
+  RESULTS+=("PASS: Health endpoint")
+else
+  RESULTS+=("FAIL: Health endpoint")
+fi
+
+# Test 2: Non-streaming completion
+RESPONSE=$(curl -sf "$TARGET_URL/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"Say hello"}]}')
+if echo "$RESPONSE" | jq -e '.choices[0].message.content' > /dev/null; then
+  RESULTS+=("PASS: Non-streaming completion")
+else
+  RESULTS+=("FAIL: Non-streaming completion")
+fi
+
+# Test 3: Streaming completion
+# ... SSE parsing and validation ...
+
+# Output results
+printf '%s\n' "${RESULTS[@]}"
+```
+
+### Pros and Cons
+
+| Pros | Cons |
+|------|------|
+| Tests the real API as clients see it | Requires LLM API key (cost per run) |
+| Catches integration issues across layers | Non-deterministic (LLM responses vary) |
+| Exercises MCP tool calling as a side effect | Two Aura instances needed for full agent approach |
+| Results post directly to PRs via `gh` CLI | Slower than unit tests (~minutes per suite) |
+| Doubles as a living example of Aura usage | |
+
+---
+
+## Option 2: Aura as Test Case Generator (Multi-Agent Pipeline)
+
+A multi-agent pipeline where one Aura agent generates Rust test code and four review agents evaluate it through different lenses — with an auto-fix loop that iterates until the tests are solid.
+
+### How It Works
+
+```
+make test-generate [FILES="crates/aura/src/mcp.rs"]
+  │
+  ├─ 1. Identify targets
+  │     (git diff vs main, or explicit FILES=)
+  │
+  ├─ 2. Generator Agent
+  │     Reads source + existing tests → writes new tests to source tree
+  │
+  ├─ 3. cargo test
+  │     Compile + run (fail fast if broken)
+  │
+  ├─ 4. Review Agents (parallel, 4 lenses)
+  │     ├─ Correctness Agent
+  │     ├─ Coverage Agent
+  │     ├─ Robustness Agent
+  │     └─ Style Agent
+  │
+  ├─ 5. Issues found?
+  │     ├─ YES → Feed review back to Generator → goto step 3 (max 3 rounds)
+  │     └─ NO  → Done
+  │
+  └─ 6. Terminal summary
+        PASS/FAIL per file, review verdicts, iteration count
+```
+
+### Agent Configurations
+
+Five Aura agents, each with a focused role. All share filesystem and shell MCP tools.
+
+#### Generator Agent
+
+```toml
+# configs/test-agents/generator.toml
+[llm]
+provider = "anthropic"
+api_key = "{{ env.ANTHROPIC_API_KEY }}"
+model = "claude-sonnet-4-20250514"
+
+[mcp]
+sanitize_schemas = true
+
+[mcp.servers.filesystem]
+transport = "http_streamable"
+url = "http://localhost:9101/mcp"
+description = "Read Rust source files and write generated test code"
+
+[mcp.servers.shell]
+transport = "http_streamable"
+url = "http://localhost:9102/mcp"
+description = "Run cargo commands to compile and test generated code"
+
+[agent]
+name = "Test Generator"
+system_prompt = """
+You are a Rust test engineer for the Aura project. You generate test cases
+for source files provided to you.
+
+Workflow:
+1. Read the target source file and any existing tests for it
+2. Identify untested functions, branches, and edge cases
+3. Generate test code following the project's conventions
+4. Write tests to the correct location in the source tree
+5. Run `cargo test` to verify compilation and correctness
+6. If tests fail, fix them and re-run until green
+
+Where to write tests:
+- Unit tests: append to existing #[cfg(test)] mod tests { } in the source file
+- If no test module exists, create one at the bottom of the source file
+- Integration tests: crates/aura-web-server/tests/ (for HTTP/SSE behavior)
+
+Conventions:
+- #[tokio::test] for async functions
+- Test names: test_<function>_<scenario>
+- Test both happy paths and error cases
+- Prefer real types over mocks
+- One logical assertion per test
+- Use aura-test-utils helpers where applicable
+- Do NOT modify source code — only write test code
+
+When given review feedback, apply the fixes precisely. Focus on the issues
+flagged — do not rewrite tests that weren't flagged.
+"""
+temperature = 0.0
+turn_depth = 20
+```
+
+#### Correctness Review Agent
+
+```toml
+# configs/test-agents/review-correctness.toml
+[llm]
+provider = "anthropic"
+api_key = "{{ env.ANTHROPIC_API_KEY }}"
+model = "claude-sonnet-4-20250514"
+
+[mcp]
+sanitize_schemas = true
+
+[mcp.servers.filesystem]
+transport = "http_streamable"
+url = "http://localhost:9101/mcp"
+description = "Read source files and generated test code for review"
+
+[agent]
+name = "Correctness Reviewer"
+system_prompt = """
+You review generated Rust tests for CORRECTNESS.
+
+For each test file you are given, read both the source file and the test code.
+Evaluate:
+
+1. Does each test actually validate what its name claims?
+2. Are assertions meaningful — not tautological (assert_eq!(x, x)) or vacuous?
+3. Does the test exercise the real code path, or does it test a mock/stub?
+4. Are setup conditions realistic — would this scenario actually occur?
+5. If the function under test returned a wrong value, would the test catch it?
+6. Are error cases testing the right error variant, not just "any error"?
+
+Output format (JSON array):
+[
+  {
+    "file": "path/to/test.rs",
+    "test_name": "test_foo_returns_bar",
+    "verdict": "PASS" | "FAIL",
+    "issue": "description of the correctness problem (if FAIL)",
+    "fix": "specific suggestion for how to fix it"
+  }
+]
+
+Only flag genuine correctness issues. A test that is correct but could have
+better coverage is NOT a correctness issue — that's the Coverage agent's job.
+"""
+temperature = 0.0
+turn_depth = 5
+```
+
+#### Coverage & Edge Cases Review Agent
+
+```toml
+# configs/test-agents/review-coverage.toml
+[llm]
+provider = "anthropic"
+api_key = "{{ env.ANTHROPIC_API_KEY }}"
+model = "claude-sonnet-4-20250514"
+
+[mcp]
+sanitize_schemas = true
+
+[mcp.servers.filesystem]
+transport = "http_streamable"
+url = "http://localhost:9101/mcp"
+description = "Read source files and generated test code for review"
+
+[agent]
+name = "Coverage Reviewer"
+system_prompt = """
+You review generated Rust tests for COVERAGE and EDGE CASES.
+
+For each test file, read the source implementation and evaluate what's missing:
+
+1. Are all public functions tested?
+2. Are error/failure paths covered (Result::Err, Option::None, panics)?
+3. Boundary values: empty collections, zero, max values, single-element?
+4. Are match arms and if/else branches all exercised?
+5. For async code: cancellation, timeout, concurrent access?
+6. For parsers: malformed input, missing fields, extra fields, wrong types?
+7. For state machines: all transitions, invalid transitions, re-entry?
+
+Output format (JSON array):
+[
+  {
+    "file": "path/to/source.rs",
+    "function": "function_name",
+    "missing_scenario": "description of the untested case",
+    "priority": "HIGH" | "MEDIUM" | "LOW",
+    "suggested_test": "brief description of what the test should do"
+  }
+]
+
+Focus on scenarios that would catch real bugs. Don't flag trivial getters
+or simple delegations that can't meaningfully fail.
+"""
+temperature = 0.0
+turn_depth = 5
+```
+
+#### Robustness & Flakiness Review Agent
+
+```toml
+# configs/test-agents/review-robustness.toml
+[llm]
+provider = "anthropic"
+api_key = "{{ env.ANTHROPIC_API_KEY }}"
+model = "claude-sonnet-4-20250514"
+
+[mcp]
+sanitize_schemas = true
+
+[mcp.servers.filesystem]
+transport = "http_streamable"
+url = "http://localhost:9101/mcp"
+description = "Read generated test code for robustness review"
+
+[agent]
+name = "Robustness Reviewer"
+system_prompt = """
+You review generated Rust tests for ROBUSTNESS and FLAKINESS risk.
+
+For each test file, evaluate whether the tests will be reliable in CI:
+
+1. Timing dependencies: Does the test depend on sleep(), wall-clock time,
+   or specific execution ordering that could vary under load?
+2. Port/resource conflicts: Does it bind to a hardcoded port that could
+   collide with other tests running in parallel?
+3. Filesystem side effects: Does it write to a shared location without cleanup?
+4. Non-determinism: Does it depend on HashMap ordering, random values,
+   or floating-point equality without epsilon?
+5. External dependencies: Does it require a network call, running service,
+   or environment variable that might not be set?
+6. Test isolation: Could this test's state leak into or from another test?
+7. Brittle assertions: Does it assert on error message strings, debug output,
+   or formatting that could change without a real bug?
+
+Output format (JSON array):
+[
+  {
+    "file": "path/to/test.rs",
+    "test_name": "test_foo",
+    "risk": "HIGH" | "MEDIUM" | "LOW",
+    "issue": "description of the flakiness/robustness concern",
+    "fix": "specific suggestion"
+  }
+]
+
+Only flag real risks. Deterministic unit tests with no I/O are inherently
+robust — don't waste time reviewing those.
+"""
+temperature = 0.0
+turn_depth = 5
+```
+
+#### Style & Convention Review Agent
+
+```toml
+# configs/test-agents/review-style.toml
+[llm]
+provider = "anthropic"
+api_key = "{{ env.ANTHROPIC_API_KEY }}"
+model = "claude-sonnet-4-20250514"
+
+[mcp]
+sanitize_schemas = true
+
+[mcp.servers.filesystem]
+transport = "http_streamable"
+url = "http://localhost:9101/mcp"
+description = "Read existing and generated test code for style review"
+
+[agent]
+name = "Style Reviewer"
+system_prompt = """
+You review generated Rust tests for STYLE and CONVENTION compliance.
+
+Read existing tests in the project to learn the established patterns, then
+evaluate the new tests against those patterns:
+
+1. Naming: Do test names follow test_<function>_<scenario> convention?
+2. Organization: Are unit tests in #[cfg(test)] mod tests {}? Integration
+   tests in crates/aura-web-server/tests/?
+3. Assertions: Does the project prefer assert_eq! vs assert!(matches!(...))?
+   Are the generated tests consistent?
+4. Async patterns: Is #[tokio::test] used correctly? Are timeouts handled
+   the same way as existing tests?
+5. Imports: Are they organized consistently with the rest of the codebase?
+6. Test helpers: Are aura-test-utils helpers used where the existing tests
+   use them, rather than reinventing inline?
+7. Feature flags: Do integration tests use the correct #[cfg(feature = "...")]?
+
+Output format (JSON array):
+[
+  {
+    "file": "path/to/test.rs",
+    "test_name": "test_foo",
+    "issue": "description of the style deviation",
+    "convention": "what the existing tests do instead",
+    "fix": "specific change needed"
+  }
+]
+
+Only flag meaningful deviations from established patterns. Minor formatting
+differences that rustfmt will fix are not worth flagging.
+"""
+temperature = 0.0
+turn_depth = 5
+```
+
+### Orchestration: `make test-generate`
+
+The Makefile target supports two modes:
+- **Changed files** (default): `make test-generate` — generates tests for files changed vs `main`
+- **Explicit files**: `make test-generate FILES="crates/aura/src/mcp.rs crates/aura/src/config.rs"`
+
+```makefile
+# Added to Makefile
+
+# Aura self-testing: multi-agent test generation pipeline
+TEST_AGENT_CONFIGS := configs/test-agents
+ORCHESTRATOR_SCRIPT := scripts/test-generate-orchestrate.sh
+MAX_REVIEW_ROUNDS := 3
+
+.PHONY: test-generate
+test-generate::           ## Generate + review tests using Aura agents
+	@if [ -n "$(FILES)" ]; then \
+		echo "[aura] Generating tests for explicit files: $(FILES)"; \
+		$(ORCHESTRATOR_SCRIPT) --files "$(FILES)" --max-rounds $(MAX_REVIEW_ROUNDS); \
+	else \
+		CHANGED=$$(git diff --name-only main -- 'crates/**/*.rs' | grep -v test); \
+		if [ -z "$$CHANGED" ]; then \
+			echo "[aura] No changed source files vs main. Use FILES= to target specific files."; \
+			exit 0; \
+		fi; \
+		echo "[aura] Generating tests for changed files vs main:"; \
+		echo "$$CHANGED" | sed 's/^/  /'; \
+		$(ORCHESTRATOR_SCRIPT) --files "$$CHANGED" --max-rounds $(MAX_REVIEW_ROUNDS); \
+	fi
+```
+
+### Orchestration Script
+
+```bash
+#!/usr/bin/env bash
+# scripts/test-generate-orchestrate.sh
+#
+# Multi-agent test generation pipeline:
+#   1. Generator agent writes tests
+#   2. cargo test validates them
+#   3. Four review agents evaluate in parallel
+#   4. If issues found, feed back to generator (up to N rounds)
+#   5. Print terminal summary
+
+set -euo pipefail
+
+# ── Parse args ───────────────────────────────────────────────────────
+FILES=""
+MAX_ROUNDS=3
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --files)    FILES="$2"; shift 2 ;;
+    --max-rounds) MAX_ROUNDS="$2"; shift 2 ;;
+    *)          echo "Unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+if [ -z "$FILES" ]; then
+  echo "No files specified." && exit 1
+fi
+
+# ── Config ───────────────────────────────────────────────────────────
+AGENT_CONFIGS="configs/test-agents"
+GENERATOR_PORT=8090
+REVIEW_PORTS=(8091 8092 8093 8094)
+REVIEW_NAMES=("correctness" "coverage" "robustness" "style")
+REVIEW_CONFIGS=("review-correctness" "review-coverage" "review-robustness" "review-style")
+PIDS=()
+
+cleanup() {
+  echo "[aura] Cleaning up agent processes..."
+  for pid in "${PIDS[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+# ── Start MCP tool servers ───────────────────────────────────────────
+echo "[aura] Starting MCP tool servers..."
+# (filesystem on :9101, shell on :9102 — assumed running or started here)
+
+# ── Start Generator Agent ────────────────────────────────────────────
+echo "[aura] Starting generator agent on :${GENERATOR_PORT}..."
+CONFIG_PATH="${AGENT_CONFIGS}/generator.toml" \
+  cargo run --bin aura-web-server -- --port $GENERATOR_PORT &
+PIDS+=($!)
+sleep 3  # Wait for server readiness
+
+# ── Generation + Review Loop ─────────────────────────────────────────
+ROUND=0
+ALL_CLEAR=false
+
+while [ $ROUND -lt $MAX_ROUNDS ] && [ "$ALL_CLEAR" = false ]; do
+  ROUND=$((ROUND + 1))
+  echo ""
+  echo "═══════════════════════════════════════════"
+  echo "  Round $ROUND / $MAX_ROUNDS"
+  echo "═══════════════════════════════════════════"
+
+  # ── Step 1: Generate (or fix) tests ──────────────────────────────
+  if [ $ROUND -eq 1 ]; then
+    echo "[generator] Generating tests for: $FILES"
+    PROMPT="Generate comprehensive tests for these source files: $FILES"
+  else
+    echo "[generator] Applying review feedback (round $ROUND)..."
+    PROMPT="Apply the following review feedback to the tests you generated. Fix all issues, then run cargo test to verify.\n\nFeedback:\n$(cat /tmp/aura-review-feedback.json)"
+  fi
+
+  # Send prompt to generator agent
+  curl -sf "http://localhost:${GENERATOR_PORT}/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "{\"messages\":[{\"role\":\"user\",\"content\":\"$PROMPT\"}]}" \
+    > /tmp/aura-generator-response.json
+
+  # ── Step 2: cargo test ───────────────────────────────────────────
+  echo "[test] Running cargo test..."
+  if ! cargo test --workspace --lib 2>&1 | tee /tmp/aura-test-output.txt; then
+    echo "[test] FAILED — feeding errors back to generator"
+    # On test failure in early rounds, let the generator fix it
+    if [ $ROUND -lt $MAX_ROUNDS ]; then
+      echo "[{\"agent\":\"cargo-test\",\"issues\":[{\"verdict\":\"FAIL\",\"issue\":\"Compilation or test failure\",\"fix\":\"See test output\",\"output\":\"$(tail -50 /tmp/aura-test-output.txt | jq -Rs .)\"}]}]" \
+        > /tmp/aura-review-feedback.json
+      continue
+    else
+      echo "[test] FAILED on final round — manual intervention needed"
+      exit 1
+    fi
+  fi
+  echo "[test] All tests pass"
+
+  # ── Step 3: Start review agents in parallel ──────────────────────
+  echo "[review] Starting 4 review agents in parallel..."
+  REVIEW_PIDS=()
+  for i in "${!REVIEW_NAMES[@]}"; do
+    PORT=${REVIEW_PORTS[$i]}
+    NAME=${REVIEW_NAMES[$i]}
+    CONFIG=${REVIEW_CONFIGS[$i]}
+
+    CONFIG_PATH="${AGENT_CONFIGS}/${CONFIG}.toml" \
+      cargo run --bin aura-web-server -- --port "$PORT" &
+    REVIEW_PIDS+=($!)
+    PIDS+=($!)
+  done
+  sleep 3  # Wait for review agents
+
+  # ── Step 4: Send review requests in parallel ─────────────────────
+  echo "[review] Reviewing generated tests..."
+  REVIEW_RESULTS=()
+  for i in "${!REVIEW_NAMES[@]}"; do
+    PORT=${REVIEW_PORTS[$i]}
+    NAME=${REVIEW_NAMES[$i]}
+
+    curl -sf "http://localhost:${PORT}/v1/chat/completions" \
+      -H "Content-Type: application/json" \
+      -d "{\"messages\":[{\"role\":\"user\",\"content\":\"Review the tests in these files: $FILES\"}]}" \
+      > "/tmp/aura-review-${NAME}.json" &
+  done
+  wait  # Wait for all reviews to complete
+
+  # ── Step 5: Consolidate review results ───────────────────────────
+  TOTAL_ISSUES=0
+  FEEDBACK="["
+  for NAME in "${REVIEW_NAMES[@]}"; do
+    RESULT=$(cat "/tmp/aura-review-${NAME}.json" | jq -r '.choices[0].message.content // empty')
+    ISSUE_COUNT=$(echo "$RESULT" | jq 'if type == "array" then [.[] | select(.verdict == "FAIL" or .risk == "HIGH" or .priority == "HIGH")] | length else 0 end' 2>/dev/null || echo 0)
+    TOTAL_ISSUES=$((TOTAL_ISSUES + ISSUE_COUNT))
+    FEEDBACK="${FEEDBACK}{\"agent\":\"${NAME}\",\"issues\":${RESULT}},"
+  done
+  FEEDBACK="${FEEDBACK%,}]"
+  echo "$FEEDBACK" > /tmp/aura-review-feedback.json
+
+  # Stop review agents
+  for pid in "${REVIEW_PIDS[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+
+  # ── Step 6: Check if we're clear ─────────────────────────────────
+  if [ "$TOTAL_ISSUES" -eq 0 ]; then
+    ALL_CLEAR=true
+    echo "[review] All clear — no issues found"
+  else
+    echo "[review] Found $TOTAL_ISSUES issues across all lenses"
+    if [ $ROUND -lt $MAX_ROUNDS ]; then
+      echo "[review] Feeding back to generator for round $((ROUND + 1))..."
+    fi
+  fi
+done
+
+# ── Terminal Summary ─────────────────────────────────────────────────
+echo ""
+echo "═══════════════════════════════════════════"
+echo "  Test Generation Summary"
+echo "═══════════════════════════════════════════"
+echo "  Files:       $FILES"
+echo "  Rounds:      $ROUND / $MAX_ROUNDS"
+echo "  cargo test:  PASS"
+if [ "$ALL_CLEAR" = true ]; then
+  echo "  Reviews:     ALL CLEAR"
+else
+  echo "  Reviews:     Issues remain (see details above)"
+fi
+echo ""
+
+# Per-lens summary
+for NAME in "${REVIEW_NAMES[@]}"; do
+  RESULT=$(cat "/tmp/aura-review-${NAME}.json" 2>/dev/null | jq -r '.choices[0].message.content // "N/A"')
+  PASS_COUNT=$(echo "$RESULT" | jq 'if type == "array" then [.[] | select(.verdict == "PASS")] | length else 0 end' 2>/dev/null || echo "?")
+  FAIL_COUNT=$(echo "$RESULT" | jq 'if type == "array" then [.[] | select(.verdict == "FAIL" or .risk == "HIGH" or .priority == "HIGH")] | length else 0 end' 2>/dev/null || echo "?")
+  printf "  %-14s  PASS: %s  ISSUES: %s\n" "$NAME" "$PASS_COUNT" "$FAIL_COUNT"
+done
+echo "═══════════════════════════════════════════"
+```
+
+### Example Terminal Output
+
+```
+$ make test-generate FILES="crates/aura/src/tool_event_broker.rs"
+[aura] Generating tests for explicit files: crates/aura/src/tool_event_broker.rs
+
+═══════════════════════════════════════════
+  Round 1 / 3
+═══════════════════════════════════════════
+[generator] Generating tests for: crates/aura/src/tool_event_broker.rs
+[test] Running cargo test...
+[test] All tests pass
+[review] Starting 4 review agents in parallel...
+[review] Reviewing generated tests...
+[review] Found 3 issues across all lenses
+
+═══════════════════════════════════════════
+  Round 2 / 3
+═══════════════════════════════════════════
+[generator] Applying review feedback (round 2)...
+[test] Running cargo test...
+[test] All tests pass
+[review] Starting 4 review agents in parallel...
+[review] Reviewing generated tests...
+[review] All clear — no issues found
+
+═══════════════════════════════════════════
+  Test Generation Summary
+═══════════════════════════════════════════
+  Files:       crates/aura/src/tool_event_broker.rs
+  Rounds:      2 / 3
+  cargo test:  PASS
+  Reviews:     ALL CLEAR
+
+  correctness     PASS: 8  ISSUES: 0
+  coverage        PASS: 6  ISSUES: 0
+  robustness      PASS: 8  ISSUES: 0
+  style           PASS: 8  ISSUES: 0
+═══════════════════════════════════════════
+```
+
+### What It Generates
+
+| Source Module | Generated Tests |
+|---------------|-----------------|
+| `provider_agent.rs` | Provider type erasure, streaming dispatch, error propagation |
+| `tool_event_broker.rs` | FIFO ordering, concurrent access, edge cases (empty queue, duplicate IDs) |
+| `request_cancellation.rs` | Token lifecycle, cleanup on drop, concurrent cancel signals |
+| `mcp_response.rs` | Response parsing, malformed JSON, content type variants |
+| `schema_sanitize.rs` | anyOf handling, missing types, nested schema fixes |
+| `config.rs` | Env interpolation, missing fields, invalid TOML, type coercion |
+| `stream_events.rs` | Event serialization, custom event payloads, edge cases |
+
+### Pros and Cons
+
+| Pros | Cons |
+|------|------|
+| Generated tests are deterministic — no LLM at runtime | LLM cost per generation cycle |
+| Multi-lens review catches issues a single pass would miss | 5 agents = 5x LLM cost per round |
+| Auto-fix loop means less manual intervention | Max 3 rounds may not resolve all issues |
+| Tests persist as regular Rust code in the repo | Requires filesystem + shell MCP servers |
+| `make test-generate` fits naturally in dev workflow | First run requires MCP server setup |
+| Compounds over time — coverage grows with each session | |
+
+---
+
+## Option 3: Aura as Chaos/Scenario Agent
+
+An Aura agent that generates adversarial and edge-case inputs, fires them at Aura's API, and reports failures — leveraging LLM creativity to find issues humans wouldn't think to test.
+
+### How It Works
+
+```
+┌──────────────────────┐         ┌─────────────────┐
+│  Aura Chaos Agent    │──HTTP──▶│  Aura Under Test │
+│  (adversarial input) │◀──SSE──│  (target)         │
+└──────────────────────┘         └─────────────────┘
+         │
+         ▼
+   ┌─────────────────┐
+   │  Failure Report  │
+   │  (reproducible)  │
+   └─────────────────┘
+```
+
+The chaos agent:
+1. Generates creative adversarial inputs (malformed JSON, boundary values, Unicode edge cases, injection attempts)
+2. Sends them to the target Aura instance
+3. Monitors for crashes, hangs, unexpected errors, or data leaks
+4. Captures reproducible failure cases with exact request/response payloads
+5. Generates regression test cases from discovered failures (feeds into Option 2)
+
+### Example Agent Configuration
+
+```toml
+# configs/chaos-test-agent.toml
+[llm]
+provider = "anthropic"
+api_key = "{{ env.ANTHROPIC_API_KEY }}"
+model = "claude-sonnet-4-20250514"
+
+[mcp]
+sanitize_schemas = true
+
+[mcp.servers.http_client]
+transport = "http_streamable"
+url = "http://localhost:9100/mcp"
+description = "HTTP client for sending adversarial requests to the target Aura API"
+
+[mcp.servers.filesystem]
+transport = "http_streamable"
+url = "http://localhost:9101/mcp"
+description = "Write failure reports and reproducible test cases"
+
+[agent]
+name = "Aura Chaos Agent"
+system_prompt = """
+You are a chaos testing agent. Your goal is to find bugs, crashes, and
+unexpected behavior in the Aura API server at http://localhost:8080.
+
+Attack categories to explore:
+1. Malformed requests: invalid JSON, missing fields, wrong types, extra fields
+2. Boundary values: empty strings, huge payloads, zero/negative numbers, max integers
+3. Unicode and encoding: null bytes, RTL characters, emoji, surrogate pairs, multi-byte
+4. Injection: prompt injection in messages, SQL-like strings, shell metacharacters
+5. Protocol abuse: invalid SSE parsing, premature disconnects, rapid reconnects
+6. Concurrency: simultaneous requests with same session_id, rapid fire
+7. Resource exhaustion: very long messages, deep conversation history, max turn_depth
+8. Header manipulation: missing content-type, conflicting headers, oversized headers
+
+For each test:
+1. Design the adversarial input with a clear hypothesis of what might break
+2. Send the request and capture the full response
+3. Classify the result: PASS (handled gracefully), FAIL (crash/hang/unexpected)
+4. For failures, write a reproducible test case to /tmp/chaos-results/
+
+Be creative. Think about what a malicious or buggy client might send.
+"""
+temperature = 0.7  # Higher creativity for diverse attack patterns
+turn_depth = 15
+```
+
+### Attack Scenarios
+
+| Category | Example Scenarios |
+|----------|-------------------|
+| **Malformed Requests** | Missing `messages` field, `messages: null`, `messages: "string"`, nested 1000 levels deep |
+| **Boundary Values** | `max_tokens: 0`, `max_tokens: 999999999`, `temperature: -1`, empty message content |
+| **Unicode Edge Cases** | Null bytes in message content, 10MB emoji string, mixed RTL/LTR, lone surrogates |
+| **Protocol Abuse** | Request with `stream: true` then immediately disconnect, 100 concurrent streams to same session |
+| **Resource Exhaustion** | Conversation with 10,000 messages in history, single message with 1M characters |
+| **Header Attacks** | 100KB `Authorization` header, null bytes in header values, duplicate `Content-Type` |
+
+### Output: Failure Pipeline
+
+Discovered failures automatically feed back into the development process:
+
+```
+Chaos Agent finds failure
+    ↓
+Writes reproducible curl command + expected vs actual behavior
+    ↓
+Developer reviews failure report
+    ↓
+Option 2 (Test Generator) creates a regression test from the failure
+    ↓
+Fix lands with test coverage — failure can never recur
+```
+
+### Pros and Cons
+
+| Pros | Cons |
+|------|------|
+| Finds edge cases humans wouldn't think of | Non-deterministic — different bugs each run |
+| LLM creativity generates diverse attack patterns | Harder to reproduce exact failures |
+| Discovered failures become regression tests | Requires running Aura instance + LLM API |
+| Great for hardening before releases | Can generate false positives (expected errors flagged as failures) |
+| No upfront test authoring — agent explores freely | Needs human triage of results |
+
+---
+
+## Comparison Matrix
+
+| | Option 1: API Test Agent | Option 2: Test Generator | Option 3: Chaos Agent |
+|---|---|---|---|
+| **Purpose** | Validate API behavior | Expand test coverage | Find unknown edge cases |
+| **Agents** | 1 (tester) | 5 (1 generator + 4 reviewers) | 1 (chaos) |
+| **Runtime LLM** | Yes (every run) | No (generate once, run forever) | Yes (every run) |
+| **Trigger** | GitHub Actions PR check | `make test-generate` (on-demand) | Periodic/pre-release |
+| **Deterministic** | No | Yes (after generation) | No |
+| **Cost per run** | Medium (LLM + compute) | Zero (`cargo test`) | Medium (LLM + compute) |
+| **Cost to generate** | N/A | Medium (5 agents x up to 3 rounds) | N/A |
+| **Best for** | Regression, API contract | Coverage gaps, new code | Security, robustness |
+| **Feeds into** | PR comments, status checks | Committed test code | Option 2 (regression tests) |
+
+## Recommended Rollout
+
+1. **Phase 1** — Option 2 (Test Generator): Highest ROI. `make test-generate` gives developers a non-abrasive, opt-in tool that produces persistent tests. Start with the modules that have the lowest coverage. Once the multi-agent pipeline is proven, the generated tests run in CI for free forever.
+2. **Phase 2** — Option 1 (API Test Agent): Add as a GitHub Actions PR gate. Validates the full API contract on every PR. Complements Option 2 by testing the assembled system, not just individual units.
+3. **Phase 3** — Option 3 (Chaos Agent): Run periodically (weekly or pre-release) to harden the system. Feed discovered failures back into Option 2's generator to create regression tests automatically.

--- a/scripts/test-generate-orchestrate.sh
+++ b/scripts/test-generate-orchestrate.sh
@@ -1,0 +1,505 @@
+#!/usr/bin/env bash
+#
+# test-generate-orchestrate.sh
+#
+# Multi-agent test generation pipeline using Aura agents.
+# Generates Rust tests, validates with cargo test, then runs 4 review agents
+# in parallel. Issues are fed back to the generator for up to N rounds.
+#
+# Usage:
+#   ./scripts/test-generate-orchestrate.sh --files "crates/aura/src/foo.rs"
+#   ./scripts/test-generate-orchestrate.sh  # auto-detect changed files vs main
+#
+# Requires: cargo, curl, jq, OPENAI_API_KEY
+set -euo pipefail
+
+# ── Constants ────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG_DIR="${PROJECT_ROOT}/configs/test-agents"
+BINARY_NAME="aura-web-server"
+
+GENERATOR_PORT=18090
+REVIEW_PORTS=(18091 18092 18093 18094)
+REVIEW_NAMES=("correctness" "coverage" "robustness" "style")
+REVIEW_CONFIGS=("review-correctness" "review-coverage" "review-robustness" "review-style")
+
+MAX_ROUNDS="${MAX_ROUNDS:-3}"
+HEALTH_TIMEOUT=90
+REQUEST_TIMEOUT=300
+
+PIDS=()
+REVIEW_OUTPUT_DIR="/tmp/aura-test-generate"
+
+# ── Colors ───────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ── Argument Parsing ─────────────────────────────────────────────────
+FILES=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --files)      FILES="$2"; shift 2 ;;
+    --max-rounds) MAX_ROUNDS="$2"; shift 2 ;;
+    *)            echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+# ── Dependency Checks ────────────────────────────────────────────────
+for cmd in curl jq cargo; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo -e "${RED}Error: $cmd is required but not found.${NC}"
+    exit 1
+  fi
+done
+
+# Verify LLM credentials are available.
+# Default configs use AWS Bedrock (credentials via ~/.aws/credentials or env vars).
+# If using OpenAI instead, set OPENAI_API_KEY.
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ] && [ ! -f ~/.aws/credentials ] && [ -z "${OPENAI_API_KEY:-}" ]; then
+  echo -e "${RED}Error: No LLM credentials found.${NC}"
+  echo "  For Bedrock: configure ~/.aws/credentials or set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"
+  echo "  For OpenAI:  export OPENAI_API_KEY=\"sk-...\""
+  exit 1
+fi
+
+# ── Cleanup ──────────────────────────────────────────────────────────
+cleanup() {
+  echo -e "\n${BLUE}[cleanup]${NC} Stopping agent processes..."
+  for pid in "${PIDS[@]+"${PIDS[@]}"}"; do
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
+  PIDS=()
+}
+trap cleanup EXIT INT TERM
+
+# ── Helper Functions ─────────────────────────────────────────────────
+
+wait_for_health() {
+  local port=$1
+  local elapsed=0
+  while [ $elapsed -lt $HEALTH_TIMEOUT ]; do
+    if curl -sf "http://127.0.0.1:${port}/health" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  echo -e "${RED}Error: Agent on port ${port} did not become healthy within ${HEALTH_TIMEOUT}s${NC}"
+  return 1
+}
+
+start_agent() {
+  local config_name=$1
+  local port=$2
+  local config_path="${CONFIG_DIR}/${config_name}.toml"
+
+  if [ ! -f "$config_path" ]; then
+    echo -e "${RED}Error: Config not found: ${config_path}${NC}"
+    return 1
+  fi
+
+  local log_file="${REVIEW_OUTPUT_DIR}/agent-${config_name}.log"
+  CONFIG_PATH="$config_path" \
+  PORT="$port" \
+  HOST="127.0.0.1" \
+    "${PROJECT_ROOT}/target/debug/${BINARY_NAME}" \
+    --streaming-timeout-secs "$REQUEST_TIMEOUT" \
+    >"$log_file" 2>&1 &
+  local pid=$!
+  PIDS+=("$pid")
+
+  if ! wait_for_health "$port"; then
+    echo -e "${RED}Failed to start agent ${config_name} on port ${port}${NC}"
+    return 1
+  fi
+  echo -e "  ${GREEN}Started${NC} ${config_name} on :${port} (pid ${pid})"
+}
+
+stop_agent_on_port() {
+  local port=$1
+  # Find and kill the process listening on this port
+  local pid
+  pid=$(lsof -ti :"$port" 2>/dev/null || true)
+  if [ -n "$pid" ]; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    # Remove from PIDS array
+    local new_pids=()
+    for p in "${PIDS[@]+"${PIDS[@]}"}"; do
+      if [ "$p" != "$pid" ]; then
+        new_pids+=("$p")
+      fi
+    done
+    PIDS=("${new_pids[@]+"${new_pids[@]}"}")
+  fi
+}
+
+stop_all_review_agents() {
+  for port in "${REVIEW_PORTS[@]+"${REVIEW_PORTS[@]}"}"; do
+    stop_agent_on_port "$port"
+  done
+}
+
+send_prompt() {
+  local port=$1
+  local prompt_text=$2
+
+  local payload
+  payload=$(jq -n --arg content "$prompt_text" '{
+    messages: [{role: "user", content: $content}],
+    stream: false
+  }')
+
+  local response
+  response=$(curl -sf --max-time "$REQUEST_TIMEOUT" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "http://127.0.0.1:${port}/v1/chat/completions" 2>&1) || {
+    echo -e "${RED}Error: Request to agent on port ${port} failed${NC}"
+    echo "$response" | tail -5
+    return 1
+  }
+
+  echo "$response" | jq -r '.choices[0].message.content // "No response content"'
+}
+
+# Derive crate name from file path: crates/<crate>/src/... -> <crate>
+get_crate_name() {
+  local file=$1
+  echo "$file" | sed -n 's|crates/\([^/]*\)/.*|\1|p'
+}
+
+# Derive test file path from source path
+get_test_file_path() {
+  local source_file=$1
+  local basename
+  basename=$(basename "$source_file" .rs)
+  local dir
+  dir=$(dirname "$source_file")
+  echo "${dir}/${basename}_tests.rs"
+}
+
+# Get the module name for the generated test file
+get_test_module_name() {
+  local source_file=$1
+  local basename
+  basename=$(basename "$source_file" .rs)
+  echo "${basename}_tests"
+}
+
+# Get the source module name (for use in imports)
+get_source_module_name() {
+  local source_file=$1
+  basename "$source_file" .rs
+}
+
+# Find lib.rs for a crate
+get_lib_rs_path() {
+  local source_file=$1
+  local crate_dir
+  crate_dir=$(echo "$source_file" | sed -n 's|\(crates/[^/]*/\).*|\1|p')
+  echo "${crate_dir}src/lib.rs"
+}
+
+# Register generated test module in lib.rs (idempotent)
+register_test_module() {
+  local source_file=$1
+  local test_module
+  test_module=$(get_test_module_name "$source_file")
+  local lib_rs
+  lib_rs="${PROJECT_ROOT}/$(get_lib_rs_path "$source_file")"
+
+  if [ ! -f "$lib_rs" ]; then
+    echo -e "  ${YELLOW}Warning: lib.rs not found at ${lib_rs}${NC}"
+    return 0
+  fi
+
+  local mod_line="#[cfg(test)] mod ${test_module};"
+
+  if ! grep -qF "$test_module" "$lib_rs"; then
+    echo "$mod_line" >> "$lib_rs"
+    echo -e "  ${BLUE}[module]${NC} Registered ${test_module} in lib.rs"
+  fi
+}
+
+# ── Target File Identification ───────────────────────────────────────
+if [ -n "$FILES" ]; then
+  IFS=' ' read -ra TARGET_FILES <<< "$FILES"
+else
+  mapfile -t TARGET_FILES < <(
+    git -C "$PROJECT_ROOT" diff --name-only main -- 'crates/**/*.rs' 2>/dev/null \
+      | grep -v '/tests/' \
+      | grep -v '_test\.rs' \
+      | grep -v '_generated_tests\.rs' \
+      || true
+  )
+fi
+
+if [ ${#TARGET_FILES[@]} -eq 0 ]; then
+  echo -e "${YELLOW}No target files found.${NC}"
+  echo "  Use: make test-generate FILES=\"crates/aura/src/foo.rs\""
+  echo "  Or have uncommitted .rs changes vs main."
+  exit 0
+fi
+
+echo -e "${BOLD}"
+echo "================================================================"
+echo "  Aura Test Generation Pipeline"
+echo "================================================================"
+echo -e "${NC}"
+echo -e "  Target files:  ${#TARGET_FILES[@]}"
+for f in "${TARGET_FILES[@]}"; do
+  echo -e "    ${BLUE}${f}${NC}"
+done
+echo -e "  Max rounds:    ${MAX_ROUNDS}"
+echo ""
+
+# ── Pre-build ────────────────────────────────────────────────────────
+echo -e "${BLUE}[build]${NC} Building aura-web-server..."
+if ! cargo build --bin "$BINARY_NAME" 2>&1 | tail -3; then
+  echo -e "${RED}Build failed.${NC}"
+  exit 1
+fi
+echo -e "${GREEN}[build]${NC} Build complete."
+echo ""
+
+# ── Ensure output directory ──────────────────────────────────────────
+mkdir -p "$REVIEW_OUTPUT_DIR"
+
+# ── Process Each Target File ─────────────────────────────────────────
+FINAL_RESULTS=()
+
+for source_file in "${TARGET_FILES[@]}"; do
+  echo -e "${BOLD}────────────────────────────────────────${NC}"
+  echo -e "${BOLD}  Processing: ${source_file}${NC}"
+  echo -e "${BOLD}────────────────────────────────────────${NC}"
+
+  crate_name=$(get_crate_name "$source_file")
+  test_file=$(get_test_file_path "$source_file")
+  abs_source="${PROJECT_ROOT}/${source_file}"
+  abs_test="${PROJECT_ROOT}/${test_file}"
+
+  if [ -z "$crate_name" ]; then
+    echo -e "${YELLOW}Skipping ${source_file} — not in a crate directory${NC}"
+    FINAL_RESULTS+=("SKIP|${source_file}|Not in crates/ directory")
+    continue
+  fi
+
+  if [ ! -f "$abs_source" ]; then
+    echo -e "${YELLOW}Skipping ${source_file} — file not found${NC}"
+    FINAL_RESULTS+=("SKIP|${source_file}|File not found")
+    continue
+  fi
+
+  source_module=$(get_source_module_name "$source_file")
+  test_module=$(get_test_module_name "$source_file")
+
+  # Pre-create test file (workaround for validate_path canonicalize)
+  mkdir -p "$(dirname "$abs_test")"
+  touch "$abs_test"
+
+  # Register test module in lib.rs
+  register_test_module "$source_file"
+
+  # Pre-create review output files
+  for name in "${REVIEW_NAMES[@]}"; do
+    touch "${REVIEW_OUTPUT_DIR}/review-${name}.json"
+  done
+
+  all_clear=false
+  round=0
+  feedback=""
+
+  while [ $round -lt "$MAX_ROUNDS" ] && [ "$all_clear" = false ]; do
+    round=$((round + 1))
+    echo ""
+    echo -e "${BLUE}  === Round ${round} / ${MAX_ROUNDS} ===${NC}"
+
+    # ── Generation ─────────────────────────────────────────────────
+    echo -e "  ${BLUE}[generator]${NC} Starting agent..."
+    start_agent "generator" "$GENERATOR_PORT"
+
+    if [ "$round" -eq 1 ]; then
+      gen_prompt="Read the Rust source file at: ${abs_source}
+
+Then generate comprehensive unit tests and write them to: ${abs_test}
+
+IMPORTANT: This test file is a sibling module registered in lib.rs, NOT a submodule of the source file.
+Use this import pattern at the top of the file:
+  use crate::${source_module}::*;
+
+Do NOT use 'use super::*;' — that would reference the crate root, not the source module.
+
+The file is in crate '${crate_name}'. Write a complete, self-contained test file."
+    else
+      gen_prompt="Read the source file at: ${abs_source}
+Read the current tests at: ${abs_test}
+
+The following issues were found by reviewers. Fix ALL issues by rewriting the test file.
+
+IMPORTANT: Use 'use crate::${source_module}::*;' for imports (NOT 'use super::*;').
+
+FEEDBACK:
+${feedback}
+
+Write the corrected tests to: ${abs_test}"
+    fi
+
+    echo -e "  ${BLUE}[generator]${NC} Generating tests..."
+    gen_response=$(send_prompt "$GENERATOR_PORT" "$gen_prompt")
+    stop_agent_on_port "$GENERATOR_PORT"
+
+    # Check if test file was written
+    if [ ! -s "$abs_test" ]; then
+      echo -e "  ${RED}[generator]${NC} Test file is empty — agent may not have called write_file"
+      feedback="The generator did not write any test file. You MUST use the write_file tool to write tests to ${abs_test}. Do not just describe the tests — actually write them."
+      continue
+    fi
+
+    echo -e "  ${GREEN}[generator]${NC} Tests written to ${test_file}"
+
+    # ── Cargo Test ─────────────────────────────────────────────────
+    echo -e "  ${BLUE}[test]${NC} Running cargo test..."
+    test_output=""
+    test_exit=0
+    test_output=$(cargo test --package "$crate_name" --lib 2>&1) || test_exit=$?
+
+    if [ "$test_exit" -ne 0 ]; then
+      echo -e "  ${RED}[test]${NC} FAILED (exit code ${test_exit})"
+      # Truncate long output for the feedback prompt
+      truncated_output=$(echo "$test_output" | tail -40)
+      feedback="cargo test FAILED with exit code ${test_exit}. Fix the compilation/test errors:
+
+${truncated_output}
+
+Read the test file at ${abs_test}, fix all errors, and write the corrected version back."
+      if [ "$round" -lt "$MAX_ROUNDS" ]; then
+        echo -e "  ${YELLOW}[test]${NC} Will retry in next round..."
+        continue
+      else
+        echo -e "  ${RED}[test]${NC} Failed on final round"
+        FINAL_RESULTS+=("FAIL|${source_file}|cargo test failed after ${MAX_ROUNDS} rounds")
+        break
+      fi
+    fi
+    echo -e "  ${GREEN}[test]${NC} All tests pass"
+
+    # ── Review Phase ───────────────────────────────────────────────
+    echo -e "  ${BLUE}[review]${NC} Starting 4 review agents..."
+    for i in "${!REVIEW_NAMES[@]}"; do
+      start_agent "${REVIEW_CONFIGS[$i]}" "${REVIEW_PORTS[$i]}"
+    done
+
+    echo -e "  ${BLUE}[review]${NC} Sending review requests (parallel)..."
+    review_pids=()
+    for i in "${!REVIEW_NAMES[@]}"; do
+      name="${REVIEW_NAMES[$i]}"
+      port="${REVIEW_PORTS[$i]}"
+      output_path="${REVIEW_OUTPUT_DIR}/review-${name}.json"
+
+      review_prompt="Review the generated tests for correctness, coverage, robustness, and style.
+
+Source file: ${abs_source}
+Test file: ${abs_test}
+
+Write your review as a JSON object to: ${output_path}"
+
+      # Run in background
+      (send_prompt "$port" "$review_prompt" >/dev/null 2>&1) &
+      review_pids+=($!)
+    done
+
+    # Wait for all reviews to complete
+    for pid in "${review_pids[@]}"; do
+      wait "$pid" 2>/dev/null || true
+    done
+
+    stop_all_review_agents
+    echo -e "  ${GREEN}[review]${NC} All reviews complete"
+
+    # ── Consolidate Reviews ────────────────────────────────────────
+    total_issues=0
+    feedback=""
+    all_clear=true
+
+    for name in "${REVIEW_NAMES[@]}"; do
+      output_path="${REVIEW_OUTPUT_DIR}/review-${name}.json"
+      if [ ! -s "$output_path" ]; then
+        echo -e "  ${YELLOW}[${name}]${NC} No review output"
+        continue
+      fi
+
+      # Try to parse as JSON; the file might contain the raw JSON or wrapped text
+      review_content=$(cat "$output_path")
+
+      # Try to extract verdict from JSON
+      verdict=$(echo "$review_content" | jq -r '.verdict // "unknown"' 2>/dev/null || echo "unknown")
+
+      if [ "$verdict" = "fail" ]; then
+        all_clear=false
+        issue_count=$(echo "$review_content" | jq '.issues | length' 2>/dev/null || echo "?")
+        total_issues=$((total_issues + ${issue_count:-0}))
+        issues_text=$(echo "$review_content" | jq -r '.issues[] | "- [\(.severity // .risk // .priority // "issue")] \(.test_name // .function // "unknown"): \(.description // .missing_scenario // .issue // "no details")"' 2>/dev/null || echo "  (could not parse issues)")
+        feedback="${feedback}
+=== ${name} review (FAIL) ===
+${issues_text}
+"
+        echo -e "  ${RED}[${name}]${NC} FAIL — ${issue_count} issue(s)"
+      elif [ "$verdict" = "pass" ]; then
+        echo -e "  ${GREEN}[${name}]${NC} PASS"
+      else
+        # Could not parse — treat as pass to avoid infinite loops
+        echo -e "  ${YELLOW}[${name}]${NC} Could not parse review (treating as pass)"
+      fi
+    done
+
+    if [ "$all_clear" = true ]; then
+      echo -e "\n  ${GREEN}All reviews passed!${NC}"
+      FINAL_RESULTS+=("PASS|${source_file}|Round ${round}/${MAX_ROUNDS}")
+    elif [ "$round" -ge "$MAX_ROUNDS" ]; then
+      echo -e "\n  ${YELLOW}Issues remain after ${MAX_ROUNDS} rounds (${total_issues} total)${NC}"
+      FINAL_RESULTS+=("WARN|${source_file}|${total_issues} review issues after ${MAX_ROUNDS} rounds")
+    else
+      echo -e "\n  ${YELLOW}${total_issues} issue(s) found — feeding back to generator${NC}"
+    fi
+  done
+done
+
+# ── Final Summary ────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}"
+echo "================================================================"
+echo "  Test Generation Summary"
+echo "================================================================"
+echo -e "${NC}"
+
+pass_count=0
+fail_count=0
+warn_count=0
+skip_count=0
+
+for result in "${FINAL_RESULTS[@]}"; do
+  IFS='|' read -r status file detail <<< "$result"
+  case "$status" in
+    PASS) echo -e "  ${GREEN}PASS${NC}  ${file}  (${detail})"; pass_count=$((pass_count + 1)) ;;
+    FAIL) echo -e "  ${RED}FAIL${NC}  ${file}  (${detail})"; fail_count=$((fail_count + 1)) ;;
+    WARN) echo -e "  ${YELLOW}WARN${NC}  ${file}  (${detail})"; warn_count=$((warn_count + 1)) ;;
+    SKIP) echo -e "  ${YELLOW}SKIP${NC}  ${file}  (${detail})"; skip_count=$((skip_count + 1)) ;;
+  esac
+done
+
+echo ""
+echo -e "  Total: ${#TARGET_FILES[@]}  Pass: ${pass_count}  Warn: ${warn_count}  Fail: ${fail_count}  Skip: ${skip_count}"
+echo ""
+echo "================================================================"
+
+# Exit with error if any failures
+if [ "$fail_count" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `make test-generate`, an on-demand Makefile target that uses Aura agents to generate and review Rust unit tests — dogfooding the platform to test itself
- Add `filesystem_write` config option to enable the WriteFileTool in agent configurations
- Generate 460 unit tests across 6 modules (tools, vector_dynamic, vector_store, builder, rag_tools, string_utils) covering filesystem security, path validation, vector search helpers, and builder pure functions
- Harden generator and reviewer agent prompts to enforce content assertions, security path testing, DRY consolidation, and upstream style compliance

## Components
- **Rust changes**: `filesystem_write` field in ToolsConfig (4 files), `pub(crate)` visibility for testable helpers, `VectorStoreManager::new_stub()` test constructor
- **Agent configs**: 5 TOML configs in `configs/test-agents/` (1 generator + 4 review lenses: correctness, coverage, robustness, style)
- **Orchestration**: `scripts/test-generate-orchestrate.sh` with generate → cargo test → parallel review → feedback loop (up to 3 rounds)
- **Tests**: 6 `_tests.rs` files with 460 passing tests, zero warnings
- **Docs**: Strategy doc and README usage guide

## Test plan
- [x] `cargo test --workspace --lib` — 743 tests pass, 0 failures, 0 warnings
- [x] `make test-generate FILES="crates/aura/src/string_utils.rs"` — full pipeline runs end-to-end
- [x] Security tests verify all 8 sensitive path patterns (/etc, /proc, /sys, /dev, /var/log, /.ssh, /.aws, /.config)
- [ ] Jenkins commitlint validation

Ref: LOG-00000