### PR TITLE
doc(readme): add license, release, discussions, and stars badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Aura
 
+[![License: Apache 2.0](https://img.shields.io/github/license/mezmo/aura.svg?color=blue)](LICENSE)
+[![Latest release](https://img.shields.io/github/v/release/mezmo/aura?sort=semver)](https://github.com/mezmo/aura/releases)
+[![GitHub Discussions](https://img.shields.io/github/discussions/mezmo/aura)](https://github.com/mezmo/aura/discussions)
+[![GitHub stars](https://img.shields.io/github/stars/mezmo/aura?style=social)](https://github.com/mezmo/aura/stargazers)
+
 A production-ready framework for composing AI agents and multi-agent workflows from declarative TOML configuration, with MCP tool integration, RAG pipelines, and an OpenAI-compatible web API. Built on [Rig.rs](https://github.com/0xPlaygrounds/rig) with reliability and operability enhancements.
 
 Key capabilities:


### PR DESCRIPTION
## Summary

Adds a 4-badge row directly under the `# Aura` heading in `README.md` so new visitors can see license, latest release, community channels, and project popularity at a glance.

Badges added (all shields.io, linked to the appropriate target):

- **License** (Apache-2.0) → `LICENSE`
- **Latest release** (semver tag) → `/releases`
- **GitHub Discussions** → `/discussions`
- **GitHub stars** → `/stargazers`

## Why no CI badge

The acceptance criteria mention a CI badge, but it depends on a public `.github/workflows/ci.yml` that doesn't exist yet. That workflow is tracked separately and the CI badge will be appended in a follow-up doc PR once it lands. Shipping a grey/broken CI badge today would be worse than no badge.

## Test plan

- [x] Diff inspected — single-file change, 5 added lines
- [x] License verified as Apache-2.0 (`LICENSE` heading check)
- [x] Discussions verified enabled on the repo (`has_discussions: true`)
- [ ] Render check on the PR's Files Changed tab once posted — all four badges resolve and link correctly
- [ ] No layout shift to existing tagline / Key capabilities / Open Alpha note

Fixes: SUP-173