### PR TITLE
doc(github): add PULL_REQUEST_TEMPLATE.md and dedupe from CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## What
+
+Brief description of what this PR does.
+
+## Why
+
+Motivation and context for the change.
+
+## How
+
+Summary of the approach and any notable implementation details.
+
+## Testing
+
+How this was tested (unit tests, integration tests, manual testing).
+
+## Checklist
+
+- [ ] Code follows existing patterns and conventions
+- [ ] `cargo test --workspace` passes locally
+- [ ] Commits follow Conventional Commits format
+- [ ] Documentation updated (if applicable)
+- [ ] Tests added or updated (if applicable)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -396,33 +396,7 @@ Update your config.toml files accordingly.
 
 ### PR Template
 
-When opening a PR, consider including:
-
-```markdown
-## What
-
-Brief description of what this PR does.
-
-## Why
-
-Motivation and context for the change.
-
-## How
-
-Summary of the approach and any notable implementation details.
-
-## Testing
-
-How this was tested (unit tests, integration tests, manual testing).
-
-## Checklist
-
-- [ ] Code follows existing patterns and conventions
-- [ ] `cargo test --workspace` passes locally
-- [ ] Commits follow Conventional Commits format
-- [ ] Documentation updated (if applicable)
-- [ ] Tests added or updated (if applicable)
-```
+When opening a pull request, fill out the template that GitHub pre-fills from [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md).
 
 ## Review Process
 


### PR DESCRIPTION
## What

Adds `.github/PULL_REQUEST_TEMPLATE.md` so GitHub pre-fills the PR checklist on new pull requests, and removes the duplicate inline template block from `CONTRIBUTING.md`, replacing it with a short pointer.

## Why

The PR template body lives inline in `CONTRIBUTING.md` today. GitHub does not auto-apply it on new PRs, so contributors miss the checklist and reviewers spend cycles asking for it.

## How

- Created `.github/PULL_REQUEST_TEMPLATE.md` containing the existing template body verbatim (sections: What / Why / How / Testing / Checklist).
- Replaced the inline fenced block in `CONTRIBUTING.md` § "PR Template" with a single sentence pointing to the new file. Surrounding PR-process prose is left intact.

## Testing

- Verified by previewing the compare view: `https://github.com/mezmo/aura/compare/main...doc/sup-169-pr-template?expand=1` — the new template renders pre-filled in the PR body.
- Documentation-only change; no code paths affected.

## Checklist

- [x] Code follows existing patterns and conventions
- [x] `cargo test --workspace` passes locally (n/a — docs-only change)
- [x] Commits follow Conventional Commits format
- [x] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable) — n/a

---

Requested by Sven Delmas.