### PR TITLE
svc(setup): make a correction to the build tag variable scope

### DIFF
--- a/.makefiles/aura.mk
+++ b/.makefiles/aura.mk
@@ -1,21 +1,18 @@
-
-BUILD_TAG ?= 1
-
 .PHONY:start
 start: ## Start the docker compose setup
-	docker compose -p aura-${BUILD_TAG:-1} -f compose/base.yml -f compose/dev.yml up --remove-orphans -d
+	docker compose -p aura-$(BUILD_SLUG) -f compose/base.yml -f compose/dev.yml up --remove-orphans -d
 
 .PHONY:stop
 stop: ## Stop the docker compose setup
-	docker compose -p aura-${BUILD_TAG:-1} -f compose/base.yml -f compose/dev.yml down
+	docker compose -p aura-$(BUILD_SLUG) -f compose/base.yml -f compose/dev.yml down
 
 .PHONY:test-integration
 test-integration: $(REPORT_DIR) ## run CI test suite via docker compose
-	docker compose -p aura-test-${BUILD_TAG:-1} -f compose/base.yml -f compose/test.yml up --remove-orphans --exit-code-from aura-integration-test --build
+	docker compose -p aura-test-$(BUILD_SLUG) -f compose/base.yml -f compose/test.yml up --remove-orphans --exit-code-from aura-integration-test --build
 
 .PHONY:test-integration-down
 test-integration-down:  ## Cleanup integration test containers
-	-docker compose -p aura-test-${BUILD_TAG:-1} \
+	-docker compose -p aura-test-$(BUILD_SLUG) \
 		-f compose/base.yml \
 		-f compose/test.yml \
 		down --remove-orphans --volumes --rmi=local 2>/dev/null || true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,6 +75,7 @@ pipeline {
     stage('Setup') {
       steps{
         sh 'make setup'
+        sh "echo ${BUILD_TAG}"
       }
     } // end setup
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ REPORT_DIR = $(COVERAGE_DIR)/ci
 AURA_AUTO_DOWNLOAD ?= true
 
 CI ?=
+BUILD_TAG ?= 1
 IS_CI := $(if $(filter true, $(CI)), true,)
 ALWAYS_TIMESTAMP_VERSION ?= false
 APP_NAME ?= $(shell git remote -v | awk '/origin/ && /fetch/ { sub(/\.git/, ""); n=split($$2, origin, "/"); print origin[n]}')
@@ -36,8 +37,8 @@ DOCKER_ENV = $(TARGET_DIR)/aura-env
 RUNNER_CMD = $(DOCKER_RUN) --env-file=$(DOCKER_ENV) $(if $(filter true, $(IS_CI)), ,-t) -v $(PWD):/home/aura $(AURA_RUNNER_IMAGE)
 RUNNER_NO_ENV_CMD = $(DOCKER_RUN) $(if $(filter true, $(IS_CI)),,-t) -v $(PWD):/home/aura $(AURA_RUNNER_IMAGE)
 DOCKER_RUN_BUILD_ENV := $(RUNNER_CMD)
-BUILD_TAG ?= 1 # this is set by Jenkins and is unique per build
-AURA_RUNNER_IMAGE := local/aura-runner:$(call slugify, $(BUILD_TAG))
+BUILD_SLUG := $(call slugify, $(BUILD_TAG))
+AURA_RUNNER_IMAGE := local/aura-runner:$(BUILD_SLUG)
 
 RUN := $(if $(filter true, $(ENABLE_DOCKER)), $(RUNNER_CMD),)
 RUN_NO_ENV := $(if $(filter true, $(ENABLE_DOCKER)), $(RUNNER_NO_ENV_CMD),)


### PR DESCRIPTION
To be overridden it needs to be in the global scope. If its in the local aura file, things can get a little wonky. This fixes a problem where the build Tag variable was not rendering correctly

Ref: REL-1791