### PR TITLE
doc(github): add SUPPORT.md and "where to ask what" guidance

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,31 @@
+# Getting help with Aura
+
+Thanks for using [Aura](https://github.com/mezmo/aura). This guide points you at the right channel so you get a response from the people who can actually help.
+
+## Where to ask what
+
+| What you have | Where it goes |
+|---|---|
+| **A bug** — Aura is doing something it shouldn't, or crashing | [Open an issue](https://github.com/mezmo/aura/issues/new/choose) and pick the bug report template |
+| **A question, idea, or "is this supported?"** | [Start a discussion](https://github.com/mezmo/aura/discussions) in the Q&A category |
+| **A security vulnerability** | See [`SECURITY.md`](../SECURITY.md) — please do not file a public issue |
+| **Commercial support, integration help, or enterprise inquiries** | Contact Mezmo at [mezmo.com/contact](https://www.mezmo.com/contact) |
+
+## Before opening an issue
+
+To make bug reports easier to triage:
+
+- Search existing [issues](https://github.com/mezmo/aura/issues?q=is%3Aissue) and [discussions](https://github.com/mezmo/aura/discussions) for prior reports.
+- Include your Aura version (release tag or commit SHA), Rust toolchain (`rustc --version`), OS, and a minimal reproduction.
+- For configuration issues, share the relevant TOML — **redact any secrets first**.
+
+## Discussion vs. issue — quick rule of thumb
+
+- "Something is broken" → issue.
+- "How do I…?" or "Should Aura do X?" → discussion.
+- Unsure? Start a discussion. We'll convert it into an issue if it turns out to be a bug.
+
+## Contributing back
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — setup, code style, PR guidance.
+- [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) — community standards.


### PR DESCRIPTION
## Summary

Adds `.github/SUPPORT.md` so GitHub surfaces a single "where to ask what" guide from the **New issue** chooser and the community-health overview. Right now, new users have to guess whether to file an issue, start a discussion, or contact us privately — this PR removes that ambiguity.

The file maps four user intents to four channels:

| Intent | Channel |
|---|---|
| Bug report | GitHub Issues (bug template) |
| Question / idea / "is this supported?" | GitHub Discussions Q&A |
| Security vulnerability | `SECURITY.md` (private reporting) |
| Commercial / enterprise inquiry | [mezmo.com/contact](https://www.mezmo.com/contact) |

Discussions and Issues are already enabled on this repo, so the routing table is immediately useful on merge.

Requested by Sven Delmas as part of the OSS readiness pass.

## Notes

- `SECURITY.md` lands in a separate follow-up; the link from `SUPPORT.md` will resolve once that file is added. This is intentional — the OSS readiness files are landing in sequence rather than in one large PR.
- The bug-template link works today (GitHub shows a blank-issue option) and will start surfacing the real bug template once the issue-templates PR lands.
- This PR is documentation only — no behavior changes.

## Test plan

- [ ] After merge: visit `https://github.com/mezmo/aura/issues/new/choose` and confirm GitHub shows the "I have a question / commercial support" sidebar entry pointing at `SUPPORT.md`.
- [ ] After merge: visit `https://github.com/mezmo/aura/community` and confirm the community-health checklist now satisfies "Support guidelines".
- [ ] After merge: open `.github/SUPPORT.md` on the default branch and click each link — Discussions, Issues, and `mezmo.com/contact` resolve. The `SECURITY.md` link is expected to 404 until that follow-up lands.