### PR TITLE
fix(scratchpad): bound recursive json walkers with depth cap

### DIFF
--- a/crates/aura/src/scratchpad/schema.rs
+++ b/crates/aura/src/scratchpad/schema.rs
@@ -5,6 +5,12 @@
 
 use serde_json::Value;
 
+/// Recursion bound for the JSON structure walker. Stops `build_node` (and
+/// `collect_keys` in `tools.rs`) before adversarial / malformed inputs can
+/// blow the stack. `serde_json::from_str`'s implicit 128-frame parse limit
+/// is not a substitute — it's easy to lose if the deserializer is swapped.
+pub(super) const MAX_SCHEMA_DEPTH: usize = 32;
+
 /// A node in the JSON structure tree.
 #[derive(Debug, Clone)]
 pub struct SchemaNode {
@@ -27,7 +33,7 @@ pub fn analyze_json_structure(content: &str) -> Option<SchemaNode> {
 
     // We'll walk the pretty-printed JSON for line mapping since raw JSON
     // may be compact. For the POC, we use the original content's lines.
-    let root = build_node("$", &value, content, &line_offsets, 0);
+    let root = build_node("$", &value, content, &line_offsets, 0, 0);
     Some(root)
 }
 
@@ -83,7 +89,18 @@ fn build_node(
     content: &str,
     line_offsets: &[usize],
     search_from: usize,
+    depth: usize,
 ) -> SchemaNode {
+    if depth >= MAX_SCHEMA_DEPTH {
+        let line = byte_offset_to_line(line_offsets, search_from);
+        return SchemaNode {
+            path: path.to_string(),
+            kind: "...truncated".to_string(),
+            line_start: line,
+            line_end: line,
+            children: vec![],
+        };
+    }
     match value {
         Value::Object(map) => {
             // Find where this object starts in content
@@ -101,7 +118,14 @@ fn build_node(
                 } else {
                     format!("{}.{}", path, key)
                 };
-                let child = build_node(&child_path, val, content, line_offsets, key_offset);
+                let child = build_node(
+                    &child_path,
+                    val,
+                    content,
+                    line_offsets,
+                    key_offset,
+                    depth + 1,
+                );
                 cursor = key_offset + 1;
                 children.push(child);
             }
@@ -129,7 +153,14 @@ fn build_node(
             if !arr.is_empty() {
                 // Show schema of first element as representative
                 let child_path = format!("{}[0]", path);
-                let child = build_node(&child_path, &arr[0], content, line_offsets, arr_start + 1);
+                let child = build_node(
+                    &child_path,
+                    &arr[0],
+                    content,
+                    line_offsets,
+                    arr_start + 1,
+                    depth + 1,
+                );
                 children.push(child);
             }
 
@@ -585,6 +616,38 @@ mod tests {
         assert!(formatted.contains("Groups"));
         // All sections should show line ranges
         assert!(formatted.contains("[L"));
+    }
+
+    #[test]
+    fn test_build_node_truncates_deeply_nested_value() {
+        // Build a 1000-level deep object value programmatically — bypasses
+        // serde_json's 128-frame parse limit so we actually exercise the
+        // walker's own depth guard rather than the parser's. Without the
+        // guard this would stack-overflow on default tokio task stacks.
+        let mut value = Value::Object(serde_json::Map::new());
+        for _ in 0..1000 {
+            let mut outer = serde_json::Map::new();
+            outer.insert("child".to_string(), value);
+            value = Value::Object(outer);
+        }
+
+        // Non-empty `content` avoids an unrelated `content.len() - 1`
+        // underflow in the matching-brace fallback; the bytes themselves
+        // don't matter for what this test is checking.
+        let content = "{}";
+        let root = build_node("$", &value, content, &[0], 0, 0);
+
+        // Walk children and verify the deepest non-truncated node is at
+        // exactly MAX_SCHEMA_DEPTH - 1 (its sole child is the truncation
+        // sentinel). No panic == stack guard worked.
+        let mut node = &root;
+        let mut depth = 0;
+        while let Some(child) = node.children.first() {
+            depth += 1;
+            node = child;
+        }
+        assert_eq!(node.kind, "...truncated");
+        assert_eq!(depth, MAX_SCHEMA_DEPTH);
     }
 
     #[test]

--- a/crates/aura/src/scratchpad/tools.rs
+++ b/crates/aura/src/scratchpad/tools.rs
@@ -5,7 +5,8 @@
 
 use super::context_budget::ContextBudget;
 use super::schema::{
-    analyze_json_structure, analyze_markdown_structure, format_markdown_schema, format_schema,
+    MAX_SCHEMA_DEPTH, analyze_json_structure, analyze_markdown_structure, format_markdown_schema,
+    format_schema,
 };
 use super::storage::ScratchpadStorage;
 use rig::completion::ToolDefinition;
@@ -1169,7 +1170,7 @@ impl Tool for ItemSchemaTool {
 
         for item in items {
             if let Some(obj) = item.as_object() {
-                collect_keys(obj, "", &mut key_info);
+                collect_keys(obj, "", &mut key_info, 0);
             }
         }
 
@@ -1212,11 +1213,32 @@ struct KeyInfo {
 }
 
 /// Recursively collect keys from an object, tracking types and counts.
+///
+/// `depth` short-circuits past `MAX_SCHEMA_DEPTH` so adversarial / malformed
+/// inputs can't blow the stack — `serde_json`'s parse-time 128-frame limit is
+/// not a substitute (easy to lose if the deserializer is swapped).
 fn collect_keys(
     obj: &serde_json::Map<String, serde_json::Value>,
     prefix: &str,
     info: &mut std::collections::BTreeMap<String, KeyInfo>,
+    depth: usize,
 ) {
+    if depth >= MAX_SCHEMA_DEPTH {
+        // Mirror build_node: surface a sentinel rather than silently dropping
+        // keys past the cap, so the LLM can tell substructure exists below.
+        let key = if prefix.is_empty() {
+            "<...truncated>".to_string()
+        } else {
+            format!("{}.<...truncated>", prefix)
+        };
+        let entry = info.entry(key).or_insert_with(|| KeyInfo {
+            types: std::collections::BTreeSet::new(),
+            count: 0,
+        });
+        entry.types.insert("...truncated".to_string());
+        entry.count += 1;
+        return;
+    }
     for (key, value) in obj {
         let full_key = if prefix.is_empty() {
             key.clone()
@@ -1242,7 +1264,7 @@ fn collect_keys(
 
         // Recurse into nested objects
         if let serde_json::Value::Object(nested) = value {
-            collect_keys(nested, &full_key, info);
+            collect_keys(nested, &full_key, info, depth + 1);
         }
     }
 }
@@ -2444,6 +2466,36 @@ mod tests {
                 def.name
             );
         }
+    }
+
+    #[test]
+    fn test_collect_keys_terminates_on_deeply_nested_value() {
+        // Build a 1000-level deep nested object programmatically — bypasses
+        // serde_json's 128-frame parse limit so we actually stress the
+        // walker's own depth guard rather than the parser's.
+        let mut value = serde_json::Value::Object(serde_json::Map::new());
+        for _ in 0..1000 {
+            let mut outer = serde_json::Map::new();
+            outer.insert("child".to_string(), value);
+            value = serde_json::Value::Object(outer);
+        }
+        let outer = value.as_object().unwrap();
+
+        let mut info: std::collections::BTreeMap<String, KeyInfo> =
+            std::collections::BTreeMap::new();
+        collect_keys(outer, "", &mut info, 0);
+
+        // No panic == stack guard worked. Collected keys are the first
+        // MAX_SCHEMA_DEPTH frames of `child.child.…` plus the truncation
+        // sentinel emitted on the next frame.
+        assert_eq!(info.len(), MAX_SCHEMA_DEPTH + 1);
+        let deepest_key = "child.".repeat(MAX_SCHEMA_DEPTH - 1) + "child";
+        assert!(info.contains_key(&deepest_key));
+        let sentinel_key = "child.".repeat(MAX_SCHEMA_DEPTH) + "<...truncated>";
+        let sentinel = info
+            .get(&sentinel_key)
+            .expect("expected truncation sentinel at MAX_SCHEMA_DEPTH");
+        assert!(sentinel.types.contains("...truncated"));
     }
 
     #[test]


### PR DESCRIPTION
Both `build_node` (schema.rs) and `collect_keys` (tools.rs) walked nested JSON values with no depth bound. Adversarial or malformed MCP output with deeply nested objects could blow the stack before any budget check fired — serde_json's implicit 128-frame parse limit is the only thing currently holding the line, and it's easy to lose if the deserializer is swapped.

Cap both walkers at MAX_SCHEMA_DEPTH (32 frames) and emit a "...truncated" sentinel at the cap so callers (LLMs reading schema / item_schema output) can tell substructure exists below the cut rather than silently seeing a flat key list.

Regression tests construct 1000-level deep Values programmatically to bypass serde_json's parse-depth cap and exercise the walkers directly, asserting graceful truncation rather than panic.

Ref: LOG-23842