### PR TITLE
feat(config): auto-migrate deprecated [llm] to [agent.llm]

### DIFF
--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -1412,7 +1412,7 @@ context_window = 200000
     }
 
     #[test]
-    fn test_legacy_top_level_llm_produces_migration_error() {
+    fn test_legacy_top_level_llm_migrated_with_warning() {
         let legacy_config = r#"
 [llm]
 provider = "openai"
@@ -1423,16 +1423,105 @@ model = "gpt-4o"
 name = "Test"
 system_prompt = "Test"
 "#;
-        let err = load_config_from_str(legacy_config)
-            .expect_err("legacy top-level [llm] should be rejected");
+        let config = load_config_from_str(legacy_config)
+            .expect("legacy top-level [llm] should be auto-migrated");
+        // Verify the LLM values were moved into agent.llm.
+        match &config.agent.llm {
+            aura::LlmConfig::OpenAI { api_key, model, .. } => {
+                assert_eq!(api_key, "test_key");
+                assert_eq!(model, "gpt-4o");
+            }
+            other => panic!("expected OpenAI LLM config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_legacy_llm_migrates_all_fields() {
+        let legacy_config = r#"
+[llm]
+provider = "openai"
+api_key = "test_key"
+model = "gpt-4o"
+context_window = 128000
+temperature = 0.7
+max_tokens = 4096
+
+[llm.additional_params.thinking]
+type = "enabled"
+budget_tokens = 8000
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let config = load_config_from_str(legacy_config)
+            .expect("legacy [llm] with additional_params should migrate");
+        match &config.agent.llm {
+            aura::LlmConfig::OpenAI {
+                api_key,
+                model,
+                context_window,
+                temperature,
+                max_tokens,
+                additional_params,
+                ..
+            } => {
+                assert_eq!(api_key, "test_key");
+                assert_eq!(model, "gpt-4o");
+                assert_eq!(*context_window, Some(128000));
+                assert_eq!(*temperature, Some(0.7));
+                assert_eq!(*max_tokens, Some(4096));
+                let params = additional_params
+                    .as_ref()
+                    .expect("additional_params should survive migration");
+                let thinking = params.get("thinking").expect("thinking key should exist");
+                assert_eq!(thinking.get("type").unwrap(), "enabled");
+                assert_eq!(thinking.get("budget_tokens").unwrap(), 8000);
+            }
+            other => panic!("expected OpenAI LLM config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_both_top_level_and_agent_llm_errors() {
+        let ambiguous_config = r#"
+[llm]
+provider = "openai"
+api_key = "old_key"
+model = "gpt-4o"
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+
+[agent.llm]
+provider = "openai"
+api_key = "new_key"
+model = "gpt-4o"
+"#;
+        let err = load_config_from_str(ambiguous_config)
+            .expect_err("both [llm] and [agent.llm] should be rejected");
         let msg = err.to_string();
         assert!(
-            msg.contains("legacy top-level [llm]"),
-            "error should mention legacy top-level [llm]: {msg}"
+            msg.contains("both a top-level [llm]"),
+            "error should mention ambiguous [llm]: {msg}"
         );
+    }
+
+    #[test]
+    fn test_legacy_llm_without_agent_errors() {
+        let no_agent_config = r#"
+[llm]
+provider = "openai"
+api_key = "test_key"
+model = "gpt-4o"
+"#;
+        let err = load_config_from_str(no_agent_config)
+            .expect_err("[llm] without [agent] should be rejected");
+        let msg = err.to_string();
         assert!(
-            msg.contains("[agent.llm]"),
-            "error should tell the user to move it under [agent.llm]: {msg}"
+            msg.contains("no [agent] section"),
+            "error should mention missing [agent]: {msg}"
         );
     }
 

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -24,33 +24,84 @@ use std::path::Path;
 fn load_single_config<P: AsRef<Path>>(path: P) -> Result<Config, ConfigError> {
     let contents = fs::read_to_string(path)?;
     let resolved = resolve_env_vars(&contents)?;
-    check_legacy_top_level_llm(&resolved)?;
-    let config: Config = toml::from_str(&resolved)?;
+    let migrated = migrate_legacy_top_level_llm(&resolved)?;
+    let config: Config = toml::from_str(&migrated)?;
     config.validate()?;
     Ok(config)
 }
 
-/// Detect the legacy top-level `[llm]` table shape and emit a migration error.
+/// Auto-migrate a deprecated top-level `[llm]` table into `[agent.llm]`.
 ///
-/// As of 2026-04-21, `[llm]` lives under `[agent.llm]`. Without this check, a
-/// stale top-level `[llm]` table is silently ignored (Config does not use
-/// `deny_unknown_fields`) and the user gets a confusing downstream error.
-fn check_legacy_top_level_llm(toml_str: &str) -> Result<(), ConfigError> {
+/// As of 2026-04-21, LLM configuration lives under `[agent.llm]`. The
+/// top-level `Config` struct does not use `deny_unknown_fields`, so a stale
+/// `[llm]` table would be silently dropped and produce a confusing downstream
+/// "missing LLM" error.
+///
+/// This function provides a temporary grace period for pre-existing configs
+/// (e.g. auto-updating containers) by moving the entire `[llm]` value into
+/// `[agent.llm]` and emitting a deprecation warning. It errors when the
+/// intent is ambiguous (both `[llm]` and `[agent.llm]` present) or when
+/// there is no `[agent]` section to migrate into. The fallback will be
+/// removed in a future release.
+fn migrate_legacy_top_level_llm(toml_str: &str) -> Result<String, ConfigError> {
     // Best-effort parse — if this fails, let the main deserialization surface
     // the real parse error rather than masking it.
-    let Ok(value) = toml::from_str::<toml::Value>(toml_str) else {
-        return Ok(());
+    let Ok(mut value) = toml::from_str::<toml::Value>(toml_str) else {
+        return Ok(toml_str.to_string());
     };
-    if value.get("llm").is_some() {
+
+    // No top-level [llm] — nothing to do.
+    let Some(top) = value.as_table_mut() else {
+        return Ok(toml_str.to_string());
+    };
+    if !top.contains_key("llm") {
+        return Ok(toml_str.to_string());
+    }
+
+    // [llm] exists. Make sure [agent] also exists so we have somewhere to move it.
+    let agent = top.get("agent").ok_or_else(|| {
+        ConfigError::Validation(
+            "Configuration contains a top-level [llm] table but no [agent] section. \
+             Move [llm] under [agent.llm] or add the required [agent] section."
+                .to_string(),
+        )
+    })?;
+    let agent_table = agent.as_table().ok_or_else(|| {
+        ConfigError::Validation(
+            "Configuration contains a top-level [llm] table but [agent] is not a table. \
+             Move [llm] under [agent.llm]."
+                .to_string(),
+        )
+    })?;
+
+    // Refuse to migrate when both [llm] and [agent.llm] are present — ambiguous.
+    if agent_table.contains_key("llm") {
         return Err(ConfigError::Validation(
-            "Configuration uses the legacy top-level [llm] table. \
-             Move it under [agent.llm] (and any [llm.additional_params] \
-             under [agent.llm.additional_params]). Workers may optionally \
-             override the LLM via [orchestration.worker.<name>.llm]."
+            "Configuration contains both a top-level [llm] table and [agent.llm]. \
+             Remove the top-level [llm] table and keep only [agent.llm]."
                 .to_string(),
         ));
     }
-    Ok(())
+
+    // Perform the migration: move top-level llm into agent.llm.
+    let llm_value = top.remove("llm").expect("checked contains_key above");
+    let agent_table = top
+        .get_mut("agent")
+        .expect("checked above")
+        .as_table_mut()
+        .expect("checked above");
+    agent_table.insert("llm".to_string(), llm_value);
+
+    tracing::warn!(
+        "DEPRECATED CONFIG: top-level [llm] was auto-migrated to [agent.llm]. \
+         Please update your TOML to use [agent.llm] directly — this fallback \
+         will be removed in a future release."
+    );
+
+    let migrated = toml::to_string(&value).map_err(|e| {
+        ConfigError::Validation(format!("Failed to serialize migrated config: {e}"))
+    })?;
+    Ok(migrated)
 }
 
 /// Load and parse TOML configuration(s) from a file or directory.
@@ -120,8 +171,8 @@ pub fn validate_unique_identifiers(configs: &[Config]) -> Result<(), ConfigError
 /// Load config from a string (useful for testing)
 pub fn load_config_from_str(contents: &str) -> Result<Config, ConfigError> {
     let resolved = resolve_env_vars(contents)?;
-    check_legacy_top_level_llm(&resolved)?;
-    let config: Config = toml::from_str(&resolved)?;
+    let migrated = migrate_legacy_top_level_llm(&resolved)?;
+    let config: Config = toml::from_str(&migrated)?;
     config.validate()?;
     Ok(config)
 }

--- a/docs/breaking-changes/20260421-llm-under-agent.md
+++ b/docs/breaking-changes/20260421-llm-under-agent.md
@@ -6,7 +6,7 @@
 
 The `[llm]` TOML section has been moved from the top level to `[agent.llm]`. LLM configuration is now a property of the agent, not a sibling of it. This unlocks **per-worker LLM overrides** in orchestration mode: each `[orchestration.worker.<name>]` may declare its own `[orchestration.worker.<name>.llm]` to run a different model (or a different provider) than the coordinator, inheriting `[agent.llm]` when omitted.
 
-**NOTE: CONFIGS THAT HAVE NOT BEEN UPDATED WILL FAIL TO PARSE AND THE APP WILL FAIL TO START.** The loader detects a top-level `[llm]` table and emits a migration error pointing to this document. See [Startup Errors](#startup-errors).
+**Update your configs to use `[agent.llm]`.** A temporary auto-migration fallback will move a top-level `[llm]` into `[agent.llm]` at load time and log a deprecation warning, so existing deployments (e.g. auto-updating containers) continue to start. **This fallback will be removed in a future release.** Ambiguous configs (both `[llm]` and `[agent.llm]` present, or `[llm]` without an `[agent]` section) still produce a hard error. See [Startup Behavior](#startup-behavior).
 
 ---
 
@@ -153,22 +153,32 @@ The worker's resolved `context_window` is what the runtime reports in `aura.sess
 
 ---
 
-## Startup Errors
+## Startup Behavior
 
-### Top-level `[llm]` is no longer accepted
+### Auto-migration (temporary fallback)
 
-The loader performs a pre-parse check before deserialization. If it sees a top-level `[llm]` table it fails with:
+The loader runs a pre-parse pass before deserialization. If it finds a top-level `[llm]` table **and** an `[agent]` section **without** an existing `[agent.llm]`, it moves the entire `[llm]` value (including nested tables like `[llm.additional_params]`) into `[agent.llm]` and logs:
 
 ```
-Configuration uses the legacy top-level [llm] table. Move it under
-[agent.llm] (and any [llm.additional_params] under
-[agent.llm.additional_params]). Workers may optionally override the
-LLM via [orchestration.worker.<name>.llm].
+DEPRECATED CONFIG: top-level [llm] was auto-migrated to [agent.llm].
+Please update your TOML to use [agent.llm] directly — this fallback
+will be removed in a future release.
 ```
+
+This keeps pre-existing deployments running after an image update, but **you should update your config files**. The fallback will be removed in a future release.
+
+### Hard errors
+
+The following cases still produce a startup error:
+
+| Condition | Error |
+| --- | --- |
+| Both `[llm]` and `[agent.llm]` present | *"Configuration contains both a top-level [llm] table and [agent.llm]. Remove the top-level [llm] table and keep only [agent.llm]."* |
+| `[llm]` without an `[agent]` section | *"Configuration contains a top-level [llm] table but no [agent] section."* |
 
 ### `deny_unknown_fields` remains
 
-`aura_config::config::AgentConfig` and `aura::config::LlmConfig` still carry `#[serde(deny_unknown_fields)]`. Any stray field in `[agent]` or `[agent.llm]` (including the fields that were moved out of `[agent]` in the 10 April 2026 migration) still produces a hard parse error.
+`aura_config::config::AgentConfig` and `aura::config::LlmConfig` still carry `#[serde(deny_unknown_fields)]`. Any stray field in `[agent]` or `[agent.llm]` (including the fields that were moved out of `[agent]` in the 10 April 2026 migration) still produces a hard parse error. Note that the top-level `Config` struct does **not** use `deny_unknown_fields` — that is why the migration function exists (without it a stale `[llm]` would be silently dropped).
 
 ### Worker LLM fields
 

--- a/examples/quickstart-orchestration-math/config.toml
+++ b/examples/quickstart-orchestration-math/config.toml
@@ -7,18 +7,6 @@
 # This config connects to the math-mcp service defined in docker-compose.yml.
 # For all available options, see: examples/reference.toml
 
-# ── LLM Provider ────────────────────────────────────────────────────
-
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.4-mini"
-
-# Anthropic:
-# provider = "anthropic"
-# api_key = "{{ env.ANTHROPIC_API_KEY }}"
-# model = "claude-sonnet-4-20250514"
-
 # ── Agent (Coordinator) ─────────────────────────────────────────────
 # In orchestration mode the [agent] system_prompt is given to the
 # coordinator. It provides routing guidance and domain context.
@@ -37,6 +25,16 @@ ROUTING GUIDANCE:
 IMPORTANT: Always delegate calculations to workers — do not compute results yourself.
 """
 turn_depth = 5
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.4-mini"
+
+# Anthropic:
+# provider = "anthropic"
+# api_key = "{{ env.ANTHROPIC_API_KEY }}"
+# model = "claude-sonnet-4-20250514"
 
 # ── MCP Tool Server ──────────────────────────────────────────────────
 # Points at the math-mcp container defined in docker-compose.yml.


### PR DESCRIPTION
## Summary
- Old configs with top-level `[llm]` now auto-migrate to `[agent.llm]` at load time instead of failing
- Deprecation warning logged so users know to update
- Ambiguous configs (both `[llm]` and `[agent.llm]`) and missing `[agent]` still fail with clear errors
- Quickstart example config updated to new shape
