### PR TITLE
Add legacy SSE MCP transport support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aura"
-version = "1.20.8"
+version = "1.21.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -171,6 +171,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "futures",
+ "http 1.4.0",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -194,12 +195,13 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 
 [[package]]
 name = "aura-cli"
-version = "1.20.8"
+version = "1.21.0"
 dependencies = [
  "anyhow",
  "aura",
@@ -233,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "aura-config"
-version = "1.20.8"
+version = "1.21.0"
 dependencies = [
  "anyhow",
  "aura",
@@ -257,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "aura-events"
-version = "1.20.8"
+version = "1.21.0"
 dependencies = [
  "rmcp",
  "serde",
@@ -266,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aura-test-utils"
-version = "1.20.8"
+version = "1.21.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -276,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "aura-web-server"
-version = "1.20.8"
+version = "1.21.0"
 dependencies = [
  "async-stream",
  "aura",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ base64 = "0.22.1"
 async-stream = "0.3.6"
 schemars = "1.0.4"
 reqwest = { version = "0.12", features = ["json", "stream"] }
+http = "1.0"
 
 # Patch rig-core to use the fork with streaming hook + span propagation fix
 [patch.crates-io]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Aura is an agentic harness that turns an LLM model into a reliable, autonomous s
 Key capabilities:
 
 - Declarative agent composition via TOML with multi-provider LLM support and multi-agent serving
-- Dynamic [MCP](https://modelcontextprotocol.io) tool discovery via HTTP Streamable transport
+- Dynamic [MCP](https://modelcontextprotocol.io) tool discovery via HTTP streamable and SSE transports
 - Automatic schema sanitization for OpenAI function-calling compatibility
 - Vector search integration with Qdrant and AWS Bedrock Knowledge Base
 - Embeddable Rust core independent from configuration layer
@@ -300,9 +300,10 @@ Configuration sections:
 
 Supported providers: OpenAI, Anthropic, Bedrock, Gemini, and Ollama.
 
-Supported MCP transport:
+Supported MCP transports:
 
-- `http_streamable`
+- `http_streamable` (recommended for production)
+- `sse`
 
 `headers_from_request` can forward incoming request headers to MCP servers for per-request auth.
 

--- a/crates/aura-cli/src/tools/rig_tools.rs
+++ b/crates/aura-cli/src/tools/rig_tools.rs
@@ -27,7 +27,7 @@ pub enum CliToolError {
 /// A single CLI tool adapted to rig's `Tool` trait.
 ///
 /// Uses dynamic dispatch via `name()` override (same pattern as
-/// `HttpMcpToolAdaptor` and `DynamicVectorSearchTool` in the aura crate).
+/// `McpToolAdaptor` and `DynamicVectorSearchTool` in the aura crate).
 pub struct CliToolAdaptor {
     tool_name: String,
     description: String,

--- a/crates/aura-config/src/builder.rs
+++ b/crates/aura-config/src/builder.rs
@@ -125,6 +125,19 @@ impl RigBuilder {
                             headers_from_request: headers_from_request.clone(),
                             scratchpad: scratchpad.clone(),
                         },
+                        crate::config::McpServerConfig::Sse {
+                            url,
+                            headers,
+                            description,
+                            headers_from_request,
+                            scratchpad,
+                        } => McpServerConfig::Sse {
+                            url: url.clone(),
+                            headers: headers.clone(),
+                            description: description.clone(),
+                            headers_from_request: headers_from_request.clone(),
+                            scratchpad: scratchpad.clone(),
+                        },
                     };
                     (name.clone(), converted_server)
                 })
@@ -282,17 +295,24 @@ fn resolve_mcp_headers(
     };
 
     for (server_name, server_config) in mcp_config.servers.iter_mut() {
-        let McpServerConfig::HttpStreamable {
-            headers: server_headers,
-            headers_from_request,
-            ..
-        } = server_config
-        else {
-            tracing::debug!(
-                "Server '{}': STDIO transport, skipping header injection",
-                server_name
-            );
-            continue;
+        let (server_headers, headers_from_request) = match server_config {
+            McpServerConfig::HttpStreamable {
+                headers,
+                headers_from_request,
+                ..
+            } => (headers, headers_from_request),
+            McpServerConfig::Sse {
+                headers,
+                headers_from_request,
+                ..
+            } => (headers, headers_from_request),
+            McpServerConfig::Stdio { .. } => {
+                tracing::debug!(
+                    "Server '{}': STDIO transport, skipping header injection",
+                    server_name
+                );
+                continue;
+            }
         };
 
         // Resolve headers_from_request mappings using the incoming request headers.

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -366,6 +366,19 @@ pub enum McpServerConfig {
         #[serde(default)]
         scratchpad: HashMap<String, ScratchpadToolEntry>,
     },
+    #[serde(rename = "sse")]
+    Sse {
+        url: String,
+        #[serde(default)]
+        headers: HashMap<String, String>,
+        #[serde(default)]
+        description: Option<String>,
+        #[serde(default)]
+        headers_from_request: HashMap<String, String>,
+        /// Per-tool scratchpad interception thresholds (glob-matched on tool name).
+        #[serde(default)]
+        scratchpad: HashMap<String, ScratchpadToolEntry>,
+    },
 }
 
 /// Vector store configuration (in-memory, Qdrant, and Bedrock KB)

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -1607,6 +1607,7 @@ url = "http://localhost:8000/mcp"
         let server = mcp.servers.get("example").expect("server present");
         let thresholds = match server {
             McpServerConfig::HttpStreamable { scratchpad, .. }
+            | McpServerConfig::Sse { scratchpad, .. }
             | McpServerConfig::Stdio { scratchpad, .. } => scratchpad,
         };
         assert_eq!(thresholds.get("*_list_*").unwrap().min_tokens, 512);

--- a/crates/aura-web-server/tests/mcp_progress_test.rs
+++ b/crates/aura-web-server/tests/mcp_progress_test.rs
@@ -3,7 +3,7 @@
 //! Integration tests for MCP progress notification forwarding.
 //!
 
-use aura::mcp_streamable_http::StreamableHttpMcpClient;
+use aura::mcp_streamable_http::McpClient;
 use aura::{request_progress_global, request_progress_subscribe, request_progress_unsubscribe};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -12,11 +12,7 @@ use tokio::time::timeout;
 #[tokio::test]
 async fn test_mcp_progress_notifications_received() {
     // Skip if mock server not running
-    let client = match StreamableHttpMcpClient::new(
-        "http://127.0.0.1:9999/mcp".to_string(),
-        &HashMap::new(),
-    )
-    .await
+    let client = match McpClient::new("http://127.0.0.1:9999/mcp".to_owned(), &HashMap::new()).await
     {
         Ok(c) => c,
         Err(_) => {
@@ -111,11 +107,7 @@ async fn test_mcp_progress_notifications_received() {
 #[tokio::test]
 async fn test_call_tool_without_progress_still_works() {
     // Skip if mock server not running
-    let client = match StreamableHttpMcpClient::new(
-        "http://127.0.0.1:9999/mcp".to_string(),
-        &HashMap::new(),
-    )
-    .await
+    let client = match McpClient::new("http://127.0.0.1:9999/mcp".to_owned(), &HashMap::new()).await
     {
         Ok(c) => c,
         Err(_) => {

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -19,6 +19,8 @@ base64 = "0.22"
 futures = "0.3"
 sse-stream = "0.2"
 reqwest = { version = "0.12", features = ["stream", "json"] }
+http = { workspace = true }
+url = "2"
 
 # Shared event types (lightweight, no agent/MCP deps)
 aura-events = { path = "../aura-events", features = ["rmcp-types"] }

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -733,13 +733,45 @@ impl Agent {
                     for mcp_tool in filtered_tools {
                         tracing::info!("  Adding dynamic HTTP tool: {}", mcp_tool.name);
 
-                        let tool_adaptor = crate::mcp_dynamic::HttpMcpToolAdaptor::new(
+                        let tool_adaptor = crate::mcp_dynamic::McpToolAdaptor::new(
                             mcp_tool.clone(),
                             server_name.clone(),
                             client_arc.clone(),
                         );
 
                         // Wrap with tool_wrapper if configured
+                        builder_state = Self::add_mcp_tool(builder_state, tool_adaptor, config);
+                    }
+                }
+            }
+        }
+
+        // Add SSE tools using dynamic adaptors
+        if let Some(mcp_manager) = mcp_manager.as_deref() {
+            for (server_name, client) in &mcp_manager.sse_clients {
+                if let Some(server_tools) = mcp_manager.sse_tools.get(server_name) {
+                    let filtered_tools: Vec<_> = server_tools
+                        .iter()
+                        .filter(|t| config.tool_matches_filter(&t.name))
+                        .collect();
+                    log_filtered_tools(
+                        "",
+                        "SSE",
+                        server_name,
+                        filtered_tools.len(),
+                        server_tools.len(),
+                    );
+
+                    let client_arc = Arc::new(client.clone());
+                    for mcp_tool in filtered_tools {
+                        tracing::info!("  Adding dynamic SSE tool: {}", mcp_tool.name);
+
+                        let tool_adaptor = crate::mcp_dynamic::McpToolAdaptor::new(
+                            mcp_tool.clone(),
+                            server_name.clone(),
+                            client_arc.clone(),
+                        );
+
                         builder_state = Self::add_mcp_tool(builder_state, tool_adaptor, config);
                     }
                 }
@@ -1527,6 +1559,24 @@ impl AgentBuilder {
                         ..
                     } => {
                         tracing::info!("MCP Server '{}' (HTTP Streamable):", name);
+                        tracing::info!("  URL: {}", url);
+                        tracing::info!("  Headers: {} defined", headers.len());
+                        if let Some(desc) = description {
+                            tracing::info!("  Description: {}", desc);
+                        }
+                        tracing::info!(
+                            "  Headers from requests: {} to forward",
+                            headers_from_request.len()
+                        );
+                    }
+                    McpServerConfig::Sse {
+                        url,
+                        headers,
+                        description,
+                        headers_from_request,
+                        ..
+                    } => {
+                        tracing::info!("MCP Server '{}' (SSE):", name);
                         tracing::info!("  URL: {}", url);
                         tracing::info!("  Headers: {} defined", headers.len());
                         if let Some(desc) = description {

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -58,7 +58,7 @@ pub struct AgentConfig {
     // These allow callers to customize agent building without modifying the builder.
     // The orchestrator uses these to inject tool wrappers and override preambles.
     /// Optional tool wrapper applied to all MCP tools (not serialized).
-    /// When set, all HTTP/SSE MCP tools are wrapped with this wrapper.
+    /// When set, all MCP tools are wrapped with this wrapper.
     #[serde(skip)]
     pub tool_wrapper: Option<Arc<dyn ToolWrapper + Send + Sync>>,
 
@@ -536,10 +536,28 @@ pub enum McpServerConfig {
     #[serde(rename = "http_streamable")]
     HttpStreamable {
         url: String,
+        #[serde(default)]
         headers: HashMap<String, String>,
+        #[serde(default)]
         description: Option<String>,
+        #[serde(default)]
         headers_from_request: HashMap<String, String>,
         /// Per-tool scratchpad interception thresholds, keyed by tool-name glob.
+        /// Parsed from `[mcp.servers.<name>.scratchpad]`.
+        #[serde(default)]
+        scratchpad: HashMap<String, ScratchpadToolEntry>,
+    },
+    #[serde(rename = "sse")]
+    Sse {
+        url: String,
+        #[serde(default)]
+        headers: HashMap<String, String>,
+        #[serde(default)]
+        description: Option<String>,
+        #[serde(default)]
+        headers_from_request: HashMap<String, String>,
+        /// Per-tool scratchpad interception thresholds, keyed by tool-name glob.
+        /// Parsed from `[mcp.servers.<name>.scratchpad]`.
         #[serde(default)]
         scratchpad: HashMap<String, ScratchpadToolEntry>,
     },
@@ -551,6 +569,7 @@ impl McpServerConfig {
         match self {
             McpServerConfig::Stdio { scratchpad, .. } => scratchpad,
             McpServerConfig::HttpStreamable { scratchpad, .. } => scratchpad,
+            McpServerConfig::Sse { scratchpad, .. } => scratchpad,
         }
     }
 }

--- a/crates/aura/src/error.rs
+++ b/crates/aura/src/error.rs
@@ -1,6 +1,27 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+pub enum SseTransportError {
+    #[error("SSE stream error: {0}")]
+    SseStream(#[from] sse_stream::Error),
+
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("Missing Content-Type header from SSE endpoint")]
+    MissingContentType,
+
+    #[error("Unexpected Content-Type: expected 'text/event-stream', got '{0}'")]
+    UnexpectedContentType(String),
+
+    #[error("URL parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+
+    #[error("SSE endpoint event not received")]
+    MissingEndpointEvent,
+}
+
+#[derive(Error, Debug)]
 pub enum BuilderError {
     #[error("Invalid provider: {0}")]
     InvalidProvider(String),
@@ -25,6 +46,9 @@ pub enum BuilderError {
 
     #[error("RMCP error: {0}")]
     RmcpError(#[from] rmcp::ErrorData),
+
+    #[error("SSE transport error: {0}")]
+    SseTransport(#[from] SseTransportError),
 
     #[error("Other error: {0}")]
     Other(String),

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -18,6 +18,7 @@ pub mod mcp;
 pub mod mcp_dynamic;
 pub mod mcp_progress;
 pub mod mcp_response;
+pub mod mcp_sse;
 pub mod mcp_streamable_http;
 pub mod mcp_tool_execution;
 #[cfg(feature = "otel")]

--- a/crates/aura/src/mcp.rs
+++ b/crates/aura/src/mcp.rs
@@ -1,6 +1,4 @@
-use crate::{
-    config::McpServerConfig, error::BuilderError, mcp_streamable_http::StreamableHttpMcpClient,
-};
+use crate::{config::McpServerConfig, error::BuilderError, mcp_streamable_http::McpClient};
 use futures::{StreamExt, stream::BoxStream};
 use rig::tool::rmcp::McpTool;
 use rig::{completion::ToolDefinition, tool::Tool as RigTool};
@@ -237,8 +235,11 @@ pub struct McpManager {
     /// Store raw tool definitions with their associated client for agent integration
     pub tool_definitions: Vec<(Tool, rmcp::service::ServerSink)>,
     /// Store streamable HTTP clients for http_streamable transport
-    pub streamable_clients: HashMap<String, StreamableHttpMcpClient>,
+    pub streamable_clients: HashMap<String, McpClient>,
     pub streamable_tools: HashMap<String, Vec<rmcp::model::Tool>>,
+    /// Store SSE clients for sse transport
+    pub sse_clients: HashMap<String, McpClient>,
+    pub sse_tools: HashMap<String, Vec<rmcp::model::Tool>>,
     /// Whether to sanitize tool schemas for OpenAI compatibility
     pub sanitize_schemas: bool,
 }
@@ -270,6 +271,8 @@ impl McpManager {
             tool_definitions: Vec::new(),
             streamable_clients: HashMap::new(),
             streamable_tools: HashMap::new(),
+            sse_clients: HashMap::new(),
+            sse_tools: HashMap::new(),
             sanitize_schemas,
         }
     }
@@ -368,6 +371,9 @@ impl McpManager {
                 self.connect_http_streamable(server_name, url, headers)
                     .await
             }
+            McpServerConfig::Sse { url, headers, .. } => {
+                self.connect_sse(server_name, url, headers).await
+            }
             McpServerConfig::Stdio { cmd, args, env, .. } => {
                 self.connect_stdio(server_name, std::slice::from_ref(cmd), args, env)
                     .await
@@ -398,7 +404,7 @@ impl McpManager {
                     || e.to_string().contains("HTTP status client error (401")
                 {
                     Err(BuilderError::McpInitError(format!(
-                        "HTTP MCP server '{server_name}' authentication failed (401 Unauthorized). This is likely because rmcp does not yet support custom headers for authentication. Your Authorization header cannot be sent."
+                        "HTTP MCP server '{server_name}' authentication failed (401 Unauthorized). Check that your forwarded headers and credentials are correct."
                     )))
                 } else {
                     warn!("  HTTP Streamable MCP connection failed: {}", e);
@@ -409,7 +415,7 @@ impl McpManager {
         }
     }
 
-    /// Attempt to connect to HTTP Streamable MCP server using the new StreamableHttpMcpClient
+    /// Attempt to connect to HTTP Streamable MCP server using McpClient
     async fn try_connect_http_streamable(
         &mut self,
         server_name: &str,
@@ -423,8 +429,8 @@ impl McpManager {
             info!("  Forwarding {} headers to MCP client", headers.len());
         }
 
-        // Use our new StreamableHttpMcpClient
-        let client = StreamableHttpMcpClient::new(url.to_string(), headers)
+        // Use McpClient
+        let client = McpClient::new(url.to_string(), headers)
             .await
             .map_err(|e| {
                 BuilderError::McpInitError(format!(
@@ -461,6 +467,79 @@ impl McpManager {
 
         // Store SANITIZED tools (not raw)
         self.streamable_tools
+            .insert(server_name.to_string(), sanitized_tools.clone());
+
+        Ok(sanitized_tools.len())
+    }
+
+    /// Connect to legacy SSE MCP server
+    async fn connect_sse(
+        &mut self,
+        server_name: &str,
+        url: &str,
+        headers: &HashMap<String, String>,
+    ) -> Result<usize, BuilderError> {
+        info!("  Connecting to SSE server at: {}", url);
+
+        match self.try_connect_sse(server_name, url, headers).await {
+            Ok(tools_count) => {
+                info!("  SSE connection successful");
+                Ok(tools_count)
+            }
+            Err(e) => {
+                if e.to_string().contains("401 Unauthorized")
+                    || e.to_string().contains("HTTP status client error (401")
+                {
+                    Err(BuilderError::McpInitError(format!(
+                        "SSE MCP server '{server_name}' authentication failed (401 Unauthorized). Check that your forwarded headers and credentials are correct."
+                    )))
+                } else {
+                    warn!("  SSE MCP connection failed: {}", e);
+                    Ok(0)
+                }
+            }
+        }
+    }
+
+    /// Attempt to connect to SSE MCP server
+    async fn try_connect_sse(
+        &mut self,
+        server_name: &str,
+        url: &str,
+        headers: &HashMap<String, String>,
+    ) -> Result<usize, BuilderError> {
+        debug!("  Creating SSE client for: {}", url);
+
+        let transport = crate::mcp_sse::SseTransport::connect(url, headers)
+            .await
+            .map_err(BuilderError::SseTransport)?;
+
+        let client = McpClient::from_transport(transport, url.to_string())
+            .await
+            .map_err(|e| {
+                BuilderError::McpInitError(format!(
+                    "Failed to establish SSE MCP connection to '{server_name}': {e}"
+                ))
+            })?;
+
+        info!("  SSE connection established, discovering tools");
+
+        let tools = client.discover_tools().await.map_err(|e| {
+            BuilderError::McpInitError(format!(
+                "Failed to discover tools from SSE server '{server_name}': {e}"
+            ))
+        })?;
+
+        info!(
+            "  Discovered {} tools from SSE server '{}'",
+            tools.len(),
+            server_name
+        );
+
+        let sanitized_tools = Self::sanitize_and_collect_tools(tools, self.sanitize_schemas, "SSE");
+
+        self.sse_clients.insert(server_name.to_string(), client);
+        self.sse_tools
             .insert(server_name.to_string(), sanitized_tools.clone());
 
         Ok(sanitized_tools.len())
@@ -782,6 +861,7 @@ impl McpManager {
     fn get_server_description(&self, server_config: &McpServerConfig) -> Option<String> {
         match server_config {
             McpServerConfig::HttpStreamable { description, .. }
+            | McpServerConfig::Sse { description, .. }
             | McpServerConfig::Stdio { description, .. } => description.clone(),
         }
     }
@@ -808,7 +888,8 @@ impl McpManager {
                 .streamable_tools
                 .values()
                 .map(|v| v.len())
-                .sum::<usize>();
+                .sum::<usize>()
+            + self.sse_tools.values().map(|v| v.len()).sum::<usize>();
         info!("  Total tools available: {}", total_tools);
     }
 
@@ -821,6 +902,17 @@ impl McpManager {
             if cancelled > 0 {
                 info!(
                     "Cancelled {} request(s) on MCP server '{}' for HTTP request {}",
+                    cancelled, server_name, http_request_id
+                );
+            }
+            total_cancelled += cancelled;
+        }
+
+        for (server_name, client) in &self.sse_clients {
+            let cancelled = client.cancel_all_for_request(http_request_id, reason).await;
+            if cancelled > 0 {
+                info!(
+                    "Cancelled {} request(s) on SSE MCP server '{}' for HTTP request {}",
                     cancelled, server_name, http_request_id
                 );
             }
@@ -846,6 +938,17 @@ impl McpManager {
             total_cancelled += cancelled;
         }
 
+        for (server_name, client) in &self.sse_clients {
+            let cancelled = client.cancel_and_close(http_request_id, reason).await;
+            if cancelled > 0 {
+                info!(
+                    "Cancelled {} request(s) and closed SSE MCP server '{}' for HTTP request {}",
+                    cancelled, server_name, http_request_id
+                );
+            }
+            total_cancelled += cancelled;
+        }
+
         total_cancelled
     }
 
@@ -854,10 +957,13 @@ impl McpManager {
         for client in self.streamable_clients.values() {
             client.set_current_request(http_request_id).await;
         }
+        for client in self.sse_clients.values() {
+            client.set_current_request(http_request_id).await;
+        }
+        let total_clients = self.streamable_clients.len() + self.sse_clients.len();
         debug!(
             "Set current HTTP request ID on {} MCP client(s): {}",
-            self.streamable_clients.len(),
-            http_request_id
+            total_clients, http_request_id
         );
     }
 
@@ -865,9 +971,13 @@ impl McpManager {
         for client in self.streamable_clients.values() {
             client.clear_current_request().await;
         }
+        for client in self.sse_clients.values() {
+            client.clear_current_request().await;
+        }
+        let total_clients = self.streamable_clients.len() + self.sse_clients.len();
         debug!(
             "Cleared current HTTP request ID on {} MCP client(s)",
-            self.streamable_clients.len()
+            total_clients
         );
     }
 
@@ -879,6 +989,13 @@ impl McpManager {
 
         // HTTP Streamable tools
         for tools in self.streamable_tools.values() {
+            for tool in tools {
+                names.push(tool.name.to_string());
+            }
+        }
+
+        // SSE tools
+        for tools in self.sse_tools.values() {
             for tool in tools {
                 names.push(tool.name.to_string());
             }
@@ -902,6 +1019,7 @@ impl McpManager {
         self.streamable_tools
             .values()
             .flat_map(|tools| tools.iter())
+            .chain(self.sse_tools.values().flat_map(|tools| tools.iter()))
             .chain(self.tool_definitions.iter().map(|(tool, _)| tool))
     }
 
@@ -920,19 +1038,25 @@ impl McpManager {
     /// the scratchpad interception path (same behavior as before this
     /// refactor for STDIO).
     pub fn tool_names_per_server(&self) -> HashMap<String, Vec<String>> {
-        self.streamable_tools
+        let mut map: HashMap<String, Vec<String>> = self
+            .streamable_tools
             .iter()
             .map(|(server_name, tools)| {
                 let names = tools.iter().map(|t| t.name.to_string()).collect();
                 (server_name.clone(), names)
             })
-            .collect()
+            .collect();
+        for (server_name, tools) in &self.sse_tools {
+            let names = tools.iter().map(|t| t.name.to_string()).collect();
+            map.insert(server_name.clone(), names);
+        }
+        map
     }
 
     /// Execute a tool by name (used by Ollama text-to-tool fallback).
     ///
     /// Called by `FallbackToolExecutor` when it detects tool calls in streamed text.
-    /// Routes to the appropriate MCP transport (HTTP Streamable or STDIO).
+    /// Routes to the appropriate MCP transport (HTTP Streamable, SSE, or STDIO).
     ///
     /// Normal Rig tool execution goes through `Tool::call()` trait implementations;
     /// this method exists specifically for the fallback parsing path.
@@ -959,6 +1083,19 @@ impl McpManager {
                     "Executing fallback tool '{}' via HTTP Streamable",
                     tool_name
                 );
+                return client
+                    .call_tool(tool_name, args_map)
+                    .await
+                    .map_err(|e| format!("Tool execution failed: {}", e));
+            }
+        }
+
+        // Try SSE clients
+        for (server_name, client) in &self.sse_clients {
+            if let Some(tools) = self.sse_tools.get(server_name)
+                && tools.iter().any(|t| t.name.as_ref() == tool_name)
+            {
+                info!("Executing fallback tool '{}' via SSE", tool_name);
                 return client
                     .call_tool(tool_name, args_map)
                     .await
@@ -1023,7 +1160,7 @@ macro_rules! create_mcp_tool_struct {
         pub struct $struct_name {
             pub tool_name: String,
             pub server_name: String,
-            pub client: Arc<StreamableHttpMcpClient>,
+            pub client: Arc<McpClient>,
             pub tool_definition: ToolDefinition,
         }
 
@@ -1031,7 +1168,7 @@ macro_rules! create_mcp_tool_struct {
             pub fn new(
                 tool_name: String,
                 server_name: String,
-                client: Arc<StreamableHttpMcpClient>,
+                client: Arc<McpClient>,
                 mcp_tool: rmcp::model::Tool,
                 sanitize_schemas: bool,
             ) -> Option<Self> {
@@ -1118,12 +1255,12 @@ create_mcp_tool_struct!(GetCurrentTimeTool, "get_current_time");
 create_mcp_tool_struct!(GetPipelineTool, "get_pipeline");
 create_mcp_tool_struct!(ListPipelinesTool, "list_pipelines");
 
-/// Generic fallback for unknown tools - A Rig-compatible tool wrapper for StreamableHttpMcpClient tools
+/// Generic fallback for unknown tools - A Rig-compatible tool wrapper for MCP client tools
 #[derive(Clone)]
 pub struct StreamableHttpMcpTool {
     pub tool_name: String,
     pub server_name: String,
-    pub client: Arc<StreamableHttpMcpClient>,
+    pub client: Arc<McpClient>,
     pub tool_definition: ToolDefinition,
 }
 
@@ -1131,7 +1268,7 @@ impl StreamableHttpMcpTool {
     pub fn new(
         tool_name: String,
         server_name: String,
-        client: Arc<StreamableHttpMcpClient>,
+        client: Arc<McpClient>,
         mcp_tool: rmcp::model::Tool,
         sanitize_schemas: bool,
     ) -> Option<Self> {
@@ -1254,7 +1391,7 @@ pub fn create_fallback_http_tool(
     unique_tool_name: String,
     original_tool_name: String,
     server_name: String,
-    client: Arc<StreamableHttpMcpClient>,
+    client: Arc<McpClient>,
     mcp_tool: rmcp::model::Tool,
     sanitize_schemas: bool,
 ) -> Option<FallbackHttpMcpTool> {
@@ -1274,7 +1411,7 @@ pub struct FallbackHttpMcpTool {
     pub unique_name: String,
     pub original_tool_name: String,
     pub server_name: String,
-    pub client: Arc<StreamableHttpMcpClient>,
+    pub client: Arc<McpClient>,
     pub tool_definition: ToolDefinition,
 }
 
@@ -1283,7 +1420,7 @@ impl FallbackHttpMcpTool {
         unique_name: String,
         original_tool_name: String,
         server_name: String,
-        client: Arc<StreamableHttpMcpClient>,
+        client: Arc<McpClient>,
         mcp_tool: rmcp::model::Tool,
         sanitize_schemas: bool,
     ) -> Option<Self> {

--- a/crates/aura/src/mcp_dynamic.rs
+++ b/crates/aura/src/mcp_dynamic.rs
@@ -6,20 +6,20 @@ use rig::tool::{Tool as RigTool, ToolError};
 use rmcp::model::Tool as McpTool;
 use serde_json::Value;
 
-use crate::mcp_streamable_http::StreamableHttpMcpClient;
-use crate::mcp_tool_execution::execute_http_mcp_tool;
+use crate::mcp_streamable_http::McpClient;
+use crate::mcp_tool_execution::execute_mcp_tool;
 
-/// Dynamic MCP Tool Adaptor for HTTP Streamable clients
+/// Dynamic MCP Tool Adaptor for MCP clients (transport-agnostic)
 #[derive(Clone)]
-pub struct HttpMcpToolAdaptor {
+pub struct McpToolAdaptor {
     tool: McpTool,
     #[allow(dead_code)]
     server_name: String,
-    client: Arc<StreamableHttpMcpClient>,
+    client: Arc<McpClient>,
 }
 
-impl HttpMcpToolAdaptor {
-    pub fn new(tool: McpTool, server_name: String, client: Arc<StreamableHttpMcpClient>) -> Self {
+impl McpToolAdaptor {
+    pub fn new(tool: McpTool, server_name: String, client: Arc<McpClient>) -> Self {
         Self {
             tool,
             server_name,
@@ -28,7 +28,7 @@ impl HttpMcpToolAdaptor {
     }
 }
 
-impl RigTool for HttpMcpToolAdaptor {
+impl RigTool for McpToolAdaptor {
     type Error = ToolError;
     type Args = Value;
     type Output = String;
@@ -74,7 +74,7 @@ impl RigTool for HttpMcpToolAdaptor {
 
         Box::pin(async move {
             // Use shared execution function for consistent logging and error handling
-            execute_http_mcp_tool(&client, &tool_name, args).await
+            execute_mcp_tool(&client, &tool_name, args).await
         })
     }
 }

--- a/crates/aura/src/mcp_sse.rs
+++ b/crates/aura/src/mcp_sse.rs
@@ -1,0 +1,235 @@
+//! Legacy SSE MCP transport.
+//!
+//! Implements the pre-2025-11-05 MCP SSE protocol:
+//! 1. HTTP GET to SSE endpoint
+//! 2. Server responds with SSE stream containing an `endpoint` event
+//! 3. Client POSTs JSON-RPC messages to the resolved message endpoint
+//! 4. Server responses arrive as `event: message` on the SSE stream
+
+use std::collections::HashMap;
+use std::pin::Pin;
+
+use futures::{Stream, StreamExt};
+use reqwest::header::{ACCEPT, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
+use rmcp::service::{RxJsonRpcMessage, TxJsonRpcMessage};
+use rmcp::{RoleClient, transport::Transport};
+use sse_stream::{Error as SseError, Sse};
+use tracing::{debug, warn};
+
+use crate::error::SseTransportError;
+
+/// SSE event type for JSON-RPC messages from server to client.
+const SSE_EVENT_MESSAGE: &str = "message";
+/// SSE event type for endpoint discovery (first event after connection).
+const SSE_EVENT_ENDPOINT: &str = "endpoint";
+
+/// MCP client transport over legacy SSE protocol.
+///
+/// State: after `connect()` the transport holds a live SSE stream and a resolved
+/// message endpoint. `close()` consumes the stream (sets it to `None`).
+pub struct SseTransport {
+    http_client: reqwest::Client,
+    message_endpoint: url::Url,
+    #[allow(clippy::type_complexity)]
+    stream: Option<Pin<Box<dyn Stream<Item = Result<Sse, SseError>> + Send>>>,
+}
+
+impl Transport<RoleClient> for SseTransport {
+    type Error = SseTransportError;
+
+    fn send(
+        &mut self,
+        item: TxJsonRpcMessage<RoleClient>,
+    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
+        let client = self.http_client.clone();
+        let uri = self.message_endpoint.clone();
+        async move {
+            let response = client
+                .post(uri.as_str())
+                .json(&item)
+                .send()
+                .await
+                .map_err(SseTransportError::Http)?;
+            let _ = response
+                .error_for_status()
+                .map_err(SseTransportError::Http)?;
+            Ok(())
+        }
+    }
+
+    async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleClient>> {
+        let stream = self.stream.as_mut()?;
+        loop {
+            let sse = match stream.next().await {
+                Some(Ok(sse)) => sse,
+                Some(Err(e)) => {
+                    warn!("SSE stream error: {}", e);
+                    return None;
+                }
+                None => {
+                    debug!("SSE stream closed by server");
+                    return None;
+                }
+            };
+            if let (Some(SSE_EVENT_MESSAGE), Some(data)) = (sse.event.as_deref(), sse.data) {
+                match serde_json::from_str(&data) {
+                    Ok(msg) => return Some(msg),
+                    Err(e) => warn!("Failed to deserialize SSE message: {}", e),
+                }
+            }
+        }
+    }
+
+    async fn close(&mut self) -> Result<(), Self::Error> {
+        self.stream.take();
+        Ok(())
+    }
+}
+
+impl SseTransport {
+    /// Connect to an SSE MCP server.
+    ///
+    /// 1. GET the SSE endpoint with `Accept: text/event-stream`
+    /// 2. Verify the response Content-Type
+    /// 3. Read SSE events until the `endpoint` event is received
+    /// 4. Resolve the message endpoint URL
+    /// 5. Return a connected `SseTransport`
+    pub async fn connect(
+        url: &str,
+        headers: &HashMap<String, String>,
+    ) -> Result<Self, SseTransportError> {
+        let sse_endpoint = url::Url::parse(url)?;
+
+        let mut header_map = HeaderMap::new();
+        for (key, value) in headers {
+            match (
+                HeaderName::from_bytes(key.as_bytes()),
+                HeaderValue::from_str(value),
+            ) {
+                (Ok(name), Ok(val)) => {
+                    header_map.insert(name, val);
+                }
+                _ => {
+                    warn!("Skipping invalid header '{}' (failed to convert)", key);
+                }
+            }
+        }
+
+        let http_client = reqwest::Client::builder()
+            .default_headers(header_map)
+            .build()
+            .map_err(SseTransportError::Http)?;
+
+        let response = http_client
+            .get(url.to_string())
+            .header(ACCEPT, "text/event-stream")
+            .send()
+            .await
+            .map_err(SseTransportError::Http)?;
+
+        let response = response
+            .error_for_status()
+            .map_err(SseTransportError::Http)?;
+
+        let content_types: Vec<_> = response
+            .headers()
+            .get_all(CONTENT_TYPE)
+            .into_iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
+        if content_types.is_empty() {
+            return Err(SseTransportError::MissingContentType);
+        }
+        if !content_types
+            .iter()
+            .any(|ct| ct.starts_with("text/event-stream"))
+        {
+            return Err(SseTransportError::UnexpectedContentType(
+                content_types[0].to_owned(),
+            ));
+        }
+
+        let mut stream = sse_stream::SseStream::from_byte_stream(response.bytes_stream()).boxed();
+
+        let message_endpoint = loop {
+            let sse = stream
+                .next()
+                .await
+                .transpose()
+                .map_err(SseTransportError::SseStream)?
+                .ok_or(SseTransportError::MissingEndpointEvent)?;
+            if let (Some(SSE_EVENT_ENDPOINT), Some(ep)) = (sse.event.as_deref(), sse.data) {
+                break resolve_message_endpoint(sse_endpoint, ep)?;
+            }
+        };
+
+        Ok(Self {
+            http_client,
+            message_endpoint,
+            stream: Some(stream),
+        })
+    }
+}
+
+/// Resolve a message endpoint URL against the SSE base URL per RFC 3986.
+fn resolve_message_endpoint(
+    base: url::Url,
+    endpoint: String,
+) -> Result<url::Url, SseTransportError> {
+    base.join(&endpoint).map_err(SseTransportError::UrlParse)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_message_endpoint_query_only() {
+        let base = url::Url::parse("https://localhost/sse").unwrap();
+        let result = resolve_message_endpoint(base, "?sessionId=x".to_owned()).unwrap();
+        assert_eq!(result.as_str(), "https://localhost/sse?sessionId=x");
+    }
+
+    #[test]
+    fn test_resolve_message_endpoint_relative_path() {
+        let base = url::Url::parse("https://localhost/sse").unwrap();
+        let result = resolve_message_endpoint(base, "mypath?sessionId=x".to_owned()).unwrap();
+        assert_eq!(result.as_str(), "https://localhost/mypath?sessionId=x");
+    }
+
+    #[test]
+    fn test_resolve_message_endpoint_absolute_path() {
+        let base = url::Url::parse("https://localhost/sse").unwrap();
+        let result = resolve_message_endpoint(base, "/xxx?sessionId=x".to_owned()).unwrap();
+        assert_eq!(result.as_str(), "https://localhost/xxx?sessionId=x");
+    }
+
+    #[test]
+    fn test_resolve_message_endpoint_full_url() {
+        let base = url::Url::parse("https://localhost/sse").unwrap();
+        let result =
+            resolve_message_endpoint(base, "http://example.com/xxx?sessionId=x".to_owned())
+                .unwrap();
+        assert_eq!(result.as_str(), "http://example.com/xxx?sessionId=x");
+    }
+
+    #[test]
+    fn test_resolve_message_endpoint_subpath_relative() {
+        let base = url::Url::parse("https://example.com/api/mcp/sse").unwrap();
+        let result = resolve_message_endpoint(base, "messages?sessionId=x".to_owned()).unwrap();
+        assert_eq!(
+            result.as_str(),
+            "https://example.com/api/mcp/messages?sessionId=x"
+        );
+    }
+
+    #[test]
+    fn test_resolve_message_endpoint_subpath_query() {
+        let base = url::Url::parse("https://example.com/api/mcp/sse").unwrap();
+        let result = resolve_message_endpoint(base, "?sessionId=x".to_owned()).unwrap();
+        assert_eq!(
+            result.as_str(),
+            "https://example.com/api/mcp/sse?sessionId=x"
+        );
+    }
+}

--- a/crates/aura/src/mcp_streamable_http.rs
+++ b/crates/aura/src/mcp_streamable_http.rs
@@ -76,7 +76,7 @@ impl InFlightRequests {
 }
 
 /// MCP client for HTTP streamable connections with progress notification support
-pub struct StreamableHttpMcpClient {
+pub struct McpClient {
     client: Arc<RunningService<RoleClient, ProgressEnabledHandler>>,
     server_url: String,
     /// Tracks in-flight MCP requests for cancellation support
@@ -85,7 +85,7 @@ pub struct StreamableHttpMcpClient {
     current_http_request_id: Arc<RwLock<Option<String>>>,
 }
 
-impl Clone for StreamableHttpMcpClient {
+impl Clone for McpClient {
     fn clone(&self) -> Self {
         Self {
             client: self.client.clone(),
@@ -96,7 +96,31 @@ impl Clone for StreamableHttpMcpClient {
     }
 }
 
-impl StreamableHttpMcpClient {
+impl McpClient {
+    /// Create an MCP client from any transport implementing `Transport<RoleClient>`.
+    ///
+    /// This is the transport-agnostic constructor used by both HTTP streamable
+    /// and legacy SSE transports.
+    pub(crate) async fn from_transport<T>(transport: T, server_url: String) -> Result<Self>
+    where
+        T: rmcp::transport::Transport<RoleClient> + Send + 'static,
+        T::Error: std::error::Error + Send + Sync + 'static,
+    {
+        let current_http_request_id = Arc::new(RwLock::new(None));
+        let handler = ProgressEnabledHandler::new(Arc::clone(&current_http_request_id));
+
+        let client = serve_client(handler, transport)
+            .await
+            .context("Failed to establish MCP client connection")?;
+
+        Ok(Self {
+            client: Arc::new(client),
+            server_url,
+            in_flight: Arc::new(InFlightRequests::new()),
+            current_http_request_id,
+        })
+    }
+
     pub async fn new(
         server_url: String,
         forwarded_headers: &HashMap<String, String>,
@@ -134,25 +158,14 @@ impl StreamableHttpMcpClient {
             },
         );
 
-        let current_http_request_id = Arc::new(RwLock::new(None));
-
-        let handler = ProgressEnabledHandler::new(current_http_request_id.clone());
-
-        let client = serve_client(handler, transport)
-            .await
-            .context("Failed to establish MCP client connection")?;
+        let client = Self::from_transport(transport, server_url.clone()).await?;
 
         info!(
             "Successfully established streamable HTTP MCP client: {}",
             server_url
         );
 
-        Ok(Self {
-            client: Arc::new(client),
-            server_url,
-            in_flight: Arc::new(InFlightRequests::new()),
-            current_http_request_id,
-        })
+        Ok(client)
     }
 
     /// Set the current HTTP request ID for cancellation tracking.

--- a/crates/aura/src/mcp_tool_execution.rs
+++ b/crates/aura/src/mcp_tool_execution.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use tracing::{error, info};
 
-use crate::mcp_streamable_http::StreamableHttpMcpClient;
+use crate::mcp_streamable_http::McpClient;
 use crate::request_cancellation::call_http_tool_cancellable;
 
 // ---------------------------------------------------------------------------
@@ -96,8 +96,8 @@ fn record_tool_call_result(span: &tracing::Span, result: &Result<String, anyhow:
 /// 3. Standardized error handling
 /// 4. Per-request cancellation support (when executed within a cancellation context)
 #[tracing::instrument(name = "mcp.tool_call", skip(client, args), fields(tool.name = %tool_name, server.url = %client.server_url()))]
-pub async fn execute_http_mcp_tool(
-    client: &StreamableHttpMcpClient,
+pub async fn execute_mcp_tool(
+    client: &McpClient,
     tool_name: &str,
     args: Value,
 ) -> Result<String, ToolError> {

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -1705,6 +1705,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
             }
         }
 
+        // Collect from SSE tools
+        for tools in mcp_manager.sse_tools.values() {
+            for tool in tools {
+                names.push(tool.name.to_string());
+            }
+        }
+
         // Collect from legacy tool definitions (rmcp::model::Tool)
         for (tool, _) in &mcp_manager.tool_definitions {
             names.push(tool.name.to_string());
@@ -1735,6 +1742,14 @@ Assign tasks to the worker whose tools best match the required operations."#,
         for tools in mcp_manager.streamable_tools.values() {
             for tool in tools {
                 // Convert Arc<Map<String, Value>> to serde_json::Value
+                let schema_value = serde_json::Value::Object((*tool.input_schema).clone());
+                schemas.insert(tool.name.to_string(), schema_value);
+            }
+        }
+
+        // Collect from SSE tools
+        for tools in mcp_manager.sse_tools.values() {
+            for tool in tools {
                 let schema_value = serde_json::Value::Object((*tool.input_schema).clone());
                 schemas.insert(tool.name.to_string(), schema_value);
             }
@@ -1808,6 +1823,15 @@ Assign tasks to the worker whose tools best match the required operations."#,
         if let Some(ref mcp_manager) = self.mcp_manager {
             // Collect from streamable HTTP tools (description is Option<Cow<'static, str>>)
             for tools in mcp_manager.streamable_tools.values() {
+                for tool in tools {
+                    if let Some(ref desc) = tool.description {
+                        descriptions.insert(tool.name.to_string(), desc.to_string());
+                    }
+                }
+            }
+
+            // Collect from SSE tools
+            for tools in mcp_manager.sse_tools.values() {
                 for tool in tools {
                     if let Some(ref desc) = tool.description {
                         descriptions.insert(tool.name.to_string(), desc.to_string());

--- a/crates/aura/src/request_cancellation.rs
+++ b/crates/aura/src/request_cancellation.rs
@@ -11,7 +11,7 @@ use std::sync::{OnceLock, RwLock};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
-use crate::mcp_streamable_http::StreamableHttpMcpClient;
+use crate::mcp_streamable_http::McpClient;
 
 pub type RequestId = String;
 
@@ -92,7 +92,7 @@ impl RequestCancellation {
 }
 
 pub async fn call_http_tool_cancellable(
-    client: &StreamableHttpMcpClient,
+    client: &McpClient,
     tool_name: &str,
     args: HashMap<String, Value>,
 ) -> Result<String> {

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -31,6 +31,21 @@ transport = "http_streamable"
 url = "http://localhost:8081/mcp"
 description = "Example HTTP MCP server"
 
+# ── SSE transport (legacy MCP servers) ──────────────────────────────
+# For MCP servers that use the pre-2025-11-05 SSE protocol.
+# Supports the same headers, headers_from_request, and scratchpad
+# options as http_streamable.
+[mcp.servers.example_sse]
+transport = "sse"
+url = "http://localhost:8082/sse"
+description = "Example SSE MCP server"
+
+# [mcp.servers.example_sse.headers]
+# Authorization = "Bearer {{ env.SSE_TOKEN }}"
+#
+# [mcp.servers.example_sse.headers_from_request]
+# Authorization = "x-user-token"
+
 # Static headers sent with every request.
 [mcp.servers.example_http.headers]
 Authorization = "Bearer {{ env.MCP_TOKEN }}"


### PR DESCRIPTION
Adds SSE as a transport option for MCP servers alongside http_streamable and stdio. Some MCP servers -- including TerminalBench's tool harness -- only expose the legacy SSE protocol, so we need this to connect.

Everything http_streamable supports (headers, headers_from_request, scratchpad, cancellation) works with SSE too. Refactored the old StreamableHttpMcpClient into a transport-agnostic McpClient so both transports share the same plumbing.

Tested against @modelcontextprotocol/server-everything in SSE mode -- ran scripted multi-turn conversations with back-to-back tool calls, rapid-fire requests, and streaming, all held up fine.

Should review after Tony's #100 docs changes land since there's some overlap.

Fixes: #153