### PR TITLE
feat: add structured error taxonomy and prometheus metrics (AURA-RM-008 + RM-001)

### DIFF
--- a/.specify/specs/AURA-RM-001/architecture-spec.md
+++ b/.specify/specs/AURA-RM-001/architecture-spec.md
@@ -20,7 +20,7 @@ Add a Prometheus-compatible `/metrics` endpoint to Aura's web server. Use the `m
 - [x] Article IV: Implementation commits will follow conventional commit format.
 - [x] Article V: New integration tests use `integration-metrics` feature flag, added to the `integration` parent flag.
 - [x] Article VI: No secrets involved.
-- [x] Article VII: `AURA_METRICS_ENABLED` defaults to `true`. `AURA_METRICS_BIND_ADDRESS` defaults to `127.0.0.1:9090`. No TOML config changes required.
+- [x] Article VII: `AURA_METRICS_ENABLED` defaults to `true`. No TOML config changes required. (Separate metrics bind address is deferred to V2.)
 
 ## Technical Context
 
@@ -88,7 +88,7 @@ pub fn record_tokens(token_type: &str, provider: &str, agent: &str, count: u64) 
     }
 }
 
-/// Track unique tool names per server to enforce cardinality cap.
+/// Track unique tool names globally (across all MCP servers) to enforce cardinality cap.
 static TOOL_NAMES: std::sync::LazyLock<std::sync::Mutex<std::collections::HashSet<String>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
 
@@ -244,11 +244,9 @@ Prometheus scrapes GET /metrics
 ### Tool Duration Recording Strategy
 
 The `aura` crate does NOT gain a `metrics` dependency. Instead, tool duration is recorded at the `aura-web-server` handler layer by:
-1. Observing `aura.tool_start` and `aura.tool_complete` custom SSE events (which already carry `tool_name`, `duration_ms`, and `success` fields — see `stream_events.rs`)
-2. The `ToolLifecycleEvent::Complete` event in `tool_event_broker.rs` already carries `duration_ms`
-3. The handler subscribes to tool events and records the histogram when `tool_complete` fires
-
-Note: There is no `ToolLifecycleEvent::Complete` variant. The `ToolLifecycleEvent` enum only has `Requested` and `Start`. Tool completion with duration is handled at the handler level in `streaming/handlers.rs` via `AuraStreamEvent::tool_complete_success/failure`, which computes duration from `state.tool_start_times`. The metrics recording hooks into this existing handler-level completion event.
+1. Tool completion with duration is handled at the handler level in `streaming/handlers.rs` via `AuraStreamEvent::tool_complete_success/failure`, which computes `duration_ms` from `state.tool_start_times`
+2. The `ToolLifecycleEvent` enum in `tool_event_broker.rs` only has `Requested` and `Start` variants (no `Complete`)
+3. Metrics recording hooks into the existing handler-level `tool_complete` event construction point, where `tool_name`, `duration_ms`, and `success` are already available
 
 This preserves Article II: the `aura` crate only produces events, the web server records metrics from them.
 

--- a/.specify/specs/AURA-RM-001/architecture-spec.md
+++ b/.specify/specs/AURA-RM-001/architecture-spec.md
@@ -1,6 +1,6 @@
 # Architecture Spec: AURA-RM-001 Prometheus Metrics Endpoint
 
-**Status:** Draft
+**Status:** In Review (Remediation Round 1)
 **Roadmap Item:** AURA-RM-001
 **Product Spec:** [product-spec.md](product-spec.md)
 **Author:** brandon.shelton
@@ -11,29 +11,30 @@
 
 ## Summary
 
-Add a Prometheus-compatible `/metrics` endpoint to Aura's web server. Use the `metrics` crate (Rust metrics facade) with `metrics-exporter-prometheus` for exposition. Instrument request handling, token tracking, MCP tool execution, and error classification using the taxonomy from AURA-RM-008.
+Add a Prometheus-compatible `/metrics` endpoint to Aura's web server. Use the `metrics` crate (Rust metrics facade) with `metrics-exporter-prometheus` for exposition. All metric recording happens in `aura-web-server` (respecting Article II crate boundaries). The `aura` crate provides data via existing tracing spans and return values — no `metrics` dependency in the core crate.
 
 ## Constitution Compliance Check
 
 - [x] Article I: `/metrics` is a new endpoint. No changes to `/v1/chat/completions` or `/v1/models`.
-- [x] Article II: Metrics recording in `aura` crate (tool execution, token tracking). Metrics exposition in `aura-web-server` (HTTP endpoint). Clean separation.
-- [x] Article V: No integration tests needed (metrics are unit-testable + manual verification).
+- [x] Article II: All metrics recording and exposition in `aura-web-server`. The `aura` crate has NO dependency on the `metrics` crate. Tool execution timing is captured from the handler layer using `Instant::now()` around tool calls, or extracted from existing OTel span data.
+- [x] Article IV: Implementation commits will follow conventional commit format.
+- [x] Article V: New integration tests use `integration-metrics` feature flag, added to the `integration` parent flag.
 - [x] Article VI: No secrets involved.
-- [x] Article VII: No config changes required (metrics enabled by default, no opt-in needed).
+- [x] Article VII: `AURA_METRICS_ENABLED` defaults to `true`. `AURA_METRICS_BIND_ADDRESS` defaults to `127.0.0.1:9090`. No TOML config changes required.
 
 ## Technical Context
 
-- **Affected Crates:** `aura-web-server` (new `/metrics` route, request middleware), `aura` (instrument tool execution, token recording)
-- **New Dependencies:**
+- **Affected Crates:** `aura-web-server` only (metrics recording + exposition)
+- **New Dependencies (aura-web-server only):**
   - `metrics = "0.24"` — metrics facade (counters, gauges, histograms)
   - `metrics-exporter-prometheus = "0.16"` — Prometheus text format exporter
-- **Performance Objectives:** < 1ms overhead per request for metric recording. Metrics scrape < 50ms.
+- **Performance Objectives:** < 1ms overhead per request for metric recording. Metrics scrape < 50ms for up to 500 unique time series.
 
 ## Design
 
 ### Crate Changes
 
-#### `aura-web-server`
+#### `aura-web-server` (ONLY crate modified)
 
 **New: `crates/aura-web-server/src/metrics.rs`**
 
@@ -41,52 +42,77 @@ Add a Prometheus-compatible `/metrics` endpoint to Aura's web server. Use the `m
 use metrics::{counter, gauge, histogram};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 
-/// Initialize the metrics registry and return a handle for the /metrics endpoint.
-pub fn init_metrics() -> PrometheusHandle {
-    PrometheusBuilder::new()
+/// Initialize the metrics registry. Returns None if metrics are disabled.
+pub fn init_metrics() -> Option<PrometheusHandle> {
+    if std::env::var("AURA_METRICS_ENABLED")
+        .map(|v| v == "false")
+        .unwrap_or(false)
+    {
+        tracing::info!("Metrics disabled via AURA_METRICS_ENABLED=false");
+        return None;
+    }
+
+    let handle = PrometheusBuilder::new()
         .set_buckets_for_metric(
-            metrics_exporter_prometheus::Matcher::Full("aura_http_request_duration_seconds".to_string()),
-            &[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0],
+            Matcher::Full("aura_http_request_duration_seconds".to_string()),
+            &[0.025, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0],
         )
-        .unwrap()
+        .expect("valid bucket config")
         .set_buckets_for_metric(
-            metrics_exporter_prometheus::Matcher::Full("aura_mcp_tool_duration_seconds".to_string()),
-            &[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0],
+            Matcher::Full("aura_mcp_tool_duration_seconds".to_string()),
+            &[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0],
         )
-        .unwrap()
+        .expect("valid bucket config")
         .install_recorder()
-        .unwrap()
+        .expect("metrics recorder installation");
+
+    tracing::info!("Metrics enabled on /metrics endpoint");
+    Some(handle)
 }
 
-/// Record request completion metrics.
-pub fn record_request(method: &str, status: u16, agent: &str, duration_secs: f64) {
+pub fn record_request_duration(method: &str, status: u16, agent: &str, duration_secs: f64) {
     histogram!("aura_http_request_duration_seconds",
         "method" => method.to_string(),
         "status_code" => status.to_string(),
         "agent" => agent.to_string(),
-    )
-    .record(duration_secs);
+    ).record(duration_secs);
 }
 
-/// Record token usage.
 pub fn record_tokens(token_type: &str, provider: &str, agent: &str, count: u64) {
-    counter!("aura_llm_tokens_total",
-        "type" => token_type.to_string(),
-        "provider" => provider.to_string(),
-        "agent" => agent.to_string(),
-    )
-    .increment(count);
+    if count > 0 {
+        counter!("aura_llm_tokens_total",
+            "type" => token_type.to_string(),
+            "provider" => provider.to_string(),
+            "agent" => agent.to_string(),
+        ).increment(count);
+    }
 }
 
-/// Record an error by taxonomy category.
+pub fn record_tool_duration(server: &str, tool: &str, status: &str, duration_secs: f64) {
+    // Cardinality guard: if tool name is very long or unusual, use "_other"
+    let tool_label = if tool.len() > 64 { "_other" } else { tool };
+    histogram!("aura_mcp_tool_duration_seconds",
+        "server" => server.to_string(),
+        "tool" => tool_label.to_string(),
+        "status" => status.to_string(),
+    ).record(duration_secs);
+}
+
 pub fn record_error(error_type: &str) {
-    counter!("aura_errors_total", "error_type" => error_type.to_string())
-        .increment(1);
+    counter!("aura_errors_total", "error_type" => error_type.to_string()).increment(1);
 }
 
-/// Update in-flight request gauge.
-pub fn set_requests_in_flight(count: usize) {
-    gauge!("aura_http_requests_in_flight").set(count as f64);
+pub fn increment_requests_in_flight() {
+    gauge!("aura_http_requests_in_flight").increment(1.0);
+}
+
+pub fn decrement_requests_in_flight() {
+    gauge!("aura_http_requests_in_flight").decrement(1.0);
+}
+
+pub fn set_mcp_server_connected(server: &str, connected: bool) {
+    gauge!("aura_mcp_server_connected", "server" => server.to_string())
+        .set(if connected { 1.0 } else { 0.0 });
 }
 ```
 
@@ -106,83 +132,87 @@ pub async fn metrics_handler(handle: web::Data<PrometheusHandle>) -> HttpRespons
 // In main():
 let metrics_handle = metrics::init_metrics();
 
-// Register route (before auth middleware, no auth required):
-.route("/metrics", web::get().to(metrics::metrics_handler))
-
-// Pass handle as app data:
-.app_data(web::Data::new(metrics_handle))
+// Register /metrics route OUTSIDE shutdown_guard middleware
+// so it remains available during graceful shutdown for final scrapes
+if let Some(handle) = metrics_handle {
+    app = app
+        .app_data(web::Data::new(handle))
+        .route("/metrics", web::get().to(metrics::metrics_handler));
+}
 ```
 
 **Modified: `handlers.rs`**
 
-At request completion (both streaming and non-streaming paths):
-
+At request entry:
 ```rust
-// After response is built:
+let start_time = std::time::Instant::now();
+metrics::increment_requests_in_flight();
+```
+
+At request completion (both streaming and non-streaming, in a finally/drop guard):
+```rust
+metrics::decrement_requests_in_flight();
 let duration = start_time.elapsed().as_secs_f64();
-let (provider, model) = agent.get_provider_info();
-metrics::record_request("POST", status_code, &agent_name, duration);
+let (provider, _model) = agent.get_provider_info();
+metrics::record_request_duration("POST", status_code, &agent_name, duration);
+
+// Token recording from UsageState
+let usage = usage_state.snapshot();
 metrics::record_tokens("prompt", provider, &agent_name, usage.prompt_tokens);
 metrics::record_tokens("completion", provider, &agent_name, usage.completion_tokens);
 
-// On error:
-metrics::record_error(error_category.as_label());
+// Error recording (if error occurred)
+if let Some(category) = error_category {
+    metrics::record_error(category.as_label());
+}
 ```
 
 **Modified: `types.rs` — ActiveRequestTracker**
 
-Add metrics recording to increment/decrement:
+The existing `ActiveRequestTracker` atomic counter is unchanged. Metrics gauge uses separate `increment(1.0)` / `decrement(1.0)` calls, avoiding the set-after-read race. The guard pattern in `ActiveRequestGuard` now also increments/decrements the metrics gauge:
 
 ```rust
-pub fn increment(&self) {
-    let count = self.count.fetch_add(1, Ordering::SeqCst) + 1;
-    crate::metrics::set_requests_in_flight(count);
+impl ActiveRequestGuard {
+    fn new(tracker: Arc<ActiveRequestTracker>) -> Self {
+        tracker.increment(); // existing atomic
+        crate::metrics::increment_requests_in_flight(); // new gauge
+        Self { tracker }
+    }
 }
 
-pub fn decrement(&self) {
-    let count = self.count.fetch_sub(1, Ordering::SeqCst) - 1;
-    crate::metrics::set_requests_in_flight(count);
+impl Drop for ActiveRequestGuard {
+    fn drop(&mut self) {
+        self.tracker.decrement(); // existing atomic
+        crate::metrics::decrement_requests_in_flight(); // new gauge
+    }
 }
 ```
 
-#### `aura` (core)
+The existing `Ordering::Release` / `Ordering::AcqRel` on the atomic counter is NOT changed. The gauge operates independently.
 
-**Modified: `mcp_tool_execution.rs`**
+**New feature flag in `aura-web-server/Cargo.toml`:**
 
-After tool execution completes, record duration:
-
-```rust
-let start = std::time::Instant::now();
-let result = call_http_tool_cancellable(...).await;
-let duration = start.elapsed().as_secs_f64();
-
-// Record metric (if metrics feature is available)
-#[cfg(feature = "metrics")]
-{
-    metrics::histogram!("aura_mcp_tool_duration_seconds",
-        "server" => server_name.to_string(),
-        "tool" => tool_name.to_string(),
-        "status" => if result.is_ok() { "ok" } else { "error" }.to_string(),
-    )
-    .record(duration);
-}
+```toml
+[features]
+integration = ["integration-streaming", "integration-header-forwarding", ..., "integration-metrics"]
+integration-metrics = []
 ```
 
 ### Data Flow
 
 ```
 Request arrives
-  → ActiveRequestTracker.increment() → gauge updated
+  → ActiveRequestGuard::new() → atomic increment + gauge increment
   → start_time = Instant::now()
   → Handler processes request
     → Agent streams response
-      → MCP tool called → tool duration histogram recorded
+      → (MCP tool timing captured at handler layer via tool event broker)
       → Token usage accumulated in UsageState
     → Response complete
-  → record_request(method, status, agent, duration)
+  → record_request_duration(method, status, agent, duration)
   → record_tokens(prompt/completion, provider, agent, count)
-  → ActiveRequestTracker.decrement() → gauge updated
-  → (on error) record_error(error_category.as_label())
+  → ActiveRequestGuard::drop() → atomic decrement + gauge decrement
+  → (on error) record_error(category.as_label())
 
 Prometheus scrapes GET /metrics
   → PrometheusHandle.render() → text exposition format
@@ -190,38 +220,51 @@ Prometheus scrapes GET /metrics
 
 ### Configuration
 
-No TOML config needed. Metrics are always enabled when the server starts. The `/metrics` endpoint is always available.
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `AURA_METRICS_ENABLED` | `true` | Set to `false` to disable `/metrics` endpoint entirely |
+| `AURA_METRICS_BIND_ADDRESS` | N/A (same server) | Future: separate bind address for metrics. V1 uses the same server. |
 
-Future enhancement: configurable metric prefix, custom labels, or opt-out via env var.
+### Tool Duration Recording Strategy
+
+The `aura` crate does NOT gain a `metrics` dependency. Instead, tool duration is recorded at the `aura-web-server` handler layer by:
+1. Observing `aura.tool_start` and `aura.tool_complete` custom SSE events (which already carry `tool_name`, `duration_ms`, and `success` fields — see `stream_events.rs`)
+2. The `ToolLifecycleEvent::Complete` event in `tool_event_broker.rs` already carries `duration_ms`
+3. The handler subscribes to tool events and records the histogram when `tool_complete` fires
+
+This preserves Article II: the `aura` crate only produces events, the web server records metrics from them.
 
 ## Migration / Backward Compatibility
 
 - New `/metrics` route — no conflict with existing routes
-- New dependencies (`metrics`, `metrics-exporter-prometheus`) — additive
-- No config changes required
-- ActiveRequestTracker gains a side-effect on increment/decrement — audit for correctness
+- New dependencies only in `aura-web-server` — `aura` crate unchanged
+- No config changes required (env vars have defaults)
+- ActiveRequestTracker atomic behavior unchanged (gauge is a parallel side-channel)
+- Metrics endpoint available during graceful shutdown (registered outside shutdown_guard)
 
 ## Alternatives Considered
 
 | Approach | Pros | Cons | Why Not |
 |----------|------|------|---------|
-| `prometheus` crate directly | Widely used, direct Prometheus registry | Heavier API, requires manual registry management | `metrics` facade is more idiomatic in async Rust |
-| OpenTelemetry metrics (OTel Meter) | Unified with existing OTel tracing | More complex setup, OTLP metrics not as widely scraped as /metrics | Prometheus scrape is the standard; can add OTel metrics later |
-| `actix-web-prom` middleware | Drop-in request metrics | Only covers HTTP metrics, not token/tool metrics | Need custom metrics beyond HTTP |
+| Add `metrics` crate to `aura` core | Simpler instrumentation | Violates Article II | Boundary preservation is more important |
+| OpenTelemetry metrics (OTel Meter) | Unified with tracing | Complex, OTLP metrics less widely scraped | Prometheus scrape is the standard |
+| Separate metrics bind address | Better security isolation | More complex networking, port conflicts | Deferred to v2 (env var documented) |
 
 ## Risks
 
-- **Cardinality explosion**: If agent names or tool names have high cardinality, Prometheus storage grows. Mitigated by using config-defined names (bounded set).
-- **Performance**: Metrics recording adds microseconds per request. Mitigated by using atomic counters (metrics crate default).
-- **Dependency size**: `metrics-exporter-prometheus` adds ~50KB. Acceptable.
+- **Cardinality from tool names**: MCP servers can expose many tools. Mitigated by 100-tool cap with `_other` aggregation, plus tool name length guard (>64 chars → `_other`).
+- **Performance on scrape**: Rendering 500+ time series on every 15s scrape. Mitigated by the `metrics-exporter-prometheus` crate's efficient rendering. Add performance test (quality spec TC) to validate < 50ms.
+- **Gauge leak on panic**: If handler panics between increment and drop, the Drop trait still runs (Rust guarantee during stack unwinding), so the gauge correctly decrements. No leak risk.
 
 ## Implementation Order
 
-1. Add `metrics` and `metrics-exporter-prometheus` to Cargo.toml — No AC (infrastructure)
-2. Create `metrics.rs` with init, record functions, and `/metrics` handler — Satisfies: AC-001.1.1
-3. Add request latency recording in handlers.rs — Satisfies: AC-001.1.2
-4. Add token recording from UsageState at request completion — Satisfies: AC-001.2.1
-5. Add MCP tool duration recording in mcp_tool_execution.rs — Satisfies: AC-001.3.1
-6. Add error recording using ErrorCategory.as_label() — Satisfies: AC-001.4.1
-7. Add in-flight gauge to ActiveRequestTracker — Satisfies: AC-001.5.1
-8. Verify /metrics exempt from future auth (document for RM-004) — Satisfies: AC-001.1.3
+1. Add `metrics` and `metrics-exporter-prometheus` to `aura-web-server/Cargo.toml` — Infrastructure
+2. Create `metrics.rs` with init, all record functions, and handler — Satisfies: AC-001.1.1, AC-001.1.3
+3. Register `/metrics` route in main.rs outside shutdown_guard — Satisfies: AC-001.1.1
+4. Add request duration recording in handlers.rs — Satisfies: AC-001.1.2
+5. Add token recording from UsageState at request completion — Satisfies: AC-001.2.1
+6. Add tool duration recording from ToolLifecycleEvent — Satisfies: AC-001.3.1
+7. Add error recording using ErrorCategory.as_label() — Satisfies: AC-001.4.1
+8. Add in-flight gauge to ActiveRequestGuard — Satisfies: AC-001.5.1
+9. Add MCP server connection state gauge — Satisfies: AC-001.6.1
+10. Add `integration-metrics` feature flag — Satisfies: Article V

--- a/.specify/specs/AURA-RM-001/architecture-spec.md
+++ b/.specify/specs/AURA-RM-001/architecture-spec.md
@@ -1,0 +1,227 @@
+# Architecture Spec: AURA-RM-001 Prometheus Metrics Endpoint
+
+**Status:** Draft
+**Roadmap Item:** AURA-RM-001
+**Product Spec:** [product-spec.md](product-spec.md)
+**Author:** brandon.shelton
+**Created:** 2026-04-28
+**Last Updated:** 2026-04-28
+
+---
+
+## Summary
+
+Add a Prometheus-compatible `/metrics` endpoint to Aura's web server. Use the `metrics` crate (Rust metrics facade) with `metrics-exporter-prometheus` for exposition. Instrument request handling, token tracking, MCP tool execution, and error classification using the taxonomy from AURA-RM-008.
+
+## Constitution Compliance Check
+
+- [x] Article I: `/metrics` is a new endpoint. No changes to `/v1/chat/completions` or `/v1/models`.
+- [x] Article II: Metrics recording in `aura` crate (tool execution, token tracking). Metrics exposition in `aura-web-server` (HTTP endpoint). Clean separation.
+- [x] Article V: No integration tests needed (metrics are unit-testable + manual verification).
+- [x] Article VI: No secrets involved.
+- [x] Article VII: No config changes required (metrics enabled by default, no opt-in needed).
+
+## Technical Context
+
+- **Affected Crates:** `aura-web-server` (new `/metrics` route, request middleware), `aura` (instrument tool execution, token recording)
+- **New Dependencies:**
+  - `metrics = "0.24"` — metrics facade (counters, gauges, histograms)
+  - `metrics-exporter-prometheus = "0.16"` — Prometheus text format exporter
+- **Performance Objectives:** < 1ms overhead per request for metric recording. Metrics scrape < 50ms.
+
+## Design
+
+### Crate Changes
+
+#### `aura-web-server`
+
+**New: `crates/aura-web-server/src/metrics.rs`**
+
+```rust
+use metrics::{counter, gauge, histogram};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+/// Initialize the metrics registry and return a handle for the /metrics endpoint.
+pub fn init_metrics() -> PrometheusHandle {
+    PrometheusBuilder::new()
+        .set_buckets_for_metric(
+            metrics_exporter_prometheus::Matcher::Full("aura_http_request_duration_seconds".to_string()),
+            &[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0],
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            metrics_exporter_prometheus::Matcher::Full("aura_mcp_tool_duration_seconds".to_string()),
+            &[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0],
+        )
+        .unwrap()
+        .install_recorder()
+        .unwrap()
+}
+
+/// Record request completion metrics.
+pub fn record_request(method: &str, status: u16, agent: &str, duration_secs: f64) {
+    histogram!("aura_http_request_duration_seconds",
+        "method" => method.to_string(),
+        "status_code" => status.to_string(),
+        "agent" => agent.to_string(),
+    )
+    .record(duration_secs);
+}
+
+/// Record token usage.
+pub fn record_tokens(token_type: &str, provider: &str, agent: &str, count: u64) {
+    counter!("aura_llm_tokens_total",
+        "type" => token_type.to_string(),
+        "provider" => provider.to_string(),
+        "agent" => agent.to_string(),
+    )
+    .increment(count);
+}
+
+/// Record an error by taxonomy category.
+pub fn record_error(error_type: &str) {
+    counter!("aura_errors_total", "error_type" => error_type.to_string())
+        .increment(1);
+}
+
+/// Update in-flight request gauge.
+pub fn set_requests_in_flight(count: usize) {
+    gauge!("aura_http_requests_in_flight").set(count as f64);
+}
+```
+
+**New: `/metrics` handler**
+
+```rust
+pub async fn metrics_handler(handle: web::Data<PrometheusHandle>) -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("text/plain; version=0.0.4; charset=utf-8")
+        .body(handle.render())
+}
+```
+
+**Modified: `main.rs`**
+
+```rust
+// In main():
+let metrics_handle = metrics::init_metrics();
+
+// Register route (before auth middleware, no auth required):
+.route("/metrics", web::get().to(metrics::metrics_handler))
+
+// Pass handle as app data:
+.app_data(web::Data::new(metrics_handle))
+```
+
+**Modified: `handlers.rs`**
+
+At request completion (both streaming and non-streaming paths):
+
+```rust
+// After response is built:
+let duration = start_time.elapsed().as_secs_f64();
+let (provider, model) = agent.get_provider_info();
+metrics::record_request("POST", status_code, &agent_name, duration);
+metrics::record_tokens("prompt", provider, &agent_name, usage.prompt_tokens);
+metrics::record_tokens("completion", provider, &agent_name, usage.completion_tokens);
+
+// On error:
+metrics::record_error(error_category.as_label());
+```
+
+**Modified: `types.rs` — ActiveRequestTracker**
+
+Add metrics recording to increment/decrement:
+
+```rust
+pub fn increment(&self) {
+    let count = self.count.fetch_add(1, Ordering::SeqCst) + 1;
+    crate::metrics::set_requests_in_flight(count);
+}
+
+pub fn decrement(&self) {
+    let count = self.count.fetch_sub(1, Ordering::SeqCst) - 1;
+    crate::metrics::set_requests_in_flight(count);
+}
+```
+
+#### `aura` (core)
+
+**Modified: `mcp_tool_execution.rs`**
+
+After tool execution completes, record duration:
+
+```rust
+let start = std::time::Instant::now();
+let result = call_http_tool_cancellable(...).await;
+let duration = start.elapsed().as_secs_f64();
+
+// Record metric (if metrics feature is available)
+#[cfg(feature = "metrics")]
+{
+    metrics::histogram!("aura_mcp_tool_duration_seconds",
+        "server" => server_name.to_string(),
+        "tool" => tool_name.to_string(),
+        "status" => if result.is_ok() { "ok" } else { "error" }.to_string(),
+    )
+    .record(duration);
+}
+```
+
+### Data Flow
+
+```
+Request arrives
+  → ActiveRequestTracker.increment() → gauge updated
+  → start_time = Instant::now()
+  → Handler processes request
+    → Agent streams response
+      → MCP tool called → tool duration histogram recorded
+      → Token usage accumulated in UsageState
+    → Response complete
+  → record_request(method, status, agent, duration)
+  → record_tokens(prompt/completion, provider, agent, count)
+  → ActiveRequestTracker.decrement() → gauge updated
+  → (on error) record_error(error_category.as_label())
+
+Prometheus scrapes GET /metrics
+  → PrometheusHandle.render() → text exposition format
+```
+
+### Configuration
+
+No TOML config needed. Metrics are always enabled when the server starts. The `/metrics` endpoint is always available.
+
+Future enhancement: configurable metric prefix, custom labels, or opt-out via env var.
+
+## Migration / Backward Compatibility
+
+- New `/metrics` route — no conflict with existing routes
+- New dependencies (`metrics`, `metrics-exporter-prometheus`) — additive
+- No config changes required
+- ActiveRequestTracker gains a side-effect on increment/decrement — audit for correctness
+
+## Alternatives Considered
+
+| Approach | Pros | Cons | Why Not |
+|----------|------|------|---------|
+| `prometheus` crate directly | Widely used, direct Prometheus registry | Heavier API, requires manual registry management | `metrics` facade is more idiomatic in async Rust |
+| OpenTelemetry metrics (OTel Meter) | Unified with existing OTel tracing | More complex setup, OTLP metrics not as widely scraped as /metrics | Prometheus scrape is the standard; can add OTel metrics later |
+| `actix-web-prom` middleware | Drop-in request metrics | Only covers HTTP metrics, not token/tool metrics | Need custom metrics beyond HTTP |
+
+## Risks
+
+- **Cardinality explosion**: If agent names or tool names have high cardinality, Prometheus storage grows. Mitigated by using config-defined names (bounded set).
+- **Performance**: Metrics recording adds microseconds per request. Mitigated by using atomic counters (metrics crate default).
+- **Dependency size**: `metrics-exporter-prometheus` adds ~50KB. Acceptable.
+
+## Implementation Order
+
+1. Add `metrics` and `metrics-exporter-prometheus` to Cargo.toml — No AC (infrastructure)
+2. Create `metrics.rs` with init, record functions, and `/metrics` handler — Satisfies: AC-001.1.1
+3. Add request latency recording in handlers.rs — Satisfies: AC-001.1.2
+4. Add token recording from UsageState at request completion — Satisfies: AC-001.2.1
+5. Add MCP tool duration recording in mcp_tool_execution.rs — Satisfies: AC-001.3.1
+6. Add error recording using ErrorCategory.as_label() — Satisfies: AC-001.4.1
+7. Add in-flight gauge to ActiveRequestTracker — Satisfies: AC-001.5.1
+8. Verify /metrics exempt from future auth (document for RM-004) — Satisfies: AC-001.1.3

--- a/.specify/specs/AURA-RM-001/architecture-spec.md
+++ b/.specify/specs/AURA-RM-001/architecture-spec.md
@@ -88,9 +88,25 @@ pub fn record_tokens(token_type: &str, provider: &str, agent: &str, count: u64) 
     }
 }
 
+/// Track unique tool names per server to enforce cardinality cap.
+static TOOL_NAMES: std::sync::LazyLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
+const MAX_UNIQUE_TOOL_LABELS: usize = 100;
+
 pub fn record_tool_duration(server: &str, tool: &str, status: &str, duration_secs: f64) {
-    // Cardinality guard: if tool name is very long or unusual, use "_other"
-    let tool_label = if tool.len() > 64 { "_other" } else { tool };
+    // Cardinality guard: cap unique tool labels at 100, length at 64 chars
+    let tool_label = if tool.len() > 64 {
+        "_other"
+    } else {
+        let mut names = TOOL_NAMES.lock().unwrap();
+        if names.contains(tool) || names.len() < MAX_UNIQUE_TOOL_LABELS {
+            names.insert(tool.to_string());
+            tool
+        } else {
+            "_other"
+        }
+    };
     histogram!("aura_mcp_tool_duration_seconds",
         "server" => server.to_string(),
         "tool" => tool_label.to_string(),
@@ -156,10 +172,10 @@ let duration = start_time.elapsed().as_secs_f64();
 let (provider, _model) = agent.get_provider_info();
 metrics::record_request_duration("POST", status_code, &agent_name, duration);
 
-// Token recording from UsageState
-let usage = usage_state.snapshot();
-metrics::record_tokens("prompt", provider, &agent_name, usage.prompt_tokens);
-metrics::record_tokens("completion", provider, &agent_name, usage.completion_tokens);
+// Token recording from UsageState (actual API: get_final_usage() -> (u64, u64, u64))
+let (prompt_tokens, completion_tokens, _total) = usage_state.get_final_usage();
+metrics::record_tokens("prompt", provider, &agent_name, prompt_tokens);
+metrics::record_tokens("completion", provider, &agent_name, completion_tokens);
 
 // Error recording (if error occurred)
 if let Some(category) = error_category {
@@ -223,7 +239,7 @@ Prometheus scrapes GET /metrics
 | Env Var | Default | Description |
 |---------|---------|-------------|
 | `AURA_METRICS_ENABLED` | `true` | Set to `false` to disable `/metrics` endpoint entirely |
-| `AURA_METRICS_BIND_ADDRESS` | N/A (same server) | Future: separate bind address for metrics. V1 uses the same server. |
+| N/A | N/A | V1 metrics are served on the same bind address as the main server. A separate `AURA_METRICS_BIND_ADDRESS` is deferred to V2. Operators must use network-level controls (firewall, Kubernetes NetworkPolicy) to restrict `/metrics` access if the main server binds to `0.0.0.0`. |
 
 ### Tool Duration Recording Strategy
 
@@ -231,6 +247,8 @@ The `aura` crate does NOT gain a `metrics` dependency. Instead, tool duration is
 1. Observing `aura.tool_start` and `aura.tool_complete` custom SSE events (which already carry `tool_name`, `duration_ms`, and `success` fields — see `stream_events.rs`)
 2. The `ToolLifecycleEvent::Complete` event in `tool_event_broker.rs` already carries `duration_ms`
 3. The handler subscribes to tool events and records the histogram when `tool_complete` fires
+
+Note: There is no `ToolLifecycleEvent::Complete` variant. The `ToolLifecycleEvent` enum only has `Requested` and `Start`. Tool completion with duration is handled at the handler level in `streaming/handlers.rs` via `AuraStreamEvent::tool_complete_success/failure`, which computes duration from `state.tool_start_times`. The metrics recording hooks into this existing handler-level completion event.
 
 This preserves Article II: the `aura` crate only produces events, the web server records metrics from them.
 

--- a/.specify/specs/AURA-RM-001/plan.md
+++ b/.specify/specs/AURA-RM-001/plan.md
@@ -1,0 +1,28 @@
+# Implementation Plan: AURA-RM-001 Prometheus Metrics Endpoint
+
+## Summary
+
+Add `/metrics` endpoint to `aura-web-server` using `metrics` + `metrics-exporter-prometheus` crates. Record request duration, token usage, tool duration, errors, in-flight count, and MCP connection state. All in `aura-web-server` only (Article II).
+
+## Implementation Order
+
+1. Add dependencies to `aura-web-server/Cargo.toml`
+2. Create `metrics.rs` with init + all recording functions + handler
+3. Register `/metrics` route in main.rs (outside shutdown_guard)
+4. Instrument request entry/exit in handlers.rs (duration + in-flight gauge)
+5. Instrument token recording from UsageState at request completion
+6. Instrument tool duration from handler-level tool_complete events
+7. Instrument error recording using ErrorCategory (from RM-008)
+8. Add MCP server connection state gauge
+9. Add `integration-metrics` feature flag
+10. Unit + integration tests
+
+## Dependencies
+
+- AURA-RM-008 must be complete (ErrorCategory for error labels)
+
+## Estimated Scope
+
+- 1 new file (metrics.rs)
+- 4 modified files (Cargo.toml, main.rs, handlers.rs, types.rs)
+- ~250 lines of new code + ~200 lines of tests

--- a/.specify/specs/AURA-RM-001/product-spec.md
+++ b/.specify/specs/AURA-RM-001/product-spec.md
@@ -1,6 +1,6 @@
 # Product Spec: AURA-RM-001 Prometheus Metrics Endpoint
 
-**Status:** Draft
+**Status:** In Review (Remediation Round 1)
 **Roadmap Item:** AURA-RM-001
 **Author:** brandon.shelton
 **Created:** 2026-04-28
@@ -10,7 +10,7 @@
 
 ## Problem Statement
 
-Aura has zero metrics exposure. Operators cannot set SLO alerts, measure request latency, track token spend, or observe MCP tool health. The only observability is OTel tracing, which requires a trace backend to query and doesn't support real-time alerting dashboards. Without a `/metrics` endpoint, production operation is blind.
+Aura has zero metrics exposure. Operators cannot set SLO alerts, measure request latency, track token spend, or observe MCP tool health. The only observability is OTel tracing, which requires a trace backend and doesn't support real-time alerting dashboards. Without a `/metrics` endpoint, production operation is blind.
 
 ## Scope
 
@@ -21,12 +21,15 @@ Aura has zero metrics exposure. Operators cannot set SLO alerts, measure request
 - MCP tool call duration histogram (by server, tool, status)
 - Error counters (by error type from AURA-RM-008 taxonomy)
 - In-flight request gauge
+- MCP server connection state gauge
+- Access control: metrics bind to a configurable address (default localhost only)
+- Kill switch: `AURA_METRICS_ENABLED` env var (default true)
 
 ### Out of Scope
 - Grafana dashboards or alerting rules (operator responsibility)
 - Push-based metrics (only pull/scrape)
-- Custom business metrics
-- Per-user/tenant metrics (requires AURA-RM multi-tenancy)
+- Per-user/tenant metrics
+- Process-level metrics (CPU, memory, FDs — use node exporter or container metrics)
 
 ## User Stories
 
@@ -41,7 +44,7 @@ Aura has zero metrics exposure. Operators cannot set SLO alerts, measure request
 #### Acceptance Criteria
 
 **AC-001.1.1:** Prometheus endpoint exists
-- **Given** a running Aura web server
+- **Given** a running Aura web server with `AURA_METRICS_ENABLED=true` (default)
 - **When** I send `GET /metrics`
 - **Then** I receive a 200 response with `text/plain; version=0.0.4; charset=utf-8` content type
 
@@ -49,12 +52,12 @@ Aura has zero metrics exposure. Operators cannot set SLO alerts, measure request
 - **Given** chat completion requests have been served
 - **When** I scrape `/metrics`
 - **Then** I see `aura_http_request_duration_seconds` histogram with `method`, `status_code`, and `agent` labels
-- **And** the histogram has buckets appropriate for LLM latency (0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 seconds)
+- **And** the histogram has buckets: `[0.025, 0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300]` (includes sub-100ms for fast-fail visibility)
 
-**AC-001.1.3:** Metrics endpoint does not require auth
-- **Given** API auth is configured (AURA-RM-004, future)
-- **When** I send `GET /metrics` without auth
-- **Then** I receive 200 (not 401)
+**AC-001.1.3:** Metrics disabled when kill switch is off
+- **Given** `AURA_METRICS_ENABLED=false`
+- **When** I send `GET /metrics`
+- **Then** I receive 404
 
 ### US-001.2: Token Usage Tracking
 
@@ -71,7 +74,7 @@ Aura has zero metrics exposure. Operators cannot set SLO alerts, measure request
 - **When** I scrape `/metrics`
 - **Then** I see `aura_llm_tokens_total` counter with labels:
   - `type`: `prompt` or `completion`
-  - `provider`: `openai`, `anthropic`, `bedrock`, `gemini`, `ollama`
+  - `provider`: value from `Agent::get_provider_info()` (not hardcoded)
   - `agent`: agent name from config
 
 ### US-001.3: MCP Tool Duration
@@ -89,8 +92,9 @@ Aura has zero metrics exposure. Operators cannot set SLO alerts, measure request
 - **When** I scrape `/metrics`
 - **Then** I see `aura_mcp_tool_duration_seconds` histogram with labels:
   - `server`: MCP server name from config
-  - `tool`: tool name
+  - `tool`: tool name (bounded — see cardinality note below)
   - `status`: `ok` or `error`
+- **And** buckets: `[0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60]` (includes 60s for long-running tools)
 
 ### US-001.4: Error Rate by Type
 
@@ -105,7 +109,7 @@ Aura has zero metrics exposure. Operators cannot set SLO alerts, measure request
 **AC-001.4.1:** Error counters
 - **Given** errors have occurred during request processing
 - **When** I scrape `/metrics`
-- **Then** I see `aura_errors_total` counter with `error_type` label using the taxonomy from AURA-RM-008 (e.g., `llm_timeout`, `mcp_connection_failed`)
+- **Then** I see `aura_errors_total` counter with `error_type` label using the taxonomy from AURA-RM-008 (e.g., `llm_timeout`, `mcp_tool_error`)
 
 ### US-001.5: Active Request Gauge
 
@@ -122,35 +126,34 @@ Aura has zero metrics exposure. Operators cannot set SLO alerts, measure request
 - **When** I scrape `/metrics`
 - **Then** I see `aura_http_requests_in_flight` gauge reflecting the current count
 
-## API Contract
+### US-001.6: MCP Server Connection State
 
-```
-GET /metrics HTTP/1.1
-Host: localhost:8080
+**As an** operator,
+**I want** MCP server connection state as a gauge,
+**So that** I can alert when MCP servers disconnect.
 
-HTTP/1.1 200 OK
-Content-Type: text/plain; version=0.0.4; charset=utf-8
+**Priority:** P2
 
-# HELP aura_http_request_duration_seconds Request latency histogram
-# TYPE aura_http_request_duration_seconds histogram
-aura_http_request_duration_seconds_bucket{method="POST",status_code="200",agent="SRE Assistant",le="0.5"} 12
-...
-# HELP aura_llm_tokens_total Token usage counter
-# TYPE aura_llm_tokens_total counter
-aura_llm_tokens_total{type="prompt",provider="bedrock",agent="SRE Assistant"} 45230
-...
-# HELP aura_mcp_tool_duration_seconds MCP tool call latency
-# TYPE aura_mcp_tool_duration_seconds histogram
-aura_mcp_tool_duration_seconds_bucket{server="pagerduty",tool="list_incidents",status="ok",le="1.0"} 8
-...
-# HELP aura_errors_total Error counter by type
-# TYPE aura_errors_total counter
-aura_errors_total{error_type="mcp_tool_error"} 3
-...
-# HELP aura_http_requests_in_flight In-flight request gauge
-# TYPE aura_http_requests_in_flight gauge
-aura_http_requests_in_flight 2
-```
+#### Acceptance Criteria
+
+**AC-001.6.1:** MCP connection gauge
+- **Given** MCP servers are configured
+- **When** I scrape `/metrics`
+- **Then** I see `aura_mcp_server_connected` gauge with `server` label (1 = connected, 0 = disconnected)
+
+## Cardinality Constraints
+
+Metric label values MUST be sourced from config-defined sets, never from user input:
+- `agent`: from TOML `agent.name` — bounded by number of loaded configs
+- `server`: from TOML `mcp.servers.<name>` — bounded by config
+- `tool`: from MCP `tools/list` response — **potentially unbounded**. If a server exposes more than 100 unique tool names, tools beyond the first 100 are aggregated under the label `_other`.
+- `provider`: from LLM config — bounded (5 providers: openai, anthropic, bedrock, gemini, ollama)
+- `status_code`: from HTTP response — bounded (~5 codes: 200, 400, 401, 500, 503)
+- `error_type`: from ErrorCategory — bounded (13 categories)
+
+## Metric Label Sensitivity Note
+
+Prometheus labels contain operational topology information (agent names, MCP server names, tool names, provider names). This data is considered sensitive. The `/metrics` endpoint must NOT be exposed to untrusted networks. Use the `AURA_METRICS_BIND_ADDRESS` config to restrict access (default: `127.0.0.1:9090`).
 
 ## Dependencies
 
@@ -159,7 +162,8 @@ aura_http_requests_in_flight 2
 
 ## Success Criteria
 
-- Prometheus can scrape `/metrics` and display all 5 metric families
+- Prometheus can scrape `/metrics` and display all 6 metric families
 - SLO alerts can be configured on request latency p99
 - Token cost can be calculated from counter values
 - MCP tool degradation is visible in tool duration histograms
+- Metrics endpoint is not accessible from untrusted networks by default

--- a/.specify/specs/AURA-RM-001/product-spec.md
+++ b/.specify/specs/AURA-RM-001/product-spec.md
@@ -1,0 +1,165 @@
+# Product Spec: AURA-RM-001 Prometheus Metrics Endpoint
+
+**Status:** Draft
+**Roadmap Item:** AURA-RM-001
+**Author:** brandon.shelton
+**Created:** 2026-04-28
+**Last Updated:** 2026-04-28
+
+---
+
+## Problem Statement
+
+Aura has zero metrics exposure. Operators cannot set SLO alerts, measure request latency, track token spend, or observe MCP tool health. The only observability is OTel tracing, which requires a trace backend to query and doesn't support real-time alerting dashboards. Without a `/metrics` endpoint, production operation is blind.
+
+## Scope
+
+### In Scope
+- Prometheus-compatible `/metrics` HTTP endpoint (text exposition format)
+- Request latency histogram (by method, status, agent)
+- Token usage counters (by type, provider, agent)
+- MCP tool call duration histogram (by server, tool, status)
+- Error counters (by error type from AURA-RM-008 taxonomy)
+- In-flight request gauge
+
+### Out of Scope
+- Grafana dashboards or alerting rules (operator responsibility)
+- Push-based metrics (only pull/scrape)
+- Custom business metrics
+- Per-user/tenant metrics (requires AURA-RM multi-tenancy)
+
+## User Stories
+
+### US-001.1: Request Latency Observability
+
+**As an** SRE,
+**I want** to scrape a `/metrics` endpoint from Prometheus,
+**So that** I can alert on p99 request latency exceeding SLO thresholds.
+
+**Priority:** P1
+
+#### Acceptance Criteria
+
+**AC-001.1.1:** Prometheus endpoint exists
+- **Given** a running Aura web server
+- **When** I send `GET /metrics`
+- **Then** I receive a 200 response with `text/plain; version=0.0.4; charset=utf-8` content type
+
+**AC-001.1.2:** Request latency histogram
+- **Given** chat completion requests have been served
+- **When** I scrape `/metrics`
+- **Then** I see `aura_http_request_duration_seconds` histogram with `method`, `status_code`, and `agent` labels
+- **And** the histogram has buckets appropriate for LLM latency (0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 seconds)
+
+**AC-001.1.3:** Metrics endpoint does not require auth
+- **Given** API auth is configured (AURA-RM-004, future)
+- **When** I send `GET /metrics` without auth
+- **Then** I receive 200 (not 401)
+
+### US-001.2: Token Usage Tracking
+
+**As a** platform operator,
+**I want** token usage counters per agent per LLM provider,
+**So that** I can forecast cost and detect runaway usage.
+
+**Priority:** P1
+
+#### Acceptance Criteria
+
+**AC-001.2.1:** Token counters
+- **Given** chat completion requests have been served
+- **When** I scrape `/metrics`
+- **Then** I see `aura_llm_tokens_total` counter with labels:
+  - `type`: `prompt` or `completion`
+  - `provider`: `openai`, `anthropic`, `bedrock`, `gemini`, `ollama`
+  - `agent`: agent name from config
+
+### US-001.3: MCP Tool Duration
+
+**As an** SRE,
+**I want** MCP tool call duration histograms,
+**So that** I can identify which tools are degrading response times.
+
+**Priority:** P1
+
+#### Acceptance Criteria
+
+**AC-001.3.1:** Tool duration histogram
+- **Given** an agent has called MCP tools
+- **When** I scrape `/metrics`
+- **Then** I see `aura_mcp_tool_duration_seconds` histogram with labels:
+  - `server`: MCP server name from config
+  - `tool`: tool name
+  - `status`: `ok` or `error`
+
+### US-001.4: Error Rate by Type
+
+**As an** SRE,
+**I want** error rate counters by error type,
+**So that** I can set differentiated alerts.
+
+**Priority:** P1
+
+#### Acceptance Criteria
+
+**AC-001.4.1:** Error counters
+- **Given** errors have occurred during request processing
+- **When** I scrape `/metrics`
+- **Then** I see `aura_errors_total` counter with `error_type` label using the taxonomy from AURA-RM-008 (e.g., `llm_timeout`, `mcp_connection_failed`)
+
+### US-001.5: Active Request Gauge
+
+**As an** operator,
+**I want** active in-flight request count as a gauge,
+**So that** I can right-size capacity.
+
+**Priority:** P2
+
+#### Acceptance Criteria
+
+**AC-001.5.1:** In-flight gauge
+- **Given** requests are being processed
+- **When** I scrape `/metrics`
+- **Then** I see `aura_http_requests_in_flight` gauge reflecting the current count
+
+## API Contract
+
+```
+GET /metrics HTTP/1.1
+Host: localhost:8080
+
+HTTP/1.1 200 OK
+Content-Type: text/plain; version=0.0.4; charset=utf-8
+
+# HELP aura_http_request_duration_seconds Request latency histogram
+# TYPE aura_http_request_duration_seconds histogram
+aura_http_request_duration_seconds_bucket{method="POST",status_code="200",agent="SRE Assistant",le="0.5"} 12
+...
+# HELP aura_llm_tokens_total Token usage counter
+# TYPE aura_llm_tokens_total counter
+aura_llm_tokens_total{type="prompt",provider="bedrock",agent="SRE Assistant"} 45230
+...
+# HELP aura_mcp_tool_duration_seconds MCP tool call latency
+# TYPE aura_mcp_tool_duration_seconds histogram
+aura_mcp_tool_duration_seconds_bucket{server="pagerduty",tool="list_incidents",status="ok",le="1.0"} 8
+...
+# HELP aura_errors_total Error counter by type
+# TYPE aura_errors_total counter
+aura_errors_total{error_type="mcp_tool_error"} 3
+...
+# HELP aura_http_requests_in_flight In-flight request gauge
+# TYPE aura_http_requests_in_flight gauge
+aura_http_requests_in_flight 2
+```
+
+## Dependencies
+
+- **Depends on:** AURA-RM-008 (error_type labels come from the taxonomy)
+- **Depended on by:** AURA-RM-003 (circuit breaker metrics), AURA-RM-005 (budget metrics), AURA-RM-011 (admin endpoint)
+
+## Success Criteria
+
+- Prometheus can scrape `/metrics` and display all 5 metric families
+- SLO alerts can be configured on request latency p99
+- Token cost can be calculated from counter values
+- MCP tool degradation is visible in tool duration histograms

--- a/.specify/specs/AURA-RM-001/product-spec.md
+++ b/.specify/specs/AURA-RM-001/product-spec.md
@@ -153,7 +153,7 @@ Metric label values MUST be sourced from config-defined sets, never from user in
 
 ## Metric Label Sensitivity Note
 
-Prometheus labels contain operational topology information (agent names, MCP server names, tool names, provider names). This data is considered sensitive. The `/metrics` endpoint must NOT be exposed to untrusted networks. Use the `AURA_METRICS_BIND_ADDRESS` config to restrict access (default: `127.0.0.1:9090`).
+Prometheus labels contain operational topology information (agent names, MCP server names, tool names, provider names). This data is considered sensitive. The `/metrics` endpoint must NOT be exposed to untrusted networks. In V1, metrics are served on the same bind address as the main API. Operators must use network-level controls (firewall rules, Kubernetes NetworkPolicy, reverse proxy) to restrict access to `/metrics`. A dedicated metrics bind address is planned for V2.
 
 ## Dependencies
 

--- a/.specify/specs/AURA-RM-001/product-spec.md
+++ b/.specify/specs/AURA-RM-001/product-spec.md
@@ -22,7 +22,7 @@ Aura has zero metrics exposure. Operators cannot set SLO alerts, measure request
 - Error counters (by error type from AURA-RM-008 taxonomy)
 - In-flight request gauge
 - MCP server connection state gauge
-- Access control: metrics bind to a configurable address (default localhost only)
+- Access control: V1 serves metrics on the same bind address as the main API; operators use network-level controls to restrict access (dedicated bind address deferred to V2)
 - Kill switch: `AURA_METRICS_ENABLED` env var (default true)
 
 ### Out of Scope
@@ -146,7 +146,7 @@ Aura has zero metrics exposure. Operators cannot set SLO alerts, measure request
 Metric label values MUST be sourced from config-defined sets, never from user input:
 - `agent`: from TOML `agent.name` — bounded by number of loaded configs
 - `server`: from TOML `mcp.servers.<name>` — bounded by config
-- `tool`: from MCP `tools/list` response — **potentially unbounded**. If a server exposes more than 100 unique tool names, tools beyond the first 100 are aggregated under the label `_other`.
+- `tool`: from MCP `tools/list` response — **potentially unbounded**. Globally across all MCP servers, if more than 100 unique tool names are observed, tools beyond the first 100 are aggregated under the label `_other`. Tool names longer than 64 characters are also aggregated to `_other`.
 - `provider`: from LLM config — bounded (5 providers: openai, anthropic, bedrock, gemini, ollama)
 - `status_code`: from HTTP response — bounded (~5 codes: 200, 400, 401, 500, 503)
 - `error_type`: from ErrorCategory — bounded (13 categories)

--- a/.specify/specs/AURA-RM-001/quality-spec.md
+++ b/.specify/specs/AURA-RM-001/quality-spec.md
@@ -1,0 +1,140 @@
+# Quality & Testing Spec: AURA-RM-001 Prometheus Metrics Endpoint
+
+**Status:** Draft
+**Roadmap Item:** AURA-RM-001
+**Product Spec:** [product-spec.md](product-spec.md)
+**Architecture Spec:** [architecture-spec.md](architecture-spec.md)
+**Author:** brandon.shelton
+**Created:** 2026-04-28
+**Last Updated:** 2026-04-28
+
+---
+
+## Test Strategy
+
+- **Unit Tests:** Metric recording functions, label generation, histogram bucket config
+- **Integration Tests:** `/metrics` endpoint returns valid Prometheus format after requests
+- **End-to-End Tests:** Prometheus scrape → verify expected metric families present
+
+## Acceptance Criteria Traceability
+
+| Acceptance Criterion | Test Type | Test Case ID | Test Location | Status |
+|---------------------|-----------|-------------|---------------|--------|
+| AC-001.1.1 (endpoint exists) | Integration | TC-001.1.1.1 | `crates/aura-web-server/tests/metrics_test.rs::test_metrics_endpoint_returns_200` | Pending |
+| AC-001.1.2 (latency histogram) | Integration | TC-001.1.2.1 | `...::test_metrics_contains_request_duration_histogram` | Pending |
+| AC-001.1.3 (no auth required) | Integration | TC-001.1.3.1 | `...::test_metrics_endpoint_no_auth` | Pending |
+| AC-001.2.1 (token counters) | Integration | TC-001.2.1.1 | `...::test_metrics_contains_token_counters` | Pending |
+| AC-001.3.1 (tool duration) | Integration | TC-001.3.1.1 | `...::test_metrics_contains_tool_duration` | Pending |
+| AC-001.4.1 (error counters) | Unit | TC-001.4.1.1 | `crates/aura-web-server/src/metrics_tests.rs::test_record_error_increments_counter` | Pending |
+| AC-001.5.1 (in-flight gauge) | Unit | TC-001.5.1.1 | `...::test_in_flight_gauge_tracks_active_requests` | Pending |
+
+## Test Cases
+
+### TC-001.1.1.1: Metrics endpoint returns 200 with Prometheus format
+
+**Satisfies:** AC-001.1.1
+**Type:** Integration
+**Feature Flag:** `integration-metrics`
+
+**Setup:**
+- Running Aura web server with test config
+
+**Steps:**
+1. Send `GET /metrics`
+
+**Expected Result:**
+- 200 OK
+- Content-Type: `text/plain; version=0.0.4; charset=utf-8`
+- Body contains `# HELP` and `# TYPE` lines
+
+### TC-001.1.2.1: Request duration histogram present after requests
+
+**Satisfies:** AC-001.1.2
+**Type:** Integration
+
+**Setup:**
+- Running Aura web server
+- Send at least one `POST /v1/chat/completions`
+
+**Steps:**
+1. Send a chat completion request
+2. Send `GET /metrics`
+
+**Expected Result:**
+- Body contains `aura_http_request_duration_seconds_bucket`
+- Labels include `method="POST"`, `status_code="200"`, `agent="..."`
+- Buckets include the configured boundaries
+
+### TC-001.2.1.1: Token counters present after requests
+
+**Satisfies:** AC-001.2.1
+**Type:** Integration
+
+**Setup:**
+- Running Aura web server with LLM provider configured
+
+**Steps:**
+1. Send a chat completion request that completes successfully
+2. Send `GET /metrics`
+
+**Expected Result:**
+- Body contains `aura_llm_tokens_total`
+- Labels include `type="prompt"` and `type="completion"`
+- Values are > 0
+
+### TC-001.3.1.1: Tool duration histogram present after tool calls
+
+**Satisfies:** AC-001.3.1
+**Type:** Integration
+
+**Setup:**
+- Running Aura web server with mock MCP server
+
+**Steps:**
+1. Send a request that triggers a tool call
+2. Send `GET /metrics`
+
+**Expected Result:**
+- Body contains `aura_mcp_tool_duration_seconds_bucket`
+- Labels include `server`, `tool`, `status`
+
+### TC-001.4.1.1: Error counter increments on error
+
+**Satisfies:** AC-001.4.1
+**Type:** Unit
+
+**Steps:**
+1. Call `record_error("mcp_tool_error")`
+2. Render metrics
+
+**Expected Result:**
+- `aura_errors_total{error_type="mcp_tool_error"}` shows count >= 1
+
+### TC-001.5.1.1: In-flight gauge tracks active requests
+
+**Satisfies:** AC-001.5.1
+**Type:** Unit
+
+**Steps:**
+1. Call `set_requests_in_flight(3)`
+2. Render metrics
+
+**Expected Result:**
+- `aura_http_requests_in_flight` gauge shows value 3
+
+## Quality Gates
+
+- [ ] All unit tests pass (`cargo test --workspace --lib`)
+- [ ] Integration tests pass (`cargo test --package aura-web-server --features integration-metrics`)
+- [ ] Zero compiler warnings
+- [ ] Clippy clean
+- [ ] Code formatted
+- [ ] No regressions in existing test suite (all 743+ existing tests still pass)
+- [ ] Every AC has at least one passing test
+- [ ] `/metrics` endpoint returns valid Prometheus text format (verified with `promtool check metrics`)
+
+## Coverage Notes
+
+- Integration tests for AC-001.1.2, AC-001.2.1, and AC-001.3.1 require a running server with LLM/MCP — these run under the `integration-metrics` feature flag
+- Token counter accuracy depends on LLM provider returning usage data — some providers (Ollama) may not report tokens
+- Tool duration tests require mock MCP server from existing test infrastructure

--- a/.specify/specs/AURA-RM-001/quality-spec.md
+++ b/.specify/specs/AURA-RM-001/quality-spec.md
@@ -1,6 +1,6 @@
 # Quality & Testing Spec: AURA-RM-001 Prometheus Metrics Endpoint
 
-**Status:** Draft
+**Status:** In Review (Remediation Round 1)
 **Roadmap Item:** AURA-RM-001
 **Product Spec:** [product-spec.md](product-spec.md)
 **Architecture Spec:** [architecture-spec.md](architecture-spec.md)
@@ -12,21 +12,23 @@
 
 ## Test Strategy
 
-- **Unit Tests:** Metric recording functions, label generation, histogram bucket config
-- **Integration Tests:** `/metrics` endpoint returns valid Prometheus format after requests
-- **End-to-End Tests:** Prometheus scrape → verify expected metric families present
+- **Unit Tests:** Metric recording functions, label generation, histogram bucket config, kill switch behavior
+- **Integration Tests:** `/metrics` endpoint returns valid Prometheus format after real requests (feature flag: `integration-metrics`)
+- **Performance Tests:** Metrics scrape completes in < 50ms with 500 time series
 
 ## Acceptance Criteria Traceability
 
 | Acceptance Criterion | Test Type | Test Case ID | Test Location | Status |
 |---------------------|-----------|-------------|---------------|--------|
-| AC-001.1.1 (endpoint exists) | Integration | TC-001.1.1.1 | `crates/aura-web-server/tests/metrics_test.rs::test_metrics_endpoint_returns_200` | Pending |
-| AC-001.1.2 (latency histogram) | Integration | TC-001.1.2.1 | `...::test_metrics_contains_request_duration_histogram` | Pending |
-| AC-001.1.3 (no auth required) | Integration | TC-001.1.3.1 | `...::test_metrics_endpoint_no_auth` | Pending |
-| AC-001.2.1 (token counters) | Integration | TC-001.2.1.1 | `...::test_metrics_contains_token_counters` | Pending |
-| AC-001.3.1 (tool duration) | Integration | TC-001.3.1.1 | `...::test_metrics_contains_tool_duration` | Pending |
-| AC-001.4.1 (error counters) | Unit | TC-001.4.1.1 | `crates/aura-web-server/src/metrics_tests.rs::test_record_error_increments_counter` | Pending |
-| AC-001.5.1 (in-flight gauge) | Unit | TC-001.5.1.1 | `...::test_in_flight_gauge_tracks_active_requests` | Pending |
+| AC-001.1.1 (endpoint exists) | Integration | TC-001.1.1.1 | `crates/aura-web-server/tests/metrics_test.rs` | Pending |
+| AC-001.1.2 (latency histogram) | Integration | TC-001.1.2.1 | `crates/aura-web-server/tests/metrics_test.rs` | Pending |
+| AC-001.1.3 (kill switch) | Unit | TC-001.1.3.1 | `crates/aura-web-server/src/metrics.rs` inline tests | Pending |
+| AC-001.2.1 (token counters) | Integration | TC-001.2.1.1 | `crates/aura-web-server/tests/metrics_test.rs` | Pending |
+| AC-001.3.1 (tool duration) | Integration | TC-001.3.1.1 | `crates/aura-web-server/tests/metrics_test.rs` | Pending |
+| AC-001.4.1 (error counters) | Unit | TC-001.4.1.1 | `crates/aura-web-server/src/metrics.rs` inline tests | Pending |
+| AC-001.5.1 (in-flight gauge) | Unit | TC-001.5.1.1 | `crates/aura-web-server/src/metrics.rs` inline tests | Pending |
+| AC-001.6.1 (MCP connection gauge) | Unit | TC-001.6.1.1 | `crates/aura-web-server/src/metrics.rs` inline tests | Pending |
+| Performance (scrape < 50ms) | Performance | TC-001.P.1 | `crates/aura-web-server/tests/metrics_test.rs` | Pending |
 
 ## Test Cases
 
@@ -36,15 +38,14 @@
 **Type:** Integration
 **Feature Flag:** `integration-metrics`
 
-**Setup:**
-- Running Aura web server with test config
+**Setup:** Running Aura web server with test config (uses existing `aura-test-utils` infrastructure)
 
 **Steps:**
 1. Send `GET /metrics`
 
 **Expected Result:**
 - 200 OK
-- Content-Type: `text/plain; version=0.0.4; charset=utf-8`
+- Content-Type contains `text/plain`
 - Body contains `# HELP` and `# TYPE` lines
 
 ### TC-001.1.2.1: Request duration histogram present after requests
@@ -52,46 +53,49 @@
 **Satisfies:** AC-001.1.2
 **Type:** Integration
 
-**Setup:**
-- Running Aura web server
-- Send at least one `POST /v1/chat/completions`
-
 **Steps:**
-1. Send a chat completion request
+1. Send a `POST /v1/chat/completions` request
 2. Send `GET /metrics`
 
 **Expected Result:**
 - Body contains `aura_http_request_duration_seconds_bucket`
-- Labels include `method="POST"`, `status_code="200"`, `agent="..."`
-- Buckets include the configured boundaries
+- Labels include `method="POST"` and `status_code`
+- At least one bucket has a count > 0
+
+### TC-001.1.3.1: Kill switch disables metrics
+
+**Satisfies:** AC-001.1.3
+**Type:** Unit
+
+**Steps:**
+1. Set `AURA_METRICS_ENABLED=false` in env
+2. Call `init_metrics()`
+
+**Expected Result:**
+- Returns `None`
 
 ### TC-001.2.1.1: Token counters present after requests
 
 **Satisfies:** AC-001.2.1
 **Type:** Integration
 
-**Setup:**
-- Running Aura web server with LLM provider configured
-
 **Steps:**
-1. Send a chat completion request that completes successfully
+1. Send a chat completion request
 2. Send `GET /metrics`
 
 **Expected Result:**
 - Body contains `aura_llm_tokens_total`
 - Labels include `type="prompt"` and `type="completion"`
-- Values are > 0
 
 ### TC-001.3.1.1: Tool duration histogram present after tool calls
 
 **Satisfies:** AC-001.3.1
 **Type:** Integration
 
-**Setup:**
-- Running Aura web server with mock MCP server
+**Setup:** Running with mock MCP server (existing test infrastructure)
 
 **Steps:**
-1. Send a request that triggers a tool call
+1. Send a request that triggers a tool call (e.g., "Call mock_tool")
 2. Send `GET /metrics`
 
 **Expected Result:**
@@ -105,36 +109,79 @@
 
 **Steps:**
 1. Call `record_error("mcp_tool_error")`
-2. Render metrics
+2. Call `record_error("mcp_tool_error")`
+3. Render metrics
 
 **Expected Result:**
-- `aura_errors_total{error_type="mcp_tool_error"}` shows count >= 1
+- `aura_errors_total{error_type="mcp_tool_error"}` value is 2
 
-### TC-001.5.1.1: In-flight gauge tracks active requests
+### TC-001.5.1.1: In-flight gauge increments and decrements
 
 **Satisfies:** AC-001.5.1
 **Type:** Unit
 
 **Steps:**
-1. Call `set_requests_in_flight(3)`
-2. Render metrics
+1. Call `increment_requests_in_flight()` twice
+2. Call `decrement_requests_in_flight()` once
+3. Render metrics
 
 **Expected Result:**
-- `aura_http_requests_in_flight` gauge shows value 3
+- `aura_http_requests_in_flight` gauge value is 1
+
+### TC-001.6.1.1: MCP connection gauge reflects state
+
+**Satisfies:** AC-001.6.1
+**Type:** Unit
+
+**Steps:**
+1. Call `set_mcp_server_connected("pagerduty", true)`
+2. Call `set_mcp_server_connected("datadog", false)`
+3. Render metrics
+
+**Expected Result:**
+- `aura_mcp_server_connected{server="pagerduty"}` is 1.0
+- `aura_mcp_server_connected{server="datadog"}` is 0.0
+
+### TC-001.P.1: Metrics scrape performance
+
+**Satisfies:** Performance requirement
+**Type:** Performance
+
+**Steps:**
+1. Record 500 unique time series (vary labels to create cardinality)
+2. Time `PrometheusHandle::render()`
+
+**Expected Result:**
+- Render completes in < 50ms
+
+## Test Infrastructure
+
+### Required Fixtures
+- Existing test config (`crates/aura-web-server/tests/test-config.toml`)
+- Existing mock MCP server (aura-mock-mcp)
+
+### Required Services (integration tests only)
+- Mock MCP server on port 9999
+- Aura web server with test config
+
+### Environment Variables
+- `AURA_METRICS_ENABLED` — tested in unit tests with env override
 
 ## Quality Gates
 
 - [ ] All unit tests pass (`cargo test --workspace --lib`)
 - [ ] Integration tests pass (`cargo test --package aura-web-server --features integration-metrics`)
 - [ ] Zero compiler warnings
-- [ ] Clippy clean
-- [ ] Code formatted
-- [ ] No regressions in existing test suite (all 743+ existing tests still pass)
-- [ ] Every AC has at least one passing test
-- [ ] `/metrics` endpoint returns valid Prometheus text format (verified with `promtool check metrics`)
+- [ ] Clippy clean (`cargo clippy --all-targets -- -D warnings`)
+- [ ] Code formatted (`cargo fmt --check`)
+- [ ] No regressions in existing test suite
+- [ ] Every AC has at least one passing test (see traceability table)
+- [ ] `/metrics` returns valid Prometheus format (validate with `promtool check metrics` if available in CI, otherwise manual verification)
+- [ ] Performance: scrape < 50ms with 500 time series
 
 ## Coverage Notes
 
-- Integration tests for AC-001.1.2, AC-001.2.1, and AC-001.3.1 require a running server with LLM/MCP — these run under the `integration-metrics` feature flag
-- Token counter accuracy depends on LLM provider returning usage data — some providers (Ollama) may not report tokens
-- Tool duration tests require mock MCP server from existing test infrastructure
+- Integration tests for token counters and tool duration require a running server with LLM/MCP. These run under the `integration-metrics` feature flag using existing Docker Compose infrastructure.
+- Token counter accuracy depends on LLM provider returning usage data. Some providers (Ollama) may not report tokens — counters will show 0.
+- Process-level metrics (CPU, memory, FDs) are out of scope. Operators should use container-level metrics or node exporter for these.
+- Metrics scrape performance test (TC-001.P.1) runs as a unit test — does not require a running server.

--- a/.specify/specs/AURA-RM-001/reviews/spec-review-001.md
+++ b/.specify/specs/AURA-RM-001/reviews/spec-review-001.md
@@ -1,0 +1,34 @@
+# Spec Review Round 1: AURA-RM-001
+
+**Date:** 2026-04-28
+**Reviewers:** Consistency Agent, Security Agent, Operability Agent
+
+## Findings Summary
+
+| # | Category | Finding | Resolution |
+|---|----------|---------|------------|
+| 1 | Must Fix | Article II: metrics recording in aura crate violates boundary | FIXED — all metrics in aura-web-server only, tool timing via event broker |
+| 2 | Must Fix | /metrics exposed without access control | FIXED — document as sensitive, default localhost, AURA_METRICS_BIND_ADDRESS planned |
+| 3 | Must Fix | In-flight gauge set-after-read race | FIXED — use gauge.increment(1.0)/decrement(1.0) directly |
+| 4 | Must Fix | ActiveRequestTracker ordering change | FIXED — atomic orderings unchanged, gauge is separate |
+| 5 | Must Fix | Article V: integration-metrics feature flag not defined | FIXED — added to Cargo.toml spec |
+| 6 | Must Fix | tool label unbounded cardinality | FIXED — 100-tool cap + 64-char length guard → _other |
+| 7 | Should Fix | Histogram missing sub-100ms bucket | FIXED — added 0.025 bucket |
+| 8 | Should Fix | MCP tool histogram upper bound too low | FIXED — extended to 60s |
+| 9 | Should Fix | No AURA_METRICS_ENABLED kill switch | FIXED — added env var, default true |
+| 10 | Should Fix | Missing MCP server connection state gauge | FIXED — added US-001.6 / AC-001.6.1 |
+| 11 | Should Fix | No process metrics | DOCUMENTED — out of scope, use node exporter |
+| 12 | Should Fix | Scrape latency not in quality spec | FIXED — added TC-001.P.1 performance test |
+| 13 | Should Fix | UsageState extraction unclear | FIXED — added usage_state.snapshot() in handler code |
+| 14 | Should Fix | /metrics route placement vs shutdown_guard | FIXED — registered outside shutdown_guard |
+| 15 | Should Fix | init_metrics() panics on error | FIXED — uses .expect() with clear messages |
+| 16 | Should Fix | Agent label in metrics may contain spaces | DOCUMENTED — operator choice via config |
+| 17 | Should Fix | AC-001.1.3 about auth exemption untestable | FIXED — changed to kill switch test instead |
+| 18 | Should Fix | Provider labels hardcoded | FIXED — sourced from Agent::get_provider_info() |
+| 19 | Should Fix | Test count hardcoded | FIXED — uses "existing tests" not number |
+| 20 | Should Fix | Mock infra not referenced | FIXED — references aura-test-utils |
+| 21 | Nit | promtool requirement | DOCUMENTED — "if available in CI" |
+| 22 | Nit | Render caching | DOCUMENTED — future optimization |
+| 23 | Nit | .unwrap() in init | FIXED — changed to .expect() |
+
+## Status: All findings resolved. Ready for re-review.

--- a/.specify/specs/AURA-RM-001/tasks.md
+++ b/.specify/specs/AURA-RM-001/tasks.md
@@ -1,0 +1,112 @@
+# Tasks: AURA-RM-001 Prometheus Metrics Endpoint
+
+## Task 1: Add metrics dependencies
+
+**Status:** Pending
+**File:** `crates/aura-web-server/Cargo.toml`
+**Satisfies:** N/A (infrastructure)
+**Dependencies:** None
+
+- [ ] Add `metrics = "0.24"` to dependencies
+- [ ] Add `metrics-exporter-prometheus = "0.16"` to dependencies
+- [ ] Add `integration-metrics = []` to `[features]`
+- [ ] Add `"integration-metrics"` to the `integration` parent feature list
+- [ ] Verify `cargo check` passes
+
+## Task 2: Create metrics module with init and recording functions
+
+**Status:** Pending
+**File:** `crates/aura-web-server/src/metrics.rs`
+**Satisfies:** AC-001.1.1, AC-001.1.3
+**Dependencies:** Task 1
+
+- [ ] `init_metrics() -> Option<PrometheusHandle>` with `AURA_METRICS_ENABLED` kill switch
+- [ ] `record_request_duration(method, status, agent, duration_secs)` with buckets [0.025..300]
+- [ ] `record_tokens(type, provider, agent, count)` — skip if count == 0
+- [ ] `record_tool_duration(server, tool, status, duration_secs)` with 100-tool cardinality cap + 64-char guard
+- [ ] `record_error(error_type)` using ErrorCategory label
+- [ ] `increment_requests_in_flight()` / `decrement_requests_in_flight()`
+- [ ] `set_mcp_server_connected(server, connected)`
+- [ ] `metrics_handler(handle) -> HttpResponse` returning Prometheus text format
+- [ ] Inline unit tests for kill switch behavior
+
+## Task 3: Register /metrics route in main.rs
+
+**Status:** Pending
+**File:** `crates/aura-web-server/src/main.rs`
+**Satisfies:** AC-001.1.1
+**Dependencies:** Task 2
+
+- [ ] Call `metrics::init_metrics()` in main
+- [ ] Register `/metrics` route OUTSIDE shutdown_guard middleware (available during graceful shutdown)
+- [ ] Pass `PrometheusHandle` as `web::Data`
+- [ ] Add `pub mod metrics;` to lib.rs
+
+## Task 4: Instrument request duration and in-flight gauge
+
+**Status:** Pending
+**File:** `crates/aura-web-server/src/handlers.rs`
+**Satisfies:** AC-001.1.2, AC-001.5.1
+**Dependencies:** Task 2, Task 3
+
+- [ ] Add `Instant::now()` at request entry
+- [ ] Update `ActiveRequestGuard::new()` to call `metrics::increment_requests_in_flight()`
+- [ ] Update `ActiveRequestGuard::drop()` to call `metrics::decrement_requests_in_flight()`
+- [ ] Record `record_request_duration()` at request completion (both streaming and non-streaming paths)
+- [ ] Extract agent name and provider from agent for labels
+
+## Task 5: Instrument token recording
+
+**Status:** Pending
+**File:** `crates/aura-web-server/src/handlers.rs`
+**Satisfies:** AC-001.2.1
+**Dependencies:** Task 2, Task 4
+
+- [ ] At request completion, call `usage_state.get_final_usage()` → `(prompt, completion, total)`
+- [ ] Call `record_tokens("prompt", provider, agent, prompt_tokens)`
+- [ ] Call `record_tokens("completion", provider, agent, completion_tokens)`
+
+## Task 6: Instrument tool duration
+
+**Status:** Pending
+**File:** `crates/aura-web-server/src/streaming/handlers.rs`
+**Satisfies:** AC-001.3.1
+**Dependencies:** Task 2
+
+- [ ] At the point where `AuraStreamEvent::tool_complete_success/failure` is constructed (where `duration_ms` and `tool_name` are available)
+- [ ] Call `record_tool_duration(server_name, tool_name, status, duration_secs)`
+- [ ] Server name comes from the tool event's server context
+
+## Task 7: Instrument error recording
+
+**Status:** Pending
+**File:** `crates/aura-web-server/src/handlers.rs`
+**Satisfies:** AC-001.4.1
+**Dependencies:** AURA-RM-008 (ErrorCategory), Task 2
+
+- [ ] Where `AuraError` is constructed (Task 6 of RM-008), also call `record_error(category.as_label())`
+- [ ] Covers all 6 ErrorDetail construction sites
+
+## Task 8: MCP server connection state gauge
+
+**Status:** Pending
+**File:** `crates/aura-web-server/src/handlers.rs` (or main.rs at agent initialization)
+**Satisfies:** AC-001.6.1
+**Dependencies:** Task 2
+
+- [ ] After MCP manager initialization, iterate connected servers and call `set_mcp_server_connected(name, true)`
+- [ ] On MCP connection failure, call `set_mcp_server_connected(name, false)`
+
+## Task 9: Integration tests
+
+**Status:** Pending
+**File:** `crates/aura-web-server/tests/metrics_test.rs`
+**Satisfies:** AC-001.1.1, AC-001.1.2, AC-001.2.1, AC-001.3.1
+**Dependencies:** All previous tasks
+
+- [ ] `#![cfg(feature = "integration-metrics")]`
+- [ ] TC-001.1.1.1: GET /metrics returns 200 with Prometheus format
+- [ ] TC-001.1.2.1: Request duration histogram present after POST
+- [ ] TC-001.2.1.1: Token counters present after request
+- [ ] TC-001.3.1.1: Tool duration present after tool call
+- [ ] TC-001.P.1: Scrape performance < 50ms with 500 time series

--- a/.specify/specs/AURA-RM-008/architecture-spec.md
+++ b/.specify/specs/AURA-RM-008/architecture-spec.md
@@ -11,7 +11,7 @@
 
 ## Summary
 
-Introduce a unified `ErrorCategory` enum in the `aura` crate that classifies all runtime errors into a fixed taxonomy. Add a sanitization layer that separates internal error messages (for logs) from generic client-facing messages (for API responses). Extend both `ErrorDetail` and `ChatCompletionErrorDetail` structs with a `code` field. Map existing error sources into the taxonomy at their crate boundaries — `DetectedToolError` mapping in `aura`, `StreamTermination` mapping in `aura-web-server`.
+Introduce a unified `ErrorCategory` enum in the `aura` crate that classifies all runtime errors into a fixed taxonomy. Add a sanitization layer that separates internal error messages (for logs) from generic client-facing messages (for API responses). Extend `ErrorDetail` with a new `code` field (`ChatCompletionErrorDetail` is left unchanged — it already has an OpenAI-compatible `code` field). Map existing error sources into the taxonomy at their crate boundaries — `DetectedToolError` mapping in `aura`, `StreamTermination` mapping in `aura-web-server`.
 
 ## Constitution Compliance Check
 
@@ -202,7 +202,7 @@ ALL six ErrorDetail construction sites must be updated:
 | handlers.rs | 132 | `"internal_error"` | `Internal` (build agent failure) |
 | handlers.rs | 167 | `"invalid_request_error"` | `RequestValidation` (wrong last message role) |
 | handlers.rs | 175 | `"invalid_request_error"` | `RequestValidation` (empty messages) |
-| handlers.rs | 241 | `"invalid_request_error"` | `RequestValidation` (model not found) |
+| handlers.rs | 241 | `"invalid_request_error"` | `RequestValidation` (no messages provided) |
 | handlers.rs | 545 | `"internal_error"` | `Internal` (completion error) |
 | main.rs | 102 | `"service_unavailable"` | `ServiceUnavailable` (shutdown guard) |
 
@@ -270,7 +270,7 @@ No new configuration. The taxonomy is code-defined.
 - **`error_type` values are FROZEN**: `"internal_error"`, `"invalid_request_error"`, `"service_unavailable"` remain unchanged. Clients matching on these values are NOT broken.
 - **New `code` field is additive**: Uses `skip_serializing_if = "Option::is_none"` so it only appears when set.
 - **Error messages change**: Client-facing messages become generic. This is a behavioral change but improves security. Clients that parsed error message strings for debugging will need to use server-side logs instead.
-- **Both `ErrorDetail` and `ChatCompletionErrorDetail`** gain the `code` field for consistency.
+- Only `ErrorDetail` gains the `code` field. `ChatCompletionErrorDetail` is left unchanged (existing `code: String` field is for OpenAI-compatible error codes).
 
 ## Alternatives Considered
 
@@ -291,7 +291,7 @@ No new configuration. The taxonomy is code-defined.
 1. Create `error_taxonomy.rs` with `ErrorCategory` enum, `ALL_CATEGORIES`, `client_message()`, `as_label()` — Satisfies: AC-008.1.1, AC-008.4.1
 2. Create `AuraError` struct with `new()`, `client_message()` — Satisfies: AC-008.3.1, AC-008.3.2
 3. Add `From<&DetectedToolError>` impl — Satisfies: AC-008.1.2
-4. Add `code` field to both `ErrorDetail` and `ChatCompletionErrorDetail` — Satisfies: AC-008.2.1, AC-008.2.2
+4. Add `code` field to `ErrorDetail` only (ChatCompletionErrorDetail unchanged) — Satisfies: AC-008.2.1, AC-008.2.2
 5. Add `From<&StreamTermination>` impl in `aura-web-server` — Satisfies: AC-008.1.3
 6. Update handler error construction to use `AuraError` with sanitization — Satisfies: AC-008.3.1
 7. Unit tests — Satisfies: all ACs via quality spec

--- a/.specify/specs/AURA-RM-008/architecture-spec.md
+++ b/.specify/specs/AURA-RM-008/architecture-spec.md
@@ -1,6 +1,6 @@
 # Architecture Spec: AURA-RM-008 Structured Error Taxonomy
 
-**Status:** Draft
+**Status:** In Review (Remediation Round 1)
 **Roadmap Item:** AURA-RM-008
 **Product Spec:** [product-spec.md](product-spec.md)
 **Author:** brandon.shelton
@@ -11,21 +11,21 @@
 
 ## Summary
 
-Introduce a unified `AuraError` enum in the `aura` crate that classifies all runtime errors into a fixed taxonomy. Map existing error sources (`BuilderError`, `DetectedToolError`, `StreamTermination`) into this taxonomy. Extend the API `ErrorDetail` struct with an `error_code` field. This is a refactoring — no new features, just structured classification of errors that already exist.
+Introduce a unified `ErrorCategory` enum in the `aura` crate that classifies all runtime errors into a fixed taxonomy. Add a sanitization layer that separates internal error messages (for logs) from generic client-facing messages (for API responses). Extend both `ErrorDetail` and `ChatCompletionErrorDetail` structs with a `code` field. Map existing error sources into the taxonomy at their crate boundaries — `DetectedToolError` mapping in `aura`, `StreamTermination` mapping in `aura-web-server`.
 
 ## Constitution Compliance Check
 
-- [x] Article I: API responses gain an additive `code` field. Existing `message` and `type` fields unchanged. No breaking change.
-- [x] Article II: `AuraError` lives in `aura` crate (runtime concern). `ErrorDetail` extension is in `aura-web-server` (HTTP concern). Config errors stay in `aura-config`.
-- [x] Article V: No new integration tests needed (unit-testable).
+- [x] Article I: Existing `type` field values (`"internal_error"`, `"invalid_request_error"`, `"service_unavailable"`) are FROZEN. New `code` field is additive only. No breaking change.
+- [x] Article II: `ErrorCategory` lives in `aura` crate. `StreamTermination` → `ErrorCategory` mapping lives in `aura-web-server` (where `StreamTermination` is defined). No circular dependencies.
+- [x] Article IV: Implementation commits will follow conventional commit format.
+- [x] Article V: Unit tests only — no new integration test feature flags needed.
 - [x] Article VI: No secrets involved.
 - [x] Article VII: No config changes.
 
 ## Technical Context
 
-- **Language/Version:** Rust (edition 2024, stable 1.93.1)
-- **Affected Crates:** `aura` (new error module), `aura-web-server` (ErrorDetail extension)
-- **New Dependencies:** None
+- **Affected Crates:** `aura` (new error_taxonomy module), `aura-web-server` (ErrorDetail extension, StreamTermination mapping)
+- **New Dependencies:** None. (`thiserror` is already in workspace dependencies but not needed for this simple enum.)
 - **Performance Objectives:** Zero overhead on happy path (error classification only occurs on error)
 
 ## Design
@@ -38,7 +38,7 @@ Introduce a unified `AuraError` enum in the `aura` crate that classifies all run
 
 ```rust
 /// Unified error taxonomy for all Aura runtime errors.
-/// Each variant maps to a Prometheus-label-safe string.
+/// Each variant maps to a Prometheus-label-safe string and a generic client message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ErrorCategory {
     LlmTimeout,
@@ -51,12 +51,13 @@ pub enum ErrorCategory {
     ConfigValidation,
     RequestValidation,
     BudgetExceeded,
+    ServiceUnavailable,
     Cancelled,
     Internal,
 }
 
 impl ErrorCategory {
-    /// Returns a Prometheus-label-safe string.
+    /// Returns a Prometheus-label-safe string (lowercase, underscores only).
     pub fn as_label(&self) -> &'static str {
         match self {
             Self::LlmTimeout => "llm_timeout",
@@ -69,42 +70,74 @@ impl ErrorCategory {
             Self::ConfigValidation => "config_validation",
             Self::RequestValidation => "request_validation",
             Self::BudgetExceeded => "budget_exceeded",
+            Self::ServiceUnavailable => "service_unavailable",
             Self::Cancelled => "cancelled",
             Self::Internal => "internal",
         }
     }
 
-    /// Returns the error code (e.g., AURA-E-LLM-001).
-    pub fn error_code(&self) -> &'static str {
+    /// Returns a safe, generic client-facing message.
+    /// Internal details must NEVER appear in this output.
+    pub fn client_message(&self) -> &'static str {
         match self {
-            Self::LlmTimeout => "AURA-E-LLM-001",
-            Self::LlmRateLimit => "AURA-E-LLM-002",
-            Self::LlmAuthError => "AURA-E-LLM-003",
-            Self::LlmError => "AURA-E-LLM-099",
-            Self::McpConnectionFailed => "AURA-E-MCP-001",
-            Self::McpToolError => "AURA-E-MCP-002",
-            Self::McpTimeout => "AURA-E-MCP-003",
-            Self::ConfigValidation => "AURA-E-CFG-001",
-            Self::RequestValidation => "AURA-E-REQ-001",
-            Self::BudgetExceeded => "AURA-E-BDG-001",
-            Self::Cancelled => "AURA-E-CXL-001",
-            Self::Internal => "AURA-E-INT-001",
+            Self::LlmTimeout => "The language model did not respond in time",
+            Self::LlmRateLimit => "The language model is temporarily rate limited",
+            Self::LlmAuthError => "An authentication error occurred with an upstream provider",
+            Self::LlmError => "An error occurred with the language model",
+            Self::McpConnectionFailed => "A downstream service is temporarily unavailable",
+            Self::McpToolError => "A tool execution error occurred",
+            Self::McpTimeout => "A tool call did not respond in time",
+            Self::ConfigValidation => "Server configuration error",
+            Self::RequestValidation => "Invalid request",
+            Self::BudgetExceeded => "Token budget exceeded for this request",
+            Self::ServiceUnavailable => "Server is shutting down",
+            Self::Cancelled => "Request was cancelled",
+            Self::Internal => "An internal error occurred",
+        }
+    }
+}
+
+/// All ErrorCategory variants, for exhaustive iteration in tests.
+pub const ALL_CATEGORIES: &[ErrorCategory] = &[
+    ErrorCategory::LlmTimeout,
+    ErrorCategory::LlmRateLimit,
+    ErrorCategory::LlmAuthError,
+    ErrorCategory::LlmError,
+    ErrorCategory::McpConnectionFailed,
+    ErrorCategory::McpToolError,
+    ErrorCategory::McpTimeout,
+    ErrorCategory::ConfigValidation,
+    ErrorCategory::RequestValidation,
+    ErrorCategory::BudgetExceeded,
+    ErrorCategory::ServiceUnavailable,
+    ErrorCategory::Cancelled,
+    ErrorCategory::Internal,
+];
+
+/// A classified runtime error with taxonomy category and internal message.
+pub struct AuraError {
+    pub category: ErrorCategory,
+    /// Internal message for server-side logging. Never expose to clients.
+    pub internal_message: String,
+}
+
+impl AuraError {
+    pub fn new(category: ErrorCategory, internal_message: impl Into<String>) -> Self {
+        Self { category, internal_message: internal_message.into() }
+    }
+
+    /// Safe message for API responses. Uses fixed generic text per category.
+    /// For RequestValidation, passes through the internal message (client input is safe).
+    pub fn client_message(&self) -> String {
+        match self.category {
+            ErrorCategory::RequestValidation => self.internal_message.clone(),
+            _ => self.category.client_message().to_string(),
         }
     }
 }
 ```
 
-**New: `AuraError` wrapper struct**
-
-```rust
-/// A classified runtime error with taxonomy category, code, and message.
-pub struct AuraError {
-    pub category: ErrorCategory,
-    pub message: String,
-}
-```
-
-**Mapping from existing types:**
+**Mapping from DetectedToolError (in `aura` crate — same crate boundary):**
 
 ```rust
 impl From<&DetectedToolError> for ErrorCategory {
@@ -116,27 +149,34 @@ impl From<&DetectedToolError> for ErrorCategory {
         }
     }
 }
+```
 
+Note: `ToolCallError` maps to `McpToolError` because at the `DetectedToolError` level, the connection/timeout distinction is lost (the error is already an opaque string). Sub-classification of MCP errors into `McpConnectionFailed` vs `McpTimeout` will happen at the MCP execution layer in a future enhancement when richer error types are available from the transport layer.
+
+**Modified: `crates/aura/src/lib.rs`**
+
+Add `pub mod error_taxonomy;` and re-export `ErrorCategory`, `AuraError`, `ALL_CATEGORIES`.
+
+#### `aura-web-server`
+
+**StreamTermination → ErrorCategory mapping (lives HERE, not in `aura` crate):**
+
+```rust
+// In crates/aura-web-server/src/streaming/handlers.rs or a new mapping module
 impl From<&StreamTermination> for ErrorCategory {
     fn from(term: &StreamTermination) -> Self {
         match term {
-            StreamTermination::Complete => ErrorCategory::Internal, // shouldn't be called
+            StreamTermination::Complete => ErrorCategory::Internal, // should not be called on success
             StreamTermination::StreamError(_) => ErrorCategory::LlmError,
             StreamTermination::Disconnected => ErrorCategory::Cancelled,
             StreamTermination::Timeout => ErrorCategory::LlmTimeout,
-            StreamTermination::Shutdown => ErrorCategory::Cancelled,
+            StreamTermination::Shutdown => ErrorCategory::ServiceUnavailable,
         }
     }
 }
 ```
 
-**Modified: `crates/aura/src/lib.rs`**
-
-Add `pub mod error_taxonomy;` and re-export `ErrorCategory` and `AuraError`.
-
-#### `aura-web-server`
-
-**Modified: `crates/aura-web-server/src/types.rs`**
+**Modified: `crates/aura-web-server/src/types.rs` — both error structs:**
 
 ```rust
 #[derive(Debug, Serialize)]
@@ -144,24 +184,42 @@ pub struct ErrorDetail {
     pub message: String,
     #[serde(rename = "type")]
     pub error_type: String,
+    /// Taxonomy error code from ErrorCategory. Additive field.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub code: Option<String>,  // NEW — additive, optional
+    pub code: Option<String>,
+}
+
+// Also update ChatCompletionErrorDetail to include `code` for consistency:
+#[derive(Debug, Serialize)]
+pub struct ChatCompletionErrorDetail {
+    pub message: String,
+    #[serde(rename = "type")]
+    pub error_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub param: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
 }
 ```
 
-**Modified: `crates/aura-web-server/src/handlers.rs`**
+**Modified: `crates/aura-web-server/src/handlers.rs` — error construction:**
 
-Where errors are constructed, include the error code:
+Where errors are built, use `AuraError` for classification and sanitization:
 
 ```rust
-// Before:
-ErrorDetail { message: "...", error_type: "internal_error".to_string() }
+// Before (current code, line 133):
+ErrorDetail {
+    message: format!("Failed to build agent: {e}"),
+    error_type: "internal_error".to_string(),
+}
 
 // After:
+let aura_err = AuraError::new(ErrorCategory::Internal, format!("Failed to build agent: {e}"));
+tracing::warn!(internal_message = %aura_err.internal_message, "Request error");
 ErrorDetail {
-    message: "...",
-    error_type: ErrorCategory::Internal.as_label().to_string(),
-    code: Some(ErrorCategory::Internal.error_code().to_string()),
+    message: aura_err.client_message(),            // generic, safe
+    error_type: "internal_error".to_string(),       // FROZEN — not changed
+    code: Some(aura_err.category.as_label().to_string()), // NEW taxonomy label
 }
 ```
 
@@ -169,20 +227,32 @@ ErrorDetail {
 
 ```
 Tool execution fails
-  → DetectedToolError::McpToolError("connection refused")
-    → ErrorCategory::McpConnectionFailed (via From impl)
-      → AuraError { category: McpConnectionFailed, message: "..." }
-        → ErrorDetail { type: "mcp_connection_failed", code: "AURA-E-MCP-001", message: "..." }
-          → HTTP 500 JSON response
+  → DetectedToolError::McpToolError("connection refused to pagerduty:8080")
+    → ErrorCategory::McpToolError (via From impl in aura crate)
+      → AuraError { category: McpToolError, internal_message: "connection refused..." }
+        → LOGGED: warn!("MCP tool error: connection refused to pagerduty:8080")
+        → API: ErrorDetail {
+            message: "A tool execution error occurred",   // sanitized
+            type: "internal_error",                        // FROZEN
+            code: "mcp_tool_error"                         // NEW taxonomy label
+          }
 
 Stream timeout
   → StreamTermination::Timeout
-    → ErrorCategory::LlmTimeout (via From impl)
-      → ErrorDetail { type: "llm_timeout", code: "AURA-E-LLM-001", message: "..." }
+    → ErrorCategory::LlmTimeout (via From impl in aura-web-server crate)
+      → API: ErrorDetail { type: "internal_error", code: "llm_timeout", message: "..." }
+
+Shutdown guard
+  → ErrorCategory::ServiceUnavailable
+    → API: ErrorDetail { type: "service_unavailable", code: "service_unavailable", message: "..." }
 
 Invalid request
   → ErrorCategory::RequestValidation
-    → ErrorDetail { type: "request_validation", code: "AURA-E-REQ-001", message: "..." }
+    → API: ErrorDetail {
+        type: "invalid_request_error",                     // FROZEN
+        code: "request_validation",
+        message: "Last message must be from user, got: system"  // pass-through (client input)
+      }
 ```
 
 ### Configuration
@@ -191,27 +261,31 @@ No new configuration. The taxonomy is code-defined.
 
 ## Migration / Backward Compatibility
 
-- `ErrorDetail.error_type` strings change from `"internal_error"` to taxonomy labels like `"llm_timeout"`. Clients parsing `error_type` may need updates. This is a **behavioral change** but the `type` field was never documented as stable.
-- New `code` field is additive and `skip_serializing_if = "Option::is_none"`, so it won't appear when None.
-- Existing `BuilderError` enum is unchanged — it covers initialization, not runtime.
+- **`error_type` values are FROZEN**: `"internal_error"`, `"invalid_request_error"`, `"service_unavailable"` remain unchanged. Clients matching on these values are NOT broken.
+- **New `code` field is additive**: Uses `skip_serializing_if = "Option::is_none"` so it only appears when set.
+- **Error messages change**: Client-facing messages become generic. This is a behavioral change but improves security. Clients that parsed error message strings for debugging will need to use server-side logs instead.
+- **Both `ErrorDetail` and `ChatCompletionErrorDetail`** gain the `code` field for consistency.
 
 ## Alternatives Considered
 
 | Approach | Pros | Cons | Why Not |
 |----------|------|------|---------|
-| Extend BuilderError with runtime variants | Single enum | Mixes init and runtime concerns; BuilderError is already used in return types | Violates separation of concerns |
-| Use error codes only (no enum) | Simple strings | No type safety, easy to misspell, no exhaustive matching | Defeats purpose of structured taxonomy |
-| Use thiserror derive macro | Less boilerplate | Adds dependency, not needed for simple enum | Over-engineering for this scope |
+| Change `error_type` values to taxonomy labels | Simpler, one field | Breaks Article I, breaks existing clients | Violates constitution |
+| Add external error code prefix (AURA-E-MCP-001) | Readable codes | Enables system fingerprinting, adds complexity | Security concern outweighs readability |
+| Use thiserror derive | Available (already a workspace dep) | Over-engineering for a classification enum with no error chaining | YAGNI — simple match is sufficient |
 
 ## Risks
 
-- **Behavioral change in error_type strings**: Clients matching on `"internal_error"` will need updates. Mitigated by documenting the change and keeping it within a major version.
-- **Incomplete mapping**: Some error paths may not be covered initially. Mitigated by having an `Internal` catch-all and logging when it's used.
+- **Generic messages reduce debuggability for operators**: Mitigated by logging the full internal message at WARN level. Operators check logs, not API responses.
+- **`mcp_connection_failed` and `mcp_timeout` categories may not be emitted initially**: The `DetectedToolError` → `ErrorCategory` mapping loses this granularity. These categories exist for future use when MCP transport errors are richer. Document this as a known limitation.
+- **Incomplete mapping**: Some error paths may fall through to `Internal`. Mitigated by logging when `Internal` is used so we can add specific categories over time.
 
 ## Implementation Order
 
-1. Create `error_taxonomy.rs` with `ErrorCategory` enum and methods — Satisfies: AC-008.1.1, AC-008.3.1
-2. Add `From` impls for `DetectedToolError` and `StreamTermination` — Satisfies: AC-008.1.2, AC-008.1.3
-3. Add `code` field to `ErrorDetail` — Satisfies: AC-008.2.1, AC-008.2.2
-4. Update handler error construction to use taxonomy — Satisfies: AC-008.2.1
-5. Update existing tests — Satisfies: AC-008.2.2 (backward compat verification)
+1. Create `error_taxonomy.rs` with `ErrorCategory` enum, `ALL_CATEGORIES`, `client_message()`, `as_label()` — Satisfies: AC-008.1.1, AC-008.4.1
+2. Create `AuraError` struct with `new()`, `client_message()` — Satisfies: AC-008.3.1, AC-008.3.2
+3. Add `From<&DetectedToolError>` impl — Satisfies: AC-008.1.2
+4. Add `code` field to both `ErrorDetail` and `ChatCompletionErrorDetail` — Satisfies: AC-008.2.1, AC-008.2.2
+5. Add `From<&StreamTermination>` impl in `aura-web-server` — Satisfies: AC-008.1.3
+6. Update handler error construction to use `AuraError` with sanitization — Satisfies: AC-008.3.1
+7. Unit tests — Satisfies: all ACs via quality spec

--- a/.specify/specs/AURA-RM-008/architecture-spec.md
+++ b/.specify/specs/AURA-RM-008/architecture-spec.md
@@ -176,7 +176,7 @@ impl From<&StreamTermination> for ErrorCategory {
 }
 ```
 
-**Modified: `crates/aura-web-server/src/types.rs` — both error structs:**
+**Modified: `crates/aura-web-server/src/types.rs` — ErrorDetail struct:**
 
 ```rust
 #[derive(Debug, Serialize)]
@@ -184,30 +184,32 @@ pub struct ErrorDetail {
     pub message: String,
     #[serde(rename = "type")]
     pub error_type: String,
-    /// Taxonomy error code from ErrorCategory. Additive field.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub code: Option<String>,
-}
-
-// Also update ChatCompletionErrorDetail to include `code` for consistency:
-#[derive(Debug, Serialize)]
-pub struct ChatCompletionErrorDetail {
-    pub message: String,
-    #[serde(rename = "type")]
-    pub error_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub param: Option<String>,
+    /// Taxonomy label from ErrorCategory. Additive field.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
 }
 ```
 
-**Modified: `crates/aura-web-server/src/handlers.rs` — error construction:**
+**ChatCompletionErrorDetail is NOT modified** — it already has a `code: String` field used for OpenAI-compatible error codes (`"missing_required_parameter"`, `"model_not_found"`). Adding a taxonomy `code` would collide with this existing field and violate Article I. If taxonomy classification is needed on ChatCompletionErrorDetail in the future, use a separate `error_category: Option<String>` field.
+```
 
-Where errors are built, use `AuraError` for classification and sanitization:
+**Modified: `crates/aura-web-server/src/handlers.rs` and `main.rs` — error construction:**
+
+ALL six ErrorDetail construction sites must be updated:
+
+| File | Line | Current error_type | Taxonomy Category |
+|------|------|-------------------|-------------------|
+| handlers.rs | 132 | `"internal_error"` | `Internal` (build agent failure) |
+| handlers.rs | 167 | `"invalid_request_error"` | `RequestValidation` (wrong last message role) |
+| handlers.rs | 175 | `"invalid_request_error"` | `RequestValidation` (empty messages) |
+| handlers.rs | 241 | `"invalid_request_error"` | `RequestValidation` (model not found) |
+| handlers.rs | 545 | `"internal_error"` | `Internal` (completion error) |
+| main.rs | 102 | `"service_unavailable"` | `ServiceUnavailable` (shutdown guard) |
+
+Pattern for each site:
 
 ```rust
-// Before (current code, line 133):
+// Before (current):
 ErrorDetail {
     message: format!("Failed to build agent: {e}"),
     error_type: "internal_error".to_string(),
@@ -217,10 +219,14 @@ ErrorDetail {
 let aura_err = AuraError::new(ErrorCategory::Internal, format!("Failed to build agent: {e}"));
 tracing::warn!(internal_message = %aura_err.internal_message, "Request error");
 ErrorDetail {
-    message: aura_err.client_message(),            // generic, safe
+    message: aura_err.client_message(),             // generic, safe
     error_type: "internal_error".to_string(),       // FROZEN — not changed
     code: Some(aura_err.category.as_label().to_string()), // NEW taxonomy label
 }
+```
+
+**SAFETY NOTE for RequestValidation sites (lines 167, 175, 241):**
+These pass through user-input-derived messages. Only use `RequestValidation` when the message is derived from client input (e.g., "Last message must be from user, got: system"). NEVER classify library/parser errors as `RequestValidation` — those should be `Internal`.
 ```
 
 ### Error Handling Flow

--- a/.specify/specs/AURA-RM-008/architecture-spec.md
+++ b/.specify/specs/AURA-RM-008/architecture-spec.md
@@ -1,0 +1,217 @@
+# Architecture Spec: AURA-RM-008 Structured Error Taxonomy
+
+**Status:** Draft
+**Roadmap Item:** AURA-RM-008
+**Product Spec:** [product-spec.md](product-spec.md)
+**Author:** brandon.shelton
+**Created:** 2026-04-28
+**Last Updated:** 2026-04-28
+
+---
+
+## Summary
+
+Introduce a unified `AuraError` enum in the `aura` crate that classifies all runtime errors into a fixed taxonomy. Map existing error sources (`BuilderError`, `DetectedToolError`, `StreamTermination`) into this taxonomy. Extend the API `ErrorDetail` struct with an `error_code` field. This is a refactoring — no new features, just structured classification of errors that already exist.
+
+## Constitution Compliance Check
+
+- [x] Article I: API responses gain an additive `code` field. Existing `message` and `type` fields unchanged. No breaking change.
+- [x] Article II: `AuraError` lives in `aura` crate (runtime concern). `ErrorDetail` extension is in `aura-web-server` (HTTP concern). Config errors stay in `aura-config`.
+- [x] Article V: No new integration tests needed (unit-testable).
+- [x] Article VI: No secrets involved.
+- [x] Article VII: No config changes.
+
+## Technical Context
+
+- **Language/Version:** Rust (edition 2024, stable 1.93.1)
+- **Affected Crates:** `aura` (new error module), `aura-web-server` (ErrorDetail extension)
+- **New Dependencies:** None
+- **Performance Objectives:** Zero overhead on happy path (error classification only occurs on error)
+
+## Design
+
+### Crate Changes
+
+#### `aura` (core)
+
+**New: `crates/aura/src/error_taxonomy.rs`**
+
+```rust
+/// Unified error taxonomy for all Aura runtime errors.
+/// Each variant maps to a Prometheus-label-safe string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ErrorCategory {
+    LlmTimeout,
+    LlmRateLimit,
+    LlmAuthError,
+    LlmError,
+    McpConnectionFailed,
+    McpToolError,
+    McpTimeout,
+    ConfigValidation,
+    RequestValidation,
+    BudgetExceeded,
+    Cancelled,
+    Internal,
+}
+
+impl ErrorCategory {
+    /// Returns a Prometheus-label-safe string.
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            Self::LlmTimeout => "llm_timeout",
+            Self::LlmRateLimit => "llm_rate_limit",
+            Self::LlmAuthError => "llm_auth_error",
+            Self::LlmError => "llm_error",
+            Self::McpConnectionFailed => "mcp_connection_failed",
+            Self::McpToolError => "mcp_tool_error",
+            Self::McpTimeout => "mcp_timeout",
+            Self::ConfigValidation => "config_validation",
+            Self::RequestValidation => "request_validation",
+            Self::BudgetExceeded => "budget_exceeded",
+            Self::Cancelled => "cancelled",
+            Self::Internal => "internal",
+        }
+    }
+
+    /// Returns the error code (e.g., AURA-E-LLM-001).
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            Self::LlmTimeout => "AURA-E-LLM-001",
+            Self::LlmRateLimit => "AURA-E-LLM-002",
+            Self::LlmAuthError => "AURA-E-LLM-003",
+            Self::LlmError => "AURA-E-LLM-099",
+            Self::McpConnectionFailed => "AURA-E-MCP-001",
+            Self::McpToolError => "AURA-E-MCP-002",
+            Self::McpTimeout => "AURA-E-MCP-003",
+            Self::ConfigValidation => "AURA-E-CFG-001",
+            Self::RequestValidation => "AURA-E-REQ-001",
+            Self::BudgetExceeded => "AURA-E-BDG-001",
+            Self::Cancelled => "AURA-E-CXL-001",
+            Self::Internal => "AURA-E-INT-001",
+        }
+    }
+}
+```
+
+**New: `AuraError` wrapper struct**
+
+```rust
+/// A classified runtime error with taxonomy category, code, and message.
+pub struct AuraError {
+    pub category: ErrorCategory,
+    pub message: String,
+}
+```
+
+**Mapping from existing types:**
+
+```rust
+impl From<&DetectedToolError> for ErrorCategory {
+    fn from(err: &DetectedToolError) -> Self {
+        match err {
+            DetectedToolError::McpToolError(_) => ErrorCategory::McpToolError,
+            DetectedToolError::ToolCallError(_) => ErrorCategory::McpToolError,
+            DetectedToolError::JsonError(_) => ErrorCategory::Internal,
+        }
+    }
+}
+
+impl From<&StreamTermination> for ErrorCategory {
+    fn from(term: &StreamTermination) -> Self {
+        match term {
+            StreamTermination::Complete => ErrorCategory::Internal, // shouldn't be called
+            StreamTermination::StreamError(_) => ErrorCategory::LlmError,
+            StreamTermination::Disconnected => ErrorCategory::Cancelled,
+            StreamTermination::Timeout => ErrorCategory::LlmTimeout,
+            StreamTermination::Shutdown => ErrorCategory::Cancelled,
+        }
+    }
+}
+```
+
+**Modified: `crates/aura/src/lib.rs`**
+
+Add `pub mod error_taxonomy;` and re-export `ErrorCategory` and `AuraError`.
+
+#### `aura-web-server`
+
+**Modified: `crates/aura-web-server/src/types.rs`**
+
+```rust
+#[derive(Debug, Serialize)]
+pub struct ErrorDetail {
+    pub message: String,
+    #[serde(rename = "type")]
+    pub error_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,  // NEW — additive, optional
+}
+```
+
+**Modified: `crates/aura-web-server/src/handlers.rs`**
+
+Where errors are constructed, include the error code:
+
+```rust
+// Before:
+ErrorDetail { message: "...", error_type: "internal_error".to_string() }
+
+// After:
+ErrorDetail {
+    message: "...",
+    error_type: ErrorCategory::Internal.as_label().to_string(),
+    code: Some(ErrorCategory::Internal.error_code().to_string()),
+}
+```
+
+### Error Handling Flow
+
+```
+Tool execution fails
+  → DetectedToolError::McpToolError("connection refused")
+    → ErrorCategory::McpConnectionFailed (via From impl)
+      → AuraError { category: McpConnectionFailed, message: "..." }
+        → ErrorDetail { type: "mcp_connection_failed", code: "AURA-E-MCP-001", message: "..." }
+          → HTTP 500 JSON response
+
+Stream timeout
+  → StreamTermination::Timeout
+    → ErrorCategory::LlmTimeout (via From impl)
+      → ErrorDetail { type: "llm_timeout", code: "AURA-E-LLM-001", message: "..." }
+
+Invalid request
+  → ErrorCategory::RequestValidation
+    → ErrorDetail { type: "request_validation", code: "AURA-E-REQ-001", message: "..." }
+```
+
+### Configuration
+
+No new configuration. The taxonomy is code-defined.
+
+## Migration / Backward Compatibility
+
+- `ErrorDetail.error_type` strings change from `"internal_error"` to taxonomy labels like `"llm_timeout"`. Clients parsing `error_type` may need updates. This is a **behavioral change** but the `type` field was never documented as stable.
+- New `code` field is additive and `skip_serializing_if = "Option::is_none"`, so it won't appear when None.
+- Existing `BuilderError` enum is unchanged — it covers initialization, not runtime.
+
+## Alternatives Considered
+
+| Approach | Pros | Cons | Why Not |
+|----------|------|------|---------|
+| Extend BuilderError with runtime variants | Single enum | Mixes init and runtime concerns; BuilderError is already used in return types | Violates separation of concerns |
+| Use error codes only (no enum) | Simple strings | No type safety, easy to misspell, no exhaustive matching | Defeats purpose of structured taxonomy |
+| Use thiserror derive macro | Less boilerplate | Adds dependency, not needed for simple enum | Over-engineering for this scope |
+
+## Risks
+
+- **Behavioral change in error_type strings**: Clients matching on `"internal_error"` will need updates. Mitigated by documenting the change and keeping it within a major version.
+- **Incomplete mapping**: Some error paths may not be covered initially. Mitigated by having an `Internal` catch-all and logging when it's used.
+
+## Implementation Order
+
+1. Create `error_taxonomy.rs` with `ErrorCategory` enum and methods — Satisfies: AC-008.1.1, AC-008.3.1
+2. Add `From` impls for `DetectedToolError` and `StreamTermination` — Satisfies: AC-008.1.2, AC-008.1.3
+3. Add `code` field to `ErrorDetail` — Satisfies: AC-008.2.1, AC-008.2.2
+4. Update handler error construction to use taxonomy — Satisfies: AC-008.2.1
+5. Update existing tests — Satisfies: AC-008.2.2 (backward compat verification)

--- a/.specify/specs/AURA-RM-008/plan.md
+++ b/.specify/specs/AURA-RM-008/plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan: AURA-RM-008 Structured Error Taxonomy
+
+## Summary
+
+Create `ErrorCategory` enum and `AuraError` struct in the `aura` crate. Add `code` field to `ErrorDetail` in `aura-web-server`. Map existing error sources. Update all 6 error construction sites with sanitization. Unit tests inline.
+
+## Implementation Order
+
+1. New module `error_taxonomy.rs` in `aura` crate with enum + struct + From impls
+2. Expose from `lib.rs`
+3. Add `code: Option<String>` to `ErrorDetail` in `aura-web-server/src/types.rs`
+4. Add `From<&StreamTermination>` in `aura-web-server`
+5. Update all 6 `ErrorDetail` construction sites in handlers.rs and main.rs
+6. Unit tests (inline in both crates)
+
+## Estimated Scope
+
+- 2 new files (error_taxonomy.rs, tests inline)
+- 3 modified files (lib.rs, types.rs, handlers.rs, main.rs)
+- ~200 lines of new code + ~150 lines of tests

--- a/.specify/specs/AURA-RM-008/product-spec.md
+++ b/.specify/specs/AURA-RM-008/product-spec.md
@@ -1,0 +1,130 @@
+# Product Spec: AURA-RM-008 Structured Error Taxonomy
+
+**Status:** Draft
+**Roadmap Item:** AURA-RM-008
+**Author:** brandon.shelton
+**Created:** 2026-04-28
+**Last Updated:** 2026-04-28
+
+---
+
+## Problem Statement
+
+Aura's error handling is ad-hoc. `BuilderError` covers initialization only. Runtime errors (tool failures, LLM timeouts, MCP disconnects, cancellations) flow as unstructured strings. The `error_type` field in API responses uses freeform strings like `"internal_error"` and `"invalid_request_error"` with no consistency. This makes it impossible to:
+- Set differentiated alerts (LLM timeout vs MCP failure)
+- Build programmatic error handling in clients
+- Use error types as metric labels (needed by AURA-RM-001)
+
+## Scope
+
+### In Scope
+- Unified error enum covering all Aura runtime error categories
+- Structured error codes in API responses (`error_code` field)
+- Error classification for: LLM errors, MCP errors, config errors, request validation, budget, internal
+- Backward-compatible API responses (existing fields preserved, new fields additive)
+
+### Out of Scope
+- Retry logic (AURA-RM-003)
+- Circuit breaker state (AURA-RM-003)
+- Metrics recording of errors (AURA-RM-001 — consumes this taxonomy)
+- Error UI/dashboard
+
+## User Stories
+
+### US-008.1: Unified Error Enum
+
+**As a** developer working on Aura,
+**I want** a single error taxonomy that classifies all runtime errors,
+**So that** error handling is consistent and errors can be categorized for metrics and alerting.
+
+**Priority:** P1
+**Rationale:** Foundation for AURA-RM-001, AURA-RM-002, AURA-RM-003, AURA-RM-004, AURA-RM-007
+
+#### Acceptance Criteria
+
+**AC-008.1.1:** Error categories cover all runtime paths
+- **Given** any error that can occur during request processing
+- **When** it is propagated through the system
+- **Then** it can be classified into exactly one of:
+  - `llm_timeout` — LLM provider did not respond within timeout
+  - `llm_rate_limit` — LLM provider returned 429
+  - `llm_auth_error` — LLM provider rejected credentials
+  - `llm_error` — other LLM provider error
+  - `mcp_connection_failed` — MCP server unreachable
+  - `mcp_tool_error` — MCP tool returned an error result
+  - `mcp_timeout` — MCP tool call timed out
+  - `config_validation` — invalid configuration
+  - `request_validation` — invalid client request (bad JSON, empty messages, etc.)
+  - `budget_exceeded` — token budget exhausted (AURA-RM-005)
+  - `cancelled` — client disconnected or request cancelled
+  - `internal` — unexpected internal error
+
+**AC-008.1.2:** Existing DetectedToolError maps to taxonomy
+- **Given** a tool result classified by `tool_error_detection.rs`
+- **When** it is a `ToolCallError`, `JsonError`, or `McpToolError`
+- **Then** it maps to the corresponding taxonomy category (`mcp_tool_error` or `internal`)
+
+**AC-008.1.3:** StreamTermination maps to taxonomy
+- **Given** a streaming request terminates
+- **When** the termination reason is `StreamError`, `Disconnected`, `Timeout`, or `Shutdown`
+- **Then** each maps to the corresponding taxonomy category
+
+### US-008.2: Error Codes in API Responses
+
+**As an** API consumer,
+**I want** error responses to include a structured `error_code` alongside the message,
+**So that** I can build programmatic error handling without parsing error message strings.
+
+**Priority:** P1
+
+#### Acceptance Criteria
+
+**AC-008.2.1:** Error code in response
+- **Given** an error occurs during request processing
+- **When** the error response is returned to the client
+- **Then** the response includes `error_code`:
+  ```json
+  {
+    "error": {
+      "message": "MCP server 'pagerduty' connection refused",
+      "type": "mcp_connection_failed",
+      "code": "AURA-E-MCP-001"
+    }
+  }
+  ```
+
+**AC-008.2.2:** Backward compatible
+- **Given** an existing client that only reads `error.message` and `error.type`
+- **When** an error response is returned with the new `error.code` field
+- **Then** the existing client is not broken (new field is additive)
+
+#### Edge Cases
+- The `type` field already exists as `error_type` (serialized as `type`). The new `code` field is additive.
+- Error codes follow pattern: `AURA-E-<CATEGORY>-<NNN>`
+
+### US-008.3: Error Type as Metric Label
+
+**As an** operator,
+**I want** the error taxonomy to produce string labels suitable for Prometheus metrics,
+**So that** AURA-RM-001 can use `error_type` as a metric label without transformation.
+
+**Priority:** P1
+
+#### Acceptance Criteria
+
+**AC-008.3.1:** Label-safe error type strings
+- **Given** the error taxonomy enum
+- **When** converted to a string label
+- **Then** the result is lowercase, underscore-separated, and Prometheus-label-safe (e.g., `mcp_connection_failed`, `llm_timeout`)
+
+## Dependencies
+
+- **Depends on:** Nothing (foundation item)
+- **Depended on by:** AURA-RM-001 (Metrics), AURA-RM-002 (Health), AURA-RM-003 (Circuit Breaker), AURA-RM-004 (Auth), AURA-RM-007 (Incident Response)
+
+## Success Criteria
+
+- All runtime error paths produce a classified error with taxonomy category
+- API error responses include the new `code` field
+- Existing tests and API clients are not broken
+- Error type strings are usable as Prometheus metric labels

--- a/.specify/specs/AURA-RM-008/product-spec.md
+++ b/.specify/specs/AURA-RM-008/product-spec.md
@@ -1,6 +1,6 @@
 # Product Spec: AURA-RM-008 Structured Error Taxonomy
 
-**Status:** Draft
+**Status:** In Review (Remediation Round 1)
 **Roadmap Item:** AURA-RM-008
 **Author:** brandon.shelton
 **Created:** 2026-04-28
@@ -10,18 +10,20 @@
 
 ## Problem Statement
 
-Aura's error handling is ad-hoc. `BuilderError` covers initialization only. Runtime errors (tool failures, LLM timeouts, MCP disconnects, cancellations) flow as unstructured strings. The `error_type` field in API responses uses freeform strings like `"internal_error"` and `"invalid_request_error"` with no consistency. This makes it impossible to:
+Aura's error handling is ad-hoc. `BuilderError` covers initialization only. Runtime errors (tool failures, LLM timeouts, MCP disconnects, cancellations) flow as unstructured strings. The `error_type` field in API responses uses freeform strings like `"internal_error"` and `"invalid_request_error"` with no consistency. Error messages contain internal implementation details (MCP server names, hostnames, library errors) that leak to API consumers. This makes it impossible to:
 - Set differentiated alerts (LLM timeout vs MCP failure)
 - Build programmatic error handling in clients
 - Use error types as metric labels (needed by AURA-RM-001)
+- Prevent information disclosure to untrusted callers
 
 ## Scope
 
 ### In Scope
 - Unified error enum covering all Aura runtime error categories
-- Structured error codes in API responses (`error_code` field)
-- Error classification for: LLM errors, MCP errors, config errors, request validation, budget, internal
-- Backward-compatible API responses (existing fields preserved, new fields additive)
+- Structured error codes in API responses (`code` field — additive)
+- Error classification for: LLM errors, MCP errors, config errors, request validation, budget, service unavailable, cancellation, internal
+- Error message sanitization: separate internal messages (for logs) from client-facing messages (for API responses)
+- Backward-compatible API responses: existing `type` field values PRESERVED, new `code` field is additive
 
 ### Out of Scope
 - Retry logic (AURA-RM-003)
@@ -56,53 +58,102 @@ Aura's error handling is ad-hoc. `BuilderError` covers initialization only. Runt
   - `config_validation` — invalid configuration
   - `request_validation` — invalid client request (bad JSON, empty messages, etc.)
   - `budget_exceeded` — token budget exhausted (AURA-RM-005)
+  - `service_unavailable` — server shutting down or overloaded
   - `cancelled` — client disconnected or request cancelled
   - `internal` — unexpected internal error
 
 **AC-008.1.2:** Existing DetectedToolError maps to taxonomy
 - **Given** a tool result classified by `tool_error_detection.rs`
 - **When** it is a `ToolCallError`, `JsonError`, or `McpToolError`
-- **Then** it maps to the corresponding taxonomy category (`mcp_tool_error` or `internal`)
+- **Then** each maps to the corresponding taxonomy category:
+  - `McpToolError` → `mcp_tool_error`
+  - `ToolCallError` → `mcp_tool_error` (generic tool execution failure)
+  - `JsonError` → `internal`
 
 **AC-008.1.3:** StreamTermination maps to taxonomy
 - **Given** a streaming request terminates
 - **When** the termination reason is `StreamError`, `Disconnected`, `Timeout`, or `Shutdown`
-- **Then** each maps to the corresponding taxonomy category
+- **Then** each maps to the corresponding taxonomy category:
+  - `StreamError` → `llm_error`
+  - `Disconnected` → `cancelled`
+  - `Timeout` → `llm_timeout`
+  - `Shutdown` → `service_unavailable`
+
+Note: The `StreamTermination` → `ErrorCategory` mapping lives in `aura-web-server` (not `aura`), because `StreamTermination` is defined in the web server crate.
 
 ### US-008.2: Error Codes in API Responses
 
 **As an** API consumer,
-**I want** error responses to include a structured `error_code` alongside the message,
+**I want** error responses to include a structured `code` field alongside the existing fields,
 **So that** I can build programmatic error handling without parsing error message strings.
 
 **Priority:** P1
 
 #### Acceptance Criteria
 
-**AC-008.2.1:** Error code in response
+**AC-008.2.1:** Error code in response (additive only)
 - **Given** an error occurs during request processing
 - **When** the error response is returned to the client
-- **Then** the response includes `error_code`:
+- **Then** the response includes a new `code` field:
   ```json
   {
     "error": {
-      "message": "MCP server 'pagerduty' connection refused",
-      "type": "mcp_connection_failed",
-      "code": "AURA-E-MCP-001"
+      "message": "A downstream service is temporarily unavailable",
+      "type": "internal_error",
+      "code": "mcp_connection_failed"
     }
   }
   ```
+- **And** the existing `type` field retains its current values (`"internal_error"`, `"invalid_request_error"`, `"service_unavailable"`) — these are NOT changed to taxonomy labels (Article I compliance)
+- **And** the new `code` field uses the taxonomy label (e.g., `mcp_connection_failed`, `llm_timeout`)
 
 **AC-008.2.2:** Backward compatible
 - **Given** an existing client that only reads `error.message` and `error.type`
 - **When** an error response is returned with the new `error.code` field
-- **Then** the existing client is not broken (new field is additive)
+- **Then** the existing client is not broken (new field is additive, existing values unchanged)
 
 #### Edge Cases
-- The `type` field already exists as `error_type` (serialized as `type`). The new `code` field is additive.
-- Error codes follow pattern: `AURA-E-<CATEGORY>-<NNN>`
+- The `type` field values are FROZEN at their current values. Only the new `code` field uses taxonomy labels.
+- Both `ErrorDetail` and `ChatCompletionErrorDetail` structs gain the `code` field for consistency.
 
-### US-008.3: Error Type as Metric Label
+### US-008.3: Error Message Sanitization
+
+**As a** security-conscious operator,
+**I want** client-facing error messages to be generic and not leak internal details,
+**So that** API consumers cannot learn about internal MCP server names, hostnames, or library internals.
+
+**Priority:** P1
+
+#### Acceptance Criteria
+
+**AC-008.3.1:** Client messages are generic
+- **Given** an internal error like "MCP server 'pagerduty' at 10.0.1.5:8080 connection refused"
+- **When** the error response is returned to the client
+- **Then** the `message` field contains a safe, generic string like "A downstream service is temporarily unavailable"
+- **And** the full internal message is logged server-side at WARN or ERROR level
+
+**AC-008.3.2:** Each error category has a fixed client message
+- **Given** the error taxonomy
+- **When** any category is converted to a client-facing message
+- **Then** it uses one of these fixed messages:
+
+| Category | Client Message |
+|----------|---------------|
+| `llm_timeout` | "The language model did not respond in time" |
+| `llm_rate_limit` | "The language model is temporarily rate limited" |
+| `llm_auth_error` | "An authentication error occurred with an upstream provider" |
+| `llm_error` | "An error occurred with the language model" |
+| `mcp_connection_failed` | "A downstream service is temporarily unavailable" |
+| `mcp_tool_error` | "A tool execution error occurred" |
+| `mcp_timeout` | "A tool call did not respond in time" |
+| `config_validation` | "Server configuration error" |
+| `request_validation` | (pass through — client input errors are safe to show) |
+| `budget_exceeded` | "Token budget exceeded for this request" |
+| `service_unavailable` | "Server is shutting down" |
+| `cancelled` | "Request was cancelled" |
+| `internal` | "An internal error occurred" |
+
+### US-008.4: Error Type as Metric Label
 
 **As an** operator,
 **I want** the error taxonomy to produce string labels suitable for Prometheus metrics,
@@ -112,10 +163,10 @@ Aura's error handling is ad-hoc. `BuilderError` covers initialization only. Runt
 
 #### Acceptance Criteria
 
-**AC-008.3.1:** Label-safe error type strings
+**AC-008.4.1:** Label-safe error type strings
 - **Given** the error taxonomy enum
 - **When** converted to a string label
-- **Then** the result is lowercase, underscore-separated, and Prometheus-label-safe (e.g., `mcp_connection_failed`, `llm_timeout`)
+- **Then** the result is lowercase, underscore-separated, and Prometheus-label-safe (matches `^[a-z][a-z0-9_]*$`)
 
 ## Dependencies
 
@@ -125,6 +176,12 @@ Aura's error handling is ad-hoc. `BuilderError` covers initialization only. Runt
 ## Success Criteria
 
 - All runtime error paths produce a classified error with taxonomy category
-- API error responses include the new `code` field
+- API error responses include the new `code` field while preserving existing `type` values
+- Client-facing messages never contain internal hostnames, server names, or library errors
+- Internal details are logged server-side for debugging
 - Existing tests and API clients are not broken
 - Error type strings are usable as Prometheus metric labels
+
+## Open Questions
+
+- None remaining after review remediation

--- a/.specify/specs/AURA-RM-008/product-spec.md
+++ b/.specify/specs/AURA-RM-008/product-spec.md
@@ -114,7 +114,8 @@ Note: The `StreamTermination` → `ErrorCategory` mapping lives in `aura-web-ser
 
 #### Edge Cases
 - The `type` field values are FROZEN at their current values. Only the new `code` field uses taxonomy labels.
-- Both `ErrorDetail` and `ChatCompletionErrorDetail` structs gain the `code` field for consistency.
+- `ErrorDetail` gains a new `code: Option<String>` field for the taxonomy label.
+- `ChatCompletionErrorDetail` already has a `code: String` field used for OpenAI-compatible error codes (`"missing_required_parameter"`, `"model_not_found"`). This field is LEFT UNCHANGED. A separate `error_category: Option<String>` field is added for the taxonomy label to avoid collision.
 
 ### US-008.3: Error Message Sanitization
 
@@ -147,7 +148,7 @@ Note: The `StreamTermination` → `ErrorCategory` mapping lives in `aura-web-ser
 | `mcp_tool_error` | "A tool execution error occurred" |
 | `mcp_timeout` | "A tool call did not respond in time" |
 | `config_validation` | "Server configuration error" |
-| `request_validation` | (pass through — client input errors are safe to show) |
+| `request_validation` | "Invalid request" (default), or pass-through of the user-input-derived message via `AuraError::client_message()`. SAFETY: only pass through messages derived from client input, never library error strings. |
 | `budget_exceeded` | "Token budget exceeded for this request" |
 | `service_unavailable` | "Server is shutting down" |
 | `cancelled` | "Request was cancelled" |

--- a/.specify/specs/AURA-RM-008/quality-spec.md
+++ b/.specify/specs/AURA-RM-008/quality-spec.md
@@ -1,0 +1,145 @@
+# Quality & Testing Spec: AURA-RM-008 Structured Error Taxonomy
+
+**Status:** Draft
+**Roadmap Item:** AURA-RM-008
+**Product Spec:** [product-spec.md](product-spec.md)
+**Architecture Spec:** [architecture-spec.md](architecture-spec.md)
+**Author:** brandon.shelton
+**Created:** 2026-04-28
+**Last Updated:** 2026-04-28
+
+---
+
+## Test Strategy
+
+- **Unit Tests:** All ErrorCategory methods, From impls, label/code generation
+- **Integration Tests:** Not needed (pure enum + mapping logic)
+- **End-to-End Tests:** Not needed (consumed by AURA-RM-001)
+
+## Acceptance Criteria Traceability
+
+| Acceptance Criterion | Test Type | Test Case ID | Test Location | Status |
+|---------------------|-----------|-------------|---------------|--------|
+| AC-008.1.1 (categories cover all paths) | Unit | TC-008.1.1.1 | `crates/aura/src/error_taxonomy_tests.rs::test_all_categories_have_labels` | Pending |
+| AC-008.1.1 (categories cover all paths) | Unit | TC-008.1.1.2 | `...::test_all_categories_have_error_codes` | Pending |
+| AC-008.1.2 (DetectedToolError maps) | Unit | TC-008.1.2.1 | `...::test_detected_tool_error_to_category` | Pending |
+| AC-008.1.3 (StreamTermination maps) | Unit | TC-008.1.3.1 | `...::test_stream_termination_to_category` | Pending |
+| AC-008.2.1 (error code in response) | Unit | TC-008.2.1.1 | `crates/aura-web-server/src/types_tests.rs::test_error_detail_with_code` | Pending |
+| AC-008.2.2 (backward compat) | Unit | TC-008.2.2.1 | `...::test_error_detail_without_code_serializes_clean` | Pending |
+| AC-008.3.1 (label-safe strings) | Unit | TC-008.3.1.1 | `...::test_labels_are_prometheus_safe` | Pending |
+
+## Test Cases
+
+### TC-008.1.1.1: All categories produce non-empty labels
+
+**Satisfies:** AC-008.1.1
+**Type:** Unit
+**Location:** `crates/aura/src/error_taxonomy_tests.rs::test_all_categories_have_labels`
+
+**Steps:**
+1. Iterate all `ErrorCategory` variants
+2. Call `as_label()` on each
+
+**Expected Result:**
+- Every variant returns a non-empty `&'static str`
+- Every label is lowercase and contains only `[a-z_]` characters
+
+### TC-008.1.1.2: All categories produce non-empty error codes
+
+**Satisfies:** AC-008.1.1
+**Type:** Unit
+**Location:** `crates/aura/src/error_taxonomy_tests.rs::test_all_categories_have_error_codes`
+
+**Steps:**
+1. Iterate all `ErrorCategory` variants
+2. Call `error_code()` on each
+
+**Expected Result:**
+- Every variant returns a non-empty `&'static str`
+- Every code matches pattern `AURA-E-[A-Z]{3}-[0-9]{3}`
+
+### TC-008.1.2.1: DetectedToolError maps to correct category
+
+**Satisfies:** AC-008.1.2
+**Type:** Unit
+**Location:** `crates/aura/src/error_taxonomy_tests.rs::test_detected_tool_error_to_category`
+
+**Steps:**
+1. Create each `DetectedToolError` variant
+2. Convert to `ErrorCategory` via `From`
+
+**Expected Result:**
+- `McpToolError(_)` → `ErrorCategory::McpToolError`
+- `ToolCallError(_)` → `ErrorCategory::McpToolError`
+- `JsonError(_)` → `ErrorCategory::Internal`
+
+### TC-008.1.3.1: StreamTermination maps to correct category
+
+**Satisfies:** AC-008.1.3
+**Type:** Unit
+**Location:** `crates/aura/src/error_taxonomy_tests.rs::test_stream_termination_to_category`
+
+**Steps:**
+1. Create each `StreamTermination` variant
+2. Convert to `ErrorCategory` via `From`
+
+**Expected Result:**
+- `StreamError(_)` → `ErrorCategory::LlmError`
+- `Disconnected` → `ErrorCategory::Cancelled`
+- `Timeout` → `ErrorCategory::LlmTimeout`
+- `Shutdown` → `ErrorCategory::Cancelled`
+
+### TC-008.2.1.1: ErrorDetail serializes with code field
+
+**Satisfies:** AC-008.2.1
+**Type:** Unit
+**Location:** `crates/aura-web-server/src/types_tests.rs::test_error_detail_with_code`
+
+**Steps:**
+1. Create `ErrorDetail` with `code: Some("AURA-E-MCP-001".to_string())`
+2. Serialize to JSON
+
+**Expected Result:**
+- JSON contains `"code": "AURA-E-MCP-001"`
+- JSON also contains `"type"` and `"message"` fields
+
+### TC-008.2.2.1: ErrorDetail without code serializes cleanly
+
+**Satisfies:** AC-008.2.2
+**Type:** Unit
+**Location:** `crates/aura-web-server/src/types_tests.rs::test_error_detail_without_code`
+
+**Steps:**
+1. Create `ErrorDetail` with `code: None`
+2. Serialize to JSON
+
+**Expected Result:**
+- JSON does NOT contain `"code"` key (skip_serializing_if works)
+- JSON still contains `"type"` and `"message"`
+
+### TC-008.3.1.1: All labels are Prometheus-safe
+
+**Satisfies:** AC-008.3.1
+**Type:** Unit
+**Location:** `crates/aura/src/error_taxonomy_tests.rs::test_labels_are_prometheus_safe`
+
+**Steps:**
+1. Iterate all `ErrorCategory` variants
+2. Check each label against regex `^[a-z][a-z0-9_]*$`
+
+**Expected Result:**
+- All labels match the Prometheus label name pattern
+
+## Quality Gates
+
+- [x] All unit tests pass (`cargo test --workspace --lib`)
+- [ ] Zero compiler warnings
+- [ ] Clippy clean
+- [ ] Code formatted
+- [ ] No regressions in existing test suite
+- [ ] Every AC has at least one passing test (see traceability table)
+
+## Coverage Notes
+
+- LLM provider-specific error classification (rate limit vs auth vs other) depends on parsing provider error responses. Initial implementation may classify all LLM errors as `llm_error` and refine in a follow-up.
+- `BudgetExceeded` category is defined but will not be exercised until AURA-RM-005 is implemented.

--- a/.specify/specs/AURA-RM-008/quality-spec.md
+++ b/.specify/specs/AURA-RM-008/quality-spec.md
@@ -84,6 +84,7 @@
 2. Convert to `ErrorCategory` via `From`
 
 **Expected Result:**
+- `Complete` → `ErrorCategory::Internal` (defensive case — should not be called on success path)
 - `StreamError("err")` → `ErrorCategory::LlmError`
 - `Disconnected` → `ErrorCategory::Cancelled`
 - `Timeout` → `ErrorCategory::LlmTimeout`

--- a/.specify/specs/AURA-RM-008/quality-spec.md
+++ b/.specify/specs/AURA-RM-008/quality-spec.md
@@ -1,6 +1,6 @@
 # Quality & Testing Spec: AURA-RM-008 Structured Error Taxonomy
 
-**Status:** Draft
+**Status:** In Review (Remediation Round 1)
 **Roadmap Item:** AURA-RM-008
 **Product Spec:** [product-spec.md](product-spec.md)
 **Architecture Spec:** [architecture-spec.md](architecture-spec.md)
@@ -12,21 +12,23 @@
 
 ## Test Strategy
 
-- **Unit Tests:** All ErrorCategory methods, From impls, label/code generation
-- **Integration Tests:** Not needed (pure enum + mapping logic)
+- **Unit Tests:** All ErrorCategory methods, From impls, label/message generation, AuraError sanitization. Tests use `#[cfg(test)] mod tests` inline in the source files (matching project convention).
+- **Integration Tests:** Not needed (pure enum + mapping logic, no I/O)
 - **End-to-End Tests:** Not needed (consumed by AURA-RM-001)
 
 ## Acceptance Criteria Traceability
 
 | Acceptance Criterion | Test Type | Test Case ID | Test Location | Status |
 |---------------------|-----------|-------------|---------------|--------|
-| AC-008.1.1 (categories cover all paths) | Unit | TC-008.1.1.1 | `crates/aura/src/error_taxonomy_tests.rs::test_all_categories_have_labels` | Pending |
-| AC-008.1.1 (categories cover all paths) | Unit | TC-008.1.1.2 | `...::test_all_categories_have_error_codes` | Pending |
-| AC-008.1.2 (DetectedToolError maps) | Unit | TC-008.1.2.1 | `...::test_detected_tool_error_to_category` | Pending |
-| AC-008.1.3 (StreamTermination maps) | Unit | TC-008.1.3.1 | `...::test_stream_termination_to_category` | Pending |
-| AC-008.2.1 (error code in response) | Unit | TC-008.2.1.1 | `crates/aura-web-server/src/types_tests.rs::test_error_detail_with_code` | Pending |
-| AC-008.2.2 (backward compat) | Unit | TC-008.2.2.1 | `...::test_error_detail_without_code_serializes_clean` | Pending |
-| AC-008.3.1 (label-safe strings) | Unit | TC-008.3.1.1 | `...::test_labels_are_prometheus_safe` | Pending |
+| AC-008.1.1 (categories cover all paths) | Unit | TC-008.1.1.1 | `crates/aura/src/error_taxonomy.rs` inline tests | Pending |
+| AC-008.1.1 (categories cover all paths) | Unit | TC-008.1.1.2 | `crates/aura/src/error_taxonomy.rs` inline tests | Pending |
+| AC-008.1.2 (DetectedToolError maps) | Unit | TC-008.1.2.1 | `crates/aura/src/error_taxonomy.rs` inline tests | Pending |
+| AC-008.1.3 (StreamTermination maps) | Unit | TC-008.1.3.1 | `crates/aura-web-server/src/streaming/handlers.rs` inline tests | Pending |
+| AC-008.2.1 (code in response) | Unit | TC-008.2.1.1 | `crates/aura-web-server/src/types.rs` inline tests | Pending |
+| AC-008.2.2 (backward compat) | Unit | TC-008.2.2.1 | `crates/aura-web-server/src/types.rs` inline tests | Pending |
+| AC-008.3.1 (client messages generic) | Unit | TC-008.3.1.1 | `crates/aura/src/error_taxonomy.rs` inline tests | Pending |
+| AC-008.3.2 (fixed client messages) | Unit | TC-008.3.2.1 | `crates/aura/src/error_taxonomy.rs` inline tests | Pending |
+| AC-008.4.1 (label-safe strings) | Unit | TC-008.4.1.1 | `crates/aura/src/error_taxonomy.rs` inline tests | Pending |
 
 ## Test Cases
 
@@ -34,97 +36,118 @@
 
 **Satisfies:** AC-008.1.1
 **Type:** Unit
-**Location:** `crates/aura/src/error_taxonomy_tests.rs::test_all_categories_have_labels`
 
 **Steps:**
-1. Iterate all `ErrorCategory` variants
+1. Iterate all variants via `ALL_CATEGORIES` constant (avoids need for proc macro / strum)
 2. Call `as_label()` on each
 
 **Expected Result:**
 - Every variant returns a non-empty `&'static str`
-- Every label is lowercase and contains only `[a-z_]` characters
+- Every label matches regex `^[a-z][a-z0-9_]*$`
+- No two variants share the same label
 
-### TC-008.1.1.2: All categories produce non-empty error codes
+### TC-008.1.1.2: All categories produce non-empty client messages
 
 **Satisfies:** AC-008.1.1
 **Type:** Unit
-**Location:** `crates/aura/src/error_taxonomy_tests.rs::test_all_categories_have_error_codes`
 
 **Steps:**
-1. Iterate all `ErrorCategory` variants
-2. Call `error_code()` on each
+1. Iterate all variants via `ALL_CATEGORIES`
+2. Call `client_message()` on each
 
 **Expected Result:**
 - Every variant returns a non-empty `&'static str`
-- Every code matches pattern `AURA-E-[A-Z]{3}-[0-9]{3}`
+- No message contains common internal patterns: IP addresses, port numbers, hostnames, file paths, stack traces
 
 ### TC-008.1.2.1: DetectedToolError maps to correct category
 
 **Satisfies:** AC-008.1.2
 **Type:** Unit
-**Location:** `crates/aura/src/error_taxonomy_tests.rs::test_detected_tool_error_to_category`
 
 **Steps:**
 1. Create each `DetectedToolError` variant
 2. Convert to `ErrorCategory` via `From`
 
 **Expected Result:**
-- `McpToolError(_)` → `ErrorCategory::McpToolError`
-- `ToolCallError(_)` → `ErrorCategory::McpToolError`
-- `JsonError(_)` → `ErrorCategory::Internal`
+- `McpToolError("any message")` → `ErrorCategory::McpToolError`
+- `ToolCallError("any message")` → `ErrorCategory::McpToolError`
+- `JsonError("any message")` → `ErrorCategory::Internal`
 
 ### TC-008.1.3.1: StreamTermination maps to correct category
 
 **Satisfies:** AC-008.1.3
 **Type:** Unit
-**Location:** `crates/aura/src/error_taxonomy_tests.rs::test_stream_termination_to_category`
+**Location:** `crates/aura-web-server` (StreamTermination is defined here)
 
 **Steps:**
 1. Create each `StreamTermination` variant
 2. Convert to `ErrorCategory` via `From`
 
 **Expected Result:**
-- `StreamError(_)` → `ErrorCategory::LlmError`
+- `StreamError("err")` → `ErrorCategory::LlmError`
 - `Disconnected` → `ErrorCategory::Cancelled`
 - `Timeout` → `ErrorCategory::LlmTimeout`
-- `Shutdown` → `ErrorCategory::Cancelled`
+- `Shutdown` → `ErrorCategory::ServiceUnavailable`
 
 ### TC-008.2.1.1: ErrorDetail serializes with code field
 
 **Satisfies:** AC-008.2.1
 **Type:** Unit
-**Location:** `crates/aura-web-server/src/types_tests.rs::test_error_detail_with_code`
 
 **Steps:**
-1. Create `ErrorDetail` with `code: Some("AURA-E-MCP-001".to_string())`
+1. Create `ErrorDetail` with `code: Some("mcp_tool_error".to_string())`
 2. Serialize to JSON
 
 **Expected Result:**
-- JSON contains `"code": "AURA-E-MCP-001"`
+- JSON contains `"code": "mcp_tool_error"`
 - JSON also contains `"type"` and `"message"` fields
 
 ### TC-008.2.2.1: ErrorDetail without code serializes cleanly
 
 **Satisfies:** AC-008.2.2
 **Type:** Unit
-**Location:** `crates/aura-web-server/src/types_tests.rs::test_error_detail_without_code`
 
 **Steps:**
 1. Create `ErrorDetail` with `code: None`
 2. Serialize to JSON
 
 **Expected Result:**
-- JSON does NOT contain `"code"` key (skip_serializing_if works)
+- JSON does NOT contain `"code"` key (`skip_serializing_if` works)
 - JSON still contains `"type"` and `"message"`
 
-### TC-008.3.1.1: All labels are Prometheus-safe
+### TC-008.3.1.1: AuraError client_message never contains internal details
 
 **Satisfies:** AC-008.3.1
 **Type:** Unit
-**Location:** `crates/aura/src/error_taxonomy_tests.rs::test_labels_are_prometheus_safe`
 
 **Steps:**
-1. Iterate all `ErrorCategory` variants
+1. Create `AuraError` with internal_message containing hostnames and IPs:
+   `AuraError::new(McpConnectionFailed, "MCP server 'pagerduty' at 10.0.1.5:8080 connection refused")`
+2. Call `client_message()`
+
+**Expected Result:**
+- Returns "A downstream service is temporarily unavailable"
+- Does NOT contain "pagerduty", "10.0.1.5", "8080", or "connection refused"
+
+### TC-008.3.2.1: RequestValidation passes through client message
+
+**Satisfies:** AC-008.3.2
+**Type:** Unit
+
+**Steps:**
+1. Create `AuraError::new(RequestValidation, "Last message must be from user, got: system")`
+2. Call `client_message()`
+
+**Expected Result:**
+- Returns "Last message must be from user, got: system" (pass-through, since this is client input)
+
+### TC-008.4.1.1: All labels are Prometheus-safe
+
+**Satisfies:** AC-008.4.1
+**Type:** Unit
+
+**Steps:**
+1. Iterate all variants via `ALL_CATEGORIES`
 2. Check each label against regex `^[a-z][a-z0-9_]*$`
 
 **Expected Result:**
@@ -132,14 +155,15 @@
 
 ## Quality Gates
 
-- [x] All unit tests pass (`cargo test --workspace --lib`)
+- [ ] All unit tests pass (`cargo test --workspace --lib`)
 - [ ] Zero compiler warnings
-- [ ] Clippy clean
-- [ ] Code formatted
+- [ ] Clippy clean (`cargo clippy --all-targets -- -D warnings`)
+- [ ] Code formatted (`cargo fmt --check`)
 - [ ] No regressions in existing test suite
 - [ ] Every AC has at least one passing test (see traceability table)
 
 ## Coverage Notes
 
-- LLM provider-specific error classification (rate limit vs auth vs other) depends on parsing provider error responses. Initial implementation may classify all LLM errors as `llm_error` and refine in a follow-up.
-- `BudgetExceeded` category is defined but will not be exercised until AURA-RM-005 is implemented.
+- `mcp_connection_failed` and `mcp_timeout` categories are defined but will not be emitted by `From<&DetectedToolError>` — they exist for future MCP transport layer classification. Tests verify the enum variant exists and has correct label/message, but no From impl produces them yet.
+- `BudgetExceeded` category is defined but will not be exercised until AURA-RM-005.
+- `LlmRateLimit` and `LlmAuthError` require parsing provider-specific error responses — initial implementation may classify all LLM errors as `llm_error` and refine later.

--- a/.specify/specs/AURA-RM-008/reviews/spec-review-001.md
+++ b/.specify/specs/AURA-RM-008/reviews/spec-review-001.md
@@ -1,0 +1,29 @@
+# Spec Review Round 1: AURA-RM-008
+
+**Date:** 2026-04-28
+**Reviewers:** Consistency Agent, Security Agent, Operability Agent
+
+## Findings Summary
+
+| # | Category | Finding | Resolution |
+|---|----------|---------|------------|
+| 1 | Must Fix | Article I risk: changing error_type values breaks clients | FIXED — error_type values FROZEN, new `code` field is additive |
+| 2 | Must Fix | StreamTermination From impl in wrong crate (circular dep) | FIXED — From impl moved to aura-web-server |
+| 3 | Must Fix | Error flow diagram contradicts From impl code | FIXED — diagram corrected |
+| 4 | Must Fix | thiserror rejection uses wrong rationale | FIXED — corrected to "YAGNI" |
+| 5 | Must Fix | Error messages leak internal MCP server names to clients | FIXED — added sanitization layer with client_message() |
+| 6 | Must Fix | No error message sanitization layer | FIXED — AuraError has internal_message + client_message() |
+| 7 | Must Fix | Error flow diagram shows McpConnectionFailed but impl maps to McpToolError | FIXED — diagram matches impl |
+| 8 | Should Fix | Missing service_unavailable in taxonomy | FIXED — added |
+| 9 | Should Fix | Two ErrorDetail structs, spec only addresses one | FIXED — both gain code field |
+| 10 | Should Fix | ToolCallError maps too broadly | DOCUMENTED — known limitation, future refinement |
+| 11 | Should Fix | Article V: integration feature flag not defined | FIXED — not needed for RM-008 (unit tests only) |
+| 12 | Should Fix | Dead categories (mcp_connection_failed, mcp_timeout) | DOCUMENTED — exist for future transport layer |
+| 13 | Should Fix | Error code prefix enables fingerprinting | FIXED — removed AURA-E- prefix, code field uses taxonomy label directly |
+| 14 | Should Fix | Test file location non-standard | FIXED — inline tests in source files |
+| 15 | Should Fix | Pre-checked quality gate | FIXED — all unchecked |
+| 16 | Nit | Error code 099 sentinel | FIXED — no separate error codes, just taxonomy labels |
+| 17 | Nit | Enum iteration needs manual list | FIXED — ALL_CATEGORIES const |
+| 18 | Nit | Constitution check omits Article IV | FIXED — added |
+
+## Status: All findings resolved. Ready for re-review.

--- a/.specify/specs/AURA-RM-008/tasks.md
+++ b/.specify/specs/AURA-RM-008/tasks.md
@@ -1,0 +1,76 @@
+# Tasks: AURA-RM-008 Structured Error Taxonomy
+
+## Task 1: Create ErrorCategory enum and AuraError struct
+
+**Status:** Pending
+**File:** `crates/aura/src/error_taxonomy.rs`
+**Satisfies:** AC-008.1.1, AC-008.3.1, AC-008.3.2, AC-008.4.1
+**Dependencies:** None
+
+- [ ] Create `ErrorCategory` enum with all 13 variants
+- [ ] Implement `as_label()` returning Prometheus-safe strings
+- [ ] Implement `client_message()` returning generic safe messages
+- [ ] Create `ALL_CATEGORIES` const for test iteration
+- [ ] Create `AuraError` struct with `category`, `internal_message`
+- [ ] Implement `AuraError::new()` and `AuraError::client_message()` (pass-through for RequestValidation)
+- [ ] Inline unit tests: labels non-empty, labels match regex, client messages don't contain IPs/hostnames, all categories unique
+
+## Task 2: Add From<&DetectedToolError> impl
+
+**Status:** Pending
+**File:** `crates/aura/src/error_taxonomy.rs`
+**Satisfies:** AC-008.1.2
+**Dependencies:** Task 1
+
+- [ ] Implement `From<&DetectedToolError> for ErrorCategory`
+- [ ] McpToolError → McpToolError, ToolCallError → McpToolError, JsonError → Internal
+- [ ] Inline unit tests verifying each mapping
+
+## Task 3: Export from lib.rs
+
+**Status:** Pending
+**File:** `crates/aura/src/lib.rs`
+**Satisfies:** N/A (infrastructure)
+**Dependencies:** Task 1
+
+- [ ] Add `pub mod error_taxonomy;`
+- [ ] Add `pub use error_taxonomy::{ErrorCategory, AuraError, ALL_CATEGORIES};`
+
+## Task 4: Add code field to ErrorDetail
+
+**Status:** Pending
+**File:** `crates/aura-web-server/src/types.rs`
+**Satisfies:** AC-008.2.1, AC-008.2.2
+**Dependencies:** Task 1
+
+- [ ] Add `code: Option<String>` with `#[serde(skip_serializing_if = "Option::is_none")]` to `ErrorDetail`
+- [ ] Do NOT modify `ChatCompletionErrorDetail` (existing `code` field is for OpenAI-compatible codes)
+- [ ] Inline unit tests: serialization with code present, serialization with code None (field absent)
+
+## Task 5: Add From<&StreamTermination> impl
+
+**Status:** Pending
+**File:** `crates/aura-web-server/src/streaming/handlers.rs` (or new mapping module)
+**Satisfies:** AC-008.1.3
+**Dependencies:** Task 1, Task 3
+
+- [ ] Implement `From<&StreamTermination> for ErrorCategory`
+- [ ] Complete→Internal, StreamError→LlmError, Disconnected→Cancelled, Timeout→LlmTimeout, Shutdown→ServiceUnavailable
+- [ ] Inline unit tests verifying all 5 mappings
+
+## Task 6: Update all ErrorDetail construction sites
+
+**Status:** Pending
+**Files:** `crates/aura-web-server/src/handlers.rs`, `crates/aura-web-server/src/main.rs`
+**Satisfies:** AC-008.2.1, AC-008.3.1
+**Dependencies:** Task 1, Task 3, Task 4
+
+Six sites to update:
+
+- [ ] handlers.rs:132 — `Internal` (build agent failure), log internal message at WARN
+- [ ] handlers.rs:167 — `RequestValidation` (wrong last message role), pass-through message
+- [ ] handlers.rs:175 — `RequestValidation` (empty messages), pass-through message
+- [ ] handlers.rs:241 — `RequestValidation` (no messages provided), pass-through message
+- [ ] handlers.rs:545 — `Internal` (completion error), log internal message at WARN
+- [ ] main.rs:102 — `ServiceUnavailable` (shutdown guard)
+- [ ] Verify no construction site is missed (`grep "ErrorDetail {" across both files`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aura"
-version = "1.17.3"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "aura-config"
-version = "1.17.3"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "aura",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "aura-test-utils"
-version = "1.17.3"
+version = "1.19.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "aura-web-server"
-version = "1.17.3"
+version = "1.19.1"
 dependencies = [
  "actix-web",
  "actix-web-lab",
@@ -497,6 +497,8 @@ dependencies = [
  "eventsource-stream",
  "futures",
  "futures-util",
+ "metrics",
+ "metrics-exporter-prometheus",
  "opentelemetry",
  "reqwest",
  "rig-core",
@@ -1357,6 +1359,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +1974,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
@@ -2192,7 +2218,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2581,6 +2607,53 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "indexmap 2.11.4",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -3103,6 +3176,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,7 +3203,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.31",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -3152,7 +3240,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3229,6 +3317,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -3367,7 +3473,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.28.0"
-source = "git+https://github.com/mezmo/rig.git?rev=0853ab14#0853ab1487b6cbdc4c8818e9fb8d475b8b59eaf6"
+source = "git+https://github.com/mezmo/rig.git?rev=d7e9d92#d7e9d92e8bab870074294b9fb7d0b98c3b6c6d6b"
 dependencies = [
  "as-any",
  "async-stream",
@@ -3857,6 +3963,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -4702,6 +4814,28 @@ checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/crates/aura-config/src/bin/architecture_diagram.rs
+++ b/crates/aura-config/src/bin/architecture_diagram.rs
@@ -193,17 +193,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("│  │  ┌─────────────────────────────────────────┐    │    │");
             match &store.store {
                 aura_config::VectorStoreType::InMemory { embedding_model }
-                | aura_config::VectorStoreType::Qdrant { embedding_model, .. } => {
+                | aura_config::VectorStoreType::Qdrant {
+                    embedding_model, ..
+                } => {
                     println!("│  │  │        🔤 EMBEDDING MODEL               │    │    │");
                     println!("│  │  │                                         │    │    │");
                     println!(
                         "│  │  │  Provider: {}                │    │    │",
                         embedding_model.provider()
                     );
-                    println!(
-                        "│  │  │  Model: {}    │    │    │",
-                        embedding_model.model()
-                    );
+                    println!("│  │  │  Model: {}    │    │    │", embedding_model.model());
                 }
                 aura_config::VectorStoreType::BedrockKb { .. } => {
                     println!("│  │  │        🔤 MANAGED EMBEDDINGS            │    │    │");

--- a/crates/aura-config/src/bin/debug_config.rs
+++ b/crates/aura-config/src/bin/debug_config.rs
@@ -139,14 +139,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             match &store.store {
                 aura_config::VectorStoreType::InMemory { embedding_model } => {
                     println!("  Store {}: {} (in_memory)", i + 1, store.name);
-                    println!("    Embedding Model: {} {}", embedding_model.provider(), embedding_model.model());
+                    println!(
+                        "    Embedding Model: {} {}",
+                        embedding_model.provider(),
+                        embedding_model.model()
+                    );
                 }
-                aura_config::VectorStoreType::Qdrant { embedding_model, .. } => {
+                aura_config::VectorStoreType::Qdrant {
+                    embedding_model, ..
+                } => {
                     println!("  Store {}: {} (qdrant)", i + 1, store.name);
-                    println!("    Embedding Model: {} {}", embedding_model.provider(), embedding_model.model());
+                    println!(
+                        "    Embedding Model: {} {}",
+                        embedding_model.provider(),
+                        embedding_model.model()
+                    );
                 }
                 aura_config::VectorStoreType::BedrockKb { .. } => {
-                    println!("  Store {}: {} (bedrock_kb, managed embeddings)", i + 1, store.name);
+                    println!(
+                        "  Store {}: {} (bedrock_kb, managed embeddings)",
+                        i + 1,
+                        store.name
+                    );
                 }
             }
         }

--- a/crates/aura-config/src/builder.rs
+++ b/crates/aura-config/src/builder.rs
@@ -8,13 +8,11 @@ use std::collections::HashMap;
 /// Convert TOML-layer EmbeddingConfig to runtime EmbeddingModelConfig
 fn convert_embedding(em: &crate::config::EmbeddingConfig) -> EmbeddingModelConfig {
     match em {
-        crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
-            EmbeddingModelConfig::OpenAI {
-                api_key: api_key.clone(),
-                model: model.clone(),
-                base_url: None,
-            }
-        }
+        crate::config::EmbeddingConfig::OpenAI { api_key, model } => EmbeddingModelConfig::OpenAI {
+            api_key: api_key.clone(),
+            model: model.clone(),
+            base_url: None,
+        },
         crate::config::EmbeddingConfig::Bedrock {
             model,
             region,

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -380,26 +380,27 @@ impl Config {
         // Validate each vector store
         for store in &self.vector_stores {
             match &store.store {
-                VectorStoreType::InMemory { embedding_model } | VectorStoreType::Qdrant { embedding_model, .. } => {
-                    match embedding_model {
-                        EmbeddingConfig::OpenAI { api_key, .. } => {
-                            if api_key.is_empty() {
-                                return Err(crate::ConfigError::Validation(format!(
-                                    "Embedding model API key is required for vector store '{}'",
-                                    store.name
-                                )));
-                            }
-                        }
-                        EmbeddingConfig::Bedrock { region, .. } => {
-                            if region.is_empty() {
-                                return Err(crate::ConfigError::Validation(format!(
-                                    "Embedding model region is required for Bedrock provider in vector store '{}'",
-                                    store.name
-                                )));
-                            }
+                VectorStoreType::InMemory { embedding_model }
+                | VectorStoreType::Qdrant {
+                    embedding_model, ..
+                } => match embedding_model {
+                    EmbeddingConfig::OpenAI { api_key, .. } => {
+                        if api_key.is_empty() {
+                            return Err(crate::ConfigError::Validation(format!(
+                                "Embedding model API key is required for vector store '{}'",
+                                store.name
+                            )));
                         }
                     }
-                }
+                    EmbeddingConfig::Bedrock { region, .. } => {
+                        if region.is_empty() {
+                            return Err(crate::ConfigError::Validation(format!(
+                                "Embedding model region is required for Bedrock provider in vector store '{}'",
+                                store.name
+                            )));
+                        }
+                    }
+                },
                 VectorStoreType::BedrockKb { .. } => {
                     // All required fields are enforced by the enum structure
                 }

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -83,15 +83,13 @@ temperature = 0.5
         );
         let vector_store = &config.vector_stores[0];
         match &vector_store.store {
-            crate::config::VectorStoreType::InMemory { embedding_model } => {
-                match embedding_model {
-                    crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
-                        assert_eq!(model, "text-embedding-3-small");
-                        assert_eq!(api_key, "test_embedding_key");
-                    }
-                    _ => panic!("Expected OpenAI embedding config"),
+            crate::config::VectorStoreType::InMemory { embedding_model } => match embedding_model {
+                crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
+                    assert_eq!(model, "text-embedding-3-small");
+                    assert_eq!(api_key, "test_embedding_key");
                 }
-            }
+                _ => panic!("Expected OpenAI embedding config"),
+            },
             _ => panic!("Expected InMemory vector store"),
         }
 
@@ -346,14 +344,12 @@ system_prompt = "Test with env vars"
             _ => panic!("Expected OpenAI LLM config"),
         }
         match &config.vector_stores[0].store {
-            crate::config::VectorStoreType::InMemory { embedding_model } => {
-                match embedding_model {
-                    crate::config::EmbeddingConfig::OpenAI { api_key, .. } => {
-                        assert_eq!(api_key, "mock_openai_key");
-                    }
-                    _ => panic!("Expected OpenAI embedding config"),
+            crate::config::VectorStoreType::InMemory { embedding_model } => match embedding_model {
+                crate::config::EmbeddingConfig::OpenAI { api_key, .. } => {
+                    assert_eq!(api_key, "mock_openai_key");
                 }
-            }
+                _ => panic!("Expected OpenAI embedding config"),
+            },
             _ => panic!("Expected InMemory vector store"),
         }
 
@@ -949,20 +945,20 @@ system_prompt = "Test"
 
         let vector_store = &config.vector_stores[0];
         match &vector_store.store {
-            crate::config::VectorStoreType::Qdrant { embedding_model, .. } => {
-                match embedding_model {
-                    crate::config::EmbeddingConfig::Bedrock {
-                        model,
-                        region,
-                        profile,
-                    } => {
-                        assert_eq!(model, "amazon.titan-embed-text-v2:0");
-                        assert_eq!(region, "us-west-2");
-                        assert_eq!(profile, &Some("my-profile".to_string()));
-                    }
-                    _ => panic!("Expected Bedrock embedding config"),
+            crate::config::VectorStoreType::Qdrant {
+                embedding_model, ..
+            } => match embedding_model {
+                crate::config::EmbeddingConfig::Bedrock {
+                    model,
+                    region,
+                    profile,
+                } => {
+                    assert_eq!(model, "amazon.titan-embed-text-v2:0");
+                    assert_eq!(region, "us-west-2");
+                    assert_eq!(profile, &Some("my-profile".to_string()));
                 }
-            }
+                _ => panic!("Expected Bedrock embedding config"),
+            },
             _ => panic!("Expected Qdrant vector store"),
         }
     }
@@ -992,17 +988,15 @@ system_prompt = "Test"
 
         let vector_store = &config.vector_stores[0];
         match &vector_store.store {
-            crate::config::VectorStoreType::InMemory { embedding_model } => {
-                match embedding_model {
-                    crate::config::EmbeddingConfig::Bedrock {
-                        region, profile, ..
-                    } => {
-                        assert_eq!(region, "us-east-1");
-                        assert_eq!(profile, &None);
-                    }
-                    _ => panic!("Expected Bedrock embedding config"),
+            crate::config::VectorStoreType::InMemory { embedding_model } => match embedding_model {
+                crate::config::EmbeddingConfig::Bedrock {
+                    region, profile, ..
+                } => {
+                    assert_eq!(region, "us-east-1");
+                    assert_eq!(profile, &None);
                 }
-            }
+                _ => panic!("Expected Bedrock embedding config"),
+            },
             _ => panic!("Expected InMemory vector store"),
         }
     }
@@ -1058,7 +1052,10 @@ name = "Test"
 system_prompt = "Test"
 "#;
         let result = load_config_from_str(config_str);
-        assert!(result.is_err(), "OpenAI embedding without api_key should fail validation");
+        assert!(
+            result.is_err(),
+            "OpenAI embedding without api_key should fail validation"
+        );
     }
 
     #[test]
@@ -1081,8 +1078,7 @@ context_prefix = "Company documentation"
 name = "Test"
 system_prompt = "Test"
 "#;
-        let config = load_config_from_str(config_str)
-            .expect("Failed to parse bedrock_kb config");
+        let config = load_config_from_str(config_str).expect("Failed to parse bedrock_kb config");
 
         let store = &config.vector_stores[0];
         assert_eq!(store.name, "company_docs");
@@ -1150,10 +1146,7 @@ system_prompt = "Test"
         let result = load_config_from_str(config_str);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("region"),
-            "Error should mention region: {err}"
-        );
+        assert!(err.contains("region"), "Error should mention region: {err}");
     }
 
     #[test]

--- a/crates/aura-web-server/Cargo.toml
+++ b/crates/aura-web-server/Cargo.toml
@@ -25,6 +25,8 @@ opentelemetry = { workspace = true, optional = true }
 env_logger = "0.11"
 uuid = { version = "1.0", features = ["v4"] }
 chrono = "0.4"
+metrics = "0.24"
+metrics-exporter-prometheus = "0.16"
 
 [features]
 default = ["otel"]
@@ -39,6 +41,7 @@ integration = [
     "integration-events",
     "integration-cancellation",
     "integration-progress",
+    "integration-metrics",
 ]
 
 # Per-suite flags (can run individually)
@@ -48,6 +51,7 @@ integration-mcp = []                      # fastmcp_structured_content_test
 integration-events = []                   # aura_events_test, proactive_tool_ui_tests
 integration-cancellation = []             # cancellation_test, cancellation_notification_test
 integration-progress = []                 # mcp_progress_test, progress_disconnect_test
+integration-metrics = []                  # metrics_test
 
 # Optional - requires Qdrant (separate epic)
 integration-vector = []         # vector_label_filter_tests

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{Instrument, error};
+use tracing::Instrument;
 use uuid::Uuid;
 
 use crate::streaming::{
@@ -127,12 +127,12 @@ async fn build_agent_for_request(
         .build_agent_with_headers(Some(req_headers))
         .await
         .map_err(|e| {
-            error!("Failed to build agent: {}", e);
             HttpResponse::InternalServerError().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: format!("Failed to build agent: {e}"),
-                    error_type: "internal_error".to_string(),
-                },
+                error: ErrorDetail::classified(
+                    "internal_error",
+                    aura::ErrorCategory::Internal,
+                    &format!("Failed to build agent: {e}"),
+                ),
             })
         })?;
     Ok(Arc::new(agent))
@@ -164,18 +164,14 @@ async fn prepare_request(
         Some(msg) if msg.role == Role::User => msg.content,
         Some(msg) => {
             return Err(HttpResponse::BadRequest().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: format!("Last message must be from user, got: {}", msg.role),
-                    error_type: "invalid_request_error".to_string(),
-                },
+                error: ErrorDetail::validation(
+                    &format!("Last message must be from user, got: {}", msg.role),
+                ),
             }));
         }
         None => {
             return Err(HttpResponse::BadRequest().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: "messages array is empty".to_string(),
-                    error_type: "invalid_request_error".to_string(),
-                },
+                error: ErrorDetail::validation("messages array is empty"),
             }));
         }
     };
@@ -238,10 +234,7 @@ pub async fn chat_completions(
     // Validate we have messages
     if req.messages.is_empty() {
         return HttpResponse::BadRequest().json(ErrorResponse {
-            error: ErrorDetail {
-                message: "No messages provided".to_string(),
-                error_type: "invalid_request_error".to_string(),
-            },
+            error: ErrorDetail::validation("No messages provided"),
         });
     }
 
@@ -540,12 +533,12 @@ async fn handle_non_streaming_completion(
     match result_rx.await {
         Ok(collected) => build_json_response(response_ctx, max_tokens, collected),
         Err(_) => {
-            error!("Completion task panicked or was dropped");
             HttpResponse::InternalServerError().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: "Internal error during completion".to_string(),
-                    error_type: "internal_error".to_string(),
-                },
+                error: ErrorDetail::classified(
+                    "internal_error",
+                    aura::ErrorCategory::Internal,
+                    "Completion task panicked or was dropped",
+                ),
             })
         }
     }

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -129,6 +129,12 @@ async fn build_agent_for_request(
         .build_agent_with_headers(Some(req_headers))
         .await
         .map_err(|e| {
+            // Record MCP server as disconnected on build failure if it looks like an MCP error
+            if let Some(mcp_config) = &config.mcp {
+                for server_name in mcp_config.servers.keys() {
+                    crate::metrics::set_mcp_server_connected(server_name, false);
+                }
+            }
             HttpResponse::InternalServerError().json(ErrorResponse {
                 error: ErrorDetail::classified(
                     "internal_error",
@@ -137,6 +143,14 @@ async fn build_agent_for_request(
                 ),
             })
         })?;
+
+    // Record MCP servers as connected on successful agent build
+    if let Some(mcp_config) = &config.mcp {
+        for server_name in mcp_config.servers.keys() {
+            crate::metrics::set_mcp_server_connected(server_name, true);
+        }
+    }
+
     Ok(Arc::new(agent))
 }
 

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -27,6 +27,7 @@ struct ActiveRequestGuard {
 impl ActiveRequestGuard {
     fn new(tracker: Arc<ActiveRequestTracker>) -> Self {
         tracker.increment();
+        crate::metrics::increment_requests_in_flight();
         Self { tracker }
     }
 }
@@ -34,6 +35,7 @@ impl ActiveRequestGuard {
 impl Drop for ActiveRequestGuard {
     fn drop(&mut self) {
         self.tracker.decrement();
+        crate::metrics::decrement_requests_in_flight();
     }
 }
 
@@ -150,6 +152,7 @@ struct RequestSetup {
     created_timestamp: u64,
     chat_session_id: String,
     has_chat_history: bool,
+    agent_name: String,
 }
 
 /// Extract query, chat history, and build agent — shared across both code paths.
@@ -211,6 +214,7 @@ async fn prepare_request(
     let created_timestamp = Utc::now().timestamp() as u64;
     let has_chat_history = !chat_history.is_empty();
 
+    let agent_name = config.agent.name.clone();
     Ok(RequestSetup {
         query,
         chat_history,
@@ -221,6 +225,7 @@ async fn prepare_request(
         created_timestamp,
         chat_session_id: chat_session_id.to_string(),
         has_chat_history,
+        agent_name,
     })
 }
 
@@ -262,17 +267,30 @@ pub async fn chat_completions(
         .filter_map(|(k, v)| v.to_str().ok().map(|val| (k.to_string(), val.to_string())))
         .collect();
 
+    let request_start = std::time::Instant::now();
+
     let mut req = req.into_inner();
     let setup = match prepare_request(&data, &mut req, &chat_session_id, &req_headers_map).await {
         Ok(s) => s,
         Err(response) => return response,
     };
 
-    if req.stream == Some(true) {
+    let agent_name = setup.agent_name.clone();
+
+    let response = if req.stream == Some(true) {
         handle_streaming_completion(data, setup, req.max_tokens).await
     } else {
         handle_non_streaming_completion(&data, setup, req.max_tokens).await
-    }
+    };
+
+    crate::metrics::record_request_duration(
+        "POST",
+        response.status().as_u16(),
+        &agent_name,
+        request_start.elapsed().as_secs_f64(),
+    );
+
+    response
 }
 
 /// Build configuration for the spawned completion task from AppState and RequestSetup.
@@ -362,6 +380,7 @@ async fn execute_completion(setup: RequestSetup, config: CompletionConfig, deliv
     };
 
     let response_content = config.response_content.clone();
+    let provider_for_metrics = config.provider.clone();
     let otel_ctx = StreamOtelContext {
         provider: config.provider,
         model: config.model,
@@ -428,6 +447,17 @@ async fn execute_completion(setup: RequestSetup, config: CompletionConfig, deliv
     };
 
     otel_ctx.record_output(&termination);
+
+    // Record token usage metrics
+    let (prompt_tokens, completion_tokens, _total) = usage_state.get_final_usage();
+    crate::metrics::record_tokens("prompt", &provider_for_metrics, &setup.agent_name, prompt_tokens);
+    crate::metrics::record_tokens("completion", &provider_for_metrics, &setup.agent_name, completion_tokens);
+
+    // Record error metrics for non-success terminations
+    if !matches!(termination, StreamTermination::Complete) {
+        let category = aura::ErrorCategory::from(&termination);
+        crate::metrics::record_error(category.as_label());
+    }
 
     match &termination {
         StreamTermination::Complete => {

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -181,9 +181,10 @@ async fn prepare_request(
         Some(msg) if msg.role == Role::User => msg.content,
         Some(msg) => {
             return Err(HttpResponse::BadRequest().json(ErrorResponse {
-                error: ErrorDetail::validation(
-                    &format!("Last message must be from user, got: {}", msg.role),
-                ),
+                error: ErrorDetail::validation(&format!(
+                    "Last message must be from user, got: {}",
+                    msg.role
+                )),
             }));
         }
         None => {
@@ -464,8 +465,18 @@ async fn execute_completion(setup: RequestSetup, config: CompletionConfig, deliv
 
     // Record token usage metrics
     let (prompt_tokens, completion_tokens, _total) = usage_state.get_final_usage();
-    crate::metrics::record_tokens("prompt", &provider_for_metrics, &setup.agent_name, prompt_tokens);
-    crate::metrics::record_tokens("completion", &provider_for_metrics, &setup.agent_name, completion_tokens);
+    crate::metrics::record_tokens(
+        "prompt",
+        &provider_for_metrics,
+        &setup.agent_name,
+        prompt_tokens,
+    );
+    crate::metrics::record_tokens(
+        "completion",
+        &provider_for_metrics,
+        &setup.agent_name,
+        completion_tokens,
+    );
 
     // Record error metrics for non-success terminations
     if !matches!(termination, StreamTermination::Complete) {
@@ -576,15 +587,13 @@ async fn handle_non_streaming_completion(
 
     match result_rx.await {
         Ok(collected) => build_json_response(response_ctx, max_tokens, collected),
-        Err(_) => {
-            HttpResponse::InternalServerError().json(ErrorResponse {
-                error: ErrorDetail::classified(
-                    "internal_error",
-                    aura::ErrorCategory::Internal,
-                    "Completion task panicked or was dropped",
-                ),
-            })
-        }
+        Err(_) => HttpResponse::InternalServerError().json(ErrorResponse {
+            error: ErrorDetail::classified(
+                "internal_error",
+                aura::ErrorCategory::Internal,
+                "Completion task panicked or was dropped",
+            ),
+        }),
     }
 }
 

--- a/crates/aura-web-server/src/lib.rs
+++ b/crates/aura-web-server/src/lib.rs
@@ -1,3 +1,4 @@
-//! Streaming support for aura-web-server
+//! Streaming support and metrics for aura-web-server
 
+pub mod metrics;
 pub mod streaming;

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -6,6 +6,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 mod handlers;
+mod metrics;
 mod streaming;
 mod types;
 
@@ -196,9 +197,12 @@ async fn run() -> std::io::Result<()> {
         args.host, args.port, shutdown_timeout_secs
     );
 
+    // Initialize Prometheus metrics (None if disabled via AURA_METRICS_ENABLED=false)
+    let metrics_handle = metrics::init();
+
     // Custom signal handling: CancellationToken bridges Actix and SSE stream lifecycles
     let server = HttpServer::new(move || {
-        App::new()
+        let mut app = App::new()
             .app_data(app_state.clone())
             .wrap(middleware::from_fn(shutdown_guard))
             .wrap(middleware::Logger::default())
@@ -207,7 +211,15 @@ async fn run() -> std::io::Result<()> {
             .route(
                 "/v1/chat/completions",
                 web::post().to(handlers::chat_completions),
-            )
+            );
+
+        if let Some(handle) = &metrics_handle {
+            app = app
+                .app_data(web::Data::new(handle.clone()))
+                .route("/metrics", web::get().to(metrics::handler));
+        }
+
+        app
     })
     .bind((args.host.as_str(), args.port))?
     .disable_signals()

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -93,12 +93,16 @@ struct Args {
 }
 
 /// Middleware that rejects new requests with 503 when shutdown_token is cancelled.
+/// Exempts /health and /metrics so Kubernetes probes and Prometheus scrapers
+/// continue working during graceful shutdown.
 async fn shutdown_guard(
     data: web::Data<AppState>,
     req: actix_web::dev::ServiceRequest,
     next: actix_web::middleware::Next<impl actix_web::body::MessageBody + 'static>,
 ) -> Result<actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>, actix_web::Error> {
-    if data.shutdown_token.is_cancelled() {
+    let path = req.path();
+    let is_exempt = path == "/health" || path == "/metrics";
+    if data.shutdown_token.is_cancelled() && !is_exempt {
         let response = HttpResponse::ServiceUnavailable().json(ErrorResponse {
             error: ErrorDetail::classified(
                 "service_unavailable",

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -99,10 +99,11 @@ async fn shutdown_guard(
 ) -> Result<actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>, actix_web::Error> {
     if data.shutdown_token.is_cancelled() {
         let response = HttpResponse::ServiceUnavailable().json(ErrorResponse {
-            error: ErrorDetail {
-                message: "Server is shutting down".to_string(),
-                error_type: "service_unavailable".to_string(),
-            },
+            error: ErrorDetail::classified(
+                "service_unavailable",
+                aura::ErrorCategory::ServiceUnavailable,
+                "Server is shutting down",
+            ),
         });
         return Ok(req.into_response(response).map_into_right_body());
     }

--- a/crates/aura-web-server/src/metrics.rs
+++ b/crates/aura-web-server/src/metrics.rs
@@ -138,14 +138,26 @@ mod tests {
         known.clear();
         drop(known);
 
-        // First 100 unique names should pass through
-        for i in 0..100 {
+        // Insert exactly MAX_UNIQUE_TOOL_LABELS unique names
+        for i in 0..MAX_UNIQUE_TOOL_LABELS {
             let name = format!("tool_{i}");
-            assert!(name.len() <= MAX_TOOL_NAME_LEN);
+            let mut set = KNOWN_TOOLS.lock().unwrap_or_else(|e| e.into_inner());
+            set.insert(name);
         }
 
-        // Very long tool names should be capped
+        let set = KNOWN_TOOLS.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(set.len(), MAX_UNIQUE_TOOL_LABELS);
+        assert!(set.contains("tool_0"));
+        assert!(set.contains("tool_99"));
+        assert!(!set.contains("tool_100"));
+        drop(set);
+
+        // Very long tool names get capped regardless of count
         let long_name = "a".repeat(MAX_TOOL_NAME_LEN + 1);
         assert!(long_name.len() > MAX_TOOL_NAME_LEN);
+
+        // Clean up for other tests
+        let mut known = KNOWN_TOOLS.lock().unwrap_or_else(|e| e.into_inner());
+        known.clear();
     }
 }

--- a/crates/aura-web-server/src/metrics.rs
+++ b/crates/aura-web-server/src/metrics.rs
@@ -79,7 +79,7 @@ pub fn record_tool_duration(server: &str, tool: &str, status: &str, duration_sec
     let tool_label = if tool.len() > MAX_TOOL_NAME_LEN {
         "_other"
     } else {
-        let mut known = KNOWN_TOOLS.lock().unwrap();
+        let mut known = KNOWN_TOOLS.lock().unwrap_or_else(|e| e.into_inner());
         if known.contains(tool) || known.len() < MAX_UNIQUE_TOOL_LABELS {
             known.insert(tool.to_string());
             tool
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_tool_label_cardinality_cap() {
-        let mut known = KNOWN_TOOLS.lock().unwrap();
+        let mut known = KNOWN_TOOLS.lock().unwrap_or_else(|e| e.into_inner());
         known.clear();
         drop(known);
 

--- a/crates/aura-web-server/src/metrics.rs
+++ b/crates/aura-web-server/src/metrics.rs
@@ -2,7 +2,7 @@
 //!
 //! Enabled by default. Set `AURA_METRICS_ENABLED=false` to disable the `/metrics` endpoint.
 
-use actix_web::{web, HttpResponse};
+use actix_web::{HttpResponse, web};
 use metrics::{counter, gauge, histogram};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 use std::collections::HashSet;
@@ -21,7 +21,9 @@ pub fn init() -> Option<PrometheusHandle> {
     let handle = PrometheusBuilder::new()
         .set_buckets_for_metric(
             Matcher::Full("aura_http_request_duration_seconds".to_string()),
-            &[0.025, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0],
+            &[
+                0.025, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+            ],
         )
         .expect("valid request duration buckets")
         .set_buckets_for_metric(
@@ -68,8 +70,7 @@ pub fn record_tokens(token_type: &str, provider: &str, agent: &str, count: u64) 
 }
 
 /// Track unique tool names globally to enforce cardinality cap.
-static KNOWN_TOOLS: LazyLock<Mutex<HashSet<String>>> =
-    LazyLock::new(|| Mutex::new(HashSet::new()));
+static KNOWN_TOOLS: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 
 const MAX_UNIQUE_TOOL_LABELS: usize = 100;
 const MAX_TOOL_NAME_LEN: usize = 64;
@@ -114,8 +115,11 @@ pub fn decrement_requests_in_flight() {
 
 /// Set MCP server connection state (1.0 = connected, 0.0 = disconnected).
 pub fn set_mcp_server_connected(server: &str, connected: bool) {
-    gauge!("aura_mcp_server_connected", "server" => server.to_string())
-        .set(if connected { 1.0 } else { 0.0 });
+    gauge!("aura_mcp_server_connected", "server" => server.to_string()).set(if connected {
+        1.0
+    } else {
+        0.0
+    });
 }
 
 #[cfg(test)]

--- a/crates/aura-web-server/src/metrics.rs
+++ b/crates/aura-web-server/src/metrics.rs
@@ -1,0 +1,151 @@
+//! Prometheus metrics for Aura request handling, token usage, and tool execution.
+//!
+//! Enabled by default. Set `AURA_METRICS_ENABLED=false` to disable the `/metrics` endpoint.
+
+use actix_web::{web, HttpResponse};
+use metrics::{counter, gauge, histogram};
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
+use std::collections::HashSet;
+use std::sync::{LazyLock, Mutex};
+
+/// Initialize the Prometheus metrics registry. Returns `None` if disabled via env var.
+pub fn init() -> Option<PrometheusHandle> {
+    if std::env::var("AURA_METRICS_ENABLED")
+        .map(|v| v == "false")
+        .unwrap_or(false)
+    {
+        tracing::info!("Metrics disabled via AURA_METRICS_ENABLED=false");
+        return None;
+    }
+
+    let handle = PrometheusBuilder::new()
+        .set_buckets_for_metric(
+            Matcher::Full("aura_http_request_duration_seconds".to_string()),
+            &[0.025, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0],
+        )
+        .expect("valid request duration buckets")
+        .set_buckets_for_metric(
+            Matcher::Full("aura_mcp_tool_duration_seconds".to_string()),
+            &[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0],
+        )
+        .expect("valid tool duration buckets")
+        .install_recorder()
+        .expect("metrics recorder installation");
+
+    tracing::info!("Metrics enabled on /metrics endpoint");
+    Some(handle)
+}
+
+/// Serve Prometheus text exposition format.
+pub async fn handler(handle: web::Data<PrometheusHandle>) -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("text/plain; version=0.0.4; charset=utf-8")
+        .body(handle.render())
+}
+
+/// Record HTTP request duration.
+pub fn record_request_duration(method: &str, status: u16, agent: &str, duration_secs: f64) {
+    histogram!(
+        "aura_http_request_duration_seconds",
+        "method" => method.to_string(),
+        "status_code" => status.to_string(),
+        "agent" => agent.to_string(),
+    )
+    .record(duration_secs);
+}
+
+/// Record LLM token usage. Skips recording if count is zero.
+pub fn record_tokens(token_type: &str, provider: &str, agent: &str, count: u64) {
+    if count > 0 {
+        counter!(
+            "aura_llm_tokens_total",
+            "type" => token_type.to_string(),
+            "provider" => provider.to_string(),
+            "agent" => agent.to_string(),
+        )
+        .increment(count);
+    }
+}
+
+/// Track unique tool names globally to enforce cardinality cap.
+static KNOWN_TOOLS: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+const MAX_UNIQUE_TOOL_LABELS: usize = 100;
+const MAX_TOOL_NAME_LEN: usize = 64;
+
+/// Record MCP tool call duration with cardinality guards on the tool label.
+pub fn record_tool_duration(server: &str, tool: &str, status: &str, duration_secs: f64) {
+    let tool_label = if tool.len() > MAX_TOOL_NAME_LEN {
+        "_other"
+    } else {
+        let mut known = KNOWN_TOOLS.lock().unwrap();
+        if known.contains(tool) || known.len() < MAX_UNIQUE_TOOL_LABELS {
+            known.insert(tool.to_string());
+            tool
+        } else {
+            "_other"
+        }
+    };
+
+    histogram!(
+        "aura_mcp_tool_duration_seconds",
+        "server" => server.to_string(),
+        "tool" => tool_label.to_string(),
+        "status" => status.to_string(),
+    )
+    .record(duration_secs);
+}
+
+/// Record an error by taxonomy category label.
+pub fn record_error(error_type: &str) {
+    counter!("aura_errors_total", "error_type" => error_type.to_string()).increment(1);
+}
+
+/// Increment the in-flight request gauge. Called at request entry.
+pub fn increment_requests_in_flight() {
+    gauge!("aura_http_requests_in_flight").increment(1.0);
+}
+
+/// Decrement the in-flight request gauge. Called at request exit (including on panic via Drop).
+pub fn decrement_requests_in_flight() {
+    gauge!("aura_http_requests_in_flight").decrement(1.0);
+}
+
+/// Set MCP server connection state (1.0 = connected, 0.0 = disconnected).
+pub fn set_mcp_server_connected(server: &str, connected: bool) {
+    gauge!("aura_mcp_server_connected", "server" => server.to_string())
+        .set(if connected { 1.0 } else { 0.0 });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_init_disabled_returns_none() {
+        // Safety: set_var/remove_var are unsafe in edition 2024 due to process-global mutation.
+        // This test runs single-threaded and restores the env var after use.
+        unsafe { std::env::set_var("AURA_METRICS_ENABLED", "false") };
+        let handle = init();
+        assert!(handle.is_none());
+        unsafe { std::env::remove_var("AURA_METRICS_ENABLED") };
+    }
+
+    #[test]
+    fn test_tool_label_cardinality_cap() {
+        let mut known = KNOWN_TOOLS.lock().unwrap();
+        known.clear();
+        drop(known);
+
+        // First 100 unique names should pass through
+        for i in 0..100 {
+            let name = format!("tool_{i}");
+            assert!(name.len() <= MAX_TOOL_NAME_LEN);
+        }
+
+        // Very long tool names should be capped
+        let long_name = "a".repeat(MAX_TOOL_NAME_LEN + 1);
+        assert!(long_name.len() > MAX_TOOL_NAME_LEN);
+    }
+}

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -76,6 +76,18 @@ pub enum StreamTermination {
     Shutdown,
 }
 
+impl From<&StreamTermination> for aura::ErrorCategory {
+    fn from(term: &StreamTermination) -> Self {
+        match term {
+            StreamTermination::Complete => aura::ErrorCategory::Internal,
+            StreamTermination::StreamError(_) => aura::ErrorCategory::LlmError,
+            StreamTermination::Disconnected => aura::ErrorCategory::Cancelled,
+            StreamTermination::Timeout => aura::ErrorCategory::LlmTimeout,
+            StreamTermination::Shutdown => aura::ErrorCategory::ServiceUnavailable,
+        }
+    }
+}
+
 /// User-facing message when context overflow is detected.
 const CONTEXT_OVERFLOW_MESSAGE: &str = "My tools returned more data than I can work with at once.\n\n\
     **To help me out, try:**\n\

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -767,19 +767,39 @@ fn handle_tool_result(
     let mut output = Vec::with_capacity(2);
     state.needs_separator = true;
 
+    // Calculate tool duration (always, for metrics even when custom events are off)
+    let duration_ms = state
+        .tool_start_times
+        .remove(&tool_result.id)
+        .map(|start| start.elapsed().as_millis() as u64)
+        .unwrap_or(0);
+
+    let tool_name_for_metrics = state
+        .tool_call_map
+        .get(&tool_result.id)
+        .map(|(name, _)| name.clone())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    // Record tool duration metric (always, regardless of custom events)
+    {
+        let result_text = serde_json::from_str::<String>(&tool_result.result)
+            .unwrap_or_else(|_| tool_result.result.clone());
+        let status = detect_tool_error(&result_text);
+        let status_label = match &status {
+            ToolResultStatus::Error(_) => "error",
+            ToolResultStatus::Success => "ok",
+        };
+        crate::metrics::record_tool_duration(
+            "default",
+            &tool_name_for_metrics,
+            status_label,
+            duration_ms as f64 / 1000.0,
+        );
+    }
+
     // Emit aura.tool_complete custom event (if enabled)
     if config.emit_custom_events {
-        let duration_ms = state
-            .tool_start_times
-            .remove(&tool_result.id)
-            .map(|start| start.elapsed().as_millis() as u64)
-            .unwrap_or(0);
-
-        let tool_name = state
-            .tool_call_map
-            .get(&tool_result.id)
-            .map(|(name, _)| name.clone())
-            .unwrap_or_else(|| "unknown".to_string());
+        let tool_name = tool_name_for_metrics.clone();
 
         // Aura's ToolResult has result as a plain String
         // Try to unescape JSON-quoted strings for error detection

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -76,6 +76,9 @@ pub enum StreamTermination {
     Shutdown,
 }
 
+/// Map stream termination reasons to the error taxonomy.
+/// Callers should guard against `Complete` (success case) before using this —
+/// the `Internal` mapping for `Complete` is defensive and should never be recorded as an error.
 impl From<&StreamTermination> for aura::ErrorCategory {
     fn from(term: &StreamTermination) -> Self {
         match term {
@@ -776,10 +779,12 @@ fn handle_tool_result(
         .map(|(name, _)| name.clone())
         .unwrap_or_else(|| "unknown".to_string());
 
+    // Parse result text once (used for both metrics and custom events)
+    let result_text = serde_json::from_str::<String>(&tool_result.result)
+        .unwrap_or_else(|_| tool_result.result.clone());
+
     // Record tool duration metric (always, regardless of custom events)
     {
-        let result_text = serde_json::from_str::<String>(&tool_result.result)
-            .unwrap_or_else(|_| tool_result.result.clone());
         let status = detect_tool_error(&result_text);
         let status_label = match &status {
             ToolResultStatus::Error(_) => "error",
@@ -796,11 +801,6 @@ fn handle_tool_result(
     // Emit aura.tool_complete custom event (if enabled)
     if config.emit_custom_events {
         let tool_name = tool_name_for_metrics.clone();
-
-        // Aura's ToolResult has result as a plain String
-        // Try to unescape JSON-quoted strings for error detection
-        let result_text = serde_json::from_str::<String>(&tool_result.result)
-            .unwrap_or_else(|_| tool_result.result.clone());
 
         tracing::debug!(
             "Tool '{}' result_text (first 200 chars): {}",

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -702,14 +702,10 @@ fn handle_tool_call(
         (tool_call.name.clone(), state.tool_call_index),
     );
 
-    // Track tool start time for duration calculation in tool_complete event
-    // Note: aura.tool_requested is emitted via StreamingRequestHook → tool_event_rx channel (not here)
-    // to avoid duplication and maintain proper correlation with tool_call_id via FIFO queue
-    if config.emit_custom_events {
-        state
-            .tool_start_times
-            .insert(tool_call.id.clone(), std::time::Instant::now());
-    }
+    // Track tool start time for duration calculation (always — used for metrics and custom events)
+    state
+        .tool_start_times
+        .insert(tool_call.id.clone(), std::time::Instant::now());
 
     // Determine arguments based on tool result mode
     let arguments = match config.tool_result_mode {
@@ -1059,6 +1055,30 @@ mod tests {
         assert!(
             output_str.contains("tool_calls"),
             "OpenAI tool_calls chunk should still be emitted"
+        );
+    }
+
+    #[test]
+    fn test_stream_termination_maps_to_error_category() {
+        assert_eq!(
+            aura::ErrorCategory::from(&StreamTermination::Complete),
+            aura::ErrorCategory::Internal,
+        );
+        assert_eq!(
+            aura::ErrorCategory::from(&StreamTermination::StreamError("err".to_string())),
+            aura::ErrorCategory::LlmError,
+        );
+        assert_eq!(
+            aura::ErrorCategory::from(&StreamTermination::Disconnected),
+            aura::ErrorCategory::Cancelled,
+        );
+        assert_eq!(
+            aura::ErrorCategory::from(&StreamTermination::Timeout),
+            aura::ErrorCategory::LlmTimeout,
+        );
+        assert_eq!(
+            aura::ErrorCategory::from(&StreamTermination::Shutdown),
+            aura::ErrorCategory::ServiceUnavailable,
         );
     }
 

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -208,6 +208,40 @@ pub struct ErrorDetail {
     pub message: String,
     #[serde(rename = "type")]
     pub error_type: String,
+    /// Error taxonomy label from ErrorCategory. Additive field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+}
+
+impl ErrorDetail {
+    /// Create an error with taxonomy classification and sanitized client message.
+    /// The internal_message is logged but not exposed to the client.
+    pub fn classified(
+        error_type: &str,
+        category: aura::ErrorCategory,
+        internal_message: &str,
+    ) -> Self {
+        let aura_err = aura::AuraError::new(category, internal_message);
+        tracing::warn!(
+            error_category = category.as_label(),
+            internal_message = internal_message,
+            "Request error"
+        );
+        Self {
+            message: aura_err.client_message(),
+            error_type: error_type.to_string(),
+            code: Some(category.as_label().to_string()),
+        }
+    }
+
+    /// Create a request validation error (passes through the message since it's client input).
+    pub fn validation(message: &str) -> Self {
+        Self {
+            message: message.to_string(),
+            error_type: "invalid_request_error".to_string(),
+            code: Some(aura::ErrorCategory::RequestValidation.as_label().to_string()),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -248,7 +248,11 @@ impl ErrorDetail {
         Self {
             message: message.to_string(),
             error_type: "invalid_request_error".to_string(),
-            code: Some(aura::ErrorCategory::RequestValidation.as_label().to_string()),
+            code: Some(
+                aura::ErrorCategory::RequestValidation
+                    .as_label()
+                    .to_string(),
+            ),
         }
     }
 }
@@ -369,7 +373,10 @@ mod tests {
             code: None,
         };
         let json = serde_json::to_value(&ErrorResponse { error: detail }).unwrap();
-        assert!(json["error"].get("code").is_none(), "code field should be absent when None");
+        assert!(
+            json["error"].get("code").is_none(),
+            "code field should be absent when None"
+        );
         assert_eq!(json["error"]["type"], "internal_error");
     }
 
@@ -380,7 +387,10 @@ mod tests {
             aura::ErrorCategory::McpConnectionFailed,
             "MCP server 'pagerduty' at 10.0.1.5:8080 refused",
         );
-        assert_eq!(detail.message, "A downstream service is temporarily unavailable");
+        assert_eq!(
+            detail.message,
+            "A downstream service is temporarily unavailable"
+        );
         assert_eq!(detail.error_type, "internal_error");
         assert_eq!(detail.code, Some("mcp_connection_failed".to_string()));
         assert!(!detail.message.contains("pagerduty"));

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -369,7 +369,7 @@ mod tests {
             code: None,
         };
         let json = serde_json::to_value(&ErrorResponse { error: detail }).unwrap();
-        assert!(json["error"]["code"].is_null(), "code field should be absent when None");
+        assert!(json["error"].get("code").is_none(), "code field should be absent when None");
         assert_eq!(json["error"]["type"], "internal_error");
     }
 

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -347,4 +347,51 @@ mod tests {
         assert_eq!(json["error"]["param"], "model");
         assert_eq!(json["error"]["code"], "model_not_found");
     }
+
+    #[test]
+    fn test_error_detail_with_code_serializes_code_field() {
+        let detail = ErrorDetail {
+            message: "test".to_string(),
+            error_type: "internal_error".to_string(),
+            code: Some("llm_timeout".to_string()),
+        };
+        let json = serde_json::to_value(&ErrorResponse { error: detail }).unwrap();
+        assert_eq!(json["error"]["code"], "llm_timeout");
+        assert_eq!(json["error"]["type"], "internal_error");
+        assert_eq!(json["error"]["message"], "test");
+    }
+
+    #[test]
+    fn test_error_detail_without_code_omits_code_field() {
+        let detail = ErrorDetail {
+            message: "test".to_string(),
+            error_type: "internal_error".to_string(),
+            code: None,
+        };
+        let json = serde_json::to_value(&ErrorResponse { error: detail }).unwrap();
+        assert!(json["error"]["code"].is_null(), "code field should be absent when None");
+        assert_eq!(json["error"]["type"], "internal_error");
+    }
+
+    #[test]
+    fn test_error_detail_classified_uses_generic_message() {
+        let detail = ErrorDetail::classified(
+            "internal_error",
+            aura::ErrorCategory::McpConnectionFailed,
+            "MCP server 'pagerduty' at 10.0.1.5:8080 refused",
+        );
+        assert_eq!(detail.message, "A downstream service is temporarily unavailable");
+        assert_eq!(detail.error_type, "internal_error");
+        assert_eq!(detail.code, Some("mcp_connection_failed".to_string()));
+        assert!(!detail.message.contains("pagerduty"));
+        assert!(!detail.message.contains("10.0.1.5"));
+    }
+
+    #[test]
+    fn test_error_detail_validation_passes_through_message() {
+        let detail = ErrorDetail::validation("messages array is empty");
+        assert_eq!(detail.message, "messages array is empty");
+        assert_eq!(detail.error_type, "invalid_request_error");
+        assert_eq!(detail.code, Some("request_validation".to_string()));
+    }
 }

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -215,7 +215,12 @@ pub struct ErrorDetail {
 
 impl ErrorDetail {
     /// Create an error with taxonomy classification and sanitized client message.
-    /// The internal_message is logged but not exposed to the client.
+    ///
+    /// Encapsulates three concerns: (1) classifying the error via ErrorCategory,
+    /// (2) logging the internal message at WARN level for debugging, and
+    /// (3) replacing the client-facing message with a safe generic string.
+    /// This prevents internal details (hostnames, ports, library errors) from
+    /// reaching API consumers while preserving the existing `error_type` values.
     pub fn classified(
         error_type: &str,
         category: aura::ErrorCategory,
@@ -234,7 +239,11 @@ impl ErrorDetail {
         }
     }
 
-    /// Create a request validation error (passes through the message since it's client input).
+    /// Create a request validation error that passes the message through directly.
+    ///
+    /// Unlike `classified()`, this does not sanitize the message because request
+    /// validation errors contain client-supplied input (e.g., "Last message must
+    /// be from user, got: system") which is safe to return.
     pub fn validation(message: &str) -> Self {
         Self {
             message: message.to_string(),

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -1040,14 +1040,22 @@ impl AgentBuilder {
                         tracing::info!("  Embedding Provider: {}", embedding_model.provider());
                         tracing::info!("  Embedding Model: {}", embedding_model.model());
                     }
-                    VectorStoreType::Qdrant { embedding_model, url, collection_name } => {
+                    VectorStoreType::Qdrant {
+                        embedding_model,
+                        url,
+                        collection_name,
+                    } => {
                         tracing::info!("  Type: qdrant");
                         tracing::info!("  URL: {}", url);
                         tracing::info!("  Collection: {}", collection_name);
                         tracing::info!("  Embedding Provider: {}", embedding_model.provider());
                         tracing::info!("  Embedding Model: {}", embedding_model.model());
                     }
-                    VectorStoreType::BedrockKb { knowledge_base_id, region, .. } => {
+                    VectorStoreType::BedrockKb {
+                        knowledge_base_id,
+                        region,
+                        ..
+                    } => {
                         tracing::info!("  Type: bedrock_kb");
                         tracing::info!("  Knowledge Base ID: {}", knowledge_base_id);
                         tracing::info!("  Region: {}", region);

--- a/crates/aura/src/error_taxonomy.rs
+++ b/crates/aura/src/error_taxonomy.rs
@@ -7,7 +7,8 @@ use crate::tool_error_detection::DetectedToolError;
 
 /// Unified error taxonomy for all Aura runtime errors.
 /// Each variant maps to a Prometheus-label-safe string and a generic client message.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ErrorCategory {
     LlmTimeout,
     LlmRateLimit,

--- a/crates/aura/src/error_taxonomy.rs
+++ b/crates/aura/src/error_taxonomy.rs
@@ -1,0 +1,258 @@
+//! Unified error taxonomy for all Aura runtime errors.
+//!
+//! Classifies errors into categories suitable for Prometheus metric labels,
+//! structured API responses, and differentiated alerting.
+
+use crate::tool_error_detection::DetectedToolError;
+
+/// Unified error taxonomy for all Aura runtime errors.
+/// Each variant maps to a Prometheus-label-safe string and a generic client message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ErrorCategory {
+    LlmTimeout,
+    LlmRateLimit,
+    LlmAuthError,
+    LlmError,
+    McpConnectionFailed,
+    McpToolError,
+    McpTimeout,
+    ConfigValidation,
+    RequestValidation,
+    BudgetExceeded,
+    ServiceUnavailable,
+    Cancelled,
+    Internal,
+}
+
+/// All ErrorCategory variants for exhaustive iteration in tests.
+pub const ALL_CATEGORIES: &[ErrorCategory] = &[
+    ErrorCategory::LlmTimeout,
+    ErrorCategory::LlmRateLimit,
+    ErrorCategory::LlmAuthError,
+    ErrorCategory::LlmError,
+    ErrorCategory::McpConnectionFailed,
+    ErrorCategory::McpToolError,
+    ErrorCategory::McpTimeout,
+    ErrorCategory::ConfigValidation,
+    ErrorCategory::RequestValidation,
+    ErrorCategory::BudgetExceeded,
+    ErrorCategory::ServiceUnavailable,
+    ErrorCategory::Cancelled,
+    ErrorCategory::Internal,
+];
+
+impl ErrorCategory {
+    /// Returns a Prometheus-label-safe string (lowercase, underscores only).
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            Self::LlmTimeout => "llm_timeout",
+            Self::LlmRateLimit => "llm_rate_limit",
+            Self::LlmAuthError => "llm_auth_error",
+            Self::LlmError => "llm_error",
+            Self::McpConnectionFailed => "mcp_connection_failed",
+            Self::McpToolError => "mcp_tool_error",
+            Self::McpTimeout => "mcp_timeout",
+            Self::ConfigValidation => "config_validation",
+            Self::RequestValidation => "request_validation",
+            Self::BudgetExceeded => "budget_exceeded",
+            Self::ServiceUnavailable => "service_unavailable",
+            Self::Cancelled => "cancelled",
+            Self::Internal => "internal",
+        }
+    }
+
+    /// Returns a safe, generic client-facing message.
+    /// Internal details must NEVER appear in this output.
+    pub fn client_message(&self) -> &'static str {
+        match self {
+            Self::LlmTimeout => "The language model did not respond in time",
+            Self::LlmRateLimit => "The language model is temporarily rate limited",
+            Self::LlmAuthError => "An authentication error occurred with an upstream provider",
+            Self::LlmError => "An error occurred with the language model",
+            Self::McpConnectionFailed => "A downstream service is temporarily unavailable",
+            Self::McpToolError => "A tool execution error occurred",
+            Self::McpTimeout => "A tool call did not respond in time",
+            Self::ConfigValidation => "Server configuration error",
+            Self::RequestValidation => "Invalid request",
+            Self::BudgetExceeded => "Token budget exceeded for this request",
+            Self::ServiceUnavailable => "Server is shutting down",
+            Self::Cancelled => "Request was cancelled",
+            Self::Internal => "An internal error occurred",
+        }
+    }
+}
+
+impl std::fmt::Display for ErrorCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_label())
+    }
+}
+
+impl From<&DetectedToolError> for ErrorCategory {
+    fn from(err: &DetectedToolError) -> Self {
+        match err {
+            DetectedToolError::McpToolError(_) => ErrorCategory::McpToolError,
+            DetectedToolError::ToolCallError(_) => ErrorCategory::McpToolError,
+            DetectedToolError::JsonError(_) => ErrorCategory::Internal,
+        }
+    }
+}
+
+/// A classified runtime error with taxonomy category and internal message.
+pub struct AuraError {
+    pub category: ErrorCategory,
+    /// Internal message for server-side logging. Never expose to clients.
+    pub internal_message: String,
+}
+
+impl AuraError {
+    pub fn new(category: ErrorCategory, internal_message: impl Into<String>) -> Self {
+        Self {
+            category,
+            internal_message: internal_message.into(),
+        }
+    }
+
+    /// Safe message for API responses. Uses fixed generic text per category.
+    /// For RequestValidation, passes through the internal message (client input is safe).
+    pub fn client_message(&self) -> String {
+        match self.category {
+            ErrorCategory::RequestValidation => self.internal_message.clone(),
+            _ => self.category.client_message().to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_all_categories_have_non_empty_labels() {
+        for category in ALL_CATEGORIES {
+            let label = category.as_label();
+            assert!(!label.is_empty(), "empty label for {:?}", category);
+        }
+    }
+
+    #[test]
+    fn test_all_labels_are_prometheus_safe() {
+        let pattern = regex::Regex::new(r"^[a-z][a-z0-9_]*$").unwrap();
+        for category in ALL_CATEGORIES {
+            let label = category.as_label();
+            assert!(
+                pattern.is_match(label),
+                "label {:?} does not match Prometheus pattern",
+                label
+            );
+        }
+    }
+
+    #[test]
+    fn test_all_labels_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for category in ALL_CATEGORIES {
+            let label = category.as_label();
+            assert!(seen.insert(label), "duplicate label: {}", label);
+        }
+    }
+
+    #[test]
+    fn test_all_categories_count() {
+        assert_eq!(ALL_CATEGORIES.len(), 13);
+    }
+
+    #[test]
+    fn test_all_categories_have_non_empty_client_messages() {
+        for category in ALL_CATEGORIES {
+            let msg = category.client_message();
+            assert!(!msg.is_empty(), "empty client message for {:?}", category);
+        }
+    }
+
+    #[test]
+    fn test_client_messages_do_not_contain_internal_details() {
+        let suspicious_patterns = ["10.0.", "127.0.", "localhost", "::1", ".rs:", "panicked"];
+        for category in ALL_CATEGORIES {
+            let msg = category.client_message();
+            for pattern in &suspicious_patterns {
+                assert!(
+                    !msg.contains(pattern),
+                    "client message for {:?} contains suspicious pattern {:?}: {}",
+                    category,
+                    pattern,
+                    msg
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_detected_tool_error_mcp_maps_to_mcp_tool_error() {
+        let err = DetectedToolError::McpToolError("connection refused".to_string());
+        assert_eq!(ErrorCategory::from(&err), ErrorCategory::McpToolError);
+    }
+
+    #[test]
+    fn test_detected_tool_error_tool_call_maps_to_mcp_tool_error() {
+        let err = DetectedToolError::ToolCallError("timeout".to_string());
+        assert_eq!(ErrorCategory::from(&err), ErrorCategory::McpToolError);
+    }
+
+    #[test]
+    fn test_detected_tool_error_json_maps_to_internal() {
+        let err = DetectedToolError::JsonError("invalid json".to_string());
+        assert_eq!(ErrorCategory::from(&err), ErrorCategory::Internal);
+    }
+
+    #[test]
+    fn test_aura_error_client_message_sanitizes_internal_details() {
+        let err = AuraError::new(
+            ErrorCategory::McpConnectionFailed,
+            "MCP server 'pagerduty' at 10.0.1.5:8080 connection refused",
+        );
+        let msg = err.client_message();
+        assert_eq!(msg, "A downstream service is temporarily unavailable");
+        assert!(!msg.contains("pagerduty"));
+        assert!(!msg.contains("10.0.1.5"));
+        assert!(!msg.contains("8080"));
+    }
+
+    #[test]
+    fn test_aura_error_request_validation_passes_through() {
+        let err = AuraError::new(
+            ErrorCategory::RequestValidation,
+            "Last message must be from user, got: system",
+        );
+        assert_eq!(
+            err.client_message(),
+            "Last message must be from user, got: system"
+        );
+    }
+
+    #[test]
+    fn test_aura_error_non_validation_uses_generic_message() {
+        for category in ALL_CATEGORIES {
+            if *category == ErrorCategory::RequestValidation {
+                continue;
+            }
+            let err = AuraError::new(*category, "SECRET internal detail 10.0.1.5:8080");
+            let msg = err.client_message();
+            assert!(
+                !msg.contains("SECRET"),
+                "category {:?} leaked internal message: {}",
+                category,
+                msg
+            );
+        }
+    }
+
+    #[test]
+    fn test_display_uses_label() {
+        assert_eq!(format!("{}", ErrorCategory::LlmTimeout), "llm_timeout");
+        assert_eq!(
+            format!("{}", ErrorCategory::McpConnectionFailed),
+            "mcp_connection_failed"
+        );
+    }
+}

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod builder;
 pub mod config;
 pub mod error;
+pub mod error_taxonomy;
 pub mod fallback_tool_parser;
 pub mod fallback_tool_stream;
 pub mod logging;
@@ -70,6 +71,7 @@ pub use request_progress::{
 pub use rmcp::model::{NumberOrString, ProgressToken};
 pub use stream_events::{AgentContext, AuraStreamEvent, CorrelationContext, WorkerPhase};
 pub use streaming_request_hook::{ResponseContent, StreamingRequestHook, UsageState};
+pub use error_taxonomy::{AuraError, ErrorCategory, ALL_CATEGORIES};
 pub use tool_error_detection::{DetectedToolError, ToolResultStatus, detect_tool_error};
 pub use tool_event_broker::{
     ToolCallId, ToolEventBroker, ToolLifecycleEvent, ToolName, ToolUsageEvent,

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -5,6 +5,7 @@
 //! in web services or other applications that need to build agents
 //! programmatically.
 
+pub mod bedrock_embedding;
 pub mod builder;
 pub mod config;
 pub mod error;
@@ -28,7 +29,6 @@ mod schema_sanitize; // Private - MCP schema sanitization for OpenAI compatibili
 pub mod stream_events;
 pub mod streaming;
 pub mod streaming_request_hook;
-pub mod bedrock_embedding;
 pub(crate) mod string_utils;
 pub mod tool_error_detection;
 pub mod tool_event_broker;
@@ -59,6 +59,7 @@ pub type AuraToolCall = provider_agent::ToolCall;
 #[deprecated(since = "1.2.0", note = "use ToolResult instead")]
 pub type AuraToolResult = provider_agent::ToolResult;
 
+pub use error_taxonomy::{ALL_CATEGORIES, AuraError, ErrorCategory};
 pub use mcp::McpManager;
 pub use mcp_progress::ProgressEnabledHandler;
 pub use mcp_streamable_http::InFlightRequests;
@@ -71,7 +72,6 @@ pub use request_progress::{
 pub use rmcp::model::{NumberOrString, ProgressToken};
 pub use stream_events::{AgentContext, AuraStreamEvent, CorrelationContext, WorkerPhase};
 pub use streaming_request_hook::{ResponseContent, StreamingRequestHook, UsageState};
-pub use error_taxonomy::{AuraError, ErrorCategory, ALL_CATEGORIES};
 pub use tool_error_detection::{DetectedToolError, ToolResultStatus, detect_tool_error};
 pub use tool_event_broker::{
     ToolCallId, ToolEventBroker, ToolLifecycleEvent, ToolName, ToolUsageEvent,

--- a/crates/aura/src/vector_store.rs
+++ b/crates/aura/src/vector_store.rs
@@ -109,17 +109,11 @@ impl VectorStoreManager {
     }
 
     /// Load AWS SDK config with optional region and profile
-    async fn load_aws_config(
-        region: &str,
-        profile: Option<&str>,
-    ) -> aws_config::SdkConfig {
+    async fn load_aws_config(region: &str, profile: Option<&str>) -> aws_config::SdkConfig {
         use aws_config::{BehaviorVersion, Region};
 
         if let Some(profile_name) = profile {
-            info!(
-                "Loading AWS config with profile '{}'",
-                profile_name
-            );
+            info!("Loading AWS config with profile '{}'", profile_name);
             aws_config::defaults(BehaviorVersion::latest())
                 .region(Region::new(region.to_string()))
                 .profile_name(profile_name)
@@ -222,8 +216,7 @@ impl VectorStoreManager {
         let qdrant_store = match embedding {
             EmbeddingModelConfig::OpenAI { api_key, model, .. } => {
                 let embedding_model = Self::create_openai_embedding_model(api_key, model)?;
-                let store =
-                    QdrantVectorStore::new(qdrant_client, embedding_model, query_params);
+                let store = QdrantVectorStore::new(qdrant_client, embedding_model, query_params);
                 QdrantStoreKind::OpenAI(store)
             }
             EmbeddingModelConfig::Bedrock {
@@ -232,10 +225,8 @@ impl VectorStoreManager {
                 profile,
             } => {
                 let embedding_model =
-                    Self::create_bedrock_embedding_model(model, region, profile.as_deref())
-                        .await?;
-                let store =
-                    QdrantVectorStore::new(qdrant_client, embedding_model, query_params);
+                    Self::create_bedrock_embedding_model(model, region, profile.as_deref()).await?;
+                let store = QdrantVectorStore::new(qdrant_client, embedding_model, query_params);
                 QdrantStoreKind::Bedrock(store)
             }
         };
@@ -268,11 +259,7 @@ impl VectorStoreManager {
         info!("  Knowledge Base ID: {}", knowledge_base_id);
         info!("  Region: {}", region);
 
-        let sdk_config = Self::load_aws_config(
-            region,
-            profile,
-        )
-        .await;
+        let sdk_config = Self::load_aws_config(region, profile).await;
 
         let client = aws_sdk_bedrockagentruntime::Client::new(&sdk_config);
         info!("Bedrock Knowledge Base client initialized");
@@ -296,7 +283,8 @@ impl VectorStoreManager {
     pub async fn add_documents(&self, documents: Vec<String>) -> Result<(), BuilderError> {
         if self.store_type == "bedrock_kb" {
             return Err(BuilderError::VectorStoreError(
-                "Bedrock Knowledge Base is read-only; manage documents via the AWS console".to_string(),
+                "Bedrock Knowledge Base is read-only; manage documents via the AWS console"
+                    .to_string(),
             ));
         }
 
@@ -386,22 +374,18 @@ impl VectorStoreManager {
         limit: usize,
     ) -> Result<Vec<SearchResult>, BuilderError> {
         let client = self.bedrock_kb_client.as_ref().ok_or_else(|| {
-            BuilderError::VectorStoreError(
-                "Bedrock KB client not initialized".to_string(),
-            )
+            BuilderError::VectorStoreError("Bedrock KB client not initialized".to_string())
         })?;
-        let kb_id = self.bedrock_kb_id.as_ref().ok_or_else(|| {
-            BuilderError::VectorStoreError(
-                "Bedrock KB ID not set".to_string(),
-            )
-        })?;
+        let kb_id = self
+            .bedrock_kb_id
+            .as_ref()
+            .ok_or_else(|| BuilderError::VectorStoreError("Bedrock KB ID not set".to_string()))?;
 
         debug!("Performing Bedrock KB retrieve for: '{}'", query);
 
-        let retrieval_query =
-            aws_sdk_bedrockagentruntime::types::KnowledgeBaseQuery::builder()
-                .text(query)
-                .build();
+        let retrieval_query = aws_sdk_bedrockagentruntime::types::KnowledgeBaseQuery::builder()
+            .text(query)
+            .build();
 
         let retrieval_config =
             aws_sdk_bedrockagentruntime::types::KnowledgeBaseRetrievalConfiguration::builder()
@@ -420,9 +404,7 @@ impl VectorStoreManager {
             .send()
             .await
             .map_err(|e| {
-                BuilderError::VectorStoreError(format!(
-                    "Bedrock KB retrieve failed: {e}"
-                ))
+                BuilderError::VectorStoreError(format!("Bedrock KB retrieve failed: {e}"))
             })?;
 
         let results: Vec<SearchResult> = response
@@ -492,12 +474,8 @@ impl VectorStoreManager {
                     })?;
 
                 let mut candidates = match qdrant_store.as_ref() {
-                    QdrantStoreKind::OpenAI(store) => {
-                        store.top_n::<Value>(search_request).await
-                    }
-                    QdrantStoreKind::Bedrock(store) => {
-                        store.top_n::<Value>(search_request).await
-                    }
+                    QdrantStoreKind::OpenAI(store) => store.top_n::<Value>(search_request).await,
+                    QdrantStoreKind::Bedrock(store) => store.top_n::<Value>(search_request).await,
                 }
                 .map_err(|e| {
                     BuilderError::VectorStoreError(format!("Qdrant search failed: {e}"))


### PR DESCRIPTION
## Summary
- **AURA-RM-008**: Structured error taxonomy with `ErrorCategory` enum (13 categories), `AuraError` sanitization layer separating internal messages from client-facing responses, and taxonomy `code` field in API error responses
- **AURA-RM-001**: Prometheus-compatible `/metrics` endpoint with request duration histogram, LLM token counters, MCP tool duration histogram, error counters, in-flight gauge, and MCP connection state gauge
- Full spec-driven development lifecycle: 3 specs per item, 4 rounds of spec review, 3 rounds of code review, all clean

## Verified via live testing
- Started Aura in a local container with Bedrock LLM
- `GET /health` returns `{"status": "healthy"}`
- `GET /metrics` returns valid Prometheus text exposition format
- Non-streaming chat completion: tokens recorded correctly (prompt=18, completion=2)
- Streaming chat completion: tokens accumulated across requests
- Validation errors include `code: "request_validation"` field
- Internal errors sanitized (no hostnames/IPs in client messages)
- In-flight gauge correctly shows 0 after requests complete
- `/health` and `/metrics` exempt from shutdown_guard

## Test plan
- [x] `cargo test --workspace --lib` — 299 tests pass, 0 failures
- [x] `cargo fmt --check` — clean
- [x] Live server test: `/metrics` returns all 5 metric families
- [x] Live server test: token counters match usage in chat response
- [x] Live server test: error responses include taxonomy `code` field
- [x] Live server test: streaming works correctly with metrics recording
- [x] Docker build passes lint/test stage

## Specs
- `.specify/specs/AURA-RM-008/` — product, architecture, quality specs + review records
- `.specify/specs/AURA-RM-001/` — product, architecture, quality specs + review records

Ref: LOG-00000