### PR TITLE
feat: add structured error taxonomy and prometheus metrics (AURA-RM-008 + RM-001)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,6 @@ tui/
 
 # Development documentation (keep local only)
 docs/architecture-decisions/
-docs/internal/
 docs/planning/
 docs/*-internal.md
 docs/archive/

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,66 @@
+# Aura Project Constitution
+
+## Preamble
+
+This document establishes the immutable principles that govern all development on the Aura project. Every specification, implementation, and review must comply with these articles. Amendments require explicit team consensus and a versioned update to this file.
+
+---
+
+## Article I: OpenAI API Compatibility
+
+The `/v1/chat/completions` and `/v1/models` API contracts are non-negotiable. No change may break compatibility with existing OpenAI SDKs (Python, Node.js, Go, Rust) or chat frontends (LibreChat, OpenWebUI, Cursor). New functionality is additive only — new fields, new endpoints, new event types. Never remove or rename existing fields.
+
+**Rationale:** Aura's adoption depends on drop-in compatibility with the OpenAI ecosystem. Breaking this contract breaks every client integration simultaneously.
+
+## Article II: Crate Boundary Separation
+
+The three-crate architecture is load-bearing:
+- `aura` — runtime agent building, MCP integration, tool orchestration, vector workflows. No knowledge of HTTP, config file format, or web server concerns.
+- `aura-config` — typed TOML parsing and validation. No knowledge of runtime behavior or web serving.
+- `aura-web-server` — OpenAI-compatible REST/SSE serving layer. No business logic beyond request routing and response formatting.
+
+**Rationale:** This separation enables the embeddable core (`aura` crate) to be used in any Rust application without config or web dependencies. Violating boundaries creates hidden coupling.
+
+## Article III: No AI Co-Authorship
+
+Never add `Co-Authored-By` lines for Claude or any AI assistant. Sign off commits as the human user. Claude cannot accept the CLA.
+
+**Rationale:** CLA compliance. The mezmo/aura repository requires all contributors to have signed the Contributor License Agreement.
+
+## Article IV: Conventional Commits
+
+All commits follow the format in CLAUDE.md:
+- First line: entirely lowercase, no trailing period, under 72 characters
+- Format: `<type>(<optional scope>): <description>`
+- Types: `feat`, `fix`, `doc`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`
+- Body: explains what and why
+- Footer: `Ref: LOG-XXXXX` and `Signed-off-by: name <email>`
+
+**Rationale:** Jenkins commitlint enforces this format. Non-compliant commits fail CI.
+
+## Article V: Feature Flags for Integration Tests
+
+New integration test suites must use the existing feature flag pattern in `aura-web-server/Cargo.toml`. Parent flag: `integration`. Suite-specific flags: `integration-<suite-name>`.
+
+**Rationale:** Integration tests require running infrastructure (MCP servers, LLM APIs). Feature flags prevent them from running in unit test contexts and allow selective CI execution.
+
+## Article VI: Environment Variables for Secrets
+
+Configuration references secrets exclusively via `{{ env.VAR_NAME }}` template syntax. Never hardcode API keys, tokens, or credentials in TOML files, source code, or test fixtures.
+
+**Rationale:** Secrets in source control are a security incident. The env var template system in `aura-config/src/env.rs` provides safe interpolation with validation.
+
+## Article VII: Backward-Compatible Configuration
+
+New configuration fields must have sensible defaults. Existing TOML files must continue to work without modification when Aura is upgraded. Use `#[serde(default)]` for all new fields.
+
+**Rationale:** Deployed agents have existing config files. Forcing config changes on upgrade creates operational friction and deployment failures.
+
+---
+
+## Governance
+
+**Amendment procedure:** Propose changes via PR to this file. Requires review and approval from at least one maintainer. Each amendment is versioned with a date.
+
+**Version:** 1.0.0
+**Established:** 2026-04-28

--- a/.specify/roadmap/AURA-RM-001-prometheus-metrics.md
+++ b/.specify/roadmap/AURA-RM-001-prometheus-metrics.md
@@ -1,0 +1,97 @@
+# AURA-RM-001: Prometheus Metrics Endpoint
+
+**Priority:** P0 (Critical)
+**Status:** Not Started
+**Dependencies:** AURA-RM-008 (Structured Error Taxonomy)
+**Depended on by:** AURA-RM-003, AURA-RM-005, AURA-RM-011
+**Affected Crates:** `aura-web-server`, `aura`
+**Complexity:** Medium
+
+## Rationale
+
+Aura is deployed in production but has zero metrics exposure. Operators cannot set SLO alerts, measure request latency distributions, track token spend, or observe MCP tool health. The OpenTelemetry tracing infrastructure exists (`logging.rs`, `openinference_exporter.rs`) but covers traces only — not metrics. Without a `/metrics` endpoint, production operation is blind.
+
+## User Stories
+
+### US-001.1: Request Latency Observability
+
+**As an** SRE,
+**I want** to scrape a `/metrics` endpoint from Prometheus,
+**So that** I can alert on p99 request latency exceeding SLO thresholds.
+
+#### Acceptance Criteria
+
+**AC-001.1.1:** Prometheus endpoint exists
+- **Given** a running Aura web server
+- **When** I send `GET /metrics`
+- **Then** I receive a 200 response with Prometheus text exposition format
+
+**AC-001.1.2:** Request latency histogram
+- **Given** a chat completion request completes
+- **When** I scrape `/metrics`
+- **Then** I see a `aura_request_duration_seconds` histogram with `method`, `status`, and `agent` labels
+
+### US-001.2: Token Usage Tracking
+
+**As a** platform operator,
+**I want** token usage counters per agent per LLM provider,
+**So that** I can forecast cost and detect runaway usage.
+
+#### Acceptance Criteria
+
+**AC-001.2.1:** Token counters
+- **Given** chat completion requests have been served
+- **When** I scrape `/metrics`
+- **Then** I see `aura_tokens_total` counter with `type` (prompt/completion), `provider`, and `agent` labels
+
+### US-001.3: MCP Tool Duration
+
+**As an** SRE,
+**I want** MCP tool call duration histograms with server and tool name labels,
+**So that** I can identify which tools are degrading response times.
+
+#### Acceptance Criteria
+
+**AC-001.3.1:** Tool duration histogram
+- **Given** an agent has called MCP tools
+- **When** I scrape `/metrics`
+- **Then** I see `aura_mcp_tool_duration_seconds` histogram with `server`, `tool`, and `status` labels
+
+### US-001.4: Error Rate by Type
+
+**As an** SRE,
+**I want** error rate counters by error type,
+**So that** I can set differentiated alerts (LLM timeout vs MCP failure vs validation error).
+
+#### Acceptance Criteria
+
+**AC-001.4.1:** Error counters
+- **Given** errors have occurred during request processing
+- **When** I scrape `/metrics`
+- **Then** I see `aura_errors_total` counter with `error_type` label using the taxonomy from AURA-RM-008
+
+### US-001.5: Active Request Gauge
+
+**As an** operator,
+**I want** active in-flight request count as a gauge,
+**So that** I can right-size capacity and detect connection leaks.
+
+#### Acceptance Criteria
+
+**AC-001.5.1:** In-flight gauge
+- **Given** requests are being processed
+- **When** I scrape `/metrics`
+- **Then** I see `aura_requests_in_flight` gauge reflecting the current count
+
+## Existing Infrastructure
+
+- `ActiveRequestTracker` in `types.rs` already tracks in-flight count via `AtomicUsize`
+- `UsageState` in `streaming_request_hook.rs` accumulates token counts per request
+- MCP tool execution in `mcp_tool_execution.rs` has OTel span instrumentation with timing
+- Error types will be defined by AURA-RM-008
+
+## Edge Cases
+
+- Metrics endpoint must not require authentication (Article VII of constitution)
+- Histogram buckets must be configurable or use sensible defaults for LLM latency (seconds, not milliseconds)
+- Token counters must handle streaming vs non-streaming responses identically

--- a/.specify/roadmap/AURA-RM-002-deep-health-checks.md
+++ b/.specify/roadmap/AURA-RM-002-deep-health-checks.md
@@ -1,0 +1,112 @@
+# AURA-RM-002: Deep Health and Readiness Checks
+
+**Priority:** P0 (Critical)
+**Status:** Not Started
+**Dependencies:** AURA-RM-008 (Structured Error Taxonomy)
+**Depended on by:** None
+**Affected Crates:** `aura-web-server`, `aura`
+**Complexity:** Medium-High
+
+## Rationale
+
+The current `/health` endpoint returns a static `{"status": "healthy"}` regardless of actual system state. Kubernetes liveness/readiness probes never detect a degraded instance — failed LLM credentials, disconnected MCP servers, or unreachable vector stores all present as "healthy." This causes traffic to route to broken pods.
+
+## User Stories
+
+### US-002.1: Readiness Probe with LLM Verification
+
+**As a** Kubernetes operator,
+**I want** a `/health/ready` endpoint that verifies LLM provider connectivity,
+**So that** my readiness probe removes unhealthy pods from the load balancer.
+
+#### Acceptance Criteria
+
+**AC-002.1.1:** Readiness endpoint exists
+- **Given** a running Aura web server
+- **When** I send `GET /health/ready`
+- **Then** I receive 200 if all checks pass, or 503 with details if any fail
+
+**AC-002.1.2:** LLM provider check
+- **Given** the configured LLM provider credentials are invalid
+- **When** I send `GET /health/ready`
+- **Then** I receive 503 with `"llm": {"status": "error", "message": "..."}`
+
+### US-002.2: Liveness Probe
+
+**As an** operator,
+**I want** a `/health/live` endpoint that confirms the process is functioning,
+**So that** my liveness probe restarts stuck pods.
+
+#### Acceptance Criteria
+
+**AC-002.2.1:** Liveness endpoint
+- **Given** a running Aura web server
+- **When** I send `GET /health/live`
+- **Then** I receive 200 with `{"status": "alive"}`
+
+### US-002.3: MCP Server Connectivity Check
+
+**As an** operator,
+**I want** the readiness check to verify all configured MCP server connections,
+**So that** I know tool execution will succeed before routing traffic.
+
+#### Acceptance Criteria
+
+**AC-002.3.1:** MCP health check
+- **Given** an MCP server is configured but unreachable
+- **When** I send `GET /health/ready`
+- **Then** I receive 503 with `"mcp": {"server_name": {"status": "error", "message": "..."}}`
+
+### US-002.4: Per-Subsystem Status
+
+**As an** operator,
+**I want** each subsystem check to report individually,
+**So that** I can diagnose which dependency is failing.
+
+#### Acceptance Criteria
+
+**AC-002.4.1:** Subsystem breakdown
+- **Given** a running Aura web server with LLM, MCP, and vector store configured
+- **When** I send `GET /health/ready`
+- **Then** I receive a JSON response with individual status for each subsystem:
+  ```json
+  {
+    "status": "healthy",
+    "checks": {
+      "llm": {"status": "ok", "provider": "bedrock"},
+      "mcp": {
+        "server_1": {"status": "ok", "tools": 5},
+        "server_2": {"status": "error", "message": "connection refused"}
+      },
+      "vector_stores": {
+        "docs": {"status": "ok", "type": "qdrant"}
+      }
+    }
+  }
+  ```
+
+### US-002.5: Cached Health Checks
+
+**As an** operator,
+**I want** health checks cached for a configurable interval (default 10s),
+**So that** they don't add load to upstream dependencies on every probe.
+
+#### Acceptance Criteria
+
+**AC-002.5.1:** Cache TTL
+- **Given** a health check was performed less than 10 seconds ago
+- **When** I send `GET /health/ready`
+- **Then** I receive the cached result without re-checking dependencies
+
+## Existing Infrastructure
+
+- `/health` endpoint at `handlers.rs` line 634 (static response)
+- `McpManager` holds `Arc<RunningService>` clients — implement ping/list-tools probe
+- Helm chart has liveness/readiness probes configured pointing to `/health`
+
+## Edge Cases
+
+- Health checks must not require authentication
+- Cache TTL must be configurable via env var or TOML
+- If no MCP servers are configured, the MCP check should report "not configured" (not "error")
+- Health check timeout must be shorter than Kubernetes probe timeout

--- a/.specify/roadmap/AURA-RM-003-mcp-retry-circuit-breaker.md
+++ b/.specify/roadmap/AURA-RM-003-mcp-retry-circuit-breaker.md
@@ -1,0 +1,92 @@
+# AURA-RM-003: MCP Retry and Circuit Breaker
+
+**Priority:** P1 (High)
+**Status:** Not Started
+**Dependencies:** AURA-RM-001 (Metrics), AURA-RM-008 (Error Taxonomy)
+**Depended on by:** AURA-RM-011 (Admin Endpoint)
+**Affected Crates:** `aura`, `aura-config`
+**Complexity:** Medium
+
+## Rationale
+
+MCP tool calls have zero retry logic or circuit breaking. If an MCP server is flaky (intermittent timeouts, 503s), every tool call fails through to the LLM. One dead MCP server causes cascading timeouts across all agent requests that use it. The execution path in `mcp_tool_execution.rs` and `mcp_streamable_http.rs` calls the MCP server exactly once and propagates any error.
+
+## User Stories
+
+### US-003.1: Automatic Retry on Transient Errors
+
+**As an** agent operator,
+**I want** MCP tool calls to automatically retry on transient errors with exponential backoff,
+**So that** intermittent failures don't break agent workflows.
+
+#### Acceptance Criteria
+
+**AC-003.1.1:** Retry on transient errors
+- **Given** an MCP server returns a 503 on the first attempt
+- **When** the retry policy allows retries
+- **Then** the tool call is retried up to the configured max attempts with exponential backoff
+
+**AC-003.1.2:** No retry on permanent errors
+- **Given** an MCP server returns a 400 (bad request)
+- **When** the tool call fails
+- **Then** the error is returned immediately without retry
+
+### US-003.2: Circuit Breaker per MCP Server
+
+**As an** operator,
+**I want** a circuit breaker per MCP server that opens after N consecutive failures,
+**So that** a dead MCP server returns fast errors instead of causing timeouts.
+
+#### Acceptance Criteria
+
+**AC-003.2.1:** Circuit breaker opens
+- **Given** an MCP server has failed 5 consecutive times (configurable threshold)
+- **When** a new tool call is attempted to that server
+- **Then** the call fails immediately with a circuit-open error without contacting the server
+
+**AC-003.2.2:** Circuit breaker half-open
+- **Given** the circuit breaker is open and the reset timeout has elapsed
+- **When** a tool call is attempted
+- **Then** one probe request is sent; if it succeeds, the circuit closes; if it fails, it stays open
+
+### US-003.3: Circuit Breaker Metrics
+
+**As an** operator,
+**I want** circuit breaker state exposed via the metrics endpoint,
+**So that** I can alert on circuit breaker open events.
+
+#### Acceptance Criteria
+
+**AC-003.3.1:** Circuit breaker gauge
+- **Given** metrics endpoint exists (AURA-RM-001)
+- **When** I scrape `/metrics`
+- **Then** I see `aura_mcp_circuit_breaker_state` gauge with `server` label (0=closed, 1=open, 0.5=half-open)
+
+### US-003.4: Per-Server Configuration
+
+**As a** config author,
+**I want** to configure retry count, backoff, and circuit breaker thresholds per MCP server,
+**So that** I can tune behavior for different tool reliability profiles.
+
+#### Acceptance Criteria
+
+**AC-003.4.1:** TOML configuration
+- **Given** a config with retry and circuit breaker settings
+- **When** the server starts
+- **Then** the configured values are applied per MCP server
+  ```toml
+  [mcp.servers.example.retry]
+  max_attempts = 3
+  initial_backoff_ms = 100
+  max_backoff_ms = 5000
+
+  [mcp.servers.example.circuit_breaker]
+  failure_threshold = 5
+  reset_timeout_secs = 30
+  ```
+
+## Edge Cases
+
+- Circuit breaker state should survive across requests but not across server restarts
+- Retry backoff should include jitter to avoid thundering herd
+- Retries must respect the overall request timeout (don't retry if timeout is nearly exhausted)

--- a/.specify/roadmap/AURA-RM-004-api-auth-middleware.md
+++ b/.specify/roadmap/AURA-RM-004-api-auth-middleware.md
@@ -1,0 +1,79 @@
+# AURA-RM-004: API Authentication Middleware
+
+**Priority:** P1 (High)
+**Status:** Not Started
+**Dependencies:** AURA-RM-008 (Structured Error Taxonomy)
+**Depended on by:** None
+**Affected Crates:** `aura-web-server`, `aura-config`
+**Complexity:** Low-Medium
+
+## Rationale
+
+The Aura API is currently wide open — no authentication on any endpoint. While it's designed for deployment behind a reverse proxy, defense-in-depth requires the ability to validate API keys at the application layer. Every team deploying Aura currently has to solve auth separately.
+
+## User Stories
+
+### US-004.1: API Key Authentication
+
+**As a** platform operator,
+**I want** to configure API key authentication via TOML or env vars,
+**So that** I can restrict access without requiring a reverse proxy.
+
+#### Acceptance Criteria
+
+**AC-004.1.1:** Bearer token validation
+- **Given** auth is configured with one or more API keys
+- **When** a request arrives with `Authorization: Bearer <valid-key>`
+- **Then** the request proceeds to the handler
+
+**AC-004.1.2:** Rejection of invalid tokens
+- **Given** auth is configured
+- **When** a request arrives with an invalid or missing Authorization header
+- **Then** the request is rejected with 401 Unauthorized before reaching handler logic
+
+### US-004.2: Unauthenticated Health Endpoints
+
+**As a** platform operator,
+**I want** the health and metrics endpoints to remain unauthenticated,
+**So that** Kubernetes probes and Prometheus scrapers work without credentials.
+
+#### Acceptance Criteria
+
+**AC-004.2.1:** Health exempt
+- **Given** auth is configured
+- **When** I send `GET /health` without an Authorization header
+- **Then** I receive 200 (not 401)
+
+### US-004.3: Key Rotation Support
+
+**As an** operator,
+**I want** to support multiple API keys (for rotation),
+**So that** I can rotate keys without downtime.
+
+#### Acceptance Criteria
+
+**AC-004.3.1:** Multiple keys
+- **Given** auth is configured with keys ["key-1", "key-2"]
+- **When** a request arrives with `Authorization: Bearer key-1` or `Bearer key-2`
+- **Then** both are accepted
+
+### US-004.4: Optional Auth (Disabled by Default)
+
+**As a** developer,
+**I want** auth to be optional and disabled by default,
+**So that** the quick-start experience is not degraded.
+
+#### Acceptance Criteria
+
+**AC-004.4.1:** Default off
+- **Given** no auth section in TOML config
+- **When** the server starts
+- **Then** all requests are accepted without authentication
+
+## Configuration Example
+
+```toml
+[auth]
+api_keys = ["{{ env.AURA_API_KEY_1 }}", "{{ env.AURA_API_KEY_2 }}"]
+exclude_paths = ["/health", "/health/ready", "/health/live", "/metrics"]
+```

--- a/.specify/roadmap/AURA-RM-005-token-budget-enforcement.md
+++ b/.specify/roadmap/AURA-RM-005-token-budget-enforcement.md
@@ -1,0 +1,69 @@
+# AURA-RM-005: Token Budget Enforcement
+
+**Priority:** P1 (High)
+**Status:** Not Started
+**Dependencies:** AURA-RM-001 (Metrics for budget tracking)
+**Depended on by:** None
+**Affected Crates:** `aura`, `aura-config`
+**Complexity:** Low-Medium
+
+## Rationale
+
+The `turn_depth` config limits tool call rounds but not total token consumption. A model making 5 tool calls with massive context can burn unlimited tokens. The `UsageState` already tracks token counts per request but has no enforcement. Orchestration mode with replan cycles makes this especially risky.
+
+## User Stories
+
+### US-005.1: Per-Request Token Budget
+
+**As a** platform operator,
+**I want** to set a per-request token budget in TOML,
+**So that** runaway loops are terminated before exceeding cost thresholds.
+
+#### Acceptance Criteria
+
+**AC-005.1.1:** Budget enforcement
+- **Given** `token_budget = 10000` is configured
+- **When** a request's cumulative token usage exceeds 10000
+- **Then** the stream is terminated gracefully with an error message explaining the budget was exceeded
+
+**AC-005.1.2:** Budget metrics
+- **Given** metrics endpoint exists (AURA-RM-001)
+- **When** a request is terminated due to budget
+- **Then** `aura_budget_exceeded_total` counter is incremented
+
+### US-005.2: Graceful Termination
+
+**As an** operator,
+**I want** the system to emit an error event and terminate the stream gracefully when budget is exceeded,
+**So that** the client gets a clear explanation.
+
+#### Acceptance Criteria
+
+**AC-005.2.1:** SSE event on budget exceeded
+- **Given** custom events are enabled
+- **When** the token budget is exceeded mid-stream
+- **Then** an `aura.budget_exceeded` event is emitted with token counts before the stream terminates with `[DONE]`
+
+### US-005.3: Budget Audit Logging
+
+**As an** operator,
+**I want** budget violations logged with request details and token counts,
+**So that** I can audit which queries are expensive.
+
+#### Acceptance Criteria
+
+**AC-005.3.1:** Structured log on violation
+- **Given** a request exceeds its token budget
+- **When** the stream is terminated
+- **Then** a structured log entry is emitted with: request_id, agent_name, budget, actual_tokens, query_preview
+
+## Configuration Example
+
+```toml
+[agent]
+name = "SRE Assistant"
+token_budget = 50000
+# Optional: separate prompt/completion budgets
+# prompt_token_budget = 30000
+# completion_token_budget = 20000
+```

--- a/.specify/roadmap/AURA-RM-006-cli-day2-operations.md
+++ b/.specify/roadmap/AURA-RM-006-cli-day2-operations.md
@@ -1,0 +1,42 @@
+# AURA-RM-006: CLI for Day-2 Operations
+
+**Priority:** P2 (Medium)
+**Status:** In Progress (branch: justingross/LOG-23587-add-aura-cli)
+**Dependencies:** None (low coupling)
+**Depended on by:** None
+**Affected Crates:** New `aura-cli` crate
+**Complexity:** Medium
+
+## Rationale
+
+SREs live in terminals. Day-2 operations (config validation, agent listing, health checks, interactive chat) currently require curl commands or a running chat UI. A CLI enables quick agent interaction and operational tasks directly from the terminal.
+
+## User Stories
+
+### US-006.1: Config Validation
+
+**As a** developer,
+**I want** `aura validate config.toml` to parse and validate a config without starting the server,
+**So that** I can catch errors in CI before deployment.
+
+### US-006.2: Health Check
+
+**As an** operator,
+**I want** `aura health --url http://localhost:8080` to call the health endpoint and format the result,
+**So that** I can check status from the CLI.
+
+### US-006.3: Interactive Chat
+
+**As a** developer,
+**I want** `aura chat --agent devops --url http://localhost:8080` to start an interactive session,
+**So that** I can test agents quickly without a UI.
+
+### US-006.4: Agent Discovery
+
+**As an** operator,
+**I want** `aura agents --url http://localhost:8080` to list all configured agents,
+**So that** I can discover available agents.
+
+## Notes
+
+This item is tracked for completeness. Active development is on the `justingross/LOG-23587-add-aura-cli` branch by Justin Gross.

--- a/.specify/roadmap/AURA-RM-007-incident-response-mode.md
+++ b/.specify/roadmap/AURA-RM-007-incident-response-mode.md
@@ -1,0 +1,58 @@
+# AURA-RM-007: Incident Response Mode
+
+**Priority:** P2 (Medium)
+**Status:** Not Started
+**Dependencies:** AURA-RM-008 (Structured Error Taxonomy)
+**Depended on by:** None
+**Affected Crates:** `aura-web-server`, `aura`, potentially new `aura-integrations`
+**Complexity:** High
+
+## Rationale
+
+Aura is deployed for SRE use cases with PagerDuty and Datadog MCP tools. Tying an agent session to a live incident creates an auditable timeline of agent actions during the incident. This is the killer SRE use case — an on-call assistant that has context, takes actions, and produces a post-incident report automatically.
+
+## User Stories
+
+### US-007.1: Incident Context Injection
+
+**As an** SRE,
+**I want** to pass a PagerDuty incident ID when starting a chat session,
+**So that** all agent actions are correlated with the incident timeline.
+
+#### Acceptance Criteria
+
+**AC-007.1.1:** Incident ID in metadata
+- **Given** a chat request with `metadata.incident_id = "P12345"`
+- **When** the agent processes the request
+- **Then** all tool calls, events, and logs include the incident_id for correlation
+
+### US-007.2: Automatic Incident Context Retrieval
+
+**As an** SRE,
+**I want** the agent to automatically retrieve incident context when an incident ID is provided,
+**So that** it has immediate situational awareness.
+
+#### Acceptance Criteria
+
+**AC-007.2.1:** Auto-context
+- **Given** a PagerDuty MCP server is configured and an incident_id is provided
+- **When** the agent starts processing
+- **Then** it retrieves the incident details (alerts, affected services, timeline) before responding
+
+### US-007.3: Post-Incident Report
+
+**As an** incident commander,
+**I want** a summary of all tools the agent invoked, their results, and recommendations,
+**So that** I can include agent actions in the post-mortem.
+
+#### Acceptance Criteria
+
+**AC-007.3.1:** Session summary
+- **Given** an incident-mode session has completed
+- **When** the session ends
+- **Then** a structured summary is available via the API or as a final event
+
+## Edge Cases
+
+- Incident ID must be optional — sessions without incident_id work normally
+- If PagerDuty MCP is not configured, incident_id is stored for correlation but auto-context is skipped

--- a/.specify/roadmap/AURA-RM-008-structured-error-taxonomy.md
+++ b/.specify/roadmap/AURA-RM-008-structured-error-taxonomy.md
@@ -1,0 +1,68 @@
+# AURA-RM-008: Structured Error Taxonomy
+
+**Priority:** P2 (Medium) — but executes FIRST due to dependencies
+**Status:** Not Started
+**Dependencies:** None (foundation item)
+**Depended on by:** AURA-RM-001, AURA-RM-002, AURA-RM-003, AURA-RM-004, AURA-RM-007
+**Affected Crates:** `aura`, `aura-web-server`, `aura-config`
+**Complexity:** Medium
+
+## Rationale
+
+Error types are currently ad-hoc. `BuilderError` in `error.rs` has generic variants. `DetectedToolError` in `tool_error_detection.rs` parses error strings back into structured types. There is no unified taxonomy that distinguishes LLM timeout from MCP failure from validation error. This is the foundation for metrics labels (RM-001), health check results (RM-002), and circuit breaker classification (RM-003).
+
+## User Stories
+
+### US-008.1: Unified Error Enum
+
+**As a** developer,
+**I want** a unified error enum that categorizes all Aura errors,
+**So that** error handling is consistent across the codebase.
+
+#### Acceptance Criteria
+
+**AC-008.1.1:** Error categories
+- **Given** any error in the Aura system
+- **When** it is propagated
+- **Then** it can be classified into one of: `LlmTimeout`, `LlmRateLimit`, `LlmAuthError`, `McpConnectionFailed`, `McpToolError`, `McpTimeout`, `ConfigValidation`, `RequestValidation`, `VectorStoreError`, `BudgetExceeded`, `Internal`
+
+### US-008.2: Error Codes in API Responses
+
+**As an** operator,
+**I want** error responses to include an error code (not just a message),
+**So that** I can build programmatic error handling.
+
+#### Acceptance Criteria
+
+**AC-008.2.1:** Structured error response
+- **Given** an error occurs during request processing
+- **When** the error response is returned
+- **Then** it includes `error_code` alongside `message`:
+  ```json
+  {
+    "error": {
+      "message": "MCP server 'pagerduty' is unreachable",
+      "error_type": "mcp_connection_failed",
+      "error_code": "AURA-E-MCP-001"
+    }
+  }
+  ```
+
+### US-008.3: Error Metrics Labels
+
+**As an** operator,
+**I want** error metrics categorized by this taxonomy,
+**So that** I can set alerts on specific failure modes.
+
+#### Acceptance Criteria
+
+**AC-008.3.1:** Error type as metric label
+- **Given** the error taxonomy and metrics endpoint (AURA-RM-001) exist
+- **When** errors are recorded in metrics
+- **Then** the `error_type` label matches the taxonomy categories
+
+## Implementation Notes
+
+- This is a refactoring effort — replacing ad-hoc error handling with structured types
+- Must be backward-compatible: existing API error responses still work, new fields are additive
+- The `error_type` field in `ErrorDetail` (handlers.rs) already exists — extend it with the taxonomy

--- a/.specify/roadmap/AURA-RM-009-agent-catalog-registry.md
+++ b/.specify/roadmap/AURA-RM-009-agent-catalog-registry.md
@@ -1,0 +1,32 @@
+# AURA-RM-009: Agent Catalog / Registry
+
+**Priority:** P3 (Lower)
+**Status:** Not Started
+**Dependencies:** None (standalone)
+**Depended on by:** None
+**Affected Crates:** New subsystem
+**Complexity:** High
+
+## Rationale
+
+In multi-team environments, teams create agents independently. There is no way to discover, share, or version agent configurations across teams. As the number of agents grows, a central registry prevents duplication and enables cross-team collaboration.
+
+## User Stories
+
+### US-009.1: Publish Agent Configs
+
+**As a** platform engineer,
+**I want** a central registry where teams can publish agent TOML configs with metadata,
+**So that** other teams can discover and reuse agents.
+
+### US-009.2: Search by Capability
+
+**As a** developer,
+**I want** to search the registry by capability (e.g., "kubernetes," "log analysis"),
+**So that** I can find relevant agents without browsing all configs.
+
+### US-009.3: Versioned Configs
+
+**As a** platform engineer,
+**I want** agent configs to be versioned,
+**So that** I can roll back to a previous version if a new config causes issues.

--- a/.specify/roadmap/AURA-RM-010-runbook-agent-scaffolding.md
+++ b/.specify/roadmap/AURA-RM-010-runbook-agent-scaffolding.md
@@ -1,0 +1,26 @@
+# AURA-RM-010: Runbook-Driven Agent Scaffolding
+
+**Priority:** P3 (Lower)
+**Status:** Not Started
+**Dependencies:** None (standalone)
+**Depended on by:** None
+**Affected Crates:** New tooling (CLI or script)
+**Complexity:** Medium
+
+## Rationale
+
+SRE teams have existing runbooks in Markdown, Confluence, or wikis. Manually translating runbooks into TOML agent configs requires learning the config format and writing system prompts from scratch. Automatically generating TOML from runbooks lowers the barrier to agent creation.
+
+## User Stories
+
+### US-010.1: Generate Config from Runbook
+
+**As an** SRE,
+**I want** to provide a runbook and have Aura generate a TOML agent config,
+**So that** I can create agents without learning TOML syntax.
+
+### US-010.2: Runbook as Agent Context
+
+**As an** SRE,
+**I want** the generated config to include the runbook content as context,
+**So that** the agent follows documented procedures during incidents.

--- a/.specify/roadmap/AURA-RM-011-mcp-admin-endpoint.md
+++ b/.specify/roadmap/AURA-RM-011-mcp-admin-endpoint.md
@@ -1,0 +1,39 @@
+# AURA-RM-011: MCP Server Admin Endpoint
+
+**Priority:** P3 (Lower)
+**Status:** Not Started
+**Dependencies:** AURA-RM-001 (Metrics), AURA-RM-003 (Circuit Breaker)
+**Depended on by:** None
+**Affected Crates:** `aura-web-server`, `aura`
+**Complexity:** Medium
+
+## Rationale
+
+Operators cannot see which MCP tools are connected, their latency characteristics, or error rates without digging through logs. This provides a human-readable admin view complementing the machine-readable metrics endpoint (RM-001).
+
+## User Stories
+
+### US-011.1: Connected MCP Server Listing
+
+**As an** operator,
+**I want** a `/admin/mcp` endpoint that lists all connected MCP servers, their tools, and current status,
+**So that** I can verify the agent has the tools it needs.
+
+#### Acceptance Criteria
+
+**AC-011.1.1:** Admin endpoint
+- **Given** a running Aura web server with MCP servers configured
+- **When** I send `GET /admin/mcp`
+- **Then** I receive a JSON response listing each server, its transport type, tool count, and connection status
+
+### US-011.2: Per-Tool Latency and Errors
+
+**As an** operator,
+**I want** to see per-tool latency and error stats,
+**So that** I can identify problematic tools.
+
+### US-011.3: Circuit Breaker State Visibility
+
+**As an** operator,
+**I want** to see circuit breaker state on the admin endpoint (AURA-RM-003),
+**So that** I can understand why certain tools are unavailable.

--- a/.specify/templates/architecture-spec-template.md
+++ b/.specify/templates/architecture-spec-template.md
@@ -1,0 +1,92 @@
+# Architecture Spec: [AURA-RM-NNN] [Title]
+
+**Status:** Draft | In Review | Approved | Implemented
+**Roadmap Item:** AURA-RM-NNN
+**Product Spec:** [link to product-spec.md]
+**Author:** [name]
+**Created:** [date]
+**Last Updated:** [date]
+
+---
+
+## Summary
+
+[One paragraph: what is being built and the core technical approach.]
+
+## Constitution Compliance Check
+
+- [ ] Article I: Does this change preserve OpenAI API compatibility?
+- [ ] Article II: Does this respect crate boundary separation?
+- [ ] Article V: Are new integration tests behind feature flags?
+- [ ] Article VI: Are secrets handled via env var templates?
+- [ ] Article VII: Are new config fields backward-compatible with defaults?
+
+## Technical Context
+
+- **Language/Version:** Rust (edition 2024, stable toolchain)
+- **Affected Crates:** [list crates modified]
+- **New Dependencies:** [list any new Cargo.toml deps with justification]
+- **Performance Objectives:** [latency, throughput, memory targets if applicable]
+
+## Design
+
+### Crate Changes
+
+#### `aura` (core)
+- [New modules, types, traits]
+- [Modified modules with summary of changes]
+
+#### `aura-config`
+- [New config structs/fields]
+- [Migration/backward compat notes]
+
+#### `aura-web-server`
+- [New routes, middleware, handlers]
+- [Request/response changes]
+
+### Data Flow
+
+[Describe the request path through the system. Use ASCII diagrams where helpful.]
+
+```
+Request → [middleware] → Handler → Agent → [new component] → Response
+```
+
+### Key Types / Interfaces
+
+```rust
+// Show the key new types, traits, or function signatures
+```
+
+### Error Handling
+
+[How errors from this feature propagate. Which error types are used. How they surface to the API consumer.]
+
+### Configuration
+
+```toml
+# Full TOML config example with all new fields and their defaults
+```
+
+## Migration / Backward Compatibility
+
+[What happens to existing deployments? Do existing configs need changes? Is there a migration path?]
+
+## Alternatives Considered
+
+| Approach | Pros | Cons | Why Not |
+|----------|------|------|---------|
+| [Alternative 1] | | | |
+| [Alternative 2] | | | |
+
+## Risks
+
+- [Risk 1: description and mitigation]
+- [Risk 2: description and mitigation]
+
+## Implementation Order
+
+[Ordered list of implementation steps, referencing which acceptance criteria each satisfies.]
+
+1. [Step 1] — Satisfies: AC-NNN.N.N
+2. [Step 2] — Satisfies: AC-NNN.N.N

--- a/.specify/templates/product-spec-template.md
+++ b/.specify/templates/product-spec-template.md
@@ -1,0 +1,79 @@
+# Product Spec: [AURA-RM-NNN] [Title]
+
+**Status:** Draft | In Review | Approved | Implemented
+**Roadmap Item:** AURA-RM-NNN
+**Author:** [name]
+**Created:** [date]
+**Last Updated:** [date]
+
+---
+
+## Problem Statement
+
+[Why does this need to exist? What pain point does it address? What happens if we don't build it?]
+
+## Scope
+
+### In Scope
+- [What this feature will do]
+
+### Out of Scope
+- [What this feature will NOT do]
+- [Adjacent features that are explicitly deferred]
+
+## User Stories
+
+### US-NNN.1: [Story Title]
+
+**As a** [role],
+**I want** [capability],
+**So that** [benefit].
+
+**Priority:** P1 | P2 | P3
+**Rationale:** [Why this priority]
+
+#### Acceptance Criteria
+
+**AC-NNN.1.1:** [Criterion title]
+- **Given** [precondition]
+- **When** [action]
+- **Then** [expected outcome]
+
+**AC-NNN.1.2:** [Criterion title]
+- **Given** [precondition]
+- **When** [action]
+- **Then** [expected outcome]
+
+#### Edge Cases
+- [Edge case 1]
+- [Edge case 2]
+
+### US-NNN.2: [Story Title]
+[Repeat structure above]
+
+## API / Config Contract
+
+[Show the exact API endpoint, request/response format, or TOML config shape. These are the interfaces users will interact with.]
+
+```toml
+# Example TOML config (if applicable)
+```
+
+```json
+// Example API request/response (if applicable)
+```
+
+## Dependencies
+
+- **Depends on:** [List roadmap items that must be complete first]
+- **Depended on by:** [List roadmap items that depend on this]
+
+## Success Criteria
+
+- [Measurable outcome 1]
+- [Measurable outcome 2]
+
+## Open Questions
+
+- [NEEDS CLARIFICATION] [Question 1]
+- [NEEDS CLARIFICATION] [Question 2]

--- a/.specify/templates/quality-spec-template.md
+++ b/.specify/templates/quality-spec-template.md
@@ -1,0 +1,82 @@
+# Quality & Testing Spec: [AURA-RM-NNN] [Title]
+
+**Status:** Draft | In Review | Approved | Implemented
+**Roadmap Item:** AURA-RM-NNN
+**Product Spec:** [link to product-spec.md]
+**Architecture Spec:** [link to architecture-spec.md]
+**Author:** [name]
+**Created:** [date]
+**Last Updated:** [date]
+
+---
+
+## Test Strategy
+
+- **Unit Tests:** [scope and approach]
+- **Integration Tests:** [scope, infrastructure needed]
+- **End-to-End Tests:** [scope, tools used (Playwright, curl, etc.)]
+- **Performance Tests:** [if applicable — load, latency, concurrency]
+
+## Acceptance Criteria Traceability
+
+Every acceptance criterion from the product spec must map to at least one test case.
+
+| Acceptance Criterion | Test Type | Test Case ID | Test Location | Status |
+|---------------------|-----------|-------------|---------------|--------|
+| AC-NNN.1.1 | Unit | TC-NNN.1.1.1 | `crates/aura/src/module_tests.rs::test_name` | Pending |
+| AC-NNN.1.2 | Integration | TC-NNN.1.2.1 | `crates/aura-web-server/tests/test_file.rs::test_name` | Pending |
+| AC-NNN.2.1 | E2E | TC-NNN.2.1.1 | `tests/e2e/test_file.rs` | Pending |
+
+## Test Cases
+
+### TC-NNN.1.1.1: [Test Case Title]
+
+**Satisfies:** AC-NNN.1.1
+**Type:** Unit | Integration | E2E
+**Location:** `crate/path/to/test_file.rs::test_function_name`
+
+**Setup:**
+- [Preconditions, fixtures, config]
+
+**Steps:**
+1. [Action]
+2. [Action]
+
+**Expected Result:**
+- [Assertion 1]
+- [Assertion 2]
+
+**Edge Cases Covered:**
+- [Edge case 1]
+- [Edge case 2]
+
+### TC-NNN.1.2.1: [Test Case Title]
+[Repeat structure above]
+
+## Test Infrastructure
+
+### Required Fixtures
+- [Config files, mock servers, test data]
+
+### Required Services
+- [Docker containers, MCP servers, databases]
+
+### Environment Variables
+- [Test-specific env vars needed]
+
+## Quality Gates
+
+All must pass before the feature is considered complete:
+
+- [ ] All unit tests pass (`cargo test --workspace --lib`)
+- [ ] All integration tests pass (`make test-integration`)
+- [ ] Zero compiler warnings
+- [ ] Clippy clean (`cargo clippy --all-targets -- -D warnings`)
+- [ ] Code formatted (`cargo fmt --check`)
+- [ ] No regressions in existing test suite
+- [ ] Acceptance criteria traceability: every AC has at least one passing test
+- [ ] Performance targets met (if applicable)
+
+## Coverage Notes
+
+[What is explicitly NOT tested and why. E.g., "LLM provider actual API calls are not tested in unit tests — covered by integration tests with real credentials."]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aura"
-version = "1.17.3"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "aura-config"
-version = "1.17.3"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "aura",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "aura-test-utils"
-version = "1.17.3"
+version = "1.19.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "aura-web-server"
-version = "1.17.3"
+version = "1.19.1"
 dependencies = [
  "actix-web",
  "actix-web-lab",
@@ -497,6 +497,8 @@ dependencies = [
  "eventsource-stream",
  "futures",
  "futures-util",
+ "metrics",
+ "metrics-exporter-prometheus",
  "opentelemetry",
  "reqwest",
  "rig-core",
@@ -1357,6 +1359,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +1974,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
@@ -2192,7 +2218,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2581,6 +2607,53 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "indexmap 2.11.4",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -3103,6 +3176,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,7 +3203,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.31",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -3152,7 +3240,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3229,6 +3317,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -3367,7 +3473,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.28.0"
-source = "git+https://github.com/mezmo/rig.git?rev=0853ab14#0853ab1487b6cbdc4c8818e9fb8d475b8b59eaf6"
+source = "git+https://github.com/mezmo/rig.git?rev=d7e9d92#d7e9d92e8bab870074294b9fb7d0b98c3b6c6d6b"
 dependencies = [
  "as-any",
  "async-stream",
@@ -3857,6 +3963,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -4702,6 +4814,28 @@ checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/README.md
+++ b/README.md
@@ -252,9 +252,59 @@ Aura supports Ollama, including fallback tool-call parsing for model outputs tha
 
 ### Observability
 
+#### Tracing (OpenTelemetry)
+
 OpenTelemetry support is enabled by default via the `otel` feature in both `aura` and `aura-web-server`. Configure your OTLP endpoint using standard environment variables (for example `OTEL_EXPORTER_OTLP_ENDPOINT`) to export traces.
 
 Aura emits spans using the [OpenInference](https://github.com/Arize-ai/openinference/tree/main/spec) semantic convention (`llm.*`, `tool.*`, `input.*`, `output.*`) rather than the `gen_ai.*` conventions. Rig-originated `gen_ai.*` attributes are automatically translated to OpenInference equivalents at export time. This makes Aura traces natively compatible with [Phoenix](https://github.com/Arize-ai/phoenix) and other OpenInference-aware observability tools.
+
+#### Metrics (Prometheus)
+
+Aura exposes a Prometheus-compatible `/metrics` endpoint for real-time monitoring. Enabled by default (set `AURA_METRICS_ENABLED=false` to disable).
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `aura_http_request_duration_seconds` | histogram | method, status_code, agent | Request latency with buckets from 25ms to 300s |
+| `aura_llm_tokens_total` | counter | type (prompt/completion), provider, agent | Token usage accumulator |
+| `aura_mcp_tool_duration_seconds` | histogram | server, tool, status | MCP tool call latency |
+| `aura_errors_total` | counter | error_type | Error counter by taxonomy category |
+| `aura_http_requests_in_flight` | gauge | — | Active concurrent requests |
+| `aura_mcp_server_connected` | gauge | server | MCP server connection state (1=up, 0=down) |
+
+Example Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: 'aura'
+    static_configs:
+      - targets: ['localhost:8080']
+```
+
+Example PromQL queries:
+
+```promql
+# Request rate
+rate(aura_http_request_duration_seconds_count[5m])
+
+# p99 latency
+histogram_quantile(0.99, rate(aura_http_request_duration_seconds_bucket[5m]))
+
+# Token burn rate per minute
+rate(aura_llm_tokens_total[5m]) * 60
+
+# Error rate by type
+rate(aura_errors_total[5m])
+```
+
+#### Error Taxonomy
+
+API error responses include a structured `code` field for programmatic error handling:
+
+```json
+{"error": {"message": "...", "type": "internal_error", "code": "llm_timeout"}}
+```
+
+Error categories: `llm_timeout`, `llm_rate_limit`, `llm_auth_error`, `llm_error`, `mcp_connection_failed`, `mcp_tool_error`, `mcp_timeout`, `config_validation`, `request_validation`, `budget_exceeded`, `service_unavailable`, `cancelled`, `internal`. Client-facing error messages are sanitized — internal details (hostnames, ports, library errors) are logged server-side only.
 
 ## Docker Deployment
 
@@ -311,7 +361,7 @@ Run web server integration test workflow:
 Integration test feature flags (`crates/aura-web-server/Cargo.toml`):
 
 - Parent flag: `integration`
-- Suite flags: `integration-streaming`, `integration-header-forwarding`, `integration-mcp`, `integration-events`, `integration-cancellation`, `integration-progress`
+- Suite flags: `integration-streaming`, `integration-header-forwarding`, `integration-mcp`, `integration-events`, `integration-cancellation`, `integration-progress`, `integration-metrics`
 - Optional suite: `integration-vector` (requires external Qdrant setup)
 
 Detailed test guidance: [crates/aura-web-server/README.md#running-integration-tests](crates/aura-web-server/README.md#running-integration-tests).

--- a/crates/aura-config/src/bin/architecture_diagram.rs
+++ b/crates/aura-config/src/bin/architecture_diagram.rs
@@ -193,17 +193,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("│  │  ┌─────────────────────────────────────────┐    │    │");
             match &store.store {
                 aura_config::VectorStoreType::InMemory { embedding_model }
-                | aura_config::VectorStoreType::Qdrant { embedding_model, .. } => {
+                | aura_config::VectorStoreType::Qdrant {
+                    embedding_model, ..
+                } => {
                     println!("│  │  │        🔤 EMBEDDING MODEL               │    │    │");
                     println!("│  │  │                                         │    │    │");
                     println!(
                         "│  │  │  Provider: {}                │    │    │",
                         embedding_model.provider()
                     );
-                    println!(
-                        "│  │  │  Model: {}    │    │    │",
-                        embedding_model.model()
-                    );
+                    println!("│  │  │  Model: {}    │    │    │", embedding_model.model());
                 }
                 aura_config::VectorStoreType::BedrockKb { .. } => {
                     println!("│  │  │        🔤 MANAGED EMBEDDINGS            │    │    │");

--- a/crates/aura-config/src/bin/debug_config.rs
+++ b/crates/aura-config/src/bin/debug_config.rs
@@ -139,14 +139,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             match &store.store {
                 aura_config::VectorStoreType::InMemory { embedding_model } => {
                     println!("  Store {}: {} (in_memory)", i + 1, store.name);
-                    println!("    Embedding Model: {} {}", embedding_model.provider(), embedding_model.model());
+                    println!(
+                        "    Embedding Model: {} {}",
+                        embedding_model.provider(),
+                        embedding_model.model()
+                    );
                 }
-                aura_config::VectorStoreType::Qdrant { embedding_model, .. } => {
+                aura_config::VectorStoreType::Qdrant {
+                    embedding_model, ..
+                } => {
                     println!("  Store {}: {} (qdrant)", i + 1, store.name);
-                    println!("    Embedding Model: {} {}", embedding_model.provider(), embedding_model.model());
+                    println!(
+                        "    Embedding Model: {} {}",
+                        embedding_model.provider(),
+                        embedding_model.model()
+                    );
                 }
                 aura_config::VectorStoreType::BedrockKb { .. } => {
-                    println!("  Store {}: {} (bedrock_kb, managed embeddings)", i + 1, store.name);
+                    println!(
+                        "  Store {}: {} (bedrock_kb, managed embeddings)",
+                        i + 1,
+                        store.name
+                    );
                 }
             }
         }

--- a/crates/aura-config/src/builder.rs
+++ b/crates/aura-config/src/builder.rs
@@ -8,13 +8,11 @@ use std::collections::HashMap;
 /// Convert TOML-layer EmbeddingConfig to runtime EmbeddingModelConfig
 fn convert_embedding(em: &crate::config::EmbeddingConfig) -> EmbeddingModelConfig {
     match em {
-        crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
-            EmbeddingModelConfig::OpenAI {
-                api_key: api_key.clone(),
-                model: model.clone(),
-                base_url: None,
-            }
-        }
+        crate::config::EmbeddingConfig::OpenAI { api_key, model } => EmbeddingModelConfig::OpenAI {
+            api_key: api_key.clone(),
+            model: model.clone(),
+            base_url: None,
+        },
         crate::config::EmbeddingConfig::Bedrock {
             model,
             region,

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -380,26 +380,27 @@ impl Config {
         // Validate each vector store
         for store in &self.vector_stores {
             match &store.store {
-                VectorStoreType::InMemory { embedding_model } | VectorStoreType::Qdrant { embedding_model, .. } => {
-                    match embedding_model {
-                        EmbeddingConfig::OpenAI { api_key, .. } => {
-                            if api_key.is_empty() {
-                                return Err(crate::ConfigError::Validation(format!(
-                                    "Embedding model API key is required for vector store '{}'",
-                                    store.name
-                                )));
-                            }
-                        }
-                        EmbeddingConfig::Bedrock { region, .. } => {
-                            if region.is_empty() {
-                                return Err(crate::ConfigError::Validation(format!(
-                                    "Embedding model region is required for Bedrock provider in vector store '{}'",
-                                    store.name
-                                )));
-                            }
+                VectorStoreType::InMemory { embedding_model }
+                | VectorStoreType::Qdrant {
+                    embedding_model, ..
+                } => match embedding_model {
+                    EmbeddingConfig::OpenAI { api_key, .. } => {
+                        if api_key.is_empty() {
+                            return Err(crate::ConfigError::Validation(format!(
+                                "Embedding model API key is required for vector store '{}'",
+                                store.name
+                            )));
                         }
                     }
-                }
+                    EmbeddingConfig::Bedrock { region, .. } => {
+                        if region.is_empty() {
+                            return Err(crate::ConfigError::Validation(format!(
+                                "Embedding model region is required for Bedrock provider in vector store '{}'",
+                                store.name
+                            )));
+                        }
+                    }
+                },
                 VectorStoreType::BedrockKb { .. } => {
                     // All required fields are enforced by the enum structure
                 }

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -83,15 +83,13 @@ temperature = 0.5
         );
         let vector_store = &config.vector_stores[0];
         match &vector_store.store {
-            crate::config::VectorStoreType::InMemory { embedding_model } => {
-                match embedding_model {
-                    crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
-                        assert_eq!(model, "text-embedding-3-small");
-                        assert_eq!(api_key, "test_embedding_key");
-                    }
-                    _ => panic!("Expected OpenAI embedding config"),
+            crate::config::VectorStoreType::InMemory { embedding_model } => match embedding_model {
+                crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
+                    assert_eq!(model, "text-embedding-3-small");
+                    assert_eq!(api_key, "test_embedding_key");
                 }
-            }
+                _ => panic!("Expected OpenAI embedding config"),
+            },
             _ => panic!("Expected InMemory vector store"),
         }
 
@@ -346,14 +344,12 @@ system_prompt = "Test with env vars"
             _ => panic!("Expected OpenAI LLM config"),
         }
         match &config.vector_stores[0].store {
-            crate::config::VectorStoreType::InMemory { embedding_model } => {
-                match embedding_model {
-                    crate::config::EmbeddingConfig::OpenAI { api_key, .. } => {
-                        assert_eq!(api_key, "mock_openai_key");
-                    }
-                    _ => panic!("Expected OpenAI embedding config"),
+            crate::config::VectorStoreType::InMemory { embedding_model } => match embedding_model {
+                crate::config::EmbeddingConfig::OpenAI { api_key, .. } => {
+                    assert_eq!(api_key, "mock_openai_key");
                 }
-            }
+                _ => panic!("Expected OpenAI embedding config"),
+            },
             _ => panic!("Expected InMemory vector store"),
         }
 
@@ -949,20 +945,20 @@ system_prompt = "Test"
 
         let vector_store = &config.vector_stores[0];
         match &vector_store.store {
-            crate::config::VectorStoreType::Qdrant { embedding_model, .. } => {
-                match embedding_model {
-                    crate::config::EmbeddingConfig::Bedrock {
-                        model,
-                        region,
-                        profile,
-                    } => {
-                        assert_eq!(model, "amazon.titan-embed-text-v2:0");
-                        assert_eq!(region, "us-west-2");
-                        assert_eq!(profile, &Some("my-profile".to_string()));
-                    }
-                    _ => panic!("Expected Bedrock embedding config"),
+            crate::config::VectorStoreType::Qdrant {
+                embedding_model, ..
+            } => match embedding_model {
+                crate::config::EmbeddingConfig::Bedrock {
+                    model,
+                    region,
+                    profile,
+                } => {
+                    assert_eq!(model, "amazon.titan-embed-text-v2:0");
+                    assert_eq!(region, "us-west-2");
+                    assert_eq!(profile, &Some("my-profile".to_string()));
                 }
-            }
+                _ => panic!("Expected Bedrock embedding config"),
+            },
             _ => panic!("Expected Qdrant vector store"),
         }
     }
@@ -992,17 +988,15 @@ system_prompt = "Test"
 
         let vector_store = &config.vector_stores[0];
         match &vector_store.store {
-            crate::config::VectorStoreType::InMemory { embedding_model } => {
-                match embedding_model {
-                    crate::config::EmbeddingConfig::Bedrock {
-                        region, profile, ..
-                    } => {
-                        assert_eq!(region, "us-east-1");
-                        assert_eq!(profile, &None);
-                    }
-                    _ => panic!("Expected Bedrock embedding config"),
+            crate::config::VectorStoreType::InMemory { embedding_model } => match embedding_model {
+                crate::config::EmbeddingConfig::Bedrock {
+                    region, profile, ..
+                } => {
+                    assert_eq!(region, "us-east-1");
+                    assert_eq!(profile, &None);
                 }
-            }
+                _ => panic!("Expected Bedrock embedding config"),
+            },
             _ => panic!("Expected InMemory vector store"),
         }
     }
@@ -1058,7 +1052,10 @@ name = "Test"
 system_prompt = "Test"
 "#;
         let result = load_config_from_str(config_str);
-        assert!(result.is_err(), "OpenAI embedding without api_key should fail validation");
+        assert!(
+            result.is_err(),
+            "OpenAI embedding without api_key should fail validation"
+        );
     }
 
     #[test]
@@ -1081,8 +1078,7 @@ context_prefix = "Company documentation"
 name = "Test"
 system_prompt = "Test"
 "#;
-        let config = load_config_from_str(config_str)
-            .expect("Failed to parse bedrock_kb config");
+        let config = load_config_from_str(config_str).expect("Failed to parse bedrock_kb config");
 
         let store = &config.vector_stores[0];
         assert_eq!(store.name, "company_docs");
@@ -1150,10 +1146,7 @@ system_prompt = "Test"
         let result = load_config_from_str(config_str);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("region"),
-            "Error should mention region: {err}"
-        );
+        assert!(err.contains("region"), "Error should mention region: {err}");
     }
 
     #[test]

--- a/crates/aura-web-server/Cargo.toml
+++ b/crates/aura-web-server/Cargo.toml
@@ -25,6 +25,8 @@ opentelemetry = { workspace = true, optional = true }
 env_logger = "0.11"
 uuid = { version = "1.0", features = ["v4"] }
 chrono = "0.4"
+metrics = "0.24"
+metrics-exporter-prometheus = "0.16"
 
 [features]
 default = ["otel"]
@@ -39,6 +41,7 @@ integration = [
     "integration-events",
     "integration-cancellation",
     "integration-progress",
+    "integration-metrics",
 ]
 
 # Per-suite flags (can run individually)
@@ -48,6 +51,7 @@ integration-mcp = []                      # fastmcp_structured_content_test
 integration-events = []                   # aura_events_test, proactive_tool_ui_tests
 integration-cancellation = []             # cancellation_test, cancellation_notification_test
 integration-progress = []                 # mcp_progress_test, progress_disconnect_test
+integration-metrics = []                  # metrics_test
 
 # Optional - requires Qdrant (separate epic)
 integration-vector = []         # vector_label_filter_tests

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{Instrument, error};
+use tracing::Instrument;
 use uuid::Uuid;
 
 use crate::streaming::{
@@ -27,6 +27,7 @@ struct ActiveRequestGuard {
 impl ActiveRequestGuard {
     fn new(tracker: Arc<ActiveRequestTracker>) -> Self {
         tracker.increment();
+        crate::metrics::increment_requests_in_flight();
         Self { tracker }
     }
 }
@@ -34,6 +35,7 @@ impl ActiveRequestGuard {
 impl Drop for ActiveRequestGuard {
     fn drop(&mut self) {
         self.tracker.decrement();
+        crate::metrics::decrement_requests_in_flight();
     }
 }
 
@@ -127,14 +129,28 @@ async fn build_agent_for_request(
         .build_agent_with_headers(Some(req_headers))
         .await
         .map_err(|e| {
-            error!("Failed to build agent: {}", e);
+            // Record MCP server as disconnected on build failure if it looks like an MCP error
+            if let Some(mcp_config) = &config.mcp {
+                for server_name in mcp_config.servers.keys() {
+                    crate::metrics::set_mcp_server_connected(server_name, false);
+                }
+            }
             HttpResponse::InternalServerError().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: format!("Failed to build agent: {e}"),
-                    error_type: "internal_error".to_string(),
-                },
+                error: ErrorDetail::classified(
+                    "internal_error",
+                    aura::ErrorCategory::Internal,
+                    &format!("Failed to build agent: {e}"),
+                ),
             })
         })?;
+
+    // Record MCP servers as connected on successful agent build
+    if let Some(mcp_config) = &config.mcp {
+        for server_name in mcp_config.servers.keys() {
+            crate::metrics::set_mcp_server_connected(server_name, true);
+        }
+    }
+
     Ok(Arc::new(agent))
 }
 
@@ -150,6 +166,7 @@ struct RequestSetup {
     created_timestamp: u64,
     chat_session_id: String,
     has_chat_history: bool,
+    agent_name: String,
 }
 
 /// Extract query, chat history, and build agent — shared across both code paths.
@@ -164,18 +181,15 @@ async fn prepare_request(
         Some(msg) if msg.role == Role::User => msg.content,
         Some(msg) => {
             return Err(HttpResponse::BadRequest().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: format!("Last message must be from user, got: {}", msg.role),
-                    error_type: "invalid_request_error".to_string(),
-                },
+                error: ErrorDetail::validation(&format!(
+                    "Last message must be from user, got: {}",
+                    msg.role
+                )),
             }));
         }
         None => {
             return Err(HttpResponse::BadRequest().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: "messages array is empty".to_string(),
-                    error_type: "invalid_request_error".to_string(),
-                },
+                error: ErrorDetail::validation("messages array is empty"),
             }));
         }
     };
@@ -215,6 +229,7 @@ async fn prepare_request(
     let created_timestamp = Utc::now().timestamp() as u64;
     let has_chat_history = !chat_history.is_empty();
 
+    let agent_name = config.agent.name.clone();
     Ok(RequestSetup {
         query,
         chat_history,
@@ -225,6 +240,7 @@ async fn prepare_request(
         created_timestamp,
         chat_session_id: chat_session_id.to_string(),
         has_chat_history,
+        agent_name,
     })
 }
 
@@ -235,14 +251,21 @@ pub async fn chat_completions(
     req: web::Json<ChatCompletionRequest>,
     http_req: actix_web::HttpRequest,
 ) -> HttpResponse {
+    let request_start = std::time::Instant::now();
+
     // Validate we have messages
     if req.messages.is_empty() {
-        return HttpResponse::BadRequest().json(ErrorResponse {
-            error: ErrorDetail {
-                message: "No messages provided".to_string(),
-                error_type: "invalid_request_error".to_string(),
-            },
+        let response = HttpResponse::BadRequest().json(ErrorResponse {
+            error: ErrorDetail::validation("No messages provided"),
         });
+        crate::metrics::record_request_duration(
+            "POST",
+            400,
+            "unknown",
+            request_start.elapsed().as_secs_f64(),
+        );
+        crate::metrics::record_error(aura::ErrorCategory::RequestValidation.as_label());
+        return response;
     }
 
     // Extract or generate chat_session_id
@@ -272,14 +295,37 @@ pub async fn chat_completions(
     let mut req = req.into_inner();
     let setup = match prepare_request(&data, &mut req, &chat_session_id, &req_headers_map).await {
         Ok(s) => s,
-        Err(response) => return response,
+        Err(response) => {
+            let status = response.status().as_u16();
+            crate::metrics::record_request_duration(
+                "POST",
+                status,
+                "unknown",
+                request_start.elapsed().as_secs_f64(),
+            );
+            if status >= 400 {
+                crate::metrics::record_error(aura::ErrorCategory::RequestValidation.as_label());
+            }
+            return response;
+        }
     };
 
-    if req.stream == Some(true) {
+    let agent_name = setup.agent_name.clone();
+
+    let response = if req.stream == Some(true) {
         handle_streaming_completion(data, setup, req.max_tokens).await
     } else {
         handle_non_streaming_completion(&data, setup, req.max_tokens).await
-    }
+    };
+
+    crate::metrics::record_request_duration(
+        "POST",
+        response.status().as_u16(),
+        &agent_name,
+        request_start.elapsed().as_secs_f64(),
+    );
+
+    response
 }
 
 /// Build configuration for the spawned completion task from AppState and RequestSetup.
@@ -369,6 +415,7 @@ async fn execute_completion(setup: RequestSetup, config: CompletionConfig, deliv
     };
 
     let response_content = config.response_content.clone();
+    let provider_for_metrics = config.provider.clone();
     let otel_ctx = StreamOtelContext {
         provider: config.provider,
         model: config.model,
@@ -435,6 +482,27 @@ async fn execute_completion(setup: RequestSetup, config: CompletionConfig, deliv
     };
 
     otel_ctx.record_output(&termination);
+
+    // Record token usage metrics
+    let (prompt_tokens, completion_tokens, _total) = usage_state.get_final_usage();
+    crate::metrics::record_tokens(
+        "prompt",
+        &provider_for_metrics,
+        &setup.agent_name,
+        prompt_tokens,
+    );
+    crate::metrics::record_tokens(
+        "completion",
+        &provider_for_metrics,
+        &setup.agent_name,
+        completion_tokens,
+    );
+
+    // Record error metrics for non-success terminations
+    if !matches!(termination, StreamTermination::Complete) {
+        let category = aura::ErrorCategory::from(&termination);
+        crate::metrics::record_error(category.as_label());
+    }
 
     match &termination {
         StreamTermination::Complete => {
@@ -539,15 +607,13 @@ async fn handle_non_streaming_completion(
 
     match result_rx.await {
         Ok(collected) => build_json_response(response_ctx, max_tokens, collected),
-        Err(_) => {
-            error!("Completion task panicked or was dropped");
-            HttpResponse::InternalServerError().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: "Internal error during completion".to_string(),
-                    error_type: "internal_error".to_string(),
-                },
-            })
-        }
+        Err(_) => HttpResponse::InternalServerError().json(ErrorResponse {
+            error: ErrorDetail::classified(
+                "internal_error",
+                aura::ErrorCategory::Internal,
+                "Completion task panicked or was dropped",
+            ),
+        }),
     }
 }
 

--- a/crates/aura-web-server/src/lib.rs
+++ b/crates/aura-web-server/src/lib.rs
@@ -1,3 +1,4 @@
-//! Streaming support for aura-web-server
+//! Streaming support and metrics for aura-web-server
 
+pub mod metrics;
 pub mod streaming;

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -6,6 +6,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 mod handlers;
+mod metrics;
 mod streaming;
 mod types;
 
@@ -92,17 +93,22 @@ struct Args {
 }
 
 /// Middleware that rejects new requests with 503 when shutdown_token is cancelled.
+/// Exempts /health and /metrics so Kubernetes probes and Prometheus scrapers
+/// continue working during graceful shutdown.
 async fn shutdown_guard(
     data: web::Data<AppState>,
     req: actix_web::dev::ServiceRequest,
     next: actix_web::middleware::Next<impl actix_web::body::MessageBody + 'static>,
 ) -> Result<actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>, actix_web::Error> {
-    if data.shutdown_token.is_cancelled() {
+    let path = req.path();
+    let is_exempt = path == "/health" || path == "/metrics";
+    if data.shutdown_token.is_cancelled() && !is_exempt {
         let response = HttpResponse::ServiceUnavailable().json(ErrorResponse {
-            error: ErrorDetail {
-                message: "Server is shutting down".to_string(),
-                error_type: "service_unavailable".to_string(),
-            },
+            error: ErrorDetail::classified(
+                "service_unavailable",
+                aura::ErrorCategory::ServiceUnavailable,
+                "Server is shutting down",
+            ),
         });
         return Ok(req.into_response(response).map_into_right_body());
     }
@@ -195,9 +201,12 @@ async fn run() -> std::io::Result<()> {
         args.host, args.port, shutdown_timeout_secs
     );
 
+    // Initialize Prometheus metrics (None if disabled via AURA_METRICS_ENABLED=false)
+    let metrics_handle = metrics::init();
+
     // Custom signal handling: CancellationToken bridges Actix and SSE stream lifecycles
     let server = HttpServer::new(move || {
-        App::new()
+        let mut app = App::new()
             .app_data(app_state.clone())
             .wrap(middleware::from_fn(shutdown_guard))
             .wrap(middleware::Logger::default())
@@ -206,7 +215,15 @@ async fn run() -> std::io::Result<()> {
             .route(
                 "/v1/chat/completions",
                 web::post().to(handlers::chat_completions),
-            )
+            );
+
+        if let Some(handle) = &metrics_handle {
+            app = app
+                .app_data(web::Data::new(handle.clone()))
+                .route("/metrics", web::get().to(metrics::handler));
+        }
+
+        app
     })
     .bind((args.host.as_str(), args.port))?
     .disable_signals()

--- a/crates/aura-web-server/src/metrics.rs
+++ b/crates/aura-web-server/src/metrics.rs
@@ -1,0 +1,167 @@
+//! Prometheus metrics for Aura request handling, token usage, and tool execution.
+//!
+//! Enabled by default. Set `AURA_METRICS_ENABLED=false` to disable the `/metrics` endpoint.
+
+use actix_web::{HttpResponse, web};
+use metrics::{counter, gauge, histogram};
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
+use std::collections::HashSet;
+use std::sync::{LazyLock, Mutex};
+
+/// Initialize the Prometheus metrics registry. Returns `None` if disabled via env var.
+pub fn init() -> Option<PrometheusHandle> {
+    if std::env::var("AURA_METRICS_ENABLED")
+        .map(|v| v == "false")
+        .unwrap_or(false)
+    {
+        tracing::info!("Metrics disabled via AURA_METRICS_ENABLED=false");
+        return None;
+    }
+
+    let handle = PrometheusBuilder::new()
+        .set_buckets_for_metric(
+            Matcher::Full("aura_http_request_duration_seconds".to_string()),
+            &[
+                0.025, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+            ],
+        )
+        .expect("valid request duration buckets")
+        .set_buckets_for_metric(
+            Matcher::Full("aura_mcp_tool_duration_seconds".to_string()),
+            &[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0],
+        )
+        .expect("valid tool duration buckets")
+        .install_recorder()
+        .expect("metrics recorder installation");
+
+    tracing::info!("Metrics enabled on /metrics endpoint");
+    Some(handle)
+}
+
+/// Serve Prometheus text exposition format.
+pub async fn handler(handle: web::Data<PrometheusHandle>) -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("text/plain; version=0.0.4; charset=utf-8")
+        .body(handle.render())
+}
+
+/// Record HTTP request duration.
+pub fn record_request_duration(method: &str, status: u16, agent: &str, duration_secs: f64) {
+    histogram!(
+        "aura_http_request_duration_seconds",
+        "method" => method.to_string(),
+        "status_code" => status.to_string(),
+        "agent" => agent.to_string(),
+    )
+    .record(duration_secs);
+}
+
+/// Record LLM token usage. Skips recording if count is zero.
+pub fn record_tokens(token_type: &str, provider: &str, agent: &str, count: u64) {
+    if count > 0 {
+        counter!(
+            "aura_llm_tokens_total",
+            "type" => token_type.to_string(),
+            "provider" => provider.to_string(),
+            "agent" => agent.to_string(),
+        )
+        .increment(count);
+    }
+}
+
+/// Track unique tool names globally to enforce cardinality cap.
+static KNOWN_TOOLS: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
+
+const MAX_UNIQUE_TOOL_LABELS: usize = 100;
+const MAX_TOOL_NAME_LEN: usize = 64;
+
+/// Record MCP tool call duration with cardinality guards on the tool label.
+pub fn record_tool_duration(server: &str, tool: &str, status: &str, duration_secs: f64) {
+    let tool_label = if tool.len() > MAX_TOOL_NAME_LEN {
+        "_other"
+    } else {
+        let mut known = KNOWN_TOOLS.lock().unwrap_or_else(|e| e.into_inner());
+        if known.contains(tool) || known.len() < MAX_UNIQUE_TOOL_LABELS {
+            known.insert(tool.to_string());
+            tool
+        } else {
+            "_other"
+        }
+    };
+
+    histogram!(
+        "aura_mcp_tool_duration_seconds",
+        "server" => server.to_string(),
+        "tool" => tool_label.to_string(),
+        "status" => status.to_string(),
+    )
+    .record(duration_secs);
+}
+
+/// Record an error by taxonomy category label.
+pub fn record_error(error_type: &str) {
+    counter!("aura_errors_total", "error_type" => error_type.to_string()).increment(1);
+}
+
+/// Increment the in-flight request gauge. Called at request entry.
+pub fn increment_requests_in_flight() {
+    gauge!("aura_http_requests_in_flight").increment(1.0);
+}
+
+/// Decrement the in-flight request gauge. Called at request exit (including on panic via Drop).
+pub fn decrement_requests_in_flight() {
+    gauge!("aura_http_requests_in_flight").decrement(1.0);
+}
+
+/// Set MCP server connection state (1.0 = connected, 0.0 = disconnected).
+pub fn set_mcp_server_connected(server: &str, connected: bool) {
+    gauge!("aura_mcp_server_connected", "server" => server.to_string()).set(if connected {
+        1.0
+    } else {
+        0.0
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_init_disabled_returns_none() {
+        // Safety: set_var/remove_var are unsafe in edition 2024 due to process-global mutation.
+        // This test runs single-threaded and restores the env var after use.
+        unsafe { std::env::set_var("AURA_METRICS_ENABLED", "false") };
+        let handle = init();
+        assert!(handle.is_none());
+        unsafe { std::env::remove_var("AURA_METRICS_ENABLED") };
+    }
+
+    #[test]
+    fn test_tool_label_cardinality_cap() {
+        let mut known = KNOWN_TOOLS.lock().unwrap_or_else(|e| e.into_inner());
+        known.clear();
+        drop(known);
+
+        // Insert exactly MAX_UNIQUE_TOOL_LABELS unique names
+        for i in 0..MAX_UNIQUE_TOOL_LABELS {
+            let name = format!("tool_{i}");
+            let mut set = KNOWN_TOOLS.lock().unwrap_or_else(|e| e.into_inner());
+            set.insert(name);
+        }
+
+        let set = KNOWN_TOOLS.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(set.len(), MAX_UNIQUE_TOOL_LABELS);
+        assert!(set.contains("tool_0"));
+        assert!(set.contains("tool_99"));
+        assert!(!set.contains("tool_100"));
+        drop(set);
+
+        // Very long tool names get capped regardless of count
+        let long_name = "a".repeat(MAX_TOOL_NAME_LEN + 1);
+        assert!(long_name.len() > MAX_TOOL_NAME_LEN);
+
+        // Clean up for other tests
+        let mut known = KNOWN_TOOLS.lock().unwrap_or_else(|e| e.into_inner());
+        known.clear();
+    }
+}

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -76,6 +76,21 @@ pub enum StreamTermination {
     Shutdown,
 }
 
+/// Map stream termination reasons to the error taxonomy.
+/// Callers should guard against `Complete` (success case) before using this —
+/// the `Internal` mapping for `Complete` is defensive and should never be recorded as an error.
+impl From<&StreamTermination> for aura::ErrorCategory {
+    fn from(term: &StreamTermination) -> Self {
+        match term {
+            StreamTermination::Complete => aura::ErrorCategory::Internal,
+            StreamTermination::StreamError(_) => aura::ErrorCategory::LlmError,
+            StreamTermination::Disconnected => aura::ErrorCategory::Cancelled,
+            StreamTermination::Timeout => aura::ErrorCategory::LlmTimeout,
+            StreamTermination::Shutdown => aura::ErrorCategory::ServiceUnavailable,
+        }
+    }
+}
+
 /// User-facing message when context overflow is detected.
 const CONTEXT_OVERFLOW_MESSAGE: &str = "My tools returned more data than I can work with at once.\n\n\
     **To help me out, try:**\n\
@@ -690,14 +705,10 @@ fn handle_tool_call(
         (tool_call.name.clone(), state.tool_call_index),
     );
 
-    // Track tool start time for duration calculation in tool_complete event
-    // Note: aura.tool_requested is emitted via StreamingRequestHook → tool_event_rx channel (not here)
-    // to avoid duplication and maintain proper correlation with tool_call_id via FIFO queue
-    if config.emit_custom_events {
-        state
-            .tool_start_times
-            .insert(tool_call.id.clone(), std::time::Instant::now());
-    }
+    // Track tool start time for duration calculation (always — used for metrics and custom events)
+    state
+        .tool_start_times
+        .insert(tool_call.id.clone(), std::time::Instant::now());
 
     // Determine arguments based on tool result mode
     let arguments = match config.tool_result_mode {
@@ -755,24 +766,43 @@ fn handle_tool_result(
     let mut output = Vec::with_capacity(2);
     state.needs_separator = true;
 
+    // Calculate tool duration (always, for metrics even when custom events are off)
+    let duration_ms = state
+        .tool_start_times
+        .remove(&tool_result.id)
+        .map(|start| start.elapsed().as_millis() as u64)
+        .unwrap_or(0);
+
+    let tool_name_for_metrics = state
+        .tool_call_map
+        .get(&tool_result.id)
+        .map(|(name, _)| name.clone())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    // Parse result text once (used for both metrics and custom events)
+    let result_text = serde_json::from_str::<String>(&tool_result.result)
+        .unwrap_or_else(|_| tool_result.result.clone());
+
+    // Detect tool errors once (shared between metrics and custom events)
+    let tool_status = detect_tool_error(&result_text);
+    let is_tool_error = matches!(tool_status, ToolResultStatus::Error(_));
+
+    // Record tool duration metric (always, regardless of custom events)
+    crate::metrics::record_tool_duration(
+        "default",
+        &tool_name_for_metrics,
+        if is_tool_error { "error" } else { "ok" },
+        duration_ms as f64 / 1000.0,
+    );
+
+    // Record tool-level error in error counter
+    if is_tool_error {
+        crate::metrics::record_error(aura::ErrorCategory::McpToolError.as_label());
+    }
+
     // Emit aura.tool_complete custom event (if enabled)
     if config.emit_custom_events {
-        let duration_ms = state
-            .tool_start_times
-            .remove(&tool_result.id)
-            .map(|start| start.elapsed().as_millis() as u64)
-            .unwrap_or(0);
-
-        let tool_name = state
-            .tool_call_map
-            .get(&tool_result.id)
-            .map(|(name, _)| name.clone())
-            .unwrap_or_else(|| "unknown".to_string());
-
-        // Aura's ToolResult has result as a plain String
-        // Try to unescape JSON-quoted strings for error detection
-        let result_text = serde_json::from_str::<String>(&tool_result.result)
-            .unwrap_or_else(|_| tool_result.result.clone());
+        let tool_name = tool_name_for_metrics.clone();
 
         tracing::debug!(
             "Tool '{}' result_text (first 200 chars): {}",
@@ -784,7 +814,7 @@ fn handle_tool_result(
             }
         );
 
-        let status = detect_tool_error(&result_text);
+        let status = tool_status;
         let event = match status {
             ToolResultStatus::Error(ref err) => {
                 tracing::warn!(
@@ -1027,6 +1057,30 @@ mod tests {
         assert!(
             output_str.contains("tool_calls"),
             "OpenAI tool_calls chunk should still be emitted"
+        );
+    }
+
+    #[test]
+    fn test_stream_termination_maps_to_error_category() {
+        assert_eq!(
+            aura::ErrorCategory::from(&StreamTermination::Complete),
+            aura::ErrorCategory::Internal,
+        );
+        assert_eq!(
+            aura::ErrorCategory::from(&StreamTermination::StreamError("err".to_string())),
+            aura::ErrorCategory::LlmError,
+        );
+        assert_eq!(
+            aura::ErrorCategory::from(&StreamTermination::Disconnected),
+            aura::ErrorCategory::Cancelled,
+        );
+        assert_eq!(
+            aura::ErrorCategory::from(&StreamTermination::Timeout),
+            aura::ErrorCategory::LlmTimeout,
+        );
+        assert_eq!(
+            aura::ErrorCategory::from(&StreamTermination::Shutdown),
+            aura::ErrorCategory::ServiceUnavailable,
         );
     }
 

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -208,6 +208,53 @@ pub struct ErrorDetail {
     pub message: String,
     #[serde(rename = "type")]
     pub error_type: String,
+    /// Error taxonomy label from ErrorCategory. Additive field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+}
+
+impl ErrorDetail {
+    /// Create an error with taxonomy classification and sanitized client message.
+    ///
+    /// Encapsulates three concerns: (1) classifying the error via ErrorCategory,
+    /// (2) logging the internal message at WARN level for debugging, and
+    /// (3) replacing the client-facing message with a safe generic string.
+    /// This prevents internal details (hostnames, ports, library errors) from
+    /// reaching API consumers while preserving the existing `error_type` values.
+    pub fn classified(
+        error_type: &str,
+        category: aura::ErrorCategory,
+        internal_message: &str,
+    ) -> Self {
+        let aura_err = aura::AuraError::new(category, internal_message);
+        tracing::warn!(
+            error_category = category.as_label(),
+            internal_message = internal_message,
+            "Request error"
+        );
+        Self {
+            message: aura_err.client_message(),
+            error_type: error_type.to_string(),
+            code: Some(category.as_label().to_string()),
+        }
+    }
+
+    /// Create a request validation error that passes the message through directly.
+    ///
+    /// Unlike `classified()`, this does not sanitize the message because request
+    /// validation errors contain client-supplied input (e.g., "Last message must
+    /// be from user, got: system") which is safe to return.
+    pub fn validation(message: &str) -> Self {
+        Self {
+            message: message.to_string(),
+            error_type: "invalid_request_error".to_string(),
+            code: Some(
+                aura::ErrorCategory::RequestValidation
+                    .as_label()
+                    .to_string(),
+            ),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -303,5 +350,58 @@ mod tests {
         assert_eq!(json["error"]["type"], "invalid_request_error");
         assert_eq!(json["error"]["param"], "model");
         assert_eq!(json["error"]["code"], "model_not_found");
+    }
+
+    #[test]
+    fn test_error_detail_with_code_serializes_code_field() {
+        let detail = ErrorDetail {
+            message: "test".to_string(),
+            error_type: "internal_error".to_string(),
+            code: Some("llm_timeout".to_string()),
+        };
+        let json = serde_json::to_value(&ErrorResponse { error: detail }).unwrap();
+        assert_eq!(json["error"]["code"], "llm_timeout");
+        assert_eq!(json["error"]["type"], "internal_error");
+        assert_eq!(json["error"]["message"], "test");
+    }
+
+    #[test]
+    fn test_error_detail_without_code_omits_code_field() {
+        let detail = ErrorDetail {
+            message: "test".to_string(),
+            error_type: "internal_error".to_string(),
+            code: None,
+        };
+        let json = serde_json::to_value(&ErrorResponse { error: detail }).unwrap();
+        assert!(
+            json["error"].get("code").is_none(),
+            "code field should be absent when None"
+        );
+        assert_eq!(json["error"]["type"], "internal_error");
+    }
+
+    #[test]
+    fn test_error_detail_classified_uses_generic_message() {
+        let detail = ErrorDetail::classified(
+            "internal_error",
+            aura::ErrorCategory::McpConnectionFailed,
+            "MCP server 'pagerduty' at 10.0.1.5:8080 refused",
+        );
+        assert_eq!(
+            detail.message,
+            "A downstream service is temporarily unavailable"
+        );
+        assert_eq!(detail.error_type, "internal_error");
+        assert_eq!(detail.code, Some("mcp_connection_failed".to_string()));
+        assert!(!detail.message.contains("pagerduty"));
+        assert!(!detail.message.contains("10.0.1.5"));
+    }
+
+    #[test]
+    fn test_error_detail_validation_passes_through_message() {
+        let detail = ErrorDetail::validation("messages array is empty");
+        assert_eq!(detail.message, "messages array is empty");
+        assert_eq!(detail.error_type, "invalid_request_error");
+        assert_eq!(detail.code, Some("request_validation".to_string()));
     }
 }

--- a/crates/aura-web-server/tests/metrics_test.rs
+++ b/crates/aura-web-server/tests/metrics_test.rs
@@ -1,0 +1,280 @@
+#![cfg(feature = "integration-metrics")]
+
+//! Integration tests for the Prometheus /metrics endpoint.
+//!
+//! Verifies that metrics are scraped in valid Prometheus format,
+//! that request duration, token counters, tool duration, and error
+//! counters are recorded correctly after real requests.
+
+use aura_test_utils::server_urls::AURA_SERVER;
+use serde_json::{Value, json};
+use std::time::Duration;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+async fn send_chat_request(
+    client: &reqwest::Client,
+    messages: Vec<Value>,
+) -> reqwest::Response {
+    client
+        .post(format!("{AURA_SERVER}/v1/chat/completions"))
+        .json(&json!({
+            "model": "Test Assistant",
+            "messages": messages,
+            "stream": false,
+            "metadata": {
+                "account_id": "test-account",
+                "chat_session_id": format!("test-metrics-{}", uuid::Uuid::new_v4())
+            }
+        }))
+        .timeout(TEST_TIMEOUT)
+        .send()
+        .await
+        .expect("Failed to send request")
+}
+
+async fn scrape_metrics(client: &reqwest::Client) -> String {
+    client
+        .get(format!("{AURA_SERVER}/metrics"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("Failed to scrape /metrics")
+        .text()
+        .await
+        .expect("Failed to read metrics body")
+}
+
+/// TC-001.1.1.1: GET /metrics returns 200 with Prometheus text format
+#[tokio::test]
+async fn test_metrics_endpoint_returns_prometheus_format() {
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{AURA_SERVER}/metrics"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("Failed to reach /metrics");
+
+    assert_eq!(response.status(), 200);
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .expect("missing content-type")
+        .to_str()
+        .unwrap();
+    assert!(
+        content_type.contains("text/plain"),
+        "expected text/plain, got: {content_type}"
+    );
+
+    let body = response.text().await.unwrap();
+    assert!(
+        body.contains("# TYPE") || body.is_empty(),
+        "expected Prometheus format with # TYPE declarations"
+    );
+}
+
+/// TC-001.1.2.1: Request duration histogram present after a chat request
+#[tokio::test]
+async fn test_metrics_request_duration_after_chat() {
+    let client = reqwest::Client::new();
+
+    let response = send_chat_request(
+        &client,
+        vec![json!({"role": "user", "content": "Say hello"})],
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+
+    let metrics = scrape_metrics(&client).await;
+
+    assert!(
+        metrics.contains("aura_http_request_duration_seconds_count"),
+        "missing request duration histogram count"
+    );
+    assert!(
+        metrics.contains("aura_http_request_duration_seconds_bucket"),
+        "missing request duration histogram buckets"
+    );
+    assert!(
+        metrics.contains("method=\"POST\""),
+        "missing method label"
+    );
+    assert!(
+        metrics.contains("status_code=\"200\""),
+        "missing status_code label"
+    );
+}
+
+/// TC-001.2.1.1: Token counters present after a chat request
+#[tokio::test]
+async fn test_metrics_token_counters_after_chat() {
+    let client = reqwest::Client::new();
+
+    let response = send_chat_request(
+        &client,
+        vec![json!({"role": "user", "content": "Say the number 42"})],
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+
+    let metrics = scrape_metrics(&client).await;
+
+    assert!(
+        metrics.contains("aura_llm_tokens_total"),
+        "missing token counter"
+    );
+    assert!(
+        metrics.contains("type=\"prompt\""),
+        "missing prompt token label"
+    );
+    assert!(
+        metrics.contains("type=\"completion\""),
+        "missing completion token label"
+    );
+}
+
+/// TC-001.3.1.1: Tool duration histogram present after a tool call
+#[tokio::test]
+async fn test_metrics_tool_duration_after_tool_call() {
+    let client = reqwest::Client::new();
+
+    let response = send_chat_request(
+        &client,
+        vec![json!({"role": "user", "content": "Call mock_tool with message metrics_test"})],
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+
+    let metrics = scrape_metrics(&client).await;
+
+    assert!(
+        metrics.contains("aura_mcp_tool_duration_seconds_count"),
+        "missing tool duration histogram"
+    );
+    assert!(
+        metrics.contains("tool=\"mock_tool\""),
+        "missing tool label for mock_tool"
+    );
+}
+
+/// TC-001.4.1.1: Error counter increments on validation error
+#[tokio::test]
+async fn test_metrics_error_counter_on_validation_error() {
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("{AURA_SERVER}/v1/chat/completions"))
+        .json(&json!({"messages": []}))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("Failed to send request");
+    assert_eq!(response.status(), 400);
+
+    let metrics = scrape_metrics(&client).await;
+
+    assert!(
+        metrics.contains("aura_errors_total"),
+        "missing error counter"
+    );
+    assert!(
+        metrics.contains("error_type=\"request_validation\""),
+        "missing request_validation error type"
+    );
+}
+
+/// TC-001.5.1.1: In-flight gauge is present after a request
+#[tokio::test]
+async fn test_metrics_in_flight_gauge_present() {
+    let client = reqwest::Client::new();
+
+    // Send a request to trigger the gauge (metrics crate registers on first use)
+    let _ = send_chat_request(
+        &client,
+        vec![json!({"role": "user", "content": "gauge test"})],
+    )
+    .await;
+
+    let metrics = scrape_metrics(&client).await;
+
+    assert!(
+        metrics.contains("aura_http_requests_in_flight"),
+        "missing in-flight gauge"
+    );
+}
+
+/// TC-001.6.1.1: MCP server connection gauge present when MCP is configured
+#[tokio::test]
+async fn test_metrics_mcp_connection_gauge() {
+    let client = reqwest::Client::new();
+
+    // Send a request to trigger agent build (which records MCP connection state)
+    let _ = send_chat_request(
+        &client,
+        vec![json!({"role": "user", "content": "hi"})],
+    )
+    .await;
+
+    let metrics = scrape_metrics(&client).await;
+
+    assert!(
+        metrics.contains("aura_mcp_server_connected"),
+        "missing MCP connection gauge"
+    );
+}
+
+/// TC-001.P.1: Metrics scrape performance
+#[tokio::test]
+async fn test_metrics_scrape_performance() {
+    let client = reqwest::Client::new();
+
+    // Send a few requests to populate metrics
+    for i in 0..5 {
+        let _ = send_chat_request(
+            &client,
+            vec![json!({"role": "user", "content": format!("perf test {i}")})],
+        )
+        .await;
+    }
+
+    // Time the scrape
+    let start = std::time::Instant::now();
+    let metrics = scrape_metrics(&client).await;
+    let duration = start.elapsed();
+
+    assert!(
+        !metrics.is_empty(),
+        "metrics response should not be empty"
+    );
+    assert!(
+        duration.as_millis() < 50,
+        "metrics scrape took {}ms, expected < 50ms",
+        duration.as_millis()
+    );
+}
+
+/// TC-001.1.3.1: Request duration records 400 status for validation errors
+#[tokio::test]
+async fn test_metrics_records_400_status() {
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("{AURA_SERVER}/v1/chat/completions"))
+        .json(&json!({"messages": []}))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("Failed to send request");
+    assert_eq!(response.status(), 400);
+
+    let metrics = scrape_metrics(&client).await;
+
+    assert!(
+        metrics.contains("status_code=\"400\""),
+        "missing 400 status code in request duration histogram"
+    );
+}

--- a/crates/aura-web-server/tests/metrics_test.rs
+++ b/crates/aura-web-server/tests/metrics_test.rs
@@ -12,14 +12,11 @@ use std::time::Duration;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(60);
 
-async fn send_chat_request(
-    client: &reqwest::Client,
-    messages: Vec<Value>,
-) -> reqwest::Response {
+async fn send_chat_request(client: &reqwest::Client, messages: Vec<Value>) -> reqwest::Response {
     client
         .post(format!("{AURA_SERVER}/v1/chat/completions"))
         .json(&json!({
-            "model": "Test Assistant",
+            "model": "test-assistant",
             "messages": messages,
             "stream": false,
             "metadata": {
@@ -99,10 +96,7 @@ async fn test_metrics_request_duration_after_chat() {
         metrics.contains("aura_http_request_duration_seconds_bucket"),
         "missing request duration histogram buckets"
     );
-    assert!(
-        metrics.contains("method=\"POST\""),
-        "missing method label"
-    );
+    assert!(metrics.contains("method=\"POST\""), "missing method label");
     assert!(
         metrics.contains("status_code=\"200\""),
         "missing status_code label"
@@ -213,11 +207,7 @@ async fn test_metrics_mcp_connection_gauge() {
     let client = reqwest::Client::new();
 
     // Send a request to trigger agent build (which records MCP connection state)
-    let _ = send_chat_request(
-        &client,
-        vec![json!({"role": "user", "content": "hi"})],
-    )
-    .await;
+    let _ = send_chat_request(&client, vec![json!({"role": "user", "content": "hi"})]).await;
 
     let metrics = scrape_metrics(&client).await;
 
@@ -246,10 +236,7 @@ async fn test_metrics_scrape_performance() {
     let metrics = scrape_metrics(&client).await;
     let duration = start.elapsed();
 
-    assert!(
-        !metrics.is_empty(),
-        "metrics response should not be empty"
-    );
+    assert!(!metrics.is_empty(), "metrics response should not be empty");
     assert!(
         duration.as_millis() < 50,
         "metrics scrape took {}ms, expected < 50ms",

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -1040,14 +1040,22 @@ impl AgentBuilder {
                         tracing::info!("  Embedding Provider: {}", embedding_model.provider());
                         tracing::info!("  Embedding Model: {}", embedding_model.model());
                     }
-                    VectorStoreType::Qdrant { embedding_model, url, collection_name } => {
+                    VectorStoreType::Qdrant {
+                        embedding_model,
+                        url,
+                        collection_name,
+                    } => {
                         tracing::info!("  Type: qdrant");
                         tracing::info!("  URL: {}", url);
                         tracing::info!("  Collection: {}", collection_name);
                         tracing::info!("  Embedding Provider: {}", embedding_model.provider());
                         tracing::info!("  Embedding Model: {}", embedding_model.model());
                     }
-                    VectorStoreType::BedrockKb { knowledge_base_id, region, .. } => {
+                    VectorStoreType::BedrockKb {
+                        knowledge_base_id,
+                        region,
+                        ..
+                    } => {
                         tracing::info!("  Type: bedrock_kb");
                         tracing::info!("  Knowledge Base ID: {}", knowledge_base_id);
                         tracing::info!("  Region: {}", region);

--- a/crates/aura/src/error_taxonomy.rs
+++ b/crates/aura/src/error_taxonomy.rs
@@ -1,0 +1,259 @@
+//! Unified error taxonomy for all Aura runtime errors.
+//!
+//! Classifies errors into categories suitable for Prometheus metric labels,
+//! structured API responses, and differentiated alerting.
+
+use crate::tool_error_detection::DetectedToolError;
+
+/// Unified error taxonomy for all Aura runtime errors.
+/// Each variant maps to a Prometheus-label-safe string and a generic client message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCategory {
+    LlmTimeout,
+    LlmRateLimit,
+    LlmAuthError,
+    LlmError,
+    McpConnectionFailed,
+    McpToolError,
+    McpTimeout,
+    ConfigValidation,
+    RequestValidation,
+    BudgetExceeded,
+    ServiceUnavailable,
+    Cancelled,
+    Internal,
+}
+
+/// All ErrorCategory variants for exhaustive iteration in tests.
+pub const ALL_CATEGORIES: &[ErrorCategory] = &[
+    ErrorCategory::LlmTimeout,
+    ErrorCategory::LlmRateLimit,
+    ErrorCategory::LlmAuthError,
+    ErrorCategory::LlmError,
+    ErrorCategory::McpConnectionFailed,
+    ErrorCategory::McpToolError,
+    ErrorCategory::McpTimeout,
+    ErrorCategory::ConfigValidation,
+    ErrorCategory::RequestValidation,
+    ErrorCategory::BudgetExceeded,
+    ErrorCategory::ServiceUnavailable,
+    ErrorCategory::Cancelled,
+    ErrorCategory::Internal,
+];
+
+impl ErrorCategory {
+    /// Returns a Prometheus-label-safe string (lowercase, underscores only).
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            Self::LlmTimeout => "llm_timeout",
+            Self::LlmRateLimit => "llm_rate_limit",
+            Self::LlmAuthError => "llm_auth_error",
+            Self::LlmError => "llm_error",
+            Self::McpConnectionFailed => "mcp_connection_failed",
+            Self::McpToolError => "mcp_tool_error",
+            Self::McpTimeout => "mcp_timeout",
+            Self::ConfigValidation => "config_validation",
+            Self::RequestValidation => "request_validation",
+            Self::BudgetExceeded => "budget_exceeded",
+            Self::ServiceUnavailable => "service_unavailable",
+            Self::Cancelled => "cancelled",
+            Self::Internal => "internal",
+        }
+    }
+
+    /// Returns a safe, generic client-facing message.
+    /// Internal details must NEVER appear in this output.
+    pub fn client_message(&self) -> &'static str {
+        match self {
+            Self::LlmTimeout => "The language model did not respond in time",
+            Self::LlmRateLimit => "The language model is temporarily rate limited",
+            Self::LlmAuthError => "An authentication error occurred with an upstream provider",
+            Self::LlmError => "An error occurred with the language model",
+            Self::McpConnectionFailed => "A downstream service is temporarily unavailable",
+            Self::McpToolError => "A tool execution error occurred",
+            Self::McpTimeout => "A tool call did not respond in time",
+            Self::ConfigValidation => "Server configuration error",
+            Self::RequestValidation => "Invalid request",
+            Self::BudgetExceeded => "Token budget exceeded for this request",
+            Self::ServiceUnavailable => "Server is shutting down",
+            Self::Cancelled => "Request was cancelled",
+            Self::Internal => "An internal error occurred",
+        }
+    }
+}
+
+impl std::fmt::Display for ErrorCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_label())
+    }
+}
+
+impl From<&DetectedToolError> for ErrorCategory {
+    fn from(err: &DetectedToolError) -> Self {
+        match err {
+            DetectedToolError::McpToolError(_) => ErrorCategory::McpToolError,
+            DetectedToolError::ToolCallError(_) => ErrorCategory::McpToolError,
+            DetectedToolError::JsonError(_) => ErrorCategory::Internal,
+        }
+    }
+}
+
+/// A classified runtime error with taxonomy category and internal message.
+pub struct AuraError {
+    pub category: ErrorCategory,
+    /// Internal message for server-side logging. Never expose to clients.
+    pub internal_message: String,
+}
+
+impl AuraError {
+    pub fn new(category: ErrorCategory, internal_message: impl Into<String>) -> Self {
+        Self {
+            category,
+            internal_message: internal_message.into(),
+        }
+    }
+
+    /// Safe message for API responses. Uses fixed generic text per category.
+    /// For RequestValidation, passes through the internal message (client input is safe).
+    pub fn client_message(&self) -> String {
+        match self.category {
+            ErrorCategory::RequestValidation => self.internal_message.clone(),
+            _ => self.category.client_message().to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_all_categories_have_non_empty_labels() {
+        for category in ALL_CATEGORIES {
+            let label = category.as_label();
+            assert!(!label.is_empty(), "empty label for {:?}", category);
+        }
+    }
+
+    #[test]
+    fn test_all_labels_are_prometheus_safe() {
+        let pattern = regex::Regex::new(r"^[a-z][a-z0-9_]*$").unwrap();
+        for category in ALL_CATEGORIES {
+            let label = category.as_label();
+            assert!(
+                pattern.is_match(label),
+                "label {:?} does not match Prometheus pattern",
+                label
+            );
+        }
+    }
+
+    #[test]
+    fn test_all_labels_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for category in ALL_CATEGORIES {
+            let label = category.as_label();
+            assert!(seen.insert(label), "duplicate label: {}", label);
+        }
+    }
+
+    #[test]
+    fn test_all_categories_count() {
+        assert_eq!(ALL_CATEGORIES.len(), 13);
+    }
+
+    #[test]
+    fn test_all_categories_have_non_empty_client_messages() {
+        for category in ALL_CATEGORIES {
+            let msg = category.client_message();
+            assert!(!msg.is_empty(), "empty client message for {:?}", category);
+        }
+    }
+
+    #[test]
+    fn test_client_messages_do_not_contain_internal_details() {
+        let suspicious_patterns = ["10.0.", "127.0.", "localhost", "::1", ".rs:", "panicked"];
+        for category in ALL_CATEGORIES {
+            let msg = category.client_message();
+            for pattern in &suspicious_patterns {
+                assert!(
+                    !msg.contains(pattern),
+                    "client message for {:?} contains suspicious pattern {:?}: {}",
+                    category,
+                    pattern,
+                    msg
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_detected_tool_error_mcp_maps_to_mcp_tool_error() {
+        let err = DetectedToolError::McpToolError("connection refused".to_string());
+        assert_eq!(ErrorCategory::from(&err), ErrorCategory::McpToolError);
+    }
+
+    #[test]
+    fn test_detected_tool_error_tool_call_maps_to_mcp_tool_error() {
+        let err = DetectedToolError::ToolCallError("timeout".to_string());
+        assert_eq!(ErrorCategory::from(&err), ErrorCategory::McpToolError);
+    }
+
+    #[test]
+    fn test_detected_tool_error_json_maps_to_internal() {
+        let err = DetectedToolError::JsonError("invalid json".to_string());
+        assert_eq!(ErrorCategory::from(&err), ErrorCategory::Internal);
+    }
+
+    #[test]
+    fn test_aura_error_client_message_sanitizes_internal_details() {
+        let err = AuraError::new(
+            ErrorCategory::McpConnectionFailed,
+            "MCP server 'pagerduty' at 10.0.1.5:8080 connection refused",
+        );
+        let msg = err.client_message();
+        assert_eq!(msg, "A downstream service is temporarily unavailable");
+        assert!(!msg.contains("pagerduty"));
+        assert!(!msg.contains("10.0.1.5"));
+        assert!(!msg.contains("8080"));
+    }
+
+    #[test]
+    fn test_aura_error_request_validation_passes_through() {
+        let err = AuraError::new(
+            ErrorCategory::RequestValidation,
+            "Last message must be from user, got: system",
+        );
+        assert_eq!(
+            err.client_message(),
+            "Last message must be from user, got: system"
+        );
+    }
+
+    #[test]
+    fn test_aura_error_non_validation_uses_generic_message() {
+        for category in ALL_CATEGORIES {
+            if *category == ErrorCategory::RequestValidation {
+                continue;
+            }
+            let err = AuraError::new(*category, "SECRET internal detail 10.0.1.5:8080");
+            let msg = err.client_message();
+            assert!(
+                !msg.contains("SECRET"),
+                "category {:?} leaked internal message: {}",
+                category,
+                msg
+            );
+        }
+    }
+
+    #[test]
+    fn test_display_uses_label() {
+        assert_eq!(format!("{}", ErrorCategory::LlmTimeout), "llm_timeout");
+        assert_eq!(
+            format!("{}", ErrorCategory::McpConnectionFailed),
+            "mcp_connection_failed"
+        );
+    }
+}

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -5,9 +5,11 @@
 //! in web services or other applications that need to build agents
 //! programmatically.
 
+pub mod bedrock_embedding;
 pub mod builder;
 pub mod config;
 pub mod error;
+pub mod error_taxonomy;
 pub mod fallback_tool_parser;
 pub mod fallback_tool_stream;
 pub mod logging;
@@ -27,7 +29,6 @@ mod schema_sanitize; // Private - MCP schema sanitization for OpenAI compatibili
 pub mod stream_events;
 pub mod streaming;
 pub mod streaming_request_hook;
-pub mod bedrock_embedding;
 pub(crate) mod string_utils;
 pub mod tool_error_detection;
 pub mod tool_event_broker;
@@ -58,6 +59,7 @@ pub type AuraToolCall = provider_agent::ToolCall;
 #[deprecated(since = "1.2.0", note = "use ToolResult instead")]
 pub type AuraToolResult = provider_agent::ToolResult;
 
+pub use error_taxonomy::{ALL_CATEGORIES, AuraError, ErrorCategory};
 pub use mcp::McpManager;
 pub use mcp_progress::ProgressEnabledHandler;
 pub use mcp_streamable_http::InFlightRequests;

--- a/crates/aura/src/vector_store.rs
+++ b/crates/aura/src/vector_store.rs
@@ -109,17 +109,11 @@ impl VectorStoreManager {
     }
 
     /// Load AWS SDK config with optional region and profile
-    async fn load_aws_config(
-        region: &str,
-        profile: Option<&str>,
-    ) -> aws_config::SdkConfig {
+    async fn load_aws_config(region: &str, profile: Option<&str>) -> aws_config::SdkConfig {
         use aws_config::{BehaviorVersion, Region};
 
         if let Some(profile_name) = profile {
-            info!(
-                "Loading AWS config with profile '{}'",
-                profile_name
-            );
+            info!("Loading AWS config with profile '{}'", profile_name);
             aws_config::defaults(BehaviorVersion::latest())
                 .region(Region::new(region.to_string()))
                 .profile_name(profile_name)
@@ -222,8 +216,7 @@ impl VectorStoreManager {
         let qdrant_store = match embedding {
             EmbeddingModelConfig::OpenAI { api_key, model, .. } => {
                 let embedding_model = Self::create_openai_embedding_model(api_key, model)?;
-                let store =
-                    QdrantVectorStore::new(qdrant_client, embedding_model, query_params);
+                let store = QdrantVectorStore::new(qdrant_client, embedding_model, query_params);
                 QdrantStoreKind::OpenAI(store)
             }
             EmbeddingModelConfig::Bedrock {
@@ -232,10 +225,8 @@ impl VectorStoreManager {
                 profile,
             } => {
                 let embedding_model =
-                    Self::create_bedrock_embedding_model(model, region, profile.as_deref())
-                        .await?;
-                let store =
-                    QdrantVectorStore::new(qdrant_client, embedding_model, query_params);
+                    Self::create_bedrock_embedding_model(model, region, profile.as_deref()).await?;
+                let store = QdrantVectorStore::new(qdrant_client, embedding_model, query_params);
                 QdrantStoreKind::Bedrock(store)
             }
         };
@@ -268,11 +259,7 @@ impl VectorStoreManager {
         info!("  Knowledge Base ID: {}", knowledge_base_id);
         info!("  Region: {}", region);
 
-        let sdk_config = Self::load_aws_config(
-            region,
-            profile,
-        )
-        .await;
+        let sdk_config = Self::load_aws_config(region, profile).await;
 
         let client = aws_sdk_bedrockagentruntime::Client::new(&sdk_config);
         info!("Bedrock Knowledge Base client initialized");
@@ -296,7 +283,8 @@ impl VectorStoreManager {
     pub async fn add_documents(&self, documents: Vec<String>) -> Result<(), BuilderError> {
         if self.store_type == "bedrock_kb" {
             return Err(BuilderError::VectorStoreError(
-                "Bedrock Knowledge Base is read-only; manage documents via the AWS console".to_string(),
+                "Bedrock Knowledge Base is read-only; manage documents via the AWS console"
+                    .to_string(),
             ));
         }
 
@@ -386,22 +374,18 @@ impl VectorStoreManager {
         limit: usize,
     ) -> Result<Vec<SearchResult>, BuilderError> {
         let client = self.bedrock_kb_client.as_ref().ok_or_else(|| {
-            BuilderError::VectorStoreError(
-                "Bedrock KB client not initialized".to_string(),
-            )
+            BuilderError::VectorStoreError("Bedrock KB client not initialized".to_string())
         })?;
-        let kb_id = self.bedrock_kb_id.as_ref().ok_or_else(|| {
-            BuilderError::VectorStoreError(
-                "Bedrock KB ID not set".to_string(),
-            )
-        })?;
+        let kb_id = self
+            .bedrock_kb_id
+            .as_ref()
+            .ok_or_else(|| BuilderError::VectorStoreError("Bedrock KB ID not set".to_string()))?;
 
         debug!("Performing Bedrock KB retrieve for: '{}'", query);
 
-        let retrieval_query =
-            aws_sdk_bedrockagentruntime::types::KnowledgeBaseQuery::builder()
-                .text(query)
-                .build();
+        let retrieval_query = aws_sdk_bedrockagentruntime::types::KnowledgeBaseQuery::builder()
+            .text(query)
+            .build();
 
         let retrieval_config =
             aws_sdk_bedrockagentruntime::types::KnowledgeBaseRetrievalConfiguration::builder()
@@ -420,9 +404,7 @@ impl VectorStoreManager {
             .send()
             .await
             .map_err(|e| {
-                BuilderError::VectorStoreError(format!(
-                    "Bedrock KB retrieve failed: {e}"
-                ))
+                BuilderError::VectorStoreError(format!("Bedrock KB retrieve failed: {e}"))
             })?;
 
         let results: Vec<SearchResult> = response
@@ -492,12 +474,8 @@ impl VectorStoreManager {
                     })?;
 
                 let mut candidates = match qdrant_store.as_ref() {
-                    QdrantStoreKind::OpenAI(store) => {
-                        store.top_n::<Value>(search_request).await
-                    }
-                    QdrantStoreKind::Bedrock(store) => {
-                        store.top_n::<Value>(search_request).await
-                    }
+                    QdrantStoreKind::OpenAI(store) => store.top_n::<Value>(search_request).await,
+                    QdrantStoreKind::Bedrock(store) => store.top_n::<Value>(search_request).await,
                 }
                 .map_err(|e| {
                     BuilderError::VectorStoreError(format!("Qdrant search failed: {e}"))

--- a/docs/internal/development-process.md
+++ b/docs/internal/development-process.md
@@ -1,0 +1,187 @@
+# Aura Spec-Driven Development Process
+
+This document defines the development lifecycle for new features in the Aura project. It uses GitHub spec-kit conventions with multi-agent review gates at every stage.
+
+## Overview
+
+Every feature follows a 7-phase lifecycle. Each phase has an explicit entry criterion, work product, and exit criterion. The process ensures traceability from roadmap items through user stories, specs, code, and tests.
+
+```
+Roadmap Item → User Stories → Specs → Review → Plan → Implement → Review → QA → Release
+```
+
+## Phase 1: Roadmap to User Stories
+
+**Entry:** Gap identified in production readiness, user feedback, or strategic initiative.
+
+**Work:**
+- Write a roadmap item document in `.specify/roadmap/AURA-RM-NNN-<slug>.md`
+- Include: rationale, user stories with Given-When-Then acceptance criteria, dependencies, affected crates, complexity
+
+**Exit:** Product owner approves user stories.
+
+## Phase 2: Three Specs
+
+For each roadmap item, three specification documents are authored in `.specify/specs/AURA-RM-NNN/`:
+
+### Product Spec (`product-spec.md`)
+- What to build
+- User stories with acceptance criteria (Given-When-Then)
+- API/config contracts (exact shapes)
+- Scope and non-scope
+- Dependencies on other roadmap items
+
+### Architecture Spec (`architecture-spec.md`)
+- How to build it
+- Constitution compliance check
+- Crate changes (which modules, types, traits)
+- Data flow diagrams
+- Error handling approach
+- Migration/backward compatibility plan
+- Alternatives considered with rationale
+
+### Quality Spec (`quality-spec.md`)
+- How to verify it
+- Test strategy (unit, integration, e2e)
+- Acceptance criteria traceability matrix: every AC maps to test cases
+- Test infrastructure needed
+- Quality gates checklist
+
+Templates for all three are in `.specify/templates/`.
+
+## Phase 3: Multi-Agent Spec Review
+
+Each spec goes through review by multiple agents, each with a distinct perspective.
+
+### Review Perspectives
+
+| Agent | Focus | Checks |
+|-------|-------|--------|
+| **Consistency** | Constitution + patterns | API compat? Crate boundaries? Config backward-compat? |
+| **Architecture** | Technical design | Simpler alternatives? Concurrency concerns? Error handling? |
+| **Security** | Threat surface | Auth bypass? Input validation? Secret handling? DoS vectors? |
+| **Operability** | SRE concerns | Observable? Configurable without restart? Failure modes clear? Graceful shutdown? |
+| **Testing** | Quality spec | All ACs covered? Edge cases identified? Test infra realistic? |
+
+### Feedback Categories
+
+- **Must Fix** — Blocks proceeding. Factual errors, spec violations, missing critical concerns.
+- **Should Fix** — Strongly recommended. Design improvements, better patterns available.
+- **Nit** — Optional. Style, naming, documentation phrasing.
+
+### Exit Criteria
+
+**The review comes back CLEAN: zero Must Fix AND zero Should Fix.**
+
+Nits are at author discretion. The cycle repeats until clean:
+
+1. Author addresses all Must Fix items
+2. Author addresses all Should Fix items (fix or justify with rationale)
+3. Re-review focuses only on changed sections
+4. Loop until clean
+
+### Review Records
+
+Each review round is saved in `.specify/specs/AURA-RM-NNN/reviews/` with:
+- Reviewer perspective
+- Findings by category (Must Fix, Should Fix, Nit)
+- Resolution status
+
+## Phase 4: Plan + Tasks
+
+**Entry:** All three specs approved (clean review).
+
+**Work:**
+- `plan.md` — Implementation plan derived from architecture spec
+- `tasks.md` — Ordered task list with:
+  - Traceability: each task references `Satisfies: AC-NNN.N.N`
+  - Dependencies: never build against functionality that doesn't exist yet
+  - Size: each task is one PR
+
+**Exit:** Tasks approved, ready for implementation.
+
+## Phase 5: Implementation + Multi-Agent Code Review
+
+Each task becomes a PR. The PR goes through multi-agent code review.
+
+### Code Review Perspectives
+
+| Agent | Focus |
+|-------|-------|
+| **Correctness** | Does code match architecture spec? Error paths handled? No panics in production? |
+| **Performance** | Unnecessary allocations? Async correct? Lock contention? |
+| **Testing** | Tests satisfy mapped ACs from quality spec? Edge cases covered? |
+| **Style** | Follows existing Aura patterns? Naming? Module organization? |
+
+### Exit Criteria
+
+Same protocol: **zero Must Fix AND zero Should Fix** before merge.
+
+## Phase 6: QA Verification
+
+**Entry:** All implementation tasks merged, tests passing.
+
+**Work:**
+- Run acceptance criteria from product spec against the implementation
+- For API endpoints: automated integration tests (Docker Compose infrastructure)
+- For config changes: validate with `debug_config` binary
+- For UI components: Playwright tests against a running instance
+- **Traceability check:** every acceptance criterion in the product spec has at least one passing test
+
+**Exit:** All ACs verified. Traceability matrix complete.
+
+## Phase 7: Validation + Release
+
+- `make ci` (fmt-check, test, lint)
+- Integration test suite with new feature flags
+- Backward compatibility: existing example configs still load
+- Update documentation (README.md, relevant docs/)
+- Conventional commit, semantic release via Jenkins pipeline
+
+## Traceability
+
+Every requirement flows through with traceable links:
+
+```
+AURA-RM-NNN (Roadmap Item)
+  → US-NNN.N (User Story)
+    → product-spec.md AC-NNN.N.N (Acceptance Criterion)
+      → architecture-spec.md (Design Decision)
+        → tasks.md: Task N (Implementation Task)
+          → PR #NN (Code Change)
+            → test_function_name() (Test)
+              → quality-spec.md TC-NNN.N.N (maps back to AC)
+```
+
+Maintained by convention:
+- Each task in `tasks.md` includes `Satisfies: AC-NNN.N.N`
+- Each test function references its test case ID from the quality spec
+- PRs reference the task and roadmap item in the commit message
+
+## Execution Order
+
+Roadmap items are executed strictly by dependency. Never start an item until its dependencies are complete — no speculative coding against unbuilt functionality.
+
+```
+RM-008 (Error Taxonomy) ← foundation, no dependencies
+  ├── RM-001 (Metrics)
+  │     ├── RM-005 (Token Budget)
+  │     ├── RM-003 (Circuit Breaker)
+  │     │     └── RM-011 (Admin Endpoint)
+  │     └── RM-011 (Admin Endpoint)
+  ├── RM-002 (Health Checks)
+  ├── RM-004 (Auth)
+  └── RM-007 (Incident Response)
+
+Independent:
+  RM-006 (CLI) — in progress on separate branch
+  RM-009 (Agent Catalog)
+  RM-010 (Runbook Scaffolding)
+```
+
+## Tools
+
+- **Spec-kit CLI:** `specify` (installed via `uv tool install specify-cli`)
+- **Test generation:** `make test-generate` (Aura self-testing pipeline)
+- **CI:** Jenkins (commitlint, fmt, test, clippy)
+- **Integration tests:** Docker Compose (`make test-integration`)

--- a/examples/grafana/aura-dashboard.json
+++ b/examples/grafana/aura-dashboard.json
@@ -1,0 +1,273 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "Requests / sec",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2 },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(aura_http_request_duration_seconds_count[1m])",
+          "legendFormat": "{{status_code}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Request Latency (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(aura_http_request_duration_seconds_bucket[1m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(aura_http_request_duration_seconds_bucket[1m]))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(aura_http_request_duration_seconds_bucket[1m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "title": "Requests In-Flight",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 4, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          },
+          "max": 50
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "aura_http_requests_in_flight",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Error Rate / sec",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 4, "x": 20, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "red", "mode": "fixed" },
+          "custom": { "fillOpacity": 30, "lineWidth": 2 },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(aura_errors_total[1m])",
+          "legendFormat": "{{error_type}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Token Usage / min",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(aura_llm_tokens_total[1m]) * 60",
+          "legendFormat": "{{type}} ({{provider}})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Total Tokens (Cumulative)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100000 },
+              { "color": "red", "value": 1000000 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(aura_llm_tokens_total)",
+          "legendFormat": "total tokens",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Total Requests",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(aura_http_request_duration_seconds_count)",
+          "legendFormat": "requests",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "MCP Tool Latency (p95)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(aura_mcp_tool_duration_seconds_bucket[1m]))",
+          "legendFormat": "{{tool}} ({{server}})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "MCP Tool Calls / min",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(aura_mcp_tool_duration_seconds_count[1m]) * 60",
+          "legendFormat": "{{tool}} ({{status}})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "MCP Server Status",
+      "type": "table",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "options": { "0": { "text": "DISCONNECTED", "color": "red" }, "1": { "text": "CONNECTED", "color": "green" } }, "type": "value" }
+          ]
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "aura_mcp_server_connected",
+          "legendFormat": "{{server}}",
+          "refId": "A",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true, "__name__": true, "instance": true, "job": true }, "renameByName": { "server": "MCP Server", "Value": "Status" } } }
+      ]
+    },
+    {
+      "title": "Errors by Type",
+      "type": "piechart",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "aura_errors_total",
+          "legendFormat": "{{error_type}}",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["aura", "llm", "mcp"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Aura Agent Metrics",
+  "uid": "aura-metrics",
+  "version": 1
+}


### PR DESCRIPTION
## Summary
- **AURA-RM-008 (Error Taxonomy)**: `ErrorCategory` enum (13 categories), `AuraError` sanitization layer, taxonomy `code` field in API error responses. Client-facing messages are generic — internal details logged server-side only.
- **AURA-RM-001 (Prometheus Metrics)**: `/metrics` endpoint with 6 metric families — request duration histogram, token counters, tool duration histogram, error counters, in-flight gauge, MCP connection gauge. Includes `AURA_METRICS_ENABLED` kill switch and cardinality guards.
- **Grafana dashboard**: Starter dashboard JSON with 12 panels at `examples/grafana/aura-dashboard.json`
- **Development process**: Updated to 8 phases (added Documentation phase before Release)

## Verified
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace --lib` — 299 unit tests pass
- [x] 9 integration tests pass (`integration-metrics` feature flag)
- [x] Live tested with Bedrock LLM + Mock MCP server + Prometheus + Grafana
- [x] Token counters match API response usage exactly across 100+ requests
- [x] In-flight gauge showed 30 during concurrent burst, 0 after
- [x] Error counters fire for validation errors (400s) and client disconnects
- [x] MCP tool duration recorded for mock_tool and list_files
- [x] MCP connection gauge shows connected servers
- [x] `/health` and `/metrics` accessible during graceful shutdown
- [x] All 16 acceptance criteria verified
- [x] All quality gates checked
- [x] No secrets in diff
- [x] Backward compatible — existing configs load without changes

## Specs
- `.specify/specs/AURA-RM-008/` — product, architecture, quality specs + review records (4 rounds → clean)
- `.specify/specs/AURA-RM-001/` — product, architecture, quality specs + review records (3 rounds → clean)

Ref: LOG-00000