### PR TITLE
fix(a2a): resolve REST streaming subscribe race (proposal)

### DIFF
--- a/crates/aura-web-server/src/a2a/handler.rs
+++ b/crates/aura-web-server/src/a2a/handler.rs
@@ -42,16 +42,15 @@ impl AuraMessageHandler {
     }
 
     fn resolve_config(&self) -> Option<aura_config::Config> {
-        if let Some(ref name) = self.app_state.default_agent {
-            if let Some(agent_config) = self
+        if let Some(ref name) = self.app_state.default_agent
+            && let Some(agent_config) = self
                 .app_state
                 .configs
                 .iter()
                 .find(|c| c.agent.alias.as_deref().unwrap_or(&c.agent.name) == name)
                 .cloned()
-            {
-                return Some(agent_config);
-            }
+        {
+            return Some(agent_config);
         }
 
         self.app_state.configs.first().cloned()

--- a/crates/aura-web-server/src/a2a/mod.rs
+++ b/crates/aura-web-server/src/a2a/mod.rs
@@ -1,3 +1,62 @@
 mod handler;
+pub mod overrides;
 
 pub use handler::AuraMessageHandler;
+
+use a2a_rs_server::AuthContext;
+use axum::http::HeaderMap;
+use std::env;
+
+/// Build an `AuthContext` from an HTTP request's headers.
+///
+/// Used by both the `A2aServer` `auth_extractor` closure (for the upstream JSON-RPC and
+/// unmodified REST endpoints) and the local override handlers in [`overrides`] (which serve
+/// `:stream` and `:subscribe` with the race fix applied).
+///
+/// `A2A_HEADER_USER_ID` and `A2A_HEADER_AUTHORIZATION` name which headers to pull the user id
+/// and access token from. `A2A_HEADER_AUTHORIZATION_STRIP_PREFIX`, if set, strips the prefix
+/// (e.g. `"Bearer "`) from the authorization value.
+///
+/// All request headers are also stashed into `metadata` so downstream tool calls (which read
+/// `auth.metadata` in `AuraMessageHandler`) can forward them to MCP servers.
+pub fn extract_auth_context(headers: &HeaderMap) -> Option<AuthContext> {
+    let header_map: serde_json::Map<String, serde_json::Value> = headers
+        .iter()
+        .filter_map(|(k, v)| {
+            v.to_str()
+                .ok()
+                .map(|val| (k.to_string(), serde_json::Value::String(val.to_string())))
+        })
+        .collect();
+
+    let user_id = env::var("A2A_HEADER_USER_ID")
+        .ok()
+        .as_ref()
+        .and_then(|h| headers.get(h))
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
+    let access_token = env::var("A2A_HEADER_AUTHORIZATION")
+        .ok()
+        .as_ref()
+        .and_then(|h| headers.get(h))
+        .and_then(|v| v.to_str().ok())
+        .map(|s| {
+            if let Some(prefix) = env::var("A2A_HEADER_AUTHORIZATION_STRIP_PREFIX")
+                .ok()
+                .as_deref()
+            {
+                s.strip_prefix(prefix).unwrap_or(s).to_string()
+            } else {
+                s.to_string()
+            }
+        })
+        .unwrap_or_default();
+
+    Some(AuthContext {
+        user_id,
+        access_token,
+        metadata: Some(serde_json::Value::Object(header_map)),
+    })
+}

--- a/crates/aura-web-server/src/a2a/overrides.rs
+++ b/crates/aura-web-server/src/a2a/overrides.rs
@@ -1,0 +1,588 @@
+//! Local overrides for the `a2a-rs-server` REST streaming endpoints.
+//!
+//! These handlers re-implement [`POST /a2a/v1/message:stream`] and
+//! [`GET /a2a/v1/tasks/{id}:subscribe`] with one critical change: they subscribe to the
+//! broadcast channel **before** invoking the handler / reading the task snapshot.
+//!
+//! ## The bug we're working around
+//!
+//! Upstream `a2a-rs-server` 1.0.26 captures the task snapshot first, then subscribes:
+//!
+//! ```text
+//! task = task_store.get(id).await;     // snapshot
+//! rx   = event_tx.subscribe();          // <-- any event broadcast between these
+//!                                       //     two lines is dropped
+//! ```
+//!
+//! For synchronous handlers this is mostly harmless. But [`super::AuraMessageHandler`] spawns
+//! a background worker and returns immediately — the worker can (and does) emit the terminal
+//! `StatusUpdate(Completed)` before the upstream code reaches `event_tx.subscribe()`. The
+//! event is persisted to the task store but never reaches the subscriber, which then loops on
+//! `rx.recv()` forever waiting for a terminal event that already happened.
+//!
+//! ## The fix
+//!
+//! Subscribe to the broadcast channel first, then snapshot. The race window collapses to "may
+//! deliver one duplicate event," and A2A clients dedupe by `task_id`/`artifact_id` so that's
+//! harmless.
+//!
+//! JSON-RPC streaming methods (`message/stream`, `tasks/resubscribe`) have the same bug
+//! upstream but are out of scope here — overriding them would require intercepting the entire
+//! `/a2a/v1/rpc` endpoint and re-dispatching every method. See `docs/a2a-implementation.md`.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use a2a_rs_core::{
+    Message, SendMessageRequest, SendMessageResponse, StreamResponse, StreamingMessageResult, Task,
+    TaskStatus, TaskStatusUpdateEvent, now_iso8601,
+};
+use a2a_rs_server::{MessageHandler, TaskStore};
+use async_stream::stream;
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+use tokio::sync::broadcast;
+use tracing::warn;
+
+use crate::a2a::{AuraMessageHandler, extract_auth_context};
+use crate::types::AppState;
+
+/// `GET /a2a/v1/tasks/{id}:subscribe`
+///
+/// Re-implementation of `rest_subscribe_to_task` from `a2a-rs-server-1.0.26/src/rest.rs:613`
+/// that subscribes to the broadcast channel before snapshotting the task.
+pub async fn subscribe_to_task(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Response {
+    let (event_tx, task_store) = match resolve_a2a_state(&state) {
+        ResolvedState::Ready(parts) => parts,
+        ResolvedState::Error(resp) => return resp,
+    };
+
+    // SUBSCRIBE FIRST. Any event emitted between this line and the snapshot below is
+    // captured by `rx` and replayed in the stream loop, which is the whole point of this
+    // override.
+    let mut rx = event_tx.subscribe();
+
+    let task = match task_store.get_flexible(&id).await {
+        Some(t) => t,
+        None => return aip_error(StatusCode::NOT_FOUND, "task not found"),
+    };
+
+    if task.status.state.is_terminal() {
+        return aip_error(
+            StatusCode::BAD_REQUEST,
+            "cannot subscribe to a task in terminal state",
+        );
+    }
+
+    let target_task_id = task.id.clone();
+    // Cache `context_id` from the snapshot we just read so we can match
+    // `StreamResponse::Message` events without re-fetching the store. The upstream code
+    // uses a non-blocking store fetch here, which silently drops events under contention.
+    let target_context_id = task.context_id.clone();
+    let task_store_for_stream = task_store.clone();
+
+    let body = stream! {
+        if let Some(ev) = task_to_event(&task) {
+            yield Ok::<_, Infallible>(ev);
+        }
+
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    if !event_matches_task(&event, &target_task_id, &target_context_id) {
+                        continue;
+                    }
+                    let is_terminal = is_terminal_event(&event);
+                    if let Some(ev) = stream_response_to_event(event) {
+                        yield Ok(ev);
+                    }
+                    if is_terminal {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    // The upstream crate silently swallows Lagged. We surface it so clients
+                    // know events were dropped — A2A clients ignore unknown metadata keys.
+                    warn!(
+                        task_id = %target_task_id,
+                        dropped = n,
+                        "broadcast receiver lagged; events dropped"
+                    );
+                    let outcome =
+                        handle_lagged(&target_task_id, &task_store_for_stream, n).await;
+                    if let Some(ev) = outcome.event {
+                        yield Ok(ev);
+                    }
+                    // If the dropped events included the terminal StatusUpdate the channel
+                    // will never deliver another event for this task and the loop would
+                    // hang. Break on terminal state read from the store post-lag.
+                    if outcome.is_terminal {
+                        break;
+                    }
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    };
+
+    Sse::new(body)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
+/// `POST /a2a/v1/message:stream`
+///
+/// Re-implementation of `rest_send_streaming_message` from
+/// `a2a-rs-server-1.0.26/src/rest.rs:397`. Subscribes before invoking the handler so events
+/// emitted by the handler's spawned worker (see [`AuraMessageHandler::handle_message`]) are
+/// caught in the stream.
+pub async fn send_streaming_message(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(params): Json<SendMessageRequest>,
+) -> Response {
+    let (event_tx, task_store) = match resolve_a2a_state(&state) {
+        ResolvedState::Ready(parts) => parts,
+        ResolvedState::Error(resp) => return resp,
+    };
+
+    if params.message.parts.is_empty() {
+        return aip_error(StatusCode::BAD_REQUEST, "message parts must not be empty");
+    }
+
+    let auth = extract_auth_context(&headers);
+
+    // SUBSCRIBE FIRST. `handle_message` immediately spawns a worker that can broadcast
+    // before this function returns; without an outstanding subscriber, tokio would drop
+    // those events.
+    let mut rx = event_tx.subscribe();
+
+    let handler = AuraMessageHandler::new(
+        state.clone(),
+        state.a2a_event_tx.clone(),
+        state.a2a_task_store.clone(),
+    );
+
+    let response = match handler.handle_message(params.message, auth).await {
+        Ok(r) => r,
+        Err(e) => return handler_error_response(e),
+    };
+
+    let task = match response {
+        SendMessageResponse::Task(t) => t,
+        SendMessageResponse::Message(m) => return single_message_sse(m),
+    };
+
+    // The handler already inserted the task; this is an idempotent overwrite that mirrors
+    // the upstream `rest_send_streaming_message` flow.
+    task_store.insert(task.clone()).await;
+
+    // Broadcast the initial Task event so any *other* subscribers (e.g. webhooks) see it.
+    // Our own `rx` will receive a copy too — the SSE loop below filters it by id, so we
+    // skip it there and yield the locally-held `task` as the first SSE event below.
+    let _ = event_tx.send(StreamResponse::Task(task.clone()));
+
+    let target_task_id = task.id.clone();
+    let target_context_id = task.context_id.clone();
+    let task_store_for_stream = task_store.clone();
+    let initial_is_terminal = task.status.state.is_terminal();
+
+    let body = stream! {
+        if let Some(ev) = task_to_event(&task) {
+            yield Ok::<_, Infallible>(ev);
+        }
+
+        if initial_is_terminal {
+            return;
+        }
+
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    // Skip the initial Task echo we just broadcast — already yielded above.
+                    if matches!(&event, StreamResponse::Task(t) if t.id == target_task_id) {
+                        continue;
+                    }
+                    if !event_matches_task(&event, &target_task_id, &target_context_id) {
+                        continue;
+                    }
+                    let is_terminal = is_terminal_event(&event);
+                    if let Some(ev) = stream_response_to_event(event) {
+                        yield Ok(ev);
+                    }
+                    if is_terminal {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(
+                        task_id = %target_task_id,
+                        dropped = n,
+                        "broadcast receiver lagged; events dropped"
+                    );
+                    let outcome =
+                        handle_lagged(&target_task_id, &task_store_for_stream, n).await;
+                    if let Some(ev) = outcome.event {
+                        yield Ok(ev);
+                    }
+                    // Same reasoning as in `subscribe_to_task`: if the dropped events
+                    // included the terminal StatusUpdate we must break, not continue.
+                    if outcome.is_terminal {
+                        break;
+                    }
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    };
+
+    Sse::new(body)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
+/// Two-state enum (rather than `Result`) to keep the large `Response` value out of a
+/// `Result::Err`, which clippy flags as `result_large_err`.
+enum ResolvedState {
+    Ready((broadcast::Sender<StreamResponse>, TaskStore)),
+    Error(Response),
+}
+
+fn resolve_a2a_state(state: &Arc<AppState>) -> ResolvedState {
+    let Some(event_tx) = state.a2a_event_tx.get().cloned() else {
+        return ResolvedState::Error(aip_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a2a streaming not initialized",
+        ));
+    };
+    let Some(task_store) = state.a2a_task_store.get().cloned() else {
+        return ResolvedState::Error(aip_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a2a task store not initialized",
+        ));
+    };
+    ResolvedState::Ready((event_tx, task_store))
+}
+
+fn single_message_sse(message: Message) -> Response {
+    let body = stream! {
+        if let Ok(val) = serde_json::to_value(StreamingMessageResult::Message(message)) {
+            let text = serde_json::to_string(&val).unwrap_or_default();
+            yield Ok::<_, Infallible>(Event::default().data(text));
+        }
+    };
+    Sse::new(body)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
+fn task_to_event(task: &Task) -> Option<Event> {
+    let val = serde_json::to_value(StreamingMessageResult::Task(task.clone())).ok()?;
+    let body = serde_json::to_string(&val).ok()?;
+    Some(Event::default().data(body))
+}
+
+fn stream_response_to_event(event: StreamResponse) -> Option<Event> {
+    let val = match event {
+        StreamResponse::Task(t) => serde_json::to_value(StreamingMessageResult::Task(t)),
+        StreamResponse::Message(m) => serde_json::to_value(StreamingMessageResult::Message(m)),
+        StreamResponse::StatusUpdate(e) => {
+            serde_json::to_value(StreamingMessageResult::StatusUpdate(e))
+        }
+        StreamResponse::ArtifactUpdate(e) => {
+            serde_json::to_value(StreamingMessageResult::ArtifactUpdate(e))
+        }
+    }
+    .ok()?;
+    let body = serde_json::to_string(&val).ok()?;
+    Some(Event::default().data(body))
+}
+
+fn event_matches_task(event: &StreamResponse, target: &str, target_context_id: &str) -> bool {
+    match event {
+        StreamResponse::Task(t) => t.id == target,
+        StreamResponse::StatusUpdate(e) => e.task_id == target,
+        StreamResponse::ArtifactUpdate(e) => e.task_id == target,
+        // `StreamResponse::Message` events are never emitted by `AuraMessageHandler`'s
+        // worker (it only broadcasts `ArtifactUpdate` / `StatusUpdate`) and a `Message` has
+        // no `task_id` field, so we match against the *cached* context_id of the task we
+        // snapshotted at subscribe time.
+        //
+        // Upstream `a2a-rs-server` 1.0.26 does this comparison with a non-blocking task-store
+        // fetch (`store.get(target).now_or_never()`); under any lock contention that fetch
+        // returns `None` and the Message is silently dropped. Caching `context_id` from the
+        // initial snapshot avoids the race entirely.
+        StreamResponse::Message(m) => m.context_id.as_deref() == Some(target_context_id),
+    }
+}
+
+fn is_terminal_event(event: &StreamResponse) -> bool {
+    match event {
+        StreamResponse::Task(t) => t.status.state.is_terminal(),
+        StreamResponse::StatusUpdate(e) => e.status.state.is_terminal(),
+        _ => false,
+    }
+}
+
+/// What to do after a `RecvError::Lagged` on the broadcast channel.
+struct LaggedOutcome {
+    /// Synthetic SSE event carrying the lag counter and the task's *current* (post-lag) state.
+    event: Option<Event>,
+    /// If true, the task store now shows a terminal state — meaning the dropped events
+    /// almost certainly included the terminal `StatusUpdate`, so the SSE loop must break
+    /// rather than wait forever for an event that will never arrive.
+    is_terminal: bool,
+}
+
+async fn handle_lagged(task_id: &str, store: &TaskStore, dropped: u64) -> LaggedOutcome {
+    let Some(task) = store.get_flexible(task_id).await else {
+        // Task store has no record — can't synthesize; assume terminal so we exit cleanly.
+        return LaggedOutcome {
+            event: None,
+            is_terminal: true,
+        };
+    };
+    let is_terminal = task.status.state.is_terminal();
+    let synthetic = StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+        kind: "status-update".to_string(),
+        task_id: task.id.clone(),
+        context_id: task.context_id.clone(),
+        status: TaskStatus {
+            state: task.status.state,
+            message: None,
+            timestamp: Some(now_iso8601()),
+        },
+        metadata: Some(json!({
+            "lagged_events": dropped,
+            "note": "subscriber fell behind broadcast channel; events were dropped",
+        })),
+    });
+    LaggedOutcome {
+        event: stream_response_to_event(synthetic),
+        is_terminal,
+    }
+}
+
+fn aip_error(status: StatusCode, message: &str) -> Response {
+    let reason = match status.as_u16() {
+        400 => "INVALID_ARGUMENT",
+        404 => "NOT_FOUND",
+        409 => "FAILED_PRECONDITION",
+        500 => "INTERNAL",
+        503 => "UNAVAILABLE",
+        _ => "UNKNOWN",
+    };
+    let grpc_status = match status.as_u16() {
+        400 => "INVALID_ARGUMENT",
+        404 => "NOT_FOUND",
+        409 => "FAILED_PRECONDITION",
+        500 => "INTERNAL",
+        503 => "UNAVAILABLE",
+        _ => "UNKNOWN",
+    };
+    (
+        status,
+        Json(json!({
+            "error": {
+                "code": status.as_u16(),
+                "message": message,
+                "status": grpc_status,
+                "details": [{
+                    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                    "reason": reason,
+                    "domain": "a2a-protocol.org",
+                }],
+            }
+        })),
+    )
+        .into_response()
+}
+
+fn handler_error_response(e: a2a_rs_server::HandlerError) -> Response {
+    use a2a_rs_server::HandlerError as H;
+    let (status, msg) = match &e {
+        H::InvalidInput(m) => (StatusCode::BAD_REQUEST, m.clone()),
+        H::AuthRequired(m) => (StatusCode::UNAUTHORIZED, m.clone()),
+        H::BackendUnavailable { message, .. } => (StatusCode::BAD_GATEWAY, message.clone()),
+        H::ProcessingFailed { message, .. } => (StatusCode::INTERNAL_SERVER_ERROR, message.clone()),
+        H::Internal(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+    };
+    aip_error(status, &msg)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Deterministic unit tests for the parts of the race fix that don't depend on
+    //! network timing or a running LLM:
+    //!
+    //! - `event_matches_task` correctly routes by `task_id` and falls back to the cached
+    //!   `context_id` for `Message` variants (the bit that replaces the upstream
+    //!   `now_or_never()` store fetch).
+    //! - `handle_lagged` returns `is_terminal = true` when the task store shows a terminal
+    //!   state after a lag, so the SSE loop will break instead of hanging on the broadcast
+    //!   channel after the terminal event was already dropped.
+    //!
+    //! The end-to-end timing race is exercised separately in
+    //! `tests/a2a_streaming_test.rs`.
+
+    use super::*;
+    use a2a_rs_core::{
+        Artifact, Message, Part, Role, Task, TaskArtifactUpdateEvent, TaskState, TaskStatus,
+    };
+
+    fn make_task(id: &str, context_id: &str, state: TaskState) -> Task {
+        Task {
+            kind: "task".to_string(),
+            id: id.to_string(),
+            context_id: context_id.to_string(),
+            status: TaskStatus {
+                state,
+                message: None,
+                timestamp: Some(now_iso8601()),
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        }
+    }
+
+    fn make_message(context_id: Option<&str>) -> Message {
+        Message {
+            kind: "message".to_string(),
+            message_id: "msg-1".to_string(),
+            role: Role::User,
+            parts: vec![Part::text("hi")],
+            context_id: context_id.map(str::to_string),
+            task_id: None,
+            reference_task_ids: None,
+            extensions: vec![],
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn matches_by_task_id_on_status_and_artifact_updates() {
+        let target_task = "task-1";
+        let target_ctx = "ctx-1";
+
+        let su = StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+            kind: "status-update".to_string(),
+            task_id: target_task.to_string(),
+            context_id: target_ctx.to_string(),
+            status: TaskStatus {
+                state: TaskState::Working,
+                message: None,
+                timestamp: None,
+            },
+            metadata: None,
+        });
+        assert!(event_matches_task(&su, target_task, target_ctx));
+
+        let au = StreamResponse::ArtifactUpdate(TaskArtifactUpdateEvent {
+            kind: "artifact-update".to_string(),
+            task_id: target_task.to_string(),
+            context_id: target_ctx.to_string(),
+            artifact: Artifact {
+                artifact_id: "a".to_string(),
+                name: None,
+                description: None,
+                parts: vec![],
+                metadata: None,
+                extensions: vec![],
+            },
+            append: None,
+            last_chunk: None,
+            metadata: None,
+        });
+        assert!(event_matches_task(&au, target_task, target_ctx));
+
+        // Different task_id — should not match.
+        let other_su = StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+            kind: "status-update".to_string(),
+            task_id: "other-task".to_string(),
+            context_id: target_ctx.to_string(),
+            status: TaskStatus {
+                state: TaskState::Working,
+                message: None,
+                timestamp: None,
+            },
+            metadata: None,
+        });
+        assert!(!event_matches_task(&other_su, target_task, target_ctx));
+    }
+
+    #[test]
+    fn matches_message_by_cached_context_id() {
+        // Regression test: upstream uses `task_store.get(...).now_or_never()` here; under
+        // lock contention that returns None and silently drops the Message. We compare
+        // against the context_id we captured from the initial task snapshot instead, so
+        // the answer is independent of any concurrent task-store activity.
+        let m = StreamResponse::Message(make_message(Some("ctx-target")));
+        assert!(event_matches_task(&m, "task-1", "ctx-target"));
+
+        let wrong = StreamResponse::Message(make_message(Some("ctx-other")));
+        assert!(!event_matches_task(&wrong, "task-1", "ctx-target"));
+
+        let no_ctx = StreamResponse::Message(make_message(None));
+        assert!(!event_matches_task(&no_ctx, "task-1", "ctx-target"));
+    }
+
+    #[tokio::test]
+    async fn lagged_with_terminal_store_state_breaks_loop() {
+        // The whole reason `handle_lagged` returns `is_terminal`: if the dropped events
+        // included the terminal `StatusUpdate`, the broadcast channel will never deliver
+        // another event for this task. The SSE loop has to break itself.
+        let store = TaskStore::new();
+        store
+            .insert(make_task("t1", "c1", TaskState::Completed))
+            .await;
+
+        let outcome = handle_lagged("t1", &store, 3).await;
+        assert!(
+            outcome.is_terminal,
+            "post-lag terminal store state must surface so the SSE loop breaks"
+        );
+        assert!(
+            outcome.event.is_some(),
+            "should still emit an informational synthetic event"
+        );
+    }
+
+    #[tokio::test]
+    async fn lagged_with_non_terminal_store_state_keeps_loop_alive() {
+        let store = TaskStore::new();
+        store
+            .insert(make_task("t1", "c1", TaskState::Working))
+            .await;
+
+        let outcome = handle_lagged("t1", &store, 1).await;
+        assert!(
+            !outcome.is_terminal,
+            "non-terminal state should let the loop keep listening for more events"
+        );
+        assert!(outcome.event.is_some());
+    }
+
+    #[tokio::test]
+    async fn lagged_with_missing_task_breaks_loop_cleanly() {
+        // No record of the task: we can't synthesize a sensible event, but we definitely
+        // shouldn't loop forever waiting for one.
+        let store = TaskStore::new();
+
+        let outcome = handle_lagged("nonexistent", &store, 5).await;
+        assert!(
+            outcome.is_terminal,
+            "missing task should terminate the loop rather than spin"
+        );
+        assert!(outcome.event.is_none());
+    }
+}

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -616,8 +616,7 @@ async fn handle_streaming_completion(
     );
 
     use futures_util::TryStreamExt;
-    let response_stream =
-        ReceiverStream::new(rx).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
+    let response_stream = ReceiverStream::new(rx).map_err(std::io::Error::other);
 
     Response::builder()
         .status(StatusCode::OK)

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -1,8 +1,7 @@
-use a2a_rs_server::{A2aServer, AuthContext};
+use a2a_rs_server::A2aServer;
 use aura_config::load_config;
 use axum::Json;
 use axum::extract::{Request, State};
-use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
@@ -11,7 +10,6 @@ use axum::{
     routing::{get, post},
 };
 use clap::Parser;
-use std::env;
 use std::sync::{Arc, OnceLock};
 use tokio_util::sync::CancellationToken;
 use tower_http::trace::TraceLayer;
@@ -202,6 +200,12 @@ async fn run() -> std::io::Result<()> {
 
     let shutdown_timeout_secs = args.shutdown_timeout_secs;
 
+    // The broadcast sender and task store live inside `A2aServer`, which we construct below.
+    // Both the message handler and the local override handlers need to see the same channel,
+    // so we share `OnceLock` cells and populate them after the server is built.
+    let event_tx_cell = Arc::new(OnceLock::new());
+    let task_store_cell = Arc::new(OnceLock::new());
+
     let app_state = Arc::new(AppState {
         configs: configs_arc,
         tool_result_mode: args.tool_result_mode,
@@ -215,6 +219,8 @@ async fn run() -> std::io::Result<()> {
         stream_shutdown_token: stream_shutdown_token.clone(),
         active_requests: active_requests.clone(),
         default_agent: args.default_agent.clone(),
+        a2a_event_tx: event_tx_cell.clone(),
+        a2a_task_store: task_store_cell.clone(),
     });
 
     info!(
@@ -226,56 +232,12 @@ async fn run() -> std::io::Result<()> {
     // JSON-RPC at /a2a/v1/rpc
     // REST at /a2a/v1/message:send, /a2a/v1/tasks/
     // REST /.well-known/agent-card.json
-    let event_tx_cell = Arc::new(OnceLock::new());
-    let task_store_cell = Arc::new(OnceLock::new());
     let a2a_server = A2aServer::new(a2a::AuraMessageHandler::new(
         app_state.clone(),
         event_tx_cell.clone(),
         task_store_cell.clone(),
     ))
-    .auth_extractor(|headers: &HeaderMap| {
-        // pulling all the headers so they can be incorporated into the
-        // rig build for calling other tools
-        let header_map: serde_json::Map<String, serde_json::Value> = headers
-            .iter()
-            .filter_map(|(k, v)| {
-                v.to_str()
-                    .ok()
-                    .map(|val| (k.to_string(), serde_json::Value::String(val.to_string())))
-            })
-            .collect();
-
-        let user_id = env::var("A2A_HEADER_USER_ID")
-            .ok()
-            .as_ref()
-            .and_then(|h| headers.get(h))
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("")
-            .to_string();
-
-        let access_token = env::var("A2A_HEADER_AUTHORIZATION")
-            .ok()
-            .as_ref()
-            .and_then(|h| headers.get(h))
-            .and_then(|v| v.to_str().ok())
-            .map(|s| {
-                if let Some(prefix) = env::var("A2A_HEADER_AUTHORIZATION_STRIP_PREFIX")
-                    .ok()
-                    .as_deref()
-                {
-                    s.strip_prefix(prefix).unwrap_or(s).to_string()
-                } else {
-                    s.to_string()
-                }
-            })
-            .unwrap_or_default();
-
-        Some(AuthContext {
-            user_id,
-            access_token,
-            metadata: Some(serde_json::Value::Object(header_map)),
-        })
-    })
+    .auth_extractor(a2a::extract_auth_context)
     .rpc_path("/a2a/v1/rpc")
     .rest_prefix(Some("/a2a/v1"));
 
@@ -290,10 +252,23 @@ async fn run() -> std::io::Result<()> {
     // Our routes take priority. Unmatched requests fall through to a2a_router.
     // This avoids a duplicate-route conflict on /health: ours is served first,
     // and the a2a-rs-server's /health is never reached.
+    //
+    // The `/a2a/v1/message:stream` and `/a2a/v1/tasks/{id}:subscribe` routes are local
+    // overrides for buggy upstream handlers — see `a2a/overrides.rs` for the race they fix.
+    // They MUST be registered before `fallback_service(a2a_router)` so axum matches them
+    // before delegating to the upstream router.
     let aura_router = Router::new()
         .route("/health", get(handlers::health))
         .route("/v1/models", get(handlers::list_models))
         .route("/v1/chat/completions", post(handlers::chat_completions))
+        .route(
+            "/a2a/v1/message:stream",
+            post(a2a::overrides::send_streaming_message),
+        )
+        .route(
+            "/a2a/v1/tasks/{id}:subscribe",
+            get(a2a::overrides::subscribe_to_task),
+        )
         .layer(TraceLayer::new_for_http())
         .layer(middleware::from_fn_with_state(
             app_state.clone(),

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -1,8 +1,12 @@
+use a2a_rs_core::StreamResponse;
+use a2a_rs_server::TaskStore;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::Notify;
+use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
 use crate::streaming::ToolResultMode;
@@ -69,6 +73,15 @@ pub struct AppState {
     pub active_requests: Arc<ActiveRequestTracker>,
     /// Default agent name or alias, used when `model` is omitted from the request
     pub default_agent: Option<String>,
+    /// Broadcast channel sender for A2A streaming events.
+    ///
+    /// Populated lazily after the `A2aServer` is constructed (the channel lives inside the
+    /// server). The local A2A override handlers (`a2a/overrides.rs`) read this cell to subscribe
+    /// *before* invoking the handler — that ordering is what avoids the upstream race where
+    /// terminal events emitted between snapshot read and subscribe were silently dropped.
+    pub a2a_event_tx: Arc<OnceLock<broadcast::Sender<StreamResponse>>>,
+    /// Shared A2A task store (cloned out of the `A2aServer` after construction).
+    pub a2a_task_store: Arc<OnceLock<TaskStore>>,
 }
 
 /// OpenAI-compatible message role

--- a/crates/aura-web-server/tests/a2a_streaming_test.rs
+++ b/crates/aura-web-server/tests/a2a_streaming_test.rs
@@ -1,0 +1,249 @@
+#![cfg(feature = "integration-a2a")]
+
+//! Integration tests for the local A2A streaming overrides in `a2a/overrides.rs`.
+//!
+//! ## What these tests can and can't prove
+//!
+//! The bug is a microsecond-scale race between snapshot and `subscribe()` in the upstream
+//! REST handlers. An over-the-network integration test can't deterministically force the
+//! worker to emit the terminal event *inside* that window — even with a 0-duration tool,
+//! the LLM round-trip dominates and the race window is comfortably empty. So the asserts
+//! here verify that the override path:
+//!
+//! 1. **Functions end-to-end** — the route is wired, SSE events flow, the initial `task`
+//!    arrives first, a terminal `statusUpdate` arrives before timeout.
+//! 2. **Probabilistically catches the race** when it does occur — both tests use the
+//!    shortest reasonable task duration and `:subscribe` runs an inner loop of N attempts
+//!    to raise the chance of landing inside the race window across CI runs. A run that
+//!    hangs without the fix would be observable as a timeout failure.
+//!
+//! For a deterministic test of the *fix mechanics* (subscribe-before-snapshot, post-lag
+//! terminal break), see the unit tests in `src/a2a/overrides.rs::tests` — those drive a
+//! `broadcast::channel` and `TaskStore` directly and don't depend on timing.
+//!
+//! Requires a running aura-web-server with the test config (`slow_task` MCP tool).
+
+use aura_test_utils::server_urls::AURA_SERVER;
+use eventsource_stream::Eventsource;
+use futures_util::StreamExt;
+use serde_json::{Value, json};
+use std::time::Duration;
+use tokio::time::timeout;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const STREAM_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// `:stream` happy path.
+///
+/// `duration_seconds=0` makes the tool return as fast as possible so the worker
+/// terminates promptly. We don't expect the race to manifest in CI under network latency,
+/// but if it ever does, this test will hang past `STREAM_TIMEOUT` and fail loudly.
+#[tokio::test]
+async fn test_a2a_stream_happy_path() {
+    let message_id = uuid::Uuid::new_v4().to_string();
+    let request_text = format!(
+        "Call the slow_task tool immediately with message_id='{}' and duration_seconds=0. \
+         Do not say anything else, just call the tool.",
+        message_id
+    );
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("{}/a2a/v1/message:stream", AURA_SERVER))
+        .header("Content-Type", "application/json")
+        .header("Accept", "text/event-stream")
+        .header("A2A-Version", "1.0")
+        .json(&json!({
+            "message": {
+                "messageId": message_id,
+                "role": "ROLE_USER",
+                "parts": [{ "text": request_text }],
+            }
+        }))
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .expect("network failure - is aura-web-server running?");
+
+    assert_eq!(
+        response.status(),
+        200,
+        ":stream should return 200 OK; got body: {:?}",
+        response.text().await.ok()
+    );
+
+    let events = collect_until_terminal(response).await;
+    assert_terminal(&events, ":stream");
+}
+
+/// `:subscribe` mid-task across `ATTEMPTS` iterations.
+///
+/// Each iteration: POST `:send` to start a near-instant task, then immediately GET
+/// `:subscribe`. The shorter the task, the higher the chance the worker's terminal event
+/// fires inside the upstream snapshot-then-subscribe window. Running the loop bumps the
+/// cumulative probability of hitting the race in a single CI invocation. If any iteration
+/// hangs we'll exceed `STREAM_TIMEOUT` and the test fails.
+///
+/// We don't assert that the race *does* occur — we assert that the stream survives it
+/// (terminal `statusUpdate` arrives) every iteration.
+#[tokio::test]
+async fn test_a2a_subscribe_mid_task_receives_terminal() {
+    const ATTEMPTS: usize = 5;
+
+    for attempt in 0..ATTEMPTS {
+        let message_id = uuid::Uuid::new_v4().to_string();
+        let request_text = format!(
+            "Call the slow_task tool immediately with message_id='{}' and duration_seconds=0. \
+             Do not say anything else, just call the tool.",
+            message_id
+        );
+
+        let client = reqwest::Client::new();
+        let send_response = client
+            .post(format!("{}/a2a/v1/message:send", AURA_SERVER))
+            .header("Content-Type", "application/json")
+            .header("A2A-Version", "1.0")
+            .json(&json!({
+                "message": {
+                    "messageId": message_id,
+                    "role": "ROLE_USER",
+                    "parts": [{ "text": request_text }],
+                }
+            }))
+            .timeout(REQUEST_TIMEOUT)
+            .send()
+            .await
+            .expect("network failure - is aura-web-server running?");
+
+        assert_eq!(send_response.status(), 200);
+        let send_body: Value = send_response
+            .json()
+            .await
+            .expect(":send response was not JSON");
+        let task_id = send_body
+            .get("task")
+            .and_then(|t| t.get("id"))
+            .and_then(|v| v.as_str())
+            .expect(":send response missing task.id")
+            .to_string();
+
+        // Subscribe with no delay — this is the moment the upstream race can drop the
+        // terminal event between snapshot and subscribe. The override subscribes first,
+        // so any event from this point on (including ones already buffered) is delivered.
+        let subscribe_response = client
+            .get(format!(
+                "{}/a2a/v1/tasks/{}:subscribe",
+                AURA_SERVER, task_id
+            ))
+            .header("Accept", "text/event-stream")
+            .header("A2A-Version", "1.0")
+            .send()
+            .await
+            .expect("network failure subscribing to task");
+
+        // The task may have already terminated before we got here. In that case upstream
+        // (and the override) return 400 "cannot subscribe to terminal state" — that's a
+        // valid outcome that proves the fix works (no hang), so we skip to the next
+        // attempt rather than failing.
+        if subscribe_response.status() == 400 {
+            continue;
+        }
+        assert_eq!(
+            subscribe_response.status(),
+            200,
+            "attempt {attempt}: :subscribe should return 200 or 400; got body: {:?}",
+            subscribe_response.text().await.ok()
+        );
+
+        let events = collect_until_terminal(subscribe_response).await;
+        assert_terminal(&events, &format!(":subscribe attempt {attempt}"));
+    }
+}
+
+fn assert_terminal(events: &[(String, Value)], context: &str) {
+    let kinds: Vec<&str> = events.iter().map(|(k, _)| k.as_str()).collect();
+
+    assert_eq!(
+        kinds.first().copied(),
+        Some("task"),
+        "{context}: must emit the initial `task` event first; got {:?}",
+        kinds
+    );
+
+    let terminal = events.iter().rev().find(|(k, _)| k == "statusUpdate");
+    assert!(
+        terminal.is_some(),
+        "{context}: did not deliver a terminal `statusUpdate` before timeout — this is \
+         exactly the symptom of the upstream race the override fixes. Events seen: {:?}",
+        kinds
+    );
+
+    let state = terminal
+        .and_then(|(_, v)| v.get("statusUpdate"))
+        .and_then(|v| v.get("status"))
+        .and_then(|v| v.get("state"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    assert!(
+        is_terminal_state(state),
+        "{context}: final status state should be terminal; got {state:?}"
+    );
+}
+
+/// Drain the SSE response, returning `(variant_tag, full_event_json)` for each
+/// `StreamingMessageResult` event, stopping after the first terminal status update or when
+/// `STREAM_TIMEOUT` elapses.
+async fn collect_until_terminal(response: reqwest::Response) -> Vec<(String, Value)> {
+    use std::sync::{Arc, Mutex};
+    let out: Arc<Mutex<Vec<(String, Value)>>> = Arc::new(Mutex::new(Vec::new()));
+    let mut stream = response.bytes_stream().eventsource();
+    let drain_out = out.clone();
+    let drain = async move {
+        while let Some(event) = stream.next().await {
+            let Ok(event) = event else { break };
+            if event.data.is_empty() {
+                continue;
+            }
+            let Ok(value) = serde_json::from_str::<Value>(&event.data) else {
+                continue;
+            };
+            // StreamingMessageResult is externally tagged camelCase: `{"task": {...}}` etc.
+            let Some(tag) = value.as_object().and_then(|o| o.keys().next().cloned()) else {
+                continue;
+            };
+
+            let is_terminal = tag == "statusUpdate"
+                && value
+                    .get("statusUpdate")
+                    .and_then(|s| s.get("status"))
+                    .and_then(|s| s.get("state"))
+                    .and_then(|s| s.as_str())
+                    .map(is_terminal_state)
+                    .unwrap_or(false);
+
+            drain_out.lock().unwrap().push((tag, value));
+
+            if is_terminal {
+                break;
+            }
+        }
+    };
+
+    let _ = timeout(STREAM_TIMEOUT, drain).await;
+    let guard = out.lock().unwrap();
+    guard.clone()
+}
+
+fn is_terminal_state(state: &str) -> bool {
+    matches!(
+        state,
+        "TASK_STATE_COMPLETED"
+            | "TASK_STATE_FAILED"
+            | "TASK_STATE_CANCELED"
+            | "TASK_STATE_REJECTED"
+            | "completed"
+            | "failed"
+            | "canceled"
+            | "rejected"
+    )
+}

--- a/crates/aura-web-server/tests/a2a_test.rs
+++ b/crates/aura-web-server/tests/a2a_test.rs
@@ -428,7 +428,10 @@ async fn test_list_task_get_details() {
         .expect("Failed to read response");
     let response_body: Value = serde_json::from_str(&body).expect("Response was not valid JSON");
 
-    println!("Tool invocation (/a2a/v1/message:send) response body: {}", body);
+    println!(
+        "Tool invocation (/a2a/v1/message:send) response body: {}",
+        body
+    );
 
     let task = response_body
         .get("task")
@@ -568,11 +571,7 @@ async fn test_list_task_get_details() {
     let state = status
         .get("state")
         .expect("Status did not contain 'state' field");
-    assert_eq!(
-        state.is_string(),
-        true,
-        "Task state should be TASK_STATE_WORKING"
-    );
+    assert!(state.is_string(), "Task state should be TASK_STATE_WORKING");
 
     let timestamp = status
         .get("timestamp")

--- a/docs/a2a-implementation.md
+++ b/docs/a2a-implementation.md
@@ -10,9 +10,11 @@ This module wires the [A2A RC 1.0](https://github.com/a2a-protocol) protocol int
 | `GET` | `/.well-known/agent.json` | — | Agent card (v0.2 fallback alias) |
 | `GET` | `/health` | — | Health check |
 | `POST` | `/a2a/v1/message:send` | REST (HTTP+JSON) | Send a message, receive a task |
+| `POST` | `/a2a/v1/message:stream` | REST SSE | Send a message, stream task updates as SSE (see [Streaming semantics](#streaming-semantics)) |
 | `GET` | `/a2a/v1/tasks` | REST | List tasks |
 | `GET` | `/a2a/v1/tasks/{id}` | REST | Get a task by ID |
 | `POST` | `/a2a/v1/tasks/{id}:cancel` | REST | Cancel a task |
+| `GET` | `/a2a/v1/tasks/{id}:subscribe` | REST SSE | Subscribe to updates for an in-flight task (see [Streaming semantics](#streaming-semantics)) |
 | `POST` | `/a2a/v1/rpc` | JSON-RPC 2.0 | All of the above via JSON-RPC envelope |
 
 The `A2A-Version` header is **optional**. When present on a JSON-RPC request to `/a2a/v1/rpc`, the version is validated and an unsupported value returns `-32009 Version not supported`. REST endpoints do not enforce the header.
@@ -135,9 +137,81 @@ curl -s -X POST http://localhost:8080/a2a/v1/rpc \
 - Tasks are stored in the `a2a-rs-server` in-memory `TaskStore` for the lifetime of the process. Use `GET /a2a/v1/tasks/{id}` or `GetTask` to poll after `message:send` returns.
 - The agent card is served at both `/.well-known/agent-card.json` (RC 1.0) and `/.well-known/agent.json` (v0.2 fallback) for interoperability.
 
+## Streaming semantics
+
+REST streaming (`message:stream`, `tasks/{id}:subscribe`) is served by local handlers in
+`aura-web-server/src/a2a/overrides.rs`, **not** by the upstream `a2a-rs-server` 1.0.26 REST
+router. The overrides exist to fix a race condition in the upstream crate.
+
+### The race in upstream 1.0.26
+
+Upstream `rest_send_streaming_message` (`a2a-rs-server-1.0.26/src/rest.rs:397`) and
+`rest_subscribe_to_task` (line 613) both follow this ordering:
+
+```text
+task = handle_message(...);                 // worker spawns and may broadcast immediately
+task_store.insert(task);
+rx = state.subscribe_events();              // <-- TOO LATE
+broadcast(StreamResponse::Task(task));
+yield initial Task(task);
+loop { rx.recv() ... }
+```
+
+Any event the handler emits before `subscribe_events()` is broadcast on a channel with no
+subscribers — `tokio::sync::broadcast` drops those. The event is still persisted to the task
+store, but it never reaches the SSE consumer.
+
+For `AuraMessageHandler` (`a2a/handler.rs`), which `tokio::spawn`s a worker and returns
+immediately, the race window is unbounded. The worker can complete and emit
+`StatusUpdate(Completed)` before the upstream code reaches `subscribe_events()`; the client
+then loops on `rx.recv()` forever waiting for a terminal event that already happened.
+
+### What the overrides change
+
+Both override handlers subscribe to the broadcast channel **first**, then read the snapshot
+or invoke the handler:
+
+```text
+rx = event_tx.subscribe();                  // FIRST
+task = handle_message(...);                 // (or get_flexible(id) for :subscribe)
+yield initial Task(task);
+loop { rx.recv() ... }
+```
+
+This collapses the race window to "may yield one duplicate event" — every A2A client de-dupes
+on `task_id` / `artifact_id`, so duplicates are harmless. Lagged receivers (the broadcast
+buffer overflowed) are surfaced as a `statusUpdate` event with a `lagged_events` metadata
+counter; the upstream code silently swallows `Lagged`. If the post-lag task-store snapshot
+shows a terminal state — i.e. the dropped events almost certainly included the terminal
+`StatusUpdate` — the loop breaks rather than waiting forever on a channel that will never
+deliver another event for this task.
+
+The `StreamResponse::Message` matching path uses the `context_id` cached from the initial
+task snapshot, not a non-blocking task-store fetch as upstream does. The upstream
+`task_store.get(target).now_or_never()` returns `None` under any lock contention and silently
+drops the Message; comparing against a cached string is race-free.
+
+### JSON-RPC streaming — known limitation
+
+The JSON-RPC methods `message/stream` and `tasks/resubscribe`
+(`a2a-rs-server-1.0.26/src/server.rs:1052` and `:1376`) have the **same** race condition
+upstream. They are **not** overridden here because the upstream JSON-RPC entry point is a
+single handler that dispatches by `method` internally — intercepting it cleanly would mean
+re-implementing every JSON-RPC method, which is too much surface area for a stopgap.
+
+Until upstream ships a fix, clients that need reliable streaming should prefer the REST
+endpoints (`:stream`, `:subscribe`). JSON-RPC streaming is best-effort and may hang on
+short-lived tasks that complete during the subscribe window.
+
+Upstream fix in flight: [tolgaki/a2a-rs#6](https://github.com/tolgaki/a2a-rs/pull/6) covers
+all four endpoints (both REST and JSON-RPC) with the same `subscribe`-then-snapshot reorder.
+When that merges and ships in a crates.io release, the local overrides in this directory can
+be deleted and this caveat removed.
+
 ## Module layout
 
 | File | Purpose |
 |------|---------|
-| `aura-web-server/src/a2a/mod.rs` | Module root |
+| `aura-web-server/src/a2a/mod.rs` | Module root; also defines `extract_auth_context`, the shared header-to-`AuthContext` mapping used by both the upstream `A2aServer` and the local override handlers |
 | `aura-web-server/src/a2a/handler.rs` | `AuraMessageHandler` — implements the `MessageHandler` trait, bridges A2A messages to the Aura agent execution pipeline |
+| `aura-web-server/src/a2a/overrides.rs` | Local REST SSE handlers for `:stream` and `:subscribe` that fix the upstream race (see [Streaming semantics](#streaming-semantics)) |


### PR DESCRIPTION
Proposing a local override for the two REST streaming endpoints in a2a-rs-server 1.0.26. Not prescriptive - happy to iterate on shape, naming, or wait on an upstream fix if you'd rather.

The bug
-------
rest_send_streaming_message (rest.rs:397) and
rest_subscribe_to_task (rest.rs:613) snapshot the task before subscribing to the broadcast channel:

    task = task_store.get_flexible(id).await;
    rx   = event_tx.subscribe();

Any event broadcast in that window goes to a channel with zero subscribers - tokio drops it. The event still lands in the task store, but the SSE consumer never sees it.

For synchronous handlers this is mostly invisible. Our AuraMessageHandler tokio::spawns a worker and returns immediately (handler.rs:148), so the worker can emit StatusUpdate(Completed) before the upstream subscribe call. The client then loops on rx.recv() forever waiting for a terminal event that already happened.

The fix
-------
`crates/aura-web-server/src/a2a/overrides.r`s adds two handlers that subscribe first, then snapshot / invoke the handler:

    rx = event_tx.subscribe();
    task = handle_message(...);
    yield initial Task(task);
    loop { rx.recv() ... }

Race window collapses to "may yield one duplicate Task event". A2A clients dedupe by task_id / artifact_id so it's harmless.

Supporting changes
------------------
- `AppState` exposes shared event_tx + task_store OnceLock cells so the override handlers see the same channel as the handler.
- `extract_auth_context()` is pulled out of the A2aServer builder closure into a2a/mod.rs and shared with the overrides.
- **Lagged** is surfaced as a synthetic statusUpdate carrying a lagged_events counter (upstream silently swallows it). If the post-lag store snapshot shows terminal state the loop breaks, otherwise the dropped events could have included the terminal and the loop would hang on the now-empty channel.
- **Message** event matching uses the cached `context_id` from the initial snapshot, not the upstream non-blocking store fetch (which silently drops events under lock contention).

Out of scope
------------
JSON-RPC streaming (message/stream, tasks/resubscribe at server.rs:1052 and :1376) has the same race upstream but isn't overridden here
- Overriding her would mean re-implementing the whole JSON-RPC dispatcher.
- Documented as a known limitation in docs/a2a-implementation.md.
- Tackling this locally would be a much larger refactor. This PR solves the REST streaming issue and adds tests to prevent regressions, but doesn't attempt to fix the JSON-RPC streaming race.
- Upstream fix in flight: [tolgaki/a2a-rs#6](https://github.com/tolgaki/a2a-rs/pull/6) covers all four endpoints (both REST and JSON-RPC) with the same `subscribe`-then-snapshot reorder.
  - When/if this merges and ships in a crates.io release, the local overrides in this directory can be deleted and this caveat removed.

Tests
-----
- 5 deterministic unit tests in `a2a::overrides::tests` cover the fix mechanics (event matching, lagged handling) without any network or timing dependence.
- 2 integration tests under integration-a2a exercise end-to-end SSE flow against a running server. They can't deterministically force the race window (microseconds over the network), but they verify the override path works and would hang loudly on a regression.

Verification
------------
- cargo build --release -p aura-web-server
- cargo clippy -p aura-web-server --tests --features integration-a2a -- -D warnings
- cargo fmt --check
- cargo test --bin aura-web-server  (46/46 pass)