### PR TITLE
doc(contributing): remove retired development/ from project tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,8 +143,7 @@ aura/
 │   ├── reference.toml       # Complete annotated configuration
 │   ├── minimal/             # Bare minimum per-provider configs
 │   └── complete/            # Full agent composition examples
-├── scripts/                 # CI and utility scripts
-└── development/             # LibreChat and OpenWebUI integration
+└── scripts/                 # CI and utility scripts
 ```
 
 **Key architectural docs** to read before diving into the code:


### PR DESCRIPTION
## Summary

- Removes the `└── development/` line from the project-structure tree in `CONTRIBUTING.md`. The directory was retired and is no longer in the repo.
- Re-flowers `scripts/` as the closing branch (`└──`) so the tree block stays well-formed.
- Companion to the `README.md` cleanup in #132 (SUP-183), which was kept tightly scoped to README per its acceptance grep.

## Acceptance

- `grep -n "development/" CONTRIBUTING.md` returns no matches.
- Tree block remains intact — no dangling pipe characters, no stray blank line.

## Test plan

- [x] `grep -n "development/" CONTRIBUTING.md` returns nothing (exit 1).
- [x] Visually inspected the rendered tree block; closing connector now sits on `scripts/`.
- [x] No other files touched.

Fixes: SUP-187