### PR TITLE
chore: fix flakey tests that write to env vars

### DIFF
--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -321,6 +321,7 @@ model = "gpt-4"
 
     #[test]
     fn test_environment_variable_placeholders() {
+        let _env_lock = crate::test_env_lock::lock();
         println!("\n=== TEST_ENVIRONMENT_VARIABLE_PLACEHOLDERS ===");
         let env_config = r#"
 [[vector_stores]]
@@ -537,6 +538,7 @@ top_p = 0.9
 
     #[test]
     fn test_ollama_additional_params_env_resolution() {
+        let _env_lock = crate::test_env_lock::lock();
         println!("\n=== TEST_OLLAMA_ADDITIONAL_PARAMS_ENV_RESOLUTION ===");
         // Set up test env var
         unsafe {
@@ -1102,6 +1104,8 @@ context_window = 200000
 
     #[test]
     fn test_all_shipped_configs_parse() {
+        let _env_lock = crate::test_env_lock::lock();
+
         // Set env vars every shipped config expects so env resolution succeeds.
         unsafe {
             std::env::set_var("OPENAI_API_KEY", "test-openai");

--- a/crates/aura-config/src/env.rs
+++ b/crates/aura-config/src/env.rs
@@ -129,6 +129,7 @@ host = "{{ env.TEST_HOST_NONEXISTENT | default: 'localhost' }}"
 
     #[test]
     fn test_default_value_when_env_set() {
+        let _env_lock = crate::test_env_lock::lock();
         unsafe {
             env::set_var("TEST_HOST_EXISTS", "myhost");
         }

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -7,6 +7,9 @@ pub mod loader;
 #[cfg(test)]
 mod config_test;
 
+#[cfg(test)]
+mod test_env_lock;
+
 pub use builder::RigBuilder;
 pub use config::*;
 pub use env::resolve_env_vars;

--- a/crates/aura-config/src/loader.rs
+++ b/crates/aura-config/src/loader.rs
@@ -239,6 +239,7 @@ mod tests {
 
     #[test]
     fn test_standard_loader() {
+        let _env_lock = crate::test_env_lock::lock();
         // Set some test environment variables
         unsafe {
             std::env::set_var("RIG_LLM_PROVIDER", "test_provider");

--- a/crates/aura-config/src/test_env_lock.rs
+++ b/crates/aura-config/src/test_env_lock.rs
@@ -1,0 +1,18 @@
+//! Process-wide lock for tests that read or mutate environment variables.
+//!
+//! Cargo runs all `#[test]` functions in a crate as parallel threads inside a
+//! single binary, but `std::env::set_var` / `remove_var` mutate global process
+//! state. Tests that touch the env therefore race with each other. Acquire
+//! this lock at the top of any such test to serialize them.
+
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire the process-wide env-mutation lock for this test binary.
+///
+/// Recovers from poisoning so a panicking test does not cascade into every
+/// later test in the binary failing to acquire the lock.
+pub(crate) fn lock() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+}

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -105,3 +105,6 @@ pub use vector_dynamic::DynamicVectorSearchTool;
 // Fallback tool parser and stream wrapper for Ollama
 pub use fallback_tool_parser::{ParsedToolCall, parse_fallback_tool_calls};
 pub use fallback_tool_stream::FallbackToolExecutor;
+
+#[cfg(test)]
+mod test_env_lock;

--- a/crates/aura/src/orchestration/types.rs
+++ b/crates/aura/src/orchestration/types.rs
@@ -1116,6 +1116,7 @@ mod tests {
 
     #[test]
     fn test_iteration_context_reflection_prompt() {
+        let _env_lock = crate::test_env_lock::lock();
         // Ensure enriched mode is active (env may leak from other tests in parallel)
         unsafe { std::env::remove_var("AURA_ENRICH_REPLAN") };
 
@@ -1150,6 +1151,7 @@ mod tests {
 
     #[test]
     fn test_iteration_context_reflection_prompt_no_gaps() {
+        let _env_lock = crate::test_env_lock::lock();
         let mut plan = Plan::new("Simple query");
         let mut task = Task::new(0, "Execute", "Run query");
         task.complete("Done".to_string());
@@ -1168,6 +1170,7 @@ mod tests {
 
     #[test]
     fn test_reflection_prompt_with_failure_history() {
+        let _env_lock = crate::test_env_lock::lock();
         let mut plan = Plan::new("Debug the issue");
         let mut task = Task::new(0, "Gather logs", "Collect logs");
         task.fail("Timeout contacting service");
@@ -1194,6 +1197,7 @@ mod tests {
 
     #[test]
     fn test_reflection_prompt_with_repeated_failures() {
+        let _env_lock = crate::test_env_lock::lock();
         let mut plan = Plan::new("Debug the issue");
         let mut task = Task::new(0, "Fetch data", "Get data");
         task.fail("Connection refused");
@@ -1226,6 +1230,7 @@ mod tests {
 
     #[test]
     fn test_reflection_prompt_enriched_truncation() {
+        let _env_lock = crate::test_env_lock::lock();
         // Ensure enriched mode is active (env may leak from other tests in parallel)
         unsafe { std::env::set_var("AURA_ENRICH_REPLAN", "true") };
 
@@ -1253,7 +1258,7 @@ mod tests {
 
     #[test]
     fn test_reflection_prompt_legacy_mode() {
-        // SAFETY: tests run with --test-threads=1 per project convention
+        let _env_lock = crate::test_env_lock::lock();
         unsafe { std::env::set_var("AURA_ENRICH_REPLAN", "false") };
 
         let mut plan = Plan::new("Test legacy");
@@ -1275,6 +1280,7 @@ mod tests {
 
     #[test]
     fn test_reflection_prompt_urgency_final_attempt() {
+        let _env_lock = crate::test_env_lock::lock();
         let mut plan = Plan::new("Goal");
         let mut task = Task::new(0, "Task", "Do it");
         task.fail("error");
@@ -1290,6 +1296,7 @@ mod tests {
 
     #[test]
     fn test_reflection_prompt_no_urgency_early_iteration() {
+        let _env_lock = crate::test_env_lock::lock();
         let mut plan = Plan::new("Goal");
         let mut task = Task::new(0, "Task", "Do it");
         task.fail("error");
@@ -1304,6 +1311,7 @@ mod tests {
 
     #[test]
     fn test_reflection_prompt_includes_reuse_guidance() {
+        let _env_lock = crate::test_env_lock::lock();
         let mut plan = Plan::new("Goal");
         let mut task = Task::new(0, "Completed task", "Done");
         task.complete("Some result");
@@ -1318,6 +1326,7 @@ mod tests {
 
     #[test]
     fn test_reflection_prompt_no_reuse_guidance_when_all_failed() {
+        let _env_lock = crate::test_env_lock::lock();
         let mut plan = Plan::new("Goal");
         let mut task = Task::new(0, "Failed task", "Tried");
         task.fail("error");
@@ -1332,6 +1341,7 @@ mod tests {
 
     #[test]
     fn test_reflection_prompt_mixed_categories() {
+        let _env_lock = crate::test_env_lock::lock();
         unsafe { std::env::remove_var("AURA_ENRICH_REPLAN") };
 
         let mut plan = Plan::new("Mixed results");

--- a/crates/aura/src/test_env_lock.rs
+++ b/crates/aura/src/test_env_lock.rs
@@ -1,0 +1,18 @@
+//! Process-wide lock for tests that read or mutate environment variables.
+//!
+//! Cargo runs all `#[test]` functions in a crate as parallel threads inside a
+//! single binary, but `std::env::set_var` / `remove_var` mutate global process
+//! state. Tests that touch the env therefore race with each other. Acquire
+//! this lock at the top of any such test to serialize them.
+
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire the process-wide env-mutation lock for this test binary.
+///
+/// Recovers from poisoning so a panicking test does not cascade into every
+/// later test in the binary failing to acquire the lock.
+pub(crate) fn lock() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+}


### PR DESCRIPTION
There are several places where tests write/read from env vars. When this is done in parallel it can cause flakey tests. This update adds a crate wide lock for tests to get rid of the flakey-ness.

Ref: LOG-23806