### PR TITLE
fix: make sure to regenerate cargo lock file during release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ EOR
 FROM runner AS test
 
 # Copy workspace files
-COPY Cargo.toml Cargo.lock ./
+COPY --chown=aura:aura Cargo.toml Cargo.lock ./
 COPY crates/ ./crates/
 # needed for make operations
 COPY .git ./.git

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -38,4 +38,5 @@ for toml in crates/*/Cargo.toml; do
     fi
 done
 
+cargo update --quiet --workspace
 echo "Version update complete"


### PR DESCRIPTION
The script used to increment version numbers in cargo manifests was accurately updating the version value in the Cargo.toml files in the root and sub crate directories. However, the lock file wasn't being updated during this stage, and the release commit didn't include it as it isn't modified. This would leave the lock file out of sync with the rest of the project. It would also result in local changes to the lock file when cargo operations were run locally which can lead to significant confusion, churn and git conflicts

Resolves: GH-137