### PR TITLE
doc(contributing): fix stray code fence breaking rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,9 +197,6 @@ All changes are merged to `main` via **rebase merging** to maintain a linear com
 | `make ci`            | Run all checks: fmt-check, test, lint |
 | `make clean`         | Clean build artifacts                 |
 
-
-```
-
 ## Code Quality Standards
 
 ### Formatting


### PR DESCRIPTION
A stray closing fence below the Useful Make Targets table caused GitHub to render the Code Quality, Testing, Commit Convention, and PR Process sections as a single code block.