### PR TITLE
fix(otel): wrap force_flush in spawn_blocking to avoid deadlock

### DIFF
--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -997,7 +997,7 @@ name = "Test"
 system_prompt = "Test"
 "#;
 
-        let config = load_config_from_str(&config_str);
+        let config = load_config_from_str(config_str);
         assert!(config.is_err(), "no additional fields allowed");
         assert!(
             config

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -485,7 +485,7 @@ async fn execute_completion(setup: RequestSetup, config: CompletionConfig, deliv
         }
     }
 
-    aura::logging::flush_tracer();
+    aura::logging::flush_tracer().await;
 }
 
 /// Build the final JSON response for non-streaming completions.

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -502,20 +502,30 @@ pub fn set_output_attributes(span: &tracing::Span, _text: &str) {
 /// task is polled, which may not happen reliably between requests.  Call this
 /// at the end of each request to guarantee spans are exported promptly.
 ///
+/// Uses `spawn_blocking` so the tokio runtime stays alive while
+/// `TracerProvider::force_flush()` blocks waiting for the `BatchSpanProcessor`
+/// background task. Calling `force_flush()` directly from a tokio worker
+/// thread deadlocks the batch processor (which itself runs on the runtime),
+/// permanently stalling subsequent exports.
+///
 /// No-op when OTel was not initialised or the `otel` feature is disabled.
 #[cfg(feature = "otel")]
-pub fn flush_tracer() {
+pub async fn flush_tracer() {
     if let Some(provider) = TRACER_PROVIDER.get() {
-        for result in provider.force_flush() {
-            if let Err(e) = result {
-                tracing::warn!("OpenTelemetry force_flush error: {e}");
+        let provider = provider.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            for result in provider.force_flush() {
+                if let Err(e) = result {
+                    eprintln!("OpenTelemetry force_flush error: {e}");
+                }
             }
-        }
+        })
+        .await;
     }
 }
 
 #[cfg(not(feature = "otel"))]
-pub fn flush_tracer() {}
+pub async fn flush_tracer() {}
 
 /// Flush and shut down the OpenTelemetry tracer provider.
 ///


### PR DESCRIPTION
Calling TracerProvider::force_flush() synchronously from inside a tokio::spawn'd task blocks a runtime worker thread, which prevents the BatchSpanProcessor's background export task from being polled. After the first orchestrated request (~55 spans across nested spawns), the exporter stalls permanently and no further traces are exported until the process restarts.

Make flush_tracer async and dispatch force_flush via tokio::task::spawn_blocking, mirroring the pattern shutdown_tracer already uses. The single call site in handlers.rs is already in an async context.

Introduced by the actix-web -> axum migration (cb87687); actix's current_thread runtime masked the deadlock.