### PR TITLE
svc(setup): remove trigger build stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,17 +56,6 @@ pipeline {
   }
 
   stages {
-    stage('Validate PR Source') {
-      when {
-        expression { env.CHANGE_FORK }
-        not {
-          triggeredBy 'issueCommentCause'
-        }
-      }
-      steps {
-        error("A maintainer needs to approve this PR for CI by commenting")
-      }
-    }
 
     stage('Setup') {
       steps{


### PR DESCRIPTION
The actual build trigger was removed, but the validation stage that validates the source PR, was not, this was still preventing a build from running in the case that it was an external contribution

Ref: REL-1793