### PR TITLE
refactor(webserver): swap actix-web for axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,239 +3,6 @@
 version = 4
 
 [[package]]
-name = "actix-codec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-sink",
- "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "actix-http"
-version = "3.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cceded2fb55f3c4b67068fa64962e2ca59614edc5b03167de9ff82ae803da0"
-dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "actix-utils",
- "base64 0.22.1",
- "bitflags",
- "brotli",
- "bytes",
- "bytestring",
- "derive_more 2.0.1",
- "encoding_rs",
- "flate2",
- "foldhash",
- "futures-core",
- "h2 0.3.27",
- "http 0.2.12",
- "httparse",
- "httpdate",
- "itoa",
- "language-tags",
- "local-channel",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand 0.9.2",
- "sha1",
- "smallvec",
- "tokio",
- "tokio-util",
- "tracing",
- "zstd",
-]
-
-[[package]]
-name = "actix-macros"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "actix-router"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
-dependencies = [
- "bytestring",
- "cfg-if",
- "http 0.2.12",
- "regex",
- "regex-lite",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "actix-rt"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
-dependencies = [
- "futures-core",
- "tokio",
-]
-
-[[package]]
-name = "actix-server"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
-dependencies = [
- "actix-rt",
- "actix-service",
- "actix-utils",
- "futures-core",
- "futures-util",
- "mio",
- "socket2 0.5.10",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "actix-service"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-utils"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
-dependencies = [
- "local-waker",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-web"
-version = "4.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a597b77b5c6d6a1e1097fddde329a83665e25c5437c696a3a9a4aa514a614dea"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-macros",
- "actix-router",
- "actix-rt",
- "actix-server",
- "actix-service",
- "actix-utils",
- "actix-web-codegen",
- "bytes",
- "bytestring",
- "cfg-if",
- "cookie",
- "derive_more 2.0.1",
- "encoding_rs",
- "foldhash",
- "futures-core",
- "futures-util",
- "impl-more",
- "itoa",
- "language-tags",
- "log",
- "mime",
- "once_cell",
- "pin-project-lite",
- "regex",
- "regex-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "smallvec",
- "socket2 0.5.10",
- "time",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "actix-web-codegen"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
-dependencies = [
- "actix-router",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "actix-web-lab"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a965e3e826aa4737af33666aa09ed949aa1837706fda2adee07039347be50d6"
-dependencies = [
- "actix-http",
- "actix-router",
- "actix-service",
- "actix-utils",
- "actix-web",
- "actix-web-lab-derive",
- "ahash",
- "arc-swap",
- "bytes",
- "bytestring",
- "csv",
- "derive_more 1.0.0",
- "form_urlencoded",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "impl-more",
- "itertools 0.13.0",
- "local-channel",
- "mediatype",
- "mime",
- "once_cell",
- "pin-project-lite",
- "regex",
- "serde",
- "serde_html_form",
- "serde_json",
- "serde_path_to_error",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "actix-web-lab-derive"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008f98f5a68eeacf5e6d44ed74ce03c1b906baa53eabfb41faf0f5f40bd685f8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,7 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -270,21 +36,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -357,12 +108,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "arc-swap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arraydeque"
@@ -497,12 +242,12 @@ dependencies = [
 name = "aura-web-server"
 version = "1.16.3"
 dependencies = [
- "actix-web",
- "actix-web-lab",
  "async-stream",
  "aura",
  "aura-config",
  "aura-test-utils",
+ "axum",
+ "bytes",
  "chrono",
  "clap",
  "env_logger",
@@ -518,6 +263,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tokio-util",
+ "tower-http",
  "tracing",
  "tracing-opentelemetry",
  "uuid",
@@ -939,6 +685,8 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -947,10 +695,15 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -971,6 +724,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1064,27 +818,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "8.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,15 +848,6 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
-]
-
-[[package]]
-name = "bytestring"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
-dependencies = [
- "bytes",
 ]
 
 [[package]]
@@ -1297,17 +1021,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,27 +1078,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "csv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1536,48 +1228,6 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
-]
-
-[[package]]
-name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
-dependencies = [
- "derive_more-impl 2.0.1",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1732,12 +1382,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -2357,12 +2001,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
-name = "impl-more"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,12 +2139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,23 +2171,6 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
-
-[[package]]
-name = "local-channel"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
-dependencies = [
- "futures-core",
- "futures-sink",
- "local-waker",
-]
-
-[[package]]
-name = "local-waker"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
@@ -2593,12 +2208,6 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "mediatype"
-version = "0.19.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33746aadcb41349ec291e7f2f0a3aa6834d1d7c58066fb4b01f68efc4c4b7631"
 
 [[package]]
 name = "memchr"
@@ -2644,7 +2253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -3821,19 +3429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_html_form"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
-dependencies = [
- "form_urlencoded",
- "indexmap 2.11.4",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
 name = "serde_json"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3876,17 +3471,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -4403,6 +3987,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4421,6 +4006,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4562,12 +4148,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -5260,32 +4840,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/crates/aura-web-server/Cargo.toml
+++ b/crates/aura-web-server/Cargo.toml
@@ -9,8 +9,9 @@ repository.workspace = true
 [dependencies]
 aura = { path = "../aura" }
 aura-config = { path = "../aura-config" }
-actix-web = "4.4"
-actix-web-lab = "0.22"
+axum = { version = "0.7", features = ["json"] }
+tower-http = { version = "0.6", features = ["trace"] }
+bytes = "1"
 async-stream = "0.3"
 clap = { version = "4.5", features = ["derive", "env"] }
 futures-util = "0.3"

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1,9 +1,14 @@
-use actix_web::{HttpResponse, web};
 use aura::{
     RequestCancellation, ResponseContent, StreamingAgent, UsageState, request_progress_subscribe,
     tool_event_subscribe, tool_usage_subscribe,
 };
 use aura_config::RigBuilder;
+use axum::Json;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use bytes::Bytes;
 use chrono::Utc;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -93,7 +98,7 @@ enum DeliveryMode {
     },
     /// Streaming SSE: send chunks via mpsc.
     Sse {
-        chunk_tx: mpsc::Sender<Result<actix_web::web::Bytes, String>>,
+        chunk_tx: mpsc::Sender<Result<Bytes, String>>,
         heartbeat_interval: std::time::Duration,
     },
 }
@@ -116,19 +121,18 @@ struct ResponseContext {
 async fn build_agent_for_request(
     config: &aura_config::Config,
     req_headers: &HashMap<String, String>,
-) -> Result<Arc<aura::Agent>, HttpResponse> {
+) -> Result<Arc<aura::Agent>, Response> {
     let builder = RigBuilder::new(config.clone());
     let agent = builder
         .build_agent_with_headers(Some(req_headers))
         .await
         .map_err(|e| {
             error!("Failed to build agent: {}", e);
-            HttpResponse::InternalServerError().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: format!("Failed to build agent: {e}"),
-                    error_type: "internal_error".to_string(),
-                },
-            })
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to build agent: {e}"),
+                "internal_error",
+            )
         })?;
     Ok(Arc::new(agent))
 }
@@ -148,29 +152,27 @@ struct RequestSetup {
 
 /// Extract query, chat history, and build agent -- shared across both code paths.
 async fn prepare_request(
-    data: &web::Data<AppState>,
+    data: &Arc<AppState>,
     req: &mut ChatCompletionRequest,
     chat_session_id: &str,
     req_headers_map: &HashMap<String, String>,
-) -> Result<RequestSetup, HttpResponse> {
+) -> Result<RequestSetup, Response> {
     // Pop the last message as the query — the remainder becomes chat history
     let query = match req.messages.pop() {
         Some(msg) if msg.role == Role::User => msg.content,
         Some(msg) => {
-            return Err(HttpResponse::BadRequest().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: format!("Last message must be from user, got: {}", msg.role),
-                    error_type: "invalid_request_error".to_string(),
-                },
-            }));
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                format!("Last message must be from user, got: {}", msg.role),
+                "invalid_request_error",
+            ));
         }
         None => {
-            return Err(HttpResponse::BadRequest().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: "messages array is empty".to_string(),
-                    error_type: "invalid_request_error".to_string(),
-                },
-            }));
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "messages array is empty",
+                "invalid_request_error",
+            ));
         }
     };
 
@@ -189,12 +191,20 @@ async fn prepare_request(
             .find(|c| c.agent.alias.as_deref().unwrap_or(&c.agent.name) == model_name)
             .cloned()
             .ok_or_else(|| {
-                HttpResponse::NotFound().json(ChatCompletionErrorResponse::ModelNotFound(
-                    model_name.to_string(),
-                ))
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(ChatCompletionErrorResponse::ModelNotFound(
+                        model_name.to_string(),
+                    )),
+                )
+                    .into_response()
             })?
     } else {
-        return Err(HttpResponse::BadRequest().json(ChatCompletionErrorResponse::ModelNotProvided));
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ChatCompletionErrorResponse::ModelNotProvided),
+        )
+            .into_response());
     };
 
     // Build the appropriate agent type based on orchestration config
@@ -209,12 +219,11 @@ async fn prepare_request(
             .await
             .map_err(|e| {
                 error!("Failed to build streaming agent: {}", e);
-                HttpResponse::InternalServerError().json(ErrorResponse {
-                    error: ErrorDetail {
-                        message: format!("Failed to build streaming agent: {e}"),
-                        error_type: "internal_error".to_string(),
-                    },
-                })
+                error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to build streaming agent: {e}"),
+                    "internal_error",
+                )
             })?
     } else {
         // Standard path: build Agent, coerce to Arc<dyn StreamingAgent>
@@ -239,20 +248,19 @@ async fn prepare_request(
 }
 
 /// Handle chat completions endpoint
-#[tracing::instrument(name = "chat_completions", skip(data, req, http_req), fields(otel.kind = "server"))]
+#[tracing::instrument(name = "chat_completions", skip(state, req, headers), fields(otel.kind = "server"))]
 pub async fn chat_completions(
-    data: web::Data<AppState>,
-    req: web::Json<ChatCompletionRequest>,
-    http_req: actix_web::HttpRequest,
-) -> HttpResponse {
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(mut req): Json<ChatCompletionRequest>,
+) -> Response {
     // Validate we have messages
     if req.messages.is_empty() {
-        return HttpResponse::BadRequest().json(ErrorResponse {
-            error: ErrorDetail {
-                message: "No messages provided".to_string(),
-                error_type: "invalid_request_error".to_string(),
-            },
-        });
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "No messages provided",
+            "invalid_request_error",
+        );
     }
 
     // Extract or generate chat_session_id
@@ -263,38 +271,35 @@ pub async fn chat_completions(
         .and_then(|m| m.get("chat_session_id"))
         .cloned()
         .or_else(|| {
-            http_req
-                .headers()
+            headers
                 .get("X-Chat-Session-Id")
-                .or_else(|| http_req.headers().get("x-openwebui-chat-id"))
+                .or_else(|| headers.get("x-openwebui-chat-id"))
                 .and_then(|h| h.to_str().ok())
                 .map(String::from)
         })
         .unwrap_or_else(generate_chat_session_id);
 
-    // Convert actix HeaderMap to HashMap for framework-agnostic passing
-    let req_headers_map: HashMap<String, String> = http_req
-        .headers()
+    // Convert HeaderMap to HashMap for framework-agnostic passing
+    let req_headers_map: HashMap<String, String> = headers
         .iter()
         .filter_map(|(k, v)| v.to_str().ok().map(|val| (k.to_string(), val.to_string())))
         .collect();
 
-    let mut req = req.into_inner();
-    let setup = match prepare_request(&data, &mut req, &chat_session_id, &req_headers_map).await {
+    let setup = match prepare_request(&state, &mut req, &chat_session_id, &req_headers_map).await {
         Ok(s) => s,
         Err(response) => return response,
     };
 
     if req.stream == Some(true) {
-        handle_streaming_completion(data, setup, req.max_tokens).await
+        handle_streaming_completion(state, setup, req.max_tokens).await
     } else {
-        handle_non_streaming_completion(&data, setup, req.max_tokens).await
+        handle_non_streaming_completion(&state, setup, req.max_tokens).await
     }
 }
 
 /// Build configuration for the spawned completion task from AppState and RequestSetup.
 fn build_completion_config(
-    data: &web::Data<AppState>,
+    data: &Arc<AppState>,
     setup: &RequestSetup,
     max_tokens: Option<u32>,
     emit_custom_events: bool,
@@ -483,7 +488,7 @@ fn build_json_response(
     response_ctx: ResponseContext,
     max_tokens: Option<u32>,
     collected: CollectedResult,
-) -> HttpResponse {
+) -> Response {
     // Get usage: prefer stream outcome (from Final), fall back to UsageState from hook
     let (prompt_tokens, completion_tokens, total_tokens) = collected
         .outcome
@@ -528,15 +533,15 @@ fn build_json_response(
         metadata: Some(response_metadata),
     };
 
-    HttpResponse::Ok().json(chat_response)
+    Json(chat_response).into_response()
 }
 
 #[tracing::instrument(name = "non_streaming_completion", skip_all, fields(session.id = %setup.chat_session_id))]
 async fn handle_non_streaming_completion(
-    data: &web::Data<AppState>,
+    data: &Arc<AppState>,
     setup: RequestSetup,
     max_tokens: Option<u32>,
-) -> HttpResponse {
+) -> Response {
     let config = build_completion_config(data, &setup, max_tokens, false, false);
 
     {
@@ -562,12 +567,11 @@ async fn handle_non_streaming_completion(
         Ok(collected) => build_json_response(response_ctx, max_tokens, collected),
         Err(_) => {
             error!("Completion task panicked or was dropped");
-            HttpResponse::InternalServerError().json(ErrorResponse {
-                error: ErrorDetail {
-                    message: "Internal error during completion".to_string(),
-                    error_type: "internal_error".to_string(),
-                },
-            })
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal error during completion",
+                "internal_error",
+            )
         }
     }
 }
@@ -575,10 +579,10 @@ async fn handle_non_streaming_completion(
 /// Handle streaming completion using Server-Sent Events.
 #[tracing::instrument(name = "streaming_completion", skip_all, fields(session.id = %setup.chat_session_id))]
 async fn handle_streaming_completion(
-    data: web::Data<AppState>,
+    data: Arc<AppState>,
     setup: RequestSetup,
     max_tokens: Option<u32>,
-) -> HttpResponse {
+) -> Response {
     let config = build_completion_config(
         &data,
         &setup,
@@ -594,8 +598,7 @@ async fn handle_streaming_completion(
 
     let chat_session_id = setup.chat_session_id.clone();
 
-    let (chunk_tx, rx) =
-        mpsc::channel::<Result<actix_web::web::Bytes, String>>(data.streaming_buffer_size);
+    let (chunk_tx, rx) = mpsc::channel::<Result<Bytes, String>>(data.streaming_buffer_size);
 
     let heartbeat_interval = std::time::Duration::from_secs(15);
 
@@ -613,14 +616,16 @@ async fn handle_streaming_completion(
 
     use futures_util::TryStreamExt;
     let response_stream =
-        ReceiverStream::new(rx).map_err(actix_web::error::ErrorInternalServerError);
+        ReceiverStream::new(rx).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
 
-    HttpResponse::Ok()
-        .content_type("text/event-stream")
-        .insert_header(("Cache-Control", "no-cache"))
-        .insert_header(("X-Accel-Buffering", "no"))
-        .insert_header(("X-Chat-Session-Id", chat_session_id))
-        .streaming(response_stream)
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "text/event-stream")
+        .header("Cache-Control", "no-cache")
+        .header("X-Accel-Buffering", "no")
+        .header("X-Chat-Session-Id", chat_session_id.as_str())
+        .body(Body::from_stream(response_stream))
+        .unwrap()
 }
 
 /// Convert OpenAI-format chat messages to Rig messages, sanitizing the history:
@@ -652,16 +657,17 @@ fn convert_chat_messages(messages: &[ChatMessage]) -> Vec<aura::Message> {
 }
 
 /// Health check endpoint
-pub async fn health() -> HttpResponse {
-    HttpResponse::Ok().json(serde_json::json!({
+pub async fn health() -> Response {
+    Json(serde_json::json!({
         "status": "healthy"
     }))
+    .into_response()
 }
 
 /// OpenAI-compatible model listing endpoint.
 /// Each model `id` maps to an agent's `alias` (if set) or `name` from the TOML config.
-pub async fn list_models(data: web::Data<AppState>) -> HttpResponse {
-    let models: Vec<serde_json::Value> = data
+pub async fn list_models(State(state): State<Arc<AppState>>) -> Response {
+    let models: Vec<serde_json::Value> = state
         .configs
         .iter()
         .map(|config| {
@@ -680,15 +686,28 @@ pub async fn list_models(data: web::Data<AppState>) -> HttpResponse {
         })
         .collect();
 
-    HttpResponse::Ok().json(serde_json::json!({
+    Json(serde_json::json!({
         "object": "list",
         "data": models
     }))
+    .into_response()
 }
 
 /// Generate a chat session ID (simple GUID)
 fn generate_chat_session_id() -> String {
     format!("cs_{}", Uuid::new_v4().simple())
+}
+
+fn error_response(status: StatusCode, message: impl Into<String>, error_type: impl Into<String>) -> Response {
+    (
+        status,
+        Json(ErrorResponse {
+            error: ErrorDetail {
+                message: message.into(),
+                error_type: error_type.into(),
+            },
+        }),
+    ).into_response()
 }
 
 #[cfg(test)]
@@ -841,8 +860,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_build_json_response_normal_stop() {
+    #[tokio::test]
+    async fn test_build_json_response_normal_stop() {
         let collected = CollectedResult {
             outcome: StreamOutcome {
                 content: "Hello!".to_string(),
@@ -858,9 +877,8 @@ mod tests {
         let resp = build_json_response(make_response_ctx(), None, collected);
         assert_eq!(resp.status(), 200);
 
-        let body = actix_web::body::to_bytes(resp.into_body());
-        let body = futures_util::FutureExt::now_or_never(body)
-            .unwrap()
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
@@ -874,8 +892,8 @@ mod tests {
         assert_eq!(json["metadata"]["chat_session_id"], "cs_test");
     }
 
-    #[test]
-    fn test_build_json_response_finish_reason_length() {
+    #[tokio::test]
+    async fn test_build_json_response_finish_reason_length() {
         let collected = CollectedResult {
             outcome: StreamOutcome {
                 content: "truncated response".to_string(),
@@ -890,17 +908,16 @@ mod tests {
 
         // max_tokens = 50, completion_tokens = 50 -> finish_reason = "length"
         let resp = build_json_response(make_response_ctx(), Some(50), collected);
-        let body =
-            futures_util::FutureExt::now_or_never(actix_web::body::to_bytes(resp.into_body()))
-                .unwrap()
-                .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(json["choices"][0]["finish_reason"], "length");
     }
 
-    #[test]
-    fn test_build_json_response_usage_fallback_to_usage_state() {
+    #[tokio::test]
+    async fn test_build_json_response_usage_fallback_to_usage_state() {
         // When outcome.usage is None, build_json_response falls back to usage_state.
         // A fresh UsageState returns (0, 0, 0) from get_final_usage().
         let collected = CollectedResult {
@@ -912,10 +929,9 @@ mod tests {
         };
 
         let resp = build_json_response(make_response_ctx(), None, collected);
-        let body =
-            futures_util::FutureExt::now_or_never(actix_web::body::to_bytes(resp.into_body()))
-                .unwrap()
-                .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
         // Falls back to UsageState::new() which returns all zeros

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -1,8 +1,17 @@
-use actix_web::{App, HttpResponse, HttpServer, middleware, web};
 use aura_config::load_config;
+use axum::Json;
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::{
+    Router, middleware,
+    routing::{get, post},
+};
 use clap::Parser;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
+use tower_http::trace::TraceLayer;
 use tracing::{error, info};
 
 mod handlers;
@@ -107,25 +116,26 @@ struct Args {
 
 /// Middleware that rejects new requests with 503 when shutdown_token is cancelled.
 async fn shutdown_guard(
-    data: web::Data<AppState>,
-    req: actix_web::dev::ServiceRequest,
-    next: actix_web::middleware::Next<impl actix_web::body::MessageBody + 'static>,
-) -> Result<actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>, actix_web::Error> {
-    if data.shutdown_token.is_cancelled() {
-        let response = HttpResponse::ServiceUnavailable().json(ErrorResponse {
-            error: ErrorDetail {
-                message: "Server is shutting down".to_string(),
-                error_type: "service_unavailable".to_string(),
-            },
-        });
-        return Ok(req.into_response(response).map_into_right_body());
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if state.shutdown_token.is_cancelled() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: ErrorDetail {
+                    message: "Server is shutting down".to_string(),
+                    error_type: "service_unavailable".to_string(),
+                },
+            }),
+        )
+            .into_response();
     }
-    next.call(req)
-        .await
-        .map(actix_web::dev::ServiceResponse::map_into_left_body)
+    next.run(request).await
 }
 
-#[actix_web::main]
+#[tokio::main]
 async fn main() -> std::io::Result<()> {
     let result = run().await;
     aura::logging::shutdown_tracer().await;
@@ -188,8 +198,7 @@ async fn run() -> std::io::Result<()> {
 
     let shutdown_timeout_secs = args.shutdown_timeout_secs;
 
-    // Create app state
-    let app_state = web::Data::new(AppState {
+    let app_state = Arc::new(AppState {
         configs: configs_arc,
         tool_result_mode: args.tool_result_mode,
         tool_result_max_length: args.tool_result_max_length,
@@ -209,28 +218,23 @@ async fn run() -> std::io::Result<()> {
         args.host, args.port, shutdown_timeout_secs
     );
 
-    // Custom signal handling: CancellationToken bridges Actix and SSE stream lifecycles
-    let server = HttpServer::new(move || {
-        App::new()
-            .app_data(app_state.clone())
-            .wrap(middleware::from_fn(shutdown_guard))
-            .wrap(middleware::Logger::default())
-            .route("/health", web::get().to(handlers::health))
-            .route("/v1/models", web::get().to(handlers::list_models))
-            .route(
-                "/v1/chat/completions",
-                web::post().to(handlers::chat_completions),
-            )
-    })
-    .bind((args.host.as_str(), args.port))?
-    .disable_signals()
-    // Buffer for Phase 2 cleanup ([DONE] send + MCP cancellation) after grace period
-    .shutdown_timeout(10)
-    .run();
+    let app = Router::new()
+        .route("/health", get(handlers::health))
+        .route("/v1/models", get(handlers::list_models))
+        .route("/v1/chat/completions", post(handlers::chat_completions))
+        .layer(TraceLayer::new_for_http())
+        .layer(middleware::from_fn_with_state(
+            app_state.clone(),
+            shutdown_guard,
+        ))
+        .with_state(app_state);
+
+    let listener = tokio::net::TcpListener::bind(format!("{}:{}", args.host, args.port)).await?;
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
     use tokio::signal::unix::{SignalKind, signal};
     let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
-    let server_handle = server.handle();
     tokio::spawn({
         let shutdown_token = shutdown_token.clone();
         let stream_shutdown_token = stream_shutdown_token.clone();
@@ -264,9 +268,13 @@ async fn run() -> std::io::Result<()> {
             // Phase 2: terminate remaining streams ([DONE] → MCP cleanup)
             stream_shutdown_token.cancel();
 
-            server_handle.stop(true).await;
+            let _ = shutdown_tx.send(());
         }
     });
 
-    server.await
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async {
+            shutdown_rx.await.ok();
+        })
+        .await
 }

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -26,7 +26,6 @@ use super::types::{
     StreamConfig, ToolCallChunk, ToolResultMode, ToolResultStatus, TurnContext, TurnState,
     detect_tool_error, format_sse_chunk, truncate_result,
 };
-use actix_web::web::Bytes;
 use aura::stream_events::AuraStreamEvent;
 use aura::{
     EventContext, OrchestrationStreamEvent, OrchestratorEvent, ProgressNotification,
@@ -34,6 +33,7 @@ use aura::{
     StreamedUserContent, StreamingAgent, ToolCall, ToolLifecycleEvent, ToolResult, ToolUsageEvent,
     UsageState,
 };
+use bytes::Bytes;
 use futures_util::{Stream, StreamExt};
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/aura-web-server/src/streaming/types.rs
+++ b/crates/aura-web-server/src/streaming/types.rs
@@ -257,15 +257,13 @@ pub fn truncate_result(result: &str, max_length: usize) -> String {
 }
 
 /// Format as SSE message: `data: {json}\n\n`
-pub fn format_sse_chunk<T: serde::Serialize>(
-    value: &T,
-) -> Result<actix_web::web::Bytes, serde_json::Error> {
+pub fn format_sse_chunk<T: serde::Serialize>(value: &T) -> Result<bytes::Bytes, serde_json::Error> {
     let json = serde_json::to_string(value)?;
     let mut buffer = String::with_capacity(json.len() + 10);
     buffer.push_str("data: ");
     buffer.push_str(&json);
     buffer.push_str("\n\n");
-    Ok(actix_web::web::Bytes::from(buffer))
+    Ok(bytes::Bytes::from(buffer))
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
summary: in preparation of bringing in the A2A rust library, swapping the webserver to axum as its the main dependency web server framework of the A2A library. This'll save us from needing to jump through many hoops or run
multiple servers.

ref: LOG-23816