### PR TITLE
fix(quickstart): always pull aura image so new releases land

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   # ── Aura Agent Server ──────────────────────────────────────────────
   aura:
     image: mezmo/aura:1-latest
+    pull_policy: always
     container_name: aura
     command:
       - ./aura-web-server


### PR DESCRIPTION
## Summary
- `docker-compose.yml` references `mezmo/aura:1-latest`, but docker compose only fetches a tag on first run and then reuses the cached image. When a new release is published, existing quickstart users keep running the stale cached image.
- Concrete symptom: v1.20.5 adds `aura-cli` to the published image (Dockerfile change from #873880f), but anyone with a cached pre-v1.20.5 `1-latest` will still see `docker exec -it aura ./aura-cli` fail with "no such file" — contradicting `docs/quickstart.md`.
- Add `pull_policy: always` to the `aura` service so `docker compose up -d` checks the registry for a fresher `1-latest` and pulls it when present.

## Test plan
- [ ] `docker compose up -d` on a fresh checkout pulls `mezmo/aura:1-latest`
- [ ] After a stale image is cached locally, re-running `docker compose up -d` pulls a newer published `1-latest` instead of reusing the cache
- [ ] Once v1.20.5 image is published, `docker exec -it aura ./aura-cli` works per the quickstart docs