### PR TITLE
fix(deps): correct mezmo rig fork commit hash in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.28.0"
-source = "git+https://github.com/mezmo/rig.git?rev=d7e9d92#d7e9d92e8bab870074294b9fb7d0b98c3b6c6d6b"
+source = "git+https://github.com/mezmo/rig.git?rev=dedfe545a4b89ef8ae787904ad0fb4324247d4d4#dedfe545a4b89ef8ae787904ad0fb4324247d4d4"
 dependencies = [
  "as-any",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mezmo/aura"
 
 [workspace.dependencies]
-rig-core = { git = "https://github.com/mezmo/rig.git", rev = "d7e9d92", features = ["rmcp"] }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "dedfe545a4b89ef8ae787904ad0fb4324247d4d4", features = ["rmcp"] }
 # Pinned to exact versions compatible with our rig-core 0.28.x fork.
 # Newer versions pull in rig-core 0.31+ which is semver-incompatible with the fork.
 rig-bedrock = "=0.3.10"
@@ -70,5 +70,5 @@ reqwest = { version = "0.12", features = ["json", "stream"] }
 
 # Patch rig-core to use the fork with streaming hook + span propagation fix
 [patch.crates-io]
-rig-core = { git = "https://github.com/mezmo/rig.git", rev = "d7e9d92" }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "dedfe545a4b89ef8ae787904ad0fb4324247d4d4" }
 


### PR DESCRIPTION
The pinned rev d7e9d92 does not resolve in the mezmo/rig repository, causing fresh build environments to fail when fetching the git dependency. Both the [workspace.dependencies] and [patch.crates-io] entries are updated to the correct full SHA.

Ref: LOG-23790