### PR TITLE
doc(readme): remove references to retired development/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ aura/
 ├── compose/                 # Docker Compose (integration + orchestration overlays)
 ├── configs/                 # E2E test and orchestration configurations
 ├── deployment/              # Helm charts and K8s manifests
-├── development/             # LibreChat and OpenWebUI setup
 ├── docs/                    # Architecture and protocol documentation
 ├── examples/                # Example and reference configurations
 └── scripts/                 # CI and utility scripts
@@ -151,8 +150,6 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 ```
 
 SSE protocol details, event types, custom events, and client handling are documented in [docs/streaming-api-guide.md](docs/streaming-api-guide.md).
-
-For LibreChat/OpenWebUI integration, see [development/README.md](development/README.md).
 
 ### Client-Side Tools
 
@@ -288,7 +285,7 @@ mcp-proxy --port=8081 --host=127.0.0.1 npx your-mcp-server
 
 Then point your config at the HTTP/SSE endpoint instead.
 
-`headers_from_request` can forward incoming request headers to MCP servers for per-request auth. See [development/README.md](development/README.md) for practical examples.
+`headers_from_request` can forward incoming request headers to MCP servers for per-request auth.
 
 `turn_depth` controls how many tool-calling rounds can happen in a single turn. Higher values allow multi-step tool workflows before final response generation. This acts as a failsafe to prevent models from spinning out in unbounded tool-call loops.
 
@@ -544,7 +541,6 @@ Detailed test guidance: [crates/aura-web-server/tests/README.md](crates/aura-web
 - [docs/rig-tool-execution-order.md](docs/rig-tool-execution-order.md): tool execution ordering analysis.
 - [docs/ollama-guide.md](docs/ollama-guide.md): Ollama configuration, fallback tool parsing, and local model guidance.
 - [docs/rig-fork-changes.md](docs/rig-fork-changes.md): Rig fork changes and rationale.
-- [development/README.md](development/README.md): LibreChat/OpenWebUI setup and header-forwarding examples.
 - [docs/breaking-changes/20260421-llm-under-agent.md](docs/breaking-changes/20260421-llm-under-agent.md): breaking configuration changes from 21 April 2026 — `[llm]` moved under `[agent.llm]` and per-worker LLM overrides.
 - [docs/breaking-changes/20260410-agent-llm-toml-configuration.md](docs/breaking-changes/20260410-agent-llm-toml-configuration.md): breaking configuration changes from 10 April 2026 — field migrations from `[agent]` to `[llm]` and Ollama parameter consolidation.
 


### PR DESCRIPTION
## Summary

The `development/` directory was removed from the repo intentionally (confirmed by Sven Delmas), but `README.md` still linked to `development/README.md` in four places. This PR removes all four stale references so the README stops pointing at a path that no longer exists on `main`.

## Changes

Four removals in `README.md`, all targeted:

| Line (pre-edit, v1.20.0) | Action |
|---|---|
| 55 — `├── development/             # LibreChat and OpenWebUI setup` | Deleted from the directory tree block |
| 155 — `For LibreChat/OpenWebUI integration, see [development/README.md](development/README.md).` | Whole line + surrounding blank line removed |
| 291 — `\`headers_from_request\` …. See [development/README.md](development/README.md) for practical examples.` | First sentence kept; trailing "see X for examples" dropped |
| 547 — `- [development/README.md](development/README.md): LibreChat/OpenWebUI setup and header-forwarding examples.` | Bullet removed from the docs index |

## Verification

- `grep -n "development/" README.md` returns nothing.
- Manual readthrough of the three affected regions: tree block stays continuous, the `### Client-Side Tools` heading retains a single blank-line separator, the `headers_from_request` paragraph still flows into the `turn_depth` paragraph, and the documentation-index bullet list has no gap.

## Follow-up flagged (out of scope here)

`CONTRIBUTING.md:147` also references `development/` in its project-structure tree block. Worth a separate small follow-up — kept out of this PR to keep the change tightly scoped to the SUP-183 acceptance criteria.

## Ticket

Fixes: SUP-183