### PR TITLE
fix(orchestration): classify size limit errors as context overflow

### DIFF
--- a/crates/aura/src/orchestration/frame_validation_tests.rs
+++ b/crates/aura/src/orchestration/frame_validation_tests.rs
@@ -256,7 +256,7 @@ fn test_continuation_full_scenario() {
     };
 
     let ctx = IterationContext::new(2, plan, Some(fs), failure_history, traces);
-    let prompt = ctx.build_continuation_prompt(3, true);
+    let prompt = ctx.build_continuation_prompt(3, true, 2000);
 
     // Header
     assert!(
@@ -346,7 +346,7 @@ fn test_continuation_final_attempt_urgency() {
     plan.add_task(t);
 
     let ctx = IterationContext::new(3, plan, None, vec![], HashMap::new());
-    let prompt = ctx.build_continuation_prompt(3, false);
+    let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
     assert!(
         prompt.contains("(FINAL ATTEMPT)"),
@@ -375,7 +375,7 @@ fn test_continuation_mixed_structured_and_raw() {
     plan.add_task(t1);
 
     let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
-    let prompt = ctx.build_continuation_prompt(3, false);
+    let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
     // Structured path with no artifact: inlines full result, not summary
     assert!(
@@ -750,7 +750,7 @@ fn test_session_history_and_continuation_independent_artifact_refs() {
     plan.add_task(t);
 
     let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
-    let continuation = ctx.build_continuation_prompt(3, false);
+    let continuation = ctx.build_continuation_prompt(3, false, 2000);
 
     assert!(
         continuation.contains("task-0-sre-iter-1-result.txt"),
@@ -797,7 +797,7 @@ fn test_continuation_tool_output_artifacts_visible() {
     );
 
     let ctx = IterationContext::new(1, plan, None, vec![], traces);
-    let prompt = ctx.build_continuation_prompt(3, true);
+    let prompt = ctx.build_continuation_prompt(3, true, 2000);
 
     // Tool chain line present
     assert!(prompt.contains("Tool chain:"), "chain line: {}", prompt);
@@ -846,7 +846,7 @@ fn test_continuation_failed_task_no_artifact_refs() {
     );
 
     let ctx = IterationContext::new(1, plan, None, vec![], traces);
-    let prompt = ctx.build_continuation_prompt(3, true);
+    let prompt = ctx.build_continuation_prompt(3, true, 2000);
 
     // Failed tools don't produce artifacts
     assert!(
@@ -881,7 +881,7 @@ fn test_continuation_all_failure_categories() {
         plan.add_task(t);
 
         let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, true);
+        let prompt = ctx.build_continuation_prompt(3, true, 2000);
 
         assert!(
             prompt.contains(&format!("[{}]", display)),
@@ -908,7 +908,7 @@ fn test_continuation_soft_failure_with_structured_output() {
     plan.add_task(t);
 
     let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
-    let prompt = ctx.build_continuation_prompt(3, false);
+    let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
     // SoftFailure with structured output uses the summary path
     assert!(
@@ -934,7 +934,7 @@ fn test_continuation_soft_failure_without_structured_output() {
     plan.add_task(t);
 
     let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
-    let prompt = ctx.build_continuation_prompt(3, false);
+    let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
     // SoftFailure without structured output falls back to bracket format
     assert!(
@@ -1139,7 +1139,7 @@ fn test_continuation_running_task_renders_as_blocked() {
     plan.add_task(t0);
 
     let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
-    let prompt = ctx.build_continuation_prompt(3, false);
+    let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
     assert!(
         prompt.contains("blocked (dependency failed)"),
@@ -1159,7 +1159,7 @@ fn test_continuation_clean_success_no_failure_sections() {
     plan.add_task(t1);
 
     let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
-    let prompt = ctx.build_continuation_prompt(3, false);
+    let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
     assert!(
         prompt.contains("COMPLETED TASKS"),
@@ -1184,7 +1184,7 @@ fn test_continuation_short_result_no_artifact() {
     plan.add_task(t);
 
     let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
-    let prompt = ctx.build_continuation_prompt(3, false);
+    let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
     assert!(
         prompt.contains("Short result, no artifact needed"),
@@ -1202,7 +1202,7 @@ fn test_continuation_result_forwarding_absent_when_all_failed() {
     plan.add_task(t);
 
     let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
-    let prompt = ctx.build_continuation_prompt(3, false);
+    let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
     assert!(
         !prompt.contains("Workers cannot see prior iteration results"),
@@ -1227,7 +1227,7 @@ fn test_continuation_failure_history_worker_none() {
     }];
 
     let ctx = IterationContext::new(1, plan, None, history, HashMap::new());
-    let prompt = ctx.build_continuation_prompt(3, false);
+    let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
     assert!(prompt.contains("FAILURE HISTORY"), "history present");
     // Should NOT contain "(worker: )" with empty worker
@@ -1280,7 +1280,7 @@ fn test_continuation_multiple_repeated_failure_patterns() {
     ];
 
     let ctx = IterationContext::new(2, plan, None, history, HashMap::new());
-    let prompt = ctx.build_continuation_prompt(3, false);
+    let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
     assert!(
         prompt.contains("OBSERVED PATTERNS"),
@@ -1314,7 +1314,7 @@ fn test_continuation_empty_reasoning_in_tool_chain() {
     );
 
     let ctx = IterationContext::new(1, plan, None, vec![], traces);
-    let prompt = ctx.build_continuation_prompt(3, true);
+    let prompt = ctx.build_continuation_prompt(3, true, 2000);
 
     let chain_line = prompt.lines().find(|l| l.contains("Tool chain:")).unwrap();
     assert!(
@@ -1566,7 +1566,7 @@ fn test_continuation_section_ordering() {
     }];
 
     let ctx = IterationContext::new(1, plan, Some(fs), history, HashMap::new());
-    let prompt = ctx.build_continuation_prompt(3, false);
+    let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
     let completed_pos = prompt.find("COMPLETED TASKS").unwrap();
     let blocked_pos = prompt.find("BLOCKED TASKS").unwrap();

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -1191,9 +1191,11 @@ impl Orchestrator {
         ctx: &IterationContext,
         max_iterations: usize,
         show_tool_chain: bool,
+        content_max_length: usize,
     ) -> String {
         let timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-        let base = ctx.build_continuation_prompt(max_iterations, show_tool_chain);
+        let base =
+            ctx.build_continuation_prompt(max_iterations, show_tool_chain, content_max_length);
         format!("Current time: {timestamp}\n\n{base}")
     }
 
@@ -1231,6 +1233,7 @@ impl Orchestrator {
                 ctx,
                 self.config.max_planning_cycles,
                 self.config.show_tool_reasoning_in_continuation(),
+                self.config.result_summary_length(),
             ),
         };
 
@@ -3021,7 +3024,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         format!("✓ complete ({} chars)", result.len())
                     }
                     TaskState::Failed { error, .. } => {
-                        format!("✗ failed: {}", error)
+                        let (truncated, was_truncated) =
+                            safe_truncate(error, self.config.result_summary_length());
+                        let suffix = if was_truncated { " [truncated]" } else { "" };
+                        format!("✗ failed: {}{}", truncated, suffix)
                     }
                     TaskState::Pending => {
                         let blocked_by = t.dependencies.iter().any(|dep_id| {
@@ -3060,13 +3066,17 @@ Assign tasks to the worker whose tools best match the required operations."#,
         } else if (lower.contains("context")
             && (lower.contains("limit")
                 || lower.contains("overflow")
-                || lower.contains("exceeded")
+                || lower.contains("exceed")
                 || lower.contains("length")))
             || lower.contains("maximum context")
             || lower.contains("token limit")
             || lower.contains("tokens exceeded")
             || lower.contains("maximum number of tokens")
             || (lower.contains("too") && lower.contains("long") && lower.contains("token"))
+            || lower.contains("string_above_max_length")
+            || (lower.contains("string") && lower.contains("too long"))
+            || lower.contains("prompt is too long")
+            || lower.contains("input is too long")
         {
             FailureCategory::ContextOverflow
         } else if lower.contains("maxdeptherror") || lower.contains("reached limit") {
@@ -5119,6 +5129,54 @@ mod tests {
         );
         assert_eq!(
             Orchestrator::categorize_failure_error("Input too long for token window"),
+            FailureCategory::ContextOverflow
+        );
+    }
+
+    #[test]
+    fn test_categorize_failure_openai_string_too_long() {
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "messages[7].content: string too long (12839884 > 10485760)"
+            ),
+            FailureCategory::ContextOverflow
+        );
+    }
+
+    #[test]
+    fn test_categorize_failure_string_above_max_length() {
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "string_above_max_length: messages[7].content exceeds maximum length"
+            ),
+            FailureCategory::ContextOverflow
+        );
+    }
+
+    #[test]
+    fn test_categorize_failure_anthropic_prompt_too_long() {
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "prompt is too long: 208310 tokens > 200000 maximum"
+            ),
+            FailureCategory::ContextOverflow
+        );
+    }
+
+    #[test]
+    fn test_categorize_failure_bedrock_input_too_long() {
+        assert_eq!(
+            Orchestrator::categorize_failure_error("Input is too long for requested model"),
+            FailureCategory::ContextOverflow
+        );
+    }
+
+    #[test]
+    fn test_categorize_failure_anthropic_exceed_context_limit() {
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "input length and max_tokens exceed context limit: 100000 + 8192 > 100000"
+            ),
             FailureCategory::ContextOverflow
         );
     }

--- a/crates/aura/src/orchestration/types.rs
+++ b/crates/aura/src/orchestration/types.rs
@@ -717,6 +717,7 @@ impl IterationContext {
         &self,
         max_iterations: usize,
         show_tool_chain: bool,
+        content_max_length: usize,
     ) -> String {
         use super::templates::{ContinuationVars, render_continuation_prompt};
 
@@ -793,10 +794,15 @@ impl IterationContext {
                                 )
                             }
                         }
-                        (cat, _) => format!(
-                            "- Task {}: {} → failed [{}]: {}",
-                            t.id, t.description, cat, error
-                        ),
+                        (cat, _) => {
+                            let (truncated_error, was_truncated) =
+                                crate::string_utils::safe_truncate(error, content_max_length);
+                            let suffix = if was_truncated { " [truncated]" } else { "" };
+                            format!(
+                                "- Task {}: {} → failed [{}]: {}{}",
+                                t.id, t.description, cat, truncated_error, suffix
+                            )
+                        }
                     };
                     redesign_lines.push(line);
                     for line in render_tool_chain_lines(self.tool_traces.get(&t.id)) {
@@ -858,13 +864,17 @@ impl IterationContext {
                     .as_deref()
                     .map(|w| format!(" (worker: {w})"))
                     .unwrap_or_default();
+                let (truncated_error, was_truncated) =
+                    crate::string_utils::safe_truncate(&record.error, content_max_length);
+                let suffix = if was_truncated { " [truncated]" } else { "" };
                 fh.push_str(&format!(
-                    "\n- Iteration {}: \"{}\"{} — [{}] {}",
+                    "\n- Iteration {}: \"{}\"{} — [{}] {}{}",
                     record.iteration,
                     record.description,
                     worker_info,
                     record.category,
-                    record.error,
+                    truncated_error,
+                    suffix,
                 ));
             }
 
@@ -1374,7 +1384,7 @@ mod tests {
         };
 
         let ctx = IterationContext::new(1, plan, Some(fs), vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         // Verify key sections are present
         assert!(prompt.contains("ITERATION 1 of 3"));
@@ -1408,7 +1418,7 @@ mod tests {
         plan.add_task(task);
 
         let ctx = IterationContext::new(2, plan, None, vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         assert!(prompt.contains("ITERATION 2 of 3"));
         assert!(prompt.contains("COMPLETED TASKS"));
@@ -1437,7 +1447,7 @@ mod tests {
         }];
 
         let ctx = IterationContext::new(1, plan, Some(fs), failures, HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         assert!(prompt.contains("FAILURE HISTORY:"));
         assert!(prompt.contains("Iteration 1: \"Gather logs\""));
@@ -1476,7 +1486,7 @@ mod tests {
         ];
 
         let ctx = IterationContext::new(2, plan, Some(fs), failures, HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         assert!(prompt.contains("FAILURE HISTORY:"));
         assert!(prompt.contains("OBSERVED PATTERNS:"));
@@ -1494,7 +1504,7 @@ mod tests {
         plan.add_task(task);
 
         let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         assert!(prompt.contains("COMPLETED TASKS"));
         // Full result inlined — no truncation when no artifact exists
@@ -1517,7 +1527,7 @@ mod tests {
         plan.add_task(task);
 
         let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         // The body is truncated but the artifact footer survives.
         assert!(prompt.contains("COMPLETED TASKS"));
@@ -1543,7 +1553,7 @@ mod tests {
         plan.add_task(task);
 
         let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         assert!(prompt.contains("Found 47 error groups"));
         assert!(prompt.contains("saved to artifact: task-0-sre-iter-1-result.txt"));
@@ -1563,7 +1573,7 @@ mod tests {
         };
         // iteration=2, max=3 → next would be iteration 3 = max, so FINAL ATTEMPT
         let ctx = IterationContext::new(2, plan, Some(fs), vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         assert!(prompt.contains("(FINAL ATTEMPT)"));
     }
@@ -1580,7 +1590,7 @@ mod tests {
             gaps: vec![],
         };
         let ctx = IterationContext::new(1, plan, Some(fs), vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         assert!(!prompt.contains("FINAL ATTEMPT"));
     }
@@ -1602,7 +1612,7 @@ mod tests {
             gaps: vec![],
         };
         let ctx = IterationContext::new(1, mixed_plan, Some(fs), vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
         assert!(
             prompt.contains(guidance_marker),
             "result forwarding guidance should appear on mixed success/failure"
@@ -1614,7 +1624,7 @@ mod tests {
         t.complete("Some result");
         all_ok.add_task(t);
         let ctx = IterationContext::new(1, all_ok, None, vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
         assert!(
             !prompt.contains(guidance_marker),
             "result forwarding guidance should NOT appear on clean success"
@@ -1630,7 +1640,7 @@ mod tests {
             gaps: vec![],
         };
         let ctx = IterationContext::new(1, all_fail, Some(fs), vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
         assert!(
             !prompt.contains(guidance_marker),
             "result forwarding guidance should NOT appear when all failed"
@@ -1659,7 +1669,7 @@ mod tests {
             gaps: vec!["Task 1 failed".into()],
         };
         let ctx = IterationContext::new(1, plan, Some(fs), vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         // All three sections should be present
         assert!(prompt.contains("COMPLETED TASKS"));
@@ -2158,7 +2168,7 @@ mod tests {
             gaps: vec![],
         };
         let ctx = IterationContext::new(1, plan, Some(fs), vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         assert!(
             prompt.contains("[agent_timeout]"),
@@ -2187,11 +2197,49 @@ mod tests {
             gaps: vec![],
         };
         let ctx = IterationContext::new(2, plan, Some(fs), failures, HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         assert!(
             prompt.contains("[agent_error]"),
             "failure history should contain category label: {}",
+            prompt
+        );
+    }
+
+    #[test]
+    fn test_long_error_strings_truncated_in_continuation_prompt() {
+        let long_error = "x".repeat(5000);
+        let mut plan = Plan::new("Goal");
+        let mut task = Task::new(0, "Fetch data", "Get data");
+        task.fail(long_error.clone(), FailureCategory::ContextOverflow);
+        plan.add_task(task);
+
+        let failures = vec![FailedTaskRecord {
+            description: "Fetch data".to_string(),
+            error: long_error,
+            iteration: 1,
+            worker: None,
+            category: FailureCategory::ContextOverflow,
+        }];
+        let fs = FailureSummary {
+            reasoning: "Failed".into(),
+            gaps: vec![],
+        };
+        let ctx = IterationContext::new(2, plan, Some(fs), failures, HashMap::new());
+        let prompt = ctx.build_continuation_prompt(3, false, 200);
+
+        assert!(
+            prompt.contains("[truncated]"),
+            "prompt should contain truncation marker: {}",
+            prompt
+        );
+        assert!(
+            !prompt.contains(&"x".repeat(5000)),
+            "prompt should not contain full 5000-char error"
+        );
+        assert!(
+            prompt.contains("[context_overflow]"),
+            "category should still be present: {}",
             prompt
         );
     }
@@ -2225,7 +2273,7 @@ mod tests {
             gaps: vec![],
         };
         let ctx = IterationContext::new(3, plan, Some(fs), failures, HashMap::new());
-        let prompt = ctx.build_continuation_prompt(4, false);
+        let prompt = ctx.build_continuation_prompt(4, false, 2000);
 
         assert!(
             !prompt.contains("OBSERVED PATTERNS"),
@@ -2272,7 +2320,7 @@ mod tests {
             gaps: vec![],
         };
         let ctx = IterationContext::new(1, plan, Some(fs), vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         assert!(
             prompt.contains("soft_failure"),
@@ -2307,7 +2355,7 @@ mod tests {
             gaps: vec![],
         };
         let ctx = IterationContext::new(1, plan, Some(fs), vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         assert!(
             prompt.contains("[soft_failure]"),
@@ -2381,7 +2429,7 @@ mod tests {
             gaps: vec![],
         };
         let ctx = IterationContext::new(3, plan, Some(fs), failures, HashMap::new());
-        let prompt = ctx.build_continuation_prompt(4, false);
+        let prompt = ctx.build_continuation_prompt(4, false, 2000);
 
         assert!(
             prompt.contains("OBSERVED PATTERNS"),
@@ -2407,7 +2455,7 @@ mod tests {
             gaps: vec![],
         };
         let ctx = IterationContext::new(1, plan, Some(fs), vec![], HashMap::new());
-        let prompt = ctx.build_continuation_prompt(3, false);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
 
         assert!(
             prompt.contains("[soft_failure]"),
@@ -2460,7 +2508,7 @@ mod tests {
         );
 
         let ctx = IterationContext::new(1, plan, None, vec![], traces);
-        let prompt = ctx.build_continuation_prompt(3, true);
+        let prompt = ctx.build_continuation_prompt(3, true, 2000);
 
         assert!(
             prompt.contains("Tool chain:"),
@@ -2504,7 +2552,7 @@ mod tests {
         );
 
         let ctx = IterationContext::new(1, plan, None, vec![], traces);
-        let prompt = ctx.build_continuation_prompt(3, true);
+        let prompt = ctx.build_continuation_prompt(3, true, 2000);
 
         assert!(
             prompt.contains("Tool chain:"),
@@ -2529,7 +2577,7 @@ mod tests {
         plan.add_task(t);
 
         let ctx_without = IterationContext::new(1, plan.clone(), None, vec![], HashMap::new());
-        let prompt_without = ctx_without.build_continuation_prompt(3, true);
+        let prompt_without = ctx_without.build_continuation_prompt(3, true, 2000);
 
         assert!(
             !prompt_without.contains("Tool chain:"),
@@ -2549,7 +2597,7 @@ mod tests {
         traces.insert(0, vec![make_trace("tool_a", &long_reasoning, 1000, None)]);
 
         let ctx = IterationContext::new(1, plan, None, vec![], traces);
-        let prompt = ctx.build_continuation_prompt(3, true);
+        let prompt = ctx.build_continuation_prompt(3, true, 2000);
 
         assert!(
             prompt.contains("…"),
@@ -2576,7 +2624,7 @@ mod tests {
         traces.insert(0, vec![make_trace("log_search", "searching", 5000, None)]);
 
         let ctx = IterationContext::new(1, plan, None, vec![], traces);
-        let prompt = ctx.build_continuation_prompt(3, true);
+        let prompt = ctx.build_continuation_prompt(3, true, 2000);
 
         let chain_count = prompt.matches("Tool chain:").count();
         assert_eq!(
@@ -2597,7 +2645,7 @@ mod tests {
         traces.insert(0, vec![make_trace("tool_a", "", 1000, None)]);
 
         let ctx = IterationContext::new(1, plan, None, vec![], traces);
-        let prompt = ctx.build_continuation_prompt(3, true);
+        let prompt = ctx.build_continuation_prompt(3, true, 2000);
 
         assert!(
             prompt.contains("tool_a (1.0s)"),
@@ -2618,7 +2666,7 @@ mod tests {
         traces.insert(0, vec![make_trace("only_tool", "single call", 2000, None)]);
 
         let ctx = IterationContext::new(1, plan, None, vec![], traces);
-        let prompt = ctx.build_continuation_prompt(3, true);
+        let prompt = ctx.build_continuation_prompt(3, true, 2000);
 
         assert!(
             prompt.contains("Tool chain: only_tool (2.0s"),


### PR DESCRIPTION
## Summary

- Widen `categorize_failure_error` to recognize per-message size limit errors (`string_above_max_length`, `"string too long"`) as `ContextOverflow` instead of the catch-all `AgentError`
- Add patterns for Anthropic (`"prompt is too long"`), Bedrock (`"input is too long"`), and fix the `"exceeded"` → `"exceed"` substring gap that missed `exceeds`/`exceed` variants from Anthropic, Ollama, and OpenAI Responses API
- Cap error strings in the continuation prompt and execution summary at `result_summary_length` (default 2000 bytes) to prevent oversized errors from cascading into the coordinator's context window

## Context

When scratchpad is disabled and a worker's MCP tool returns oversized output (e.g. 11MB from `deduplicate_logs_relative_time`), OpenAI rejects the next turn with `string_above_max_length`. This error was misclassified as `AgentError`, causing the coordinator to replan with the same failing task up to `max_planning_cycles` times — each cycle a wasted LLM round-trip reproducing the same failure.

Scratchpad remains the correct prevention mechanism. This fix handles the failure gracefully when it occurs: classify it immediately so the worker breaks without retrying, and bound error strings so they can't poison the coordinator's context.

## Test plan

- [x] 5 new classification unit tests covering OpenAI, Anthropic, Bedrock error formats
- [x] 1 new truncation test verifying long errors are capped with `[truncated]` suffix
- [x] 784/784 unit tests pass (781 existing + 3 net new)
- [x] Commitlint passes
- [ ] Live reproduction via aura-sandbox with no-scratchpad config

Fixes: #120