### PR TITLE
chore(aura-cli): update the messaging when user interupts AURA

### DIFF
--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -1688,12 +1688,12 @@ pub fn run_repl(
                         "●"
                             .with(random_bullet_color())
                             .attribute(crossterm::style::Attribute::Bold),
-                        "Canceled request".attribute(crossterm::style::Attribute::Bold),
+                        "Interrupted (user requested)".attribute(crossterm::style::Attribute::Bold),
                     );
                     println!(
                         "{} {}",
                         "└─".themed(AuraStyle::Connector),
-                        "User requested.".themed(AuraStyle::Muted),
+                        "what should AURA do next?".themed(AuraStyle::Muted),
                     );
                     println!();
                     push_display_event(DisplayEvent::Cancelled);

--- a/crates/aura-cli/src/ui/event_replay.rs
+++ b/crates/aura-cli/src/ui/event_replay.rs
@@ -158,12 +158,12 @@ pub fn replay_event_log_global() {
                 println!(
                     "{} {}",
                     "●".with(random_bullet_color()).attribute(Attribute::Bold),
-                    "Canceled request".attribute(Attribute::Bold),
+                    "Interrupted (user requested)".attribute(Attribute::Bold),
                 );
                 println!(
                     "{} {}",
                     "└─".themed(AuraStyle::Connector),
-                    "User requested.".themed(AuraStyle::Muted),
+                    "what should AURA do next?".themed(AuraStyle::Muted),
                 );
                 println!();
                 i += 1;


### PR DESCRIPTION
The current message could be more helpful and "nudge" the user into what to do next.

**Current output:**

● Canceled request
└─ User requested.

**Updated output:**

● Interrupted (user requested)
└─ what should AURA do next?

This feels like a better experience.