### PR TITLE
feat(aura-cli): display LLM reasoning output for coordinator and workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "unicode-segmentation",
  "uuid",
 ]
 
@@ -343,6 +344,7 @@ dependencies = [
  "async-trait",
  "aura",
  "aura-config",
+ "aura-events",
  "aura-test-utils",
  "axum 0.8.9",
  "bytes",

--- a/crates/aura-cli/Cargo.toml
+++ b/crates/aura-cli/Cargo.toml
@@ -32,6 +32,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "str
 aura-events = { path = "../aura-events" }
 eventsource-stream = "0.2"
 futures-util = "0.3"
+unicode-segmentation = "1"
 termimad = "0.34"
 crossterm = "0.29"
 rustyline = "17"

--- a/crates/aura-cli/src/api/stream.rs
+++ b/crates/aura-cli/src/api/stream.rs
@@ -11,6 +11,7 @@ use reqwest::Response;
 use aura_events::AuraStreamEvent;
 
 use crate::api::types::{AccumulatedToolCall, ChatCompletionChunk};
+use crate::event_names;
 
 /// Result of processing a stream — either a text response or tool calls.
 #[derive(Debug)]
@@ -36,35 +37,76 @@ async fn wait_for_cancel(flag: &AtomicBool) {
     }
 }
 
+/// Sink for the events produced while processing a stream.
+///
+/// Every method defaults to a no-op, so implementors override only the
+/// events they care about; [`NoopHandler`] ignores all of them.
+///
+/// Correlate by `tool_id`, not `tool_name`: a single turn may invoke the
+/// same tool more than once.
+pub trait StreamHandler {
+    /// Called for each content delta (standard chat completions).
+    fn on_token(&mut self, _token: &str) {}
+
+    /// Called when a tool is requested, with (tool_id, tool_name, arguments).
+    fn on_tool_requested(
+        &mut self,
+        _tool_id: &str,
+        _tool_name: &str,
+        _arguments: &BTreeMap<String, serde_json::Value>,
+    ) {
+    }
+
+    /// Called when a tool begins execution, with (tool_id, tool_name).
+    fn on_tool_start(&mut self, _tool_id: &str, _tool_name: &str) {}
+
+    /// Called when a tool finishes, with (tool_id, tool_name, duration, result).
+    fn on_tool_complete(
+        &mut self,
+        _tool_id: &str,
+        _tool_name: &str,
+        _duration: Duration,
+        _result: Option<&str>,
+    ) {
+    }
+
+    /// Called with (prompt_tokens, completion_tokens) from `aura.usage` events.
+    fn on_usage(&mut self, _prompt_tokens: u64, _completion_tokens: u64) {}
+
+    /// Called for `aura.reasoning` events, with (content, agent_id, fields).
+    fn on_reasoning(
+        &mut self,
+        _content: &str,
+        _agent_id: &str,
+        _fields: &BTreeMap<String, serde_json::Value>,
+    ) {
+    }
+
+    /// Called for every named (`aura.*`) SSE event, with (event_name, raw_data).
+    fn on_raw_event(&mut self, _event_name: &str, _data: &str) {}
+
+    /// Called for `aura.orchestrator.*`, `aura.session_info`, `aura.progress`,
+    /// `aura.worker_phase`, and any future events, with (event_name, value).
+    fn on_orchestrator_event(&mut self, _event_name: &str, _value: &serde_json::Value) {}
+}
+
+/// A [`StreamHandler`] that ignores every event. Used by one-shot mode and
+/// tests where only the final [`StreamResult`] matters.
+pub struct NoopHandler;
+
+impl StreamHandler for NoopHandler {}
+
 /// Process an SSE streaming response from an HTTP reqwest::Response.
 ///
 /// Thin wrapper around `process_sse_events` that extracts the byte stream
 /// and converts it to an eventsource stream.
-#[allow(clippy::too_many_arguments)]
 pub async fn process_stream(
     response: Response,
     cancel: Arc<AtomicBool>,
-    on_token: impl FnMut(&str),
-    on_tool_requested: impl FnMut(&str, &str, &BTreeMap<String, serde_json::Value>),
-    on_tool_start: impl FnMut(&str, &str),
-    on_tool_complete: impl FnMut(&str, &str, Duration, Option<&str>),
-    on_usage: impl FnMut(u64, u64),
-    on_raw_event: impl FnMut(&str, &str),
-    on_orchestrator_event: impl FnMut(&str, &serde_json::Value),
+    handler: &mut impl StreamHandler,
 ) -> Result<StreamResult> {
     let stream = response.bytes_stream().eventsource();
-    process_sse_events(
-        stream,
-        cancel,
-        on_token,
-        on_tool_requested,
-        on_tool_start,
-        on_tool_complete,
-        on_usage,
-        on_raw_event,
-        on_orchestrator_event,
-    )
-    .await
+    process_sse_events(stream, cancel, handler).await
 }
 
 /// Process SSE events from any eventsource-compatible stream.
@@ -73,29 +115,13 @@ pub async fn process_stream(
 /// (via `DirectBackend`) to ensure identical event handling.
 ///
 /// - `cancel`: when set to `true`, the stream is abandoned early
-/// - `on_token`: called for each content delta (standard chat completions)
-/// - `on_tool_requested`: called when a tool is requested with (tool_id, tool_name, arguments)
-/// - `on_tool_start`: called when a tool begins execution with (tool_id, tool_name)
-/// - `on_tool_complete`: called when a tool finishes with (tool_id, tool_name, duration, result)
-/// - `on_usage`: called with (prompt_tokens, completion_tokens) from aura.usage events
-/// - `on_orchestrator_event`: called for `aura.orchestrator.*`, `aura.session_info`, and `aura.progress` events
-///
-/// `tool_id` is the per-call identifier emitted by the server. Callers should
-/// use it (not `tool_name`) as the key when correlating arguments with results,
-/// since a single turn may contain multiple invocations of the same tool.
+/// - `handler`: a [`StreamHandler`] whose methods are invoked as events arrive
 ///
 /// Returns a `StreamResult` — either `TextResponse` or `ToolCalls`.
-#[allow(clippy::too_many_arguments)]
 pub async fn process_sse_events<S, E>(
     mut stream: S,
     cancel: Arc<AtomicBool>,
-    mut on_token: impl FnMut(&str),
-    mut on_tool_requested: impl FnMut(&str, &str, &BTreeMap<String, serde_json::Value>),
-    mut on_tool_start: impl FnMut(&str, &str),
-    mut on_tool_complete: impl FnMut(&str, &str, Duration, Option<&str>),
-    mut on_usage: impl FnMut(u64, u64),
-    mut on_raw_event: impl FnMut(&str, &str),
-    mut on_orchestrator_event: impl FnMut(&str, &serde_json::Value),
+    handler: &mut impl StreamHandler,
 ) -> Result<StreamResult>
 where
     S: futures_util::Stream<Item = Result<eventsource_stream::Event, E>> + Unpin,
@@ -142,7 +168,7 @@ where
         // Capture raw SSE events with non-empty event names (aura.* custom events).
         // Standard chat completion chunks have empty event names and would flood the panel.
         if !event_name.is_empty() {
-            on_raw_event(event_name, &event.data);
+            handler.on_raw_event(event_name, &event.data);
         }
 
         // Parse aura-specific events using shared types from aura-events crate.
@@ -150,7 +176,7 @@ where
         // deserialization handles the JSON → enum mapping.
         if event_name.starts_with("aura.") {
             match event_name.as_str() {
-                "aura.tool_requested" => {
+                event_names::TOOL_REQUESTED => {
                     if let Ok(AuraStreamEvent::ToolRequested {
                         tool_id,
                         tool_name,
@@ -164,19 +190,19 @@ where
                             }
                             _ => BTreeMap::new(),
                         };
-                        on_tool_requested(&tool_id, &tool_name, &args);
+                        handler.on_tool_requested(&tool_id, &tool_name, &args);
                     }
                 }
-                "aura.tool_start" => {
+                event_names::TOOL_START => {
                     if let Ok(AuraStreamEvent::ToolStart {
                         tool_id, tool_name, ..
                     }) = serde_json::from_str::<AuraStreamEvent>(&event.data)
                     {
                         tool_timers.insert(tool_id.clone(), Instant::now());
-                        on_tool_start(&tool_id, &tool_name);
+                        handler.on_tool_start(&tool_id, &tool_name);
                     }
                 }
-                "aura.tool_complete" => {
+                event_names::TOOL_COMPLETE => {
                     if let Ok(AuraStreamEvent::ToolComplete {
                         tool_id,
                         tool_name,
@@ -188,7 +214,7 @@ where
                     {
                         let elapsed = Duration::from_millis(duration_ms);
                         tool_timers.remove(&tool_id);
-                        on_tool_complete(&tool_id, &tool_name, elapsed, result.as_deref());
+                        handler.on_tool_complete(&tool_id, &tool_name, elapsed, result.as_deref());
 
                         // Cache server-side result by tool_call_id for hybrid mode.
                         // For failures, cache the error message so the model sees the
@@ -200,24 +226,49 @@ where
                         }
                     }
                 }
-                "aura.usage" => {
+                event_names::USAGE => {
                     if let Ok(AuraStreamEvent::Usage {
                         prompt_tokens,
                         completion_tokens,
                         ..
                     }) = serde_json::from_str::<AuraStreamEvent>(&event.data)
                     {
-                        on_usage(prompt_tokens, completion_tokens);
+                        handler.on_usage(prompt_tokens, completion_tokens);
                     }
                 }
-                "aura.tool_usage" => {
+                event_names::TOOL_USAGE => {
                     // Silently skip — usage is tracked via aura.usage at stream end
+                }
+                event_names::REASONING => {
+                    // Parse the raw payload into a BTreeMap so the consumer
+                    // can render every wire-level field (agent_id, content,
+                    // parent_agent_id, session_id, trace_id, ...) in /expand
+                    // without us having to enumerate them here. Separately
+                    // extract `content` and `agent_id` as named args because
+                    // every consumer wants those for the live block header
+                    // and body.
+                    if let Ok(serde_json::Value::Object(map)) =
+                        serde_json::from_str::<serde_json::Value>(&event.data)
+                    {
+                        let content = map
+                            .get("content")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let agent_id = map
+                            .get("agent_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let fields: BTreeMap<String, serde_json::Value> = map.into_iter().collect();
+                        handler.on_reasoning(&content, &agent_id, &fields);
+                    }
                 }
                 _ => {
                     // aura.orchestrator.*, aura.session_info, aura.progress,
-                    // aura.reasoning, aura.worker_phase, and any future events
+                    // aura.worker_phase, and any future events
                     if let Ok(val) = serde_json::from_str::<serde_json::Value>(&event.data) {
-                        on_orchestrator_event(event_name, &val);
+                        handler.on_orchestrator_event(event_name, &val);
                     }
                 }
             }
@@ -233,7 +284,7 @@ where
         for choice in &chunk.choices {
             // Accumulate text content
             if let Some(ref content) = choice.delta.content {
-                on_token(content);
+                handler.on_token(content);
                 full_response.push_str(content);
             }
 
@@ -362,8 +413,64 @@ mod tests {
         tools_started: Vec<(String, String)>,
         tools_completed: Vec<(String, String, Option<String>)>,
         usages: Vec<(u64, u64)>,
+        reasoning: Vec<(String, String)>,
         raw_events: Vec<(String, String)>,
         orchestrator_events: Vec<(String, serde_json::Value)>,
+    }
+
+    impl StreamHandler for Captures {
+        fn on_token(&mut self, token: &str) {
+            self.tokens.push(token.to_string());
+        }
+        fn on_tool_requested(
+            &mut self,
+            tool_id: &str,
+            tool_name: &str,
+            arguments: &BTreeMap<String, serde_json::Value>,
+        ) {
+            self.tools_requested.push((
+                tool_id.to_string(),
+                tool_name.to_string(),
+                arguments.clone(),
+            ));
+        }
+        fn on_tool_start(&mut self, tool_id: &str, tool_name: &str) {
+            self.tools_started
+                .push((tool_id.to_string(), tool_name.to_string()));
+        }
+        fn on_tool_complete(
+            &mut self,
+            tool_id: &str,
+            tool_name: &str,
+            _duration: Duration,
+            result: Option<&str>,
+        ) {
+            self.tools_completed.push((
+                tool_id.to_string(),
+                tool_name.to_string(),
+                result.map(|s| s.to_string()),
+            ));
+        }
+        fn on_usage(&mut self, prompt_tokens: u64, completion_tokens: u64) {
+            self.usages.push((prompt_tokens, completion_tokens));
+        }
+        fn on_reasoning(
+            &mut self,
+            content: &str,
+            agent_id: &str,
+            _fields: &BTreeMap<String, serde_json::Value>,
+        ) {
+            self.reasoning
+                .push((content.to_string(), agent_id.to_string()));
+        }
+        fn on_raw_event(&mut self, event_name: &str, data: &str) {
+            self.raw_events
+                .push((event_name.to_string(), data.to_string()));
+        }
+        fn on_orchestrator_event(&mut self, event_name: &str, value: &serde_json::Value) {
+            self.orchestrator_events
+                .push((event_name.to_string(), value.clone()));
+        }
     }
 
     /// Drive process_sse_events with a vec of synthetic events and tracking callbacks.
@@ -377,38 +484,7 @@ mod tests {
                 .collect::<Vec<_>>(),
         );
         let mut caps = Captures::default();
-
-        let result = {
-            let tokens = &mut caps.tokens;
-            let tools_requested = &mut caps.tools_requested;
-            let tools_started = &mut caps.tools_started;
-            let tools_completed = &mut caps.tools_completed;
-            let usages = &mut caps.usages;
-            let raw_events = &mut caps.raw_events;
-            let orchestrator_events = &mut caps.orchestrator_events;
-
-            process_sse_events(
-                event_stream,
-                no_cancel(),
-                |t| tokens.push(t.to_string()),
-                |id, name, args| {
-                    tools_requested.push((id.to_string(), name.to_string(), args.clone()))
-                },
-                |id, name| tools_started.push((id.to_string(), name.to_string())),
-                |id, name, _dur, result| {
-                    tools_completed.push((
-                        id.to_string(),
-                        name.to_string(),
-                        result.map(|s| s.to_string()),
-                    ))
-                },
-                |p, c| usages.push((p, c)),
-                |name, data| raw_events.push((name.to_string(), data.to_string())),
-                |name, val| orchestrator_events.push((name.to_string(), val.clone())),
-            )
-            .await
-        };
-
+        let result = process_sse_events(event_stream, no_cancel(), &mut caps).await;
         (result, caps)
     }
 
@@ -568,7 +644,7 @@ mod tests {
             "session_id": "s1"
         });
         let events = vec![
-            sse("aura.tool_requested", &data.to_string()),
+            sse(event_names::TOOL_REQUESTED, &data.to_string()),
             sse("", "[DONE]"),
         ];
         let (_, caps) = run_stream(events).await;
@@ -580,7 +656,7 @@ mod tests {
         assert!(
             caps.raw_events
                 .iter()
-                .any(|(n, _)| n == "aura.tool_requested")
+                .any(|(n, _)| n == event_names::TOOL_REQUESTED)
         );
     }
 
@@ -592,7 +668,10 @@ mod tests {
             "agent_id": "main",
             "session_id": "s1"
         });
-        let events = vec![sse("aura.tool_start", &data.to_string()), sse("", "[DONE]")];
+        let events = vec![
+            sse(event_names::TOOL_START, &data.to_string()),
+            sse("", "[DONE]"),
+        ];
         let (_, caps) = run_stream(events).await;
         assert_eq!(
             caps.tools_started,
@@ -611,7 +690,7 @@ mod tests {
             "session_id": "s1"
         });
         let events = vec![
-            sse("aura.tool_complete", &data.to_string()),
+            sse(event_names::TOOL_COMPLETE, &data.to_string()),
             sse("", "[DONE]"),
         ];
         let (_, caps) = run_stream(events).await;
@@ -635,7 +714,7 @@ mod tests {
             "session_id": "s1"
         });
         let events = vec![
-            sse("aura.tool_complete", &data.to_string()),
+            sse(event_names::TOOL_COMPLETE, &data.to_string()),
             sse(
                 "",
                 &tool_call_chunk(
@@ -672,7 +751,7 @@ mod tests {
             "session_id": "s1"
         });
         let events = vec![
-            sse("aura.tool_complete", &data.to_string()),
+            sse(event_names::TOOL_COMPLETE, &data.to_string()),
             // Now add a tool call with the same id and finish
             sse(
                 "",
@@ -703,7 +782,10 @@ mod tests {
             "total_tokens": 150,
             "session_id": "s1"
         });
-        let events = vec![sse("aura.usage", &data.to_string()), sse("", "[DONE]")];
+        let events = vec![
+            sse(event_names::USAGE, &data.to_string()),
+            sse("", "[DONE]"),
+        ];
         let (_, caps) = run_stream(events).await;
         assert_eq!(caps.usages, vec![(100, 50)]);
     }
@@ -712,36 +794,105 @@ mod tests {
     async fn aura_orchestrator_event_callback() {
         let data = serde_json::json!({"goal": "compute sum"});
         let events = vec![
-            sse("aura.orchestrator.plan_created", &data.to_string()),
+            sse(event_names::PLAN_CREATED, &data.to_string()),
             sse("", "[DONE]"),
         ];
         let (_, caps) = run_stream(events).await;
         assert_eq!(caps.orchestrator_events.len(), 1);
-        assert_eq!(
-            caps.orchestrator_events[0].0,
-            "aura.orchestrator.plan_created"
-        );
+        assert_eq!(caps.orchestrator_events[0].0, event_names::PLAN_CREATED);
     }
 
     #[tokio::test]
     async fn aura_session_info_routed_to_orchestrator() {
         let data = serde_json::json!({"model": "gpt-4o"});
         let events = vec![
-            sse("aura.session_info", &data.to_string()),
+            sse(event_names::SESSION_INFO, &data.to_string()),
             sse("", "[DONE]"),
         ];
         let (_, caps) = run_stream(events).await;
         assert_eq!(caps.orchestrator_events.len(), 1);
-        assert_eq!(caps.orchestrator_events[0].0, "aura.session_info");
+        assert_eq!(caps.orchestrator_events[0].0, event_names::SESSION_INFO);
+    }
+
+    #[tokio::test]
+    async fn aura_reasoning_callback_fires() {
+        let data = serde_json::json!({
+            "content": "Let me think about this problem step by step.",
+            "agent_id": "main",
+            "session_id": "s1"
+        });
+        let events = vec![
+            sse(event_names::REASONING, &data.to_string()),
+            sse("", "[DONE]"),
+        ];
+        let (_, caps) = run_stream(events).await;
+        assert_eq!(caps.reasoning.len(), 1);
+        assert_eq!(
+            caps.reasoning[0].0,
+            "Let me think about this problem step by step."
+        );
+        assert_eq!(caps.reasoning[0].1, "main");
+        // Reasoning should NOT have been routed to the orchestrator fallback
+        assert!(caps.orchestrator_events.is_empty());
+        // But it IS a named event, so raw_event should have captured it
+        assert!(
+            caps.raw_events
+                .iter()
+                .any(|(n, _)| n == event_names::REASONING)
+        );
+    }
+
+    #[tokio::test]
+    async fn aura_reasoning_callback_carries_worker_agent_id() {
+        // In orchestration mode the server emits aura.reasoning with the
+        // worker's agent_id so the CLI can attribute reasoning to a worker.
+        let data = serde_json::json!({
+            "content": "Analyzing the logs.",
+            "agent_id": "log_worker",
+            "parent_agent_id": "coordinator",
+            "session_id": "s1"
+        });
+        let events = vec![
+            sse(event_names::REASONING, &data.to_string()),
+            sse("", "[DONE]"),
+        ];
+        let (_, caps) = run_stream(events).await;
+        assert_eq!(caps.reasoning.len(), 1);
+        assert_eq!(caps.reasoning[0].1, "log_worker");
+    }
+
+    #[tokio::test]
+    async fn aura_reasoning_chunks_accumulate() {
+        let chunk = |c: &str| {
+            serde_json::json!({
+                "content": c,
+                "agent_id": "main",
+                "session_id": "s1"
+            })
+            .to_string()
+        };
+        let events = vec![
+            sse(event_names::REASONING, &chunk("First, ")),
+            sse(event_names::REASONING, &chunk("I'll check ")),
+            sse(event_names::REASONING, &chunk("the inputs.")),
+            sse("", "[DONE]"),
+        ];
+        let (_, caps) = run_stream(events).await;
+        assert_eq!(caps.reasoning.len(), 3);
+        let joined: String = caps.reasoning.iter().map(|(c, _)| c.as_str()).collect();
+        assert_eq!(joined, "First, I'll check the inputs.");
     }
 
     #[tokio::test]
     async fn aura_progress_routed_to_orchestrator() {
         let data = serde_json::json!({"message": "Discovering tools"});
-        let events = vec![sse("aura.progress", &data.to_string()), sse("", "[DONE]")];
+        let events = vec![
+            sse(event_names::PROGRESS, &data.to_string()),
+            sse("", "[DONE]"),
+        ];
         let (_, caps) = run_stream(events).await;
         assert_eq!(caps.orchestrator_events.len(), 1);
-        assert_eq!(caps.orchestrator_events[0].0, "aura.progress");
+        assert_eq!(caps.orchestrator_events[0].0, event_names::PROGRESS);
     }
 
     // -----------------------------------------------------------------------
@@ -752,7 +903,7 @@ mod tests {
     async fn raw_event_only_for_named_events() {
         let events = vec![
             sse(
-                "aura.usage",
+                event_names::USAGE,
                 &serde_json::json!({"prompt_tokens":1,"completion_tokens":1}).to_string(),
             ),
             sse("", &text_chunk("hi", Some("stop"))), // empty event name
@@ -761,7 +912,7 @@ mod tests {
         let (_, caps) = run_stream(events).await;
         // Only the named event should appear in raw_events
         assert_eq!(caps.raw_events.len(), 1);
-        assert_eq!(caps.raw_events[0].0, "aura.usage");
+        assert_eq!(caps.raw_events[0].0, event_names::USAGE);
     }
 
     #[tokio::test]
@@ -794,19 +945,9 @@ mod tests {
                 .collect::<Vec<_>>(),
         );
         let cancel = Arc::new(AtomicBool::new(true)); // pre-cancelled
-        let result = process_sse_events(
-            event_stream,
-            cancel,
-            |_| {},
-            |_, _, _| {},
-            |_, _| {},
-            |_, _, _, _| {},
-            |_, _| {},
-            |_, _| {},
-            |_, _| {},
-        )
-        .await
-        .unwrap();
+        let result = process_sse_events(event_stream, cancel, &mut NoopHandler)
+            .await
+            .unwrap();
         match result {
             StreamResult::TextResponse(text) => assert_eq!(text, ""),
             other => panic!("expected empty TextResponse on cancel, got {:?}", other),
@@ -816,7 +957,10 @@ mod tests {
     #[tokio::test]
     async fn aura_tool_usage_silently_skipped() {
         let data = serde_json::json!({"tool_ids": ["c1"], "prompt_tokens": 10});
-        let events = vec![sse("aura.tool_usage", &data.to_string()), sse("", "[DONE]")];
+        let events = vec![
+            sse(event_names::TOOL_USAGE, &data.to_string()),
+            sse("", "[DONE]"),
+        ];
         let (_, caps) = run_stream(events).await;
         // tool_usage is explicitly skipped — only raw_event should fire
         assert!(caps.usages.is_empty());
@@ -833,7 +977,10 @@ mod tests {
             "total_tokens": 275,
             "session_id": "s1"
         });
-        let events = vec![sse("aura.usage", &data.to_string()), sse("", "[DONE]")];
+        let events = vec![
+            sse(event_names::USAGE, &data.to_string()),
+            sse("", "[DONE]"),
+        ];
         let (_, caps) = run_stream(events).await;
         assert_eq!(caps.usages, vec![(200, 75)]);
     }

--- a/crates/aura-cli/src/api/types.rs
+++ b/crates/aura-cli/src/api/types.rs
@@ -298,6 +298,19 @@ pub enum DisplayEvent {
         tokens_intercepted: u64,
         tokens_extracted: u64,
     },
+    /// LLM reasoning content (e.g. Anthropic extended thinking, Bedrock, etc...).
+    /// `agent_id` identifies which agent produced it — `"main"` for single-agent,
+    /// the worker name (e.g. `"log_worker"`) when emitted by an orchestration worker.
+    /// `content` holds the final accumulated text for the whole reasoning stretch
+    /// (one `DisplayEvent::Reasoning` per agent-contiguous stretch, not per delta).
+    /// `fields` carries the raw SSE payload (agent_id, content, parent_agent_id,
+    /// session_id, trace_id, ...) so /expand can render a complete fields tree.
+    Reasoning {
+        content: String,
+        agent_id: String,
+        #[serde(default)]
+        fields: BTreeMap<String, serde_json::Value>,
+    },
 }
 
 /// Convert a snake_case string to PascalCase. E.g. `get_me` → `GetMe`.

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -6,7 +6,7 @@
 //! same `process_sse_events` parser used by the HTTP backend. This guarantees
 //! identical behavior whether the CLI connects via HTTP or runs standalone.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::Duration;
@@ -26,7 +26,7 @@ use aura_web_server::types::{
     ChatMessageToolCall, ClientFunctionDefinition, ClientToolDefinition, Role,
 };
 
-use crate::api::stream::{StreamResult, process_sse_events};
+use crate::api::stream::{StreamHandler, StreamResult, process_sse_events};
 use crate::api::types::{Message, ToolCallInfo, ToolDefinition};
 use crate::ui::prompt::get_selected_model;
 
@@ -239,13 +239,7 @@ impl DirectBackend {
         tools: Option<&[ToolDefinition]>,
         session_id: &str,
         cancel: Arc<AtomicBool>,
-        on_token: impl FnMut(&str),
-        on_tool_requested: impl FnMut(&str, &str, &BTreeMap<String, serde_json::Value>),
-        on_tool_start: impl FnMut(&str, &str),
-        on_tool_complete: impl FnMut(&str, &str, Duration, Option<&str>),
-        on_usage: impl FnMut(u64, u64),
-        on_raw_event: impl FnMut(&str, &str),
-        on_orchestrator_event: impl FnMut(&str, &serde_json::Value),
+        handler: &mut impl StreamHandler,
     ) -> Result<StreamResult> {
         let selected = get_selected_model();
         let mut req = Self::build_chat_request(messages, tools, selected);
@@ -283,18 +277,7 @@ impl DirectBackend {
         let sse_stream = byte_stream.eventsource();
 
         // Parse SSE events through the same parser used by the HTTP backend
-        process_sse_events(
-            sse_stream,
-            cancel,
-            on_token,
-            on_tool_requested,
-            on_tool_start,
-            on_tool_complete,
-            on_usage,
-            on_raw_event,
-            on_orchestrator_event,
-        )
-        .await
+        process_sse_events(sse_stream, cancel, handler).await
     }
 
     pub async fn summarize(

--- a/crates/aura-cli/src/backend/http.rs
+++ b/crates/aura-cli/src/backend/http.rs
@@ -1,12 +1,10 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::time::Duration;
 
 use anyhow::Result;
 
 use crate::api::client::ChatClient;
-use crate::api::stream::{StreamResult, process_stream};
+use crate::api::stream::{StreamHandler, StreamResult, process_stream};
 use crate::api::types::{Message, ToolDefinition};
 use crate::config::AppConfig;
 
@@ -25,37 +23,19 @@ impl HttpBackend {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub async fn stream_chat(
         &self,
         messages: &[Message],
         tools: Option<&[ToolDefinition]>,
         session_id: &str,
         cancel: Arc<AtomicBool>,
-        on_token: impl FnMut(&str),
-        on_tool_requested: impl FnMut(&str, &str, &BTreeMap<String, serde_json::Value>),
-        on_tool_start: impl FnMut(&str, &str),
-        on_tool_complete: impl FnMut(&str, &str, Duration, Option<&str>),
-        on_usage: impl FnMut(u64, u64),
-        on_raw_event: impl FnMut(&str, &str),
-        on_orchestrator_event: impl FnMut(&str, &serde_json::Value),
+        handler: &mut impl StreamHandler,
     ) -> Result<StreamResult> {
         let response = self
             .client
             .send_streaming(messages, tools, session_id)
             .await?;
-        process_stream(
-            response,
-            cancel,
-            on_token,
-            on_tool_requested,
-            on_tool_start,
-            on_tool_complete,
-            on_usage,
-            on_raw_event,
-            on_orchestrator_event,
-        )
-        .await
+        process_stream(response, cancel, handler).await
     }
 
     pub async fn summarize(

--- a/crates/aura-cli/src/backend/mod.rs
+++ b/crates/aura-cli/src/backend/mod.rs
@@ -3,14 +3,12 @@ pub mod http;
 #[cfg(feature = "standalone-cli")]
 pub mod direct;
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::time::Duration;
 
 use anyhow::Result;
 
-use crate::api::stream::StreamResult;
+use crate::api::stream::{StreamHandler, StreamResult};
 use crate::api::types::{Message, ToolDefinition};
 use crate::cli::Args;
 use crate::config::AppConfig;
@@ -50,59 +48,25 @@ impl Backend {
         Ok(Self::Http(http::HttpBackend::new(config.clone())))
     }
 
-    /// Send a streaming chat completion and process the response,
-    /// invoking callbacks for each event.
-    ///
-    /// The callback signatures match `process_stream` exactly so that
-    /// callers (REPL, oneshot) need minimal changes.
-    #[allow(clippy::too_many_arguments)]
+    /// Send a streaming chat completion and process the response, invoking
+    /// `handler`'s methods for each event.
     pub async fn stream_chat(
         &self,
         messages: &[Message],
         tools: Option<&[ToolDefinition]>,
         session_id: &str,
         cancel: Arc<AtomicBool>,
-        on_token: impl FnMut(&str),
-        on_tool_requested: impl FnMut(&str, &str, &BTreeMap<String, serde_json::Value>),
-        on_tool_start: impl FnMut(&str, &str),
-        on_tool_complete: impl FnMut(&str, &str, Duration, Option<&str>),
-        on_usage: impl FnMut(u64, u64),
-        on_raw_event: impl FnMut(&str, &str),
-        on_orchestrator_event: impl FnMut(&str, &serde_json::Value),
+        handler: &mut impl StreamHandler,
     ) -> Result<StreamResult> {
         match self {
             Self::Http(http) => {
-                http.stream_chat(
-                    messages,
-                    tools,
-                    session_id,
-                    cancel,
-                    on_token,
-                    on_tool_requested,
-                    on_tool_start,
-                    on_tool_complete,
-                    on_usage,
-                    on_raw_event,
-                    on_orchestrator_event,
-                )
-                .await
+                http.stream_chat(messages, tools, session_id, cancel, handler)
+                    .await
             }
             #[cfg(feature = "standalone-cli")]
             Self::Direct(direct) => {
                 direct
-                    .stream_chat(
-                        messages,
-                        tools,
-                        session_id,
-                        cancel,
-                        on_token,
-                        on_tool_requested,
-                        on_tool_start,
-                        on_tool_complete,
-                        on_usage,
-                        on_raw_event,
-                        on_orchestrator_event,
-                    )
+                    .stream_chat(messages, tools, session_id, cancel, handler)
                     .await
             }
         }

--- a/crates/aura-cli/src/event_names.rs
+++ b/crates/aura-cli/src/event_names.rs
@@ -1,0 +1,10 @@
+//! SSE event-name constants used by the CLI's stream consumer.
+//!
+//! Re-exported from [`aura_events`], the shared source of truth: base
+//! `aura.*` names from [`aura_events::event_names`] and orchestrator
+//! `aura.orchestrator.*` names from [`aura_events::orchestration::event_names`].
+//! The two namespaces have no overlapping const names, so both are flattened
+//! here for one-import access at call sites.
+
+pub use aura_events::event_names::*;
+pub use aura_events::orchestration::event_names::*;

--- a/crates/aura-cli/src/lib.rs
+++ b/crates/aura-cli/src/lib.rs
@@ -3,6 +3,7 @@ pub mod aura_dir;
 pub mod backend;
 pub mod cli;
 pub mod config;
+pub mod event_names;
 pub mod logging;
 pub mod oneshot;
 pub mod permissions;

--- a/crates/aura-cli/src/oneshot.rs
+++ b/crates/aura-cli/src/oneshot.rs
@@ -24,7 +24,7 @@ use std::sync::atomic::AtomicBool;
 use anyhow::Result;
 use tokio::runtime::Runtime;
 
-use crate::api::stream::StreamResult;
+use crate::api::stream::{NoopHandler, StreamResult};
 use crate::api::types::ToolCallInfo;
 use crate::backend::Backend;
 use crate::config::AppConfig;
@@ -78,10 +78,8 @@ pub fn run_oneshot(
         crate::api::session::SessionKind::Chat,
     );
 
-    // Tool execution loop. All on_* callbacks are deliberately no-ops:
-    // events like tool_requested / tool_complete / usage are REPL
-    // affordances; stdout in one-shot mode is reserved for the final
-    // assistant text.
+    // Tool execution loop. One-shot ignores every stream event — stdout is
+    // reserved for the final assistant text — so a NoopHandler suffices.
     let result: Result<()> = loop {
         let stream_result = rt.block_on(async {
             backend
@@ -90,13 +88,7 @@ pub fn run_oneshot(
                     tool_defs_arg,
                     &chat_session_id,
                     Arc::new(AtomicBool::new(false)),
-                    |_token| {},
-                    |_tool_id, _tool_name, _args| {},
-                    |_tool_id, _tool_name| {},
-                    |_tool_id, _tool_name, _duration, _result: Option<&str>| {},
-                    |_prompt_tokens, _completion_tokens| {},
-                    |_event_name, _event_data| {},
-                    |_event_name, _val| {},
+                    &mut NoopHandler,
                 )
                 .await
         });

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -11,10 +11,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::runtime::Runtime;
 
-use crate::api::stream::StreamResult;
+use crate::api::stream::{StreamHandler, StreamResult};
 use crate::api::types::{DisplayEvent, ShellCallDetail, ToolCallInfo, snake_to_pascal_case};
 use crate::backend::Backend;
 use crate::config::AppConfig;
+use crate::event_names;
 use crate::repl::commands;
 use crate::repl::conversations::ConversationStore;
 use crate::repl::history::ConversationHistory;
@@ -37,6 +38,371 @@ use crate::ui::prompt::{
     update_status_bar, update_status_bar_unlocked, with_event_log, with_event_log_mut,
 };
 use crate::ui::welcome::WelcomeState;
+
+/// Orchestrator task tracking — promoted to module scope so reasoning
+/// helpers can look up which task a worker's reasoning belongs to.
+pub(crate) struct OrchTaskInfo {
+    pub header_line_num: u32,
+    pub worker_id: String,
+    pub tools: Vec<String>,
+}
+
+pub(crate) struct OrchDisplayState {
+    pub tasks: std::collections::HashMap<String, OrchTaskInfo>,
+}
+
+/// Live reasoning state.
+///
+/// Top-level reasoning (no `parent_agent_id`) renders as a top-level
+/// `● Reasoning` header followed by one or more `│ <body>` rows in scrollback.
+/// Each `\n` in incoming content pushes a new body row; sub-line content
+/// updates the current body row in place via cursor save/move/clear/print/restore.
+///
+/// Worker reasoning (has `parent_agent_id`) renders as a tree entry inside
+/// the worker's task: `└─ ● Reasoning` plus a single `   ⎿ <body>` line that
+/// updates in place as chunks arrive. Newlines in worker reasoning are
+/// flattened to spaces so the body stays on one line — matching the format
+/// of tool-call entries already in the tree.
+///
+/// Live updates use cursor SavePosition / MoveUp / Clear / Print /
+/// RestorePosition (the same pattern the WaveAnimation thread uses for tool
+/// duration in-place updates), so the cursor never lives mid-line and the
+/// next event lands cleanly.
+struct LiveReasoning {
+    agent_id: String,
+    /// Carried so we can persist it back into the DisplayEvent's fields map
+    /// on flush; `is_worker` drives the rendering branch.
+    #[allow(dead_code)]
+    parent_agent_id: Option<String>,
+    /// Task id for worker reasoning (filled in at first chunk via
+    /// `orch_state` lookup). `None` for top-level reasoning.
+    task_id: Option<String>,
+    combined: String,
+    fields: BTreeMap<String, serde_json::Value>,
+    /// `true` once the header line has been printed to scrollback.
+    #[allow(dead_code)]
+    started: bool,
+    /// Scrollback line number of the FIRST body row (top-level reasoning
+    /// may now span multiple rows, growing as newlines arrive). For worker
+    /// reasoning this is the single in-place updated row.
+    body_line_num: u32,
+    /// Text currently displayed on the body (worker: one row; top-level:
+    /// multi-line content rendered across `body_visual_rows` rows).
+    body_line_text: String,
+    /// Number of scrollback rows the body region currently occupies. Always
+    /// `1` for worker reasoning. For top-level reasoning this grows by one
+    /// for each newline encountered in incoming chunks — the growth is
+    /// committed to scrollback via a brief halt+extend+restart of the
+    /// WaveAnimation (same pattern `tool_call_started` uses to push the
+    /// frame down when a new tree entry is added).
+    body_visual_rows: u32,
+    is_worker: bool,
+}
+
+/// Worker reasoning body connector (`   ⎿ <text>`). Caller must hold
+/// `lock_term()`.
+fn write_worker_reasoning_body_line(text: &str) {
+    print!(
+        "{}{} {}",
+        crate::ui::orchestrator::TREE_END_DURATION.themed(AuraStyle::Connector),
+        "⎿".themed(AuraStyle::Connector),
+        text.themed(AuraStyle::Muted),
+    );
+}
+
+/// Flatten + truncate worker reasoning body to one terminal row.
+fn worker_reasoning_body_for_terminal(text: &str) -> String {
+    // Connector width: "   ⎿ " = 5 cols visible.
+    let prefix_cols: usize = 5;
+    let (term_w, _) = crate::ui::prompt::term_size();
+    let avail = (term_w as usize).saturating_sub(prefix_cols).max(8);
+    let flattened: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flattened.chars().count() <= avail {
+        flattened
+    } else {
+        let truncated: String = flattened.chars().take(avail.saturating_sub(3)).collect();
+        format!("{truncated}...")
+    }
+}
+
+/// In-place rewrite of the worker reasoning body row.
+/// Caller must already hold `lock_term()`. The WaveAnimation is restarted
+/// after the worker block opens, so the cursor lives at the input line and
+/// we use the same `+3` offset that the animation thread uses for tool
+/// durations (line 372 of `ui/animation.rs`).
+fn rewrite_worker_reasoning_body_inplace(state: &LiveReasoning, body_text: &str) {
+    use std::io::Write;
+    let total_sb = crate::ui::prompt::current_orch_scrollback();
+    let body_up = (total_sb + 3).saturating_sub(state.body_line_num);
+    let (_, th) = crate::ui::prompt::term_size();
+    if body_up == 0 || body_up >= th as u32 {
+        return;
+    }
+    let mut stdout = std::io::stdout();
+    let _ = execute!(stdout, crossterm::cursor::SavePosition);
+    let _ = execute!(
+        stdout,
+        crossterm::cursor::MoveUp(body_up as u16),
+        crossterm::cursor::MoveToColumn(0)
+    );
+    let _ = execute!(
+        stdout,
+        crossterm::terminal::Clear(crossterm::terminal::ClearType::CurrentLine)
+    );
+    write_worker_reasoning_body_line(body_text);
+    let _ = execute!(stdout, crossterm::cursor::RestorePosition);
+    let _ = stdout.flush();
+}
+
+/// Render the top-level `● Reasoning` header and an opening `⎿ ` body row
+/// in scrollback. Subsequent reasoning chunks update the body row in-place
+/// via the same SavePosition/MoveUp/Clear/Print/RestorePosition pattern
+/// that the animation thread uses for tool durations. The cursor lives at
+/// the scrollback bottom (spinner is halted before this is called), so
+/// the rewrite uses the bare `total_sb - body_line_num` distance.
+///
+/// `agent_id` is appended when it identifies the coordinator or some other
+/// non-default agent (e.g., `● Reasoning - coordinator`); single-agent
+/// deployments with `agent_id == "main"` render just `● Reasoning`.
+///
+/// Caller must already hold `lock_term()`.
+fn open_top_level_reasoning_block(state: &mut LiveReasoning, agent_id: &str) {
+    let bullet_color = task_color_for(if agent_id.is_empty() {
+        "__orchestrator__"
+    } else {
+        agent_id
+    });
+    let header = if agent_id == "main" || agent_id.is_empty() {
+        "Reasoning".to_string()
+    } else {
+        format!("Reasoning - {agent_id}")
+    };
+    println!(
+        "{} {}",
+        "●"
+            .with(bullet_color)
+            .attribute(crossterm::style::Attribute::Bold),
+        header
+            .as_str()
+            .themed(AuraStyle::Primary)
+            .attribute(crossterm::style::Attribute::Bold),
+    );
+    crate::ui::prompt::increment_orch_scrollback();
+    // Body row: print "⎿ " (no content yet) and commit with a newline so
+    // the body has a stable scrollback index. The `⎿` corner is final —
+    // streaming chunks update only the body text (single-line, flattened);
+    // multi-line content remains visible via `/expand` replay.
+    print!("{} ", "⎿".themed(AuraStyle::Connector));
+    println!();
+    crate::ui::prompt::increment_orch_scrollback();
+    state.body_line_num = crate::ui::prompt::current_orch_scrollback() - 1;
+    state.body_line_text = String::new();
+    state.started = true;
+    // Trailing blank separator row — counted in scrollback so the next
+    // event (Plan/Task/Thinking) has a visible gap from the body row.
+    // The animation overlay is printed *below* this blank, so the
+    // separator stays visible during streaming AND after teardown.
+    println!();
+    crate::ui::prompt::increment_orch_scrollback();
+}
+
+/// Render the worker tree entry: `└─ ● Reasoning` + initial empty body row.
+/// Also upgrades any prior tool-call entry's connector from `└─` to `├─`
+/// (via `register_orch_reasoning_in_tree`) and registers this entry in
+/// `ORCH_LAST_TOOL_LINES` so the next tool call can upgrade reasoning's
+/// connector in turn. Caller must already hold `lock_term()`.
+fn open_worker_reasoning_block(state: &mut LiveReasoning, task_id: &str) {
+    crate::ui::orchestrator::register_orch_reasoning_in_tree(
+        task_id,
+        |bullet_line_num, body_line_num| {
+            state.body_line_num = body_line_num;
+            state.body_line_text = String::new();
+            state.started = true;
+            let _ = bullet_line_num;
+        },
+    );
+}
+
+/// Apply a chunk of content to the currently-open live block.
+/// Caller must already hold `lock_term()`.
+///
+/// Both top-level and worker reasoning use in-place body rewrites so the
+/// cursor never leaves the input line — the WaveAnimation thread can keep
+/// ticking in parallel. Both use the animation's `+3` offset (same as the
+/// in-flight tool duration updates in `ui/animation.rs`).
+///
+/// Newlines in incoming content are flattened to spaces — the live body
+/// stays on one terminal row to avoid wrapping into the animation rows.
+/// The full multi-line content is preserved in `DisplayEvent::Reasoning`
+/// for `/expand` replay.
+fn apply_reasoning_chunk(state: &mut LiveReasoning, delta: &str) {
+    state.combined.push_str(delta);
+    state.body_line_text.push_str(delta);
+    if state.is_worker {
+        let display = worker_reasoning_body_for_terminal(&state.body_line_text);
+        rewrite_worker_reasoning_body_inplace(state, &display);
+    } else {
+        let lines = top_level_reasoning_body_for_terminal(&state.body_line_text);
+        rewrite_top_level_reasoning_body_inplace(state, &lines);
+    }
+}
+
+/// Split top-level body content into one display string per visual row.
+/// Each logical line (separated by `\n` in the streamed content) is
+/// flattened (consecutive whitespace collapsed) and then word-wrapped to
+/// fit `term_width - 2` columns (the 2 columns are reserved for the
+/// `⎿ ` / `  ` row prefix). The wrap prefers word boundaries; if a single
+/// token is longer than the available width it hard-wraps in the middle.
+///
+/// Returns at least one (possibly empty) string so the body always has a
+/// visible row.
+fn top_level_reasoning_body_for_terminal(text: &str) -> Vec<String> {
+    let prefix_cols: usize = 2;
+    let (term_w, _) = crate::ui::prompt::term_size();
+    let avail = (term_w as usize).saturating_sub(prefix_cols).max(8);
+    let mut visual: Vec<String> = Vec::new();
+    for line in text.split('\n') {
+        let flat: String = line.split_whitespace().collect::<Vec<_>>().join(" ");
+        if flat.is_empty() {
+            visual.push(String::new());
+            continue;
+        }
+        let chars: Vec<char> = flat.chars().collect();
+        let mut start = 0;
+        while start < chars.len() {
+            let remaining = chars.len() - start;
+            if remaining <= avail {
+                let seg: String = chars[start..].iter().collect();
+                visual.push(seg);
+                break;
+            }
+            let hard_end = start + avail;
+            // Prefer a soft break at the last space within [start, hard_end).
+            let mut soft_end = hard_end;
+            while soft_end > start && chars[soft_end - 1] != ' ' {
+                soft_end -= 1;
+            }
+            let wrap_end = if soft_end > start { soft_end } else { hard_end };
+            let seg: String = chars[start..wrap_end].iter().collect();
+            // Strip the trailing space we broke at, if any.
+            visual.push(seg.trim_end().to_string());
+            start = wrap_end;
+            // Skip the run of spaces we just broke on.
+            while start < chars.len() && chars[start] == ' ' {
+                start += 1;
+            }
+        }
+    }
+    if visual.is_empty() {
+        visual.push(String::new());
+    }
+    visual
+}
+
+/// In-place rewrite of the top-level body. The WaveAnimation is running
+/// (cursor at the input line); we use the same `+3` offset that the
+/// animation thread uses for tool durations so `MoveUp` lands on the body's
+/// FIRST scrollback row, above the anim overlay. Subsequent body rows are
+/// rewritten by `MoveDown`-ing one row at a time.
+///
+/// `state.body_visual_rows` rows in scrollback are owned by the body — the
+/// caller must extend that allocation BEFORE calling this with more logical
+/// lines than the body currently has rows for (otherwise the trailing
+/// logical lines are silently dropped).
+fn rewrite_top_level_reasoning_body_inplace(state: &LiveReasoning, lines: &[String]) {
+    use std::io::Write;
+    let total_sb = crate::ui::prompt::current_orch_scrollback();
+    let body_up = (total_sb + 3).saturating_sub(state.body_line_num);
+    let (_, th) = crate::ui::prompt::term_size();
+    if body_up == 0 || body_up >= th as u32 {
+        return;
+    }
+    let mut stdout = std::io::stdout();
+    let _ = execute!(stdout, crossterm::cursor::SavePosition);
+    let _ = execute!(
+        stdout,
+        crossterm::cursor::MoveUp(body_up as u16),
+        crossterm::cursor::MoveToColumn(0)
+    );
+
+    let rows = state.body_visual_rows as usize;
+    for i in 0..rows {
+        let _ = execute!(
+            stdout,
+            crossterm::terminal::Clear(crossterm::terminal::ClearType::CurrentLine)
+        );
+        // First row gets the `⎿ ` connector (descent from the bullet);
+        // subsequent rows use 2 spaces so the body content stays aligned
+        // visually under the connector.
+        let connector = if i == 0 { "⎿" } else { " " };
+        let content = lines.get(i).map(|s| s.as_str()).unwrap_or("");
+        print!(
+            "{} {}",
+            connector.themed(AuraStyle::Connector),
+            content.themed(AuraStyle::Muted),
+        );
+        if i + 1 < rows {
+            let _ = execute!(
+                stdout,
+                crossterm::cursor::MoveDown(1),
+                crossterm::cursor::MoveToColumn(0)
+            );
+        }
+    }
+    let _ = execute!(stdout, crossterm::cursor::RestorePosition);
+    let _ = stdout.flush();
+}
+
+/// Persist the live reasoning block as a `DisplayEvent::Reasoning` so
+/// replay/resume see one block per agent stretch.
+///
+/// Returns `true` when a top-level block was flushed — the caller (the
+/// orchestrator-event handler) uses this to defer a separator blank row
+/// until AFTER `erase_input_frame` has run, so the println lands in
+/// scrollback rather than clobbering the live input frame.
+///
+/// No terminal output happens inside this function: the body row already
+/// lives in scrollback at `body_line_num`, and the deferred separator
+/// (when applicable) is committed by the caller.
+fn flush_live_reasoning(state: &Arc<Mutex<Option<LiveReasoning>>>) -> bool {
+    let Some(s) = state.lock().ok().and_then(|mut g| g.take()) else {
+        return false;
+    };
+    if s.combined.is_empty() {
+        return false;
+    }
+    let was_top_level = !s.is_worker;
+    let mut fields = s.fields;
+    fields.insert(
+        "content".to_string(),
+        serde_json::Value::String(s.combined.clone()),
+    );
+    push_display_event(DisplayEvent::Reasoning {
+        content: s.combined,
+        agent_id: s.agent_id,
+        fields,
+    });
+    was_top_level
+}
+
+/// Orchestrator events that actually `println!` scrollback content.
+/// `flush_live_reasoning` must run before these so the open reasoning block
+/// closes cleanly and the next event lands on its own row. Events that only
+/// touch the spinner sub-line or do in-place updates (`worker_reasoning`,
+/// `synthesizing`) are deliberately excluded — flushing on them would slice
+/// multi-chunk reasoning into separate `DisplayEvent::Reasoning` entries, one
+/// per delta.
+fn orch_event_prints_scrollback(event_name: &str) -> bool {
+    matches!(
+        event_name,
+        event_names::PLAN_CREATED
+            | event_names::TASK_STARTED
+            | event_names::TOOL_CALL_STARTED
+            | event_names::TOOL_CALL_COMPLETED
+            | event_names::TASK_COMPLETED
+            | event_names::ITERATION_COMPLETE
+    )
+}
 
 pub fn run_repl(
     rt: &Runtime,
@@ -361,11 +727,15 @@ pub fn run_repl(
                     Mutex<std::collections::HashMap<String, BTreeMap<String, serde_json::Value>>>,
                 > = Arc::new(Mutex::new(std::collections::HashMap::new()));
                 let turn_events: Arc<Mutex<Vec<DisplayEvent>>> = Arc::new(Mutex::new(Vec::new()));
-                let pending_args_for_tool = pending_args.clone();
-                let pending_args_for_complete = pending_args.clone();
-                let turn_events_for_complete = turn_events.clone();
-                let turn_events_for_usage = turn_events.clone();
                 let cancel_flag = Arc::new(AtomicBool::new(false));
+
+                // Live reasoning block — accumulated as chunks stream in,
+                // closed by `flush_live_reasoning` on the next non-reasoning
+                // event (or end of stream). Reasoning is NOT routed through
+                // `set_agent_reasoning` — that sub-line is reserved for the
+                // `_aura_reasoning` blurbs attached to tool calls and to
+                // `aura.progress` messages.
+                let live_reasoning: Arc<Mutex<Option<LiveReasoning>>> = Arc::new(Mutex::new(None));
 
                 let (anim, stop_flag) = WaveAnimation::start(
                     "Thinking",
@@ -377,43 +747,22 @@ pub fn run_repl(
                 prepare_input_line(&input_buf, Some(&cancel_flag));
 
                 let anim_cleared = Arc::new(AtomicBool::new(false));
-                let anim_cleared_for_complete = anim_cleared.clone();
-                let anim_cleared_for_orch = anim_cleared.clone();
-                let stop_flag_for_token = stop_flag.clone();
-                let stop_flag_for_orch = stop_flag.clone();
 
-                let cancel_for_complete = cancel_flag.clone();
                 let cancel_for_stream = cancel_flag.clone();
-                let cancel_for_orch = cancel_flag.clone();
 
                 #[allow(clippy::type_complexity)]
                 let post_tool_wave: Arc<
                     Mutex<Option<(WaveAnimation, Arc<AtomicBool>)>>,
                 > = Arc::new(Mutex::new(None));
-                let ptw_for_complete = post_tool_wave.clone();
-                let ptw_for_orch = post_tool_wave.clone();
-
-                let input_buf_for_complete = input_buf.clone();
-                let input_buf_for_orch = input_buf.clone();
 
                 // --- Orchestrator display state ---
-                struct OrchTaskInfo {
-                    header_line_num: u32,
-                    worker_id: String,
-                    tools: Vec<String>,
-                }
-                struct OrchDisplayState {
-                    tasks: std::collections::HashMap<String, OrchTaskInfo>,
-                }
                 let orch_state: Arc<Mutex<OrchDisplayState>> =
                     Arc::new(Mutex::new(OrchDisplayState {
                         tasks: std::collections::HashMap::new(),
                     }));
-                let orch_for_cb = orch_state.clone();
                 // Set after tool_call_completed; consumed before the next
                 // non-tool event to insert a blank line separator.
                 let needs_blank = Arc::new(AtomicBool::new(false));
-                let needs_blank_for_cb = needs_blank.clone();
 
                 // Build tool defs only when client tools are enabled. When
                 // disabled the CLI sends no `tools` field, the model has no
@@ -502,7 +851,6 @@ pub fn run_repl(
                 // Shared flag so streaming callbacks can suppress Shell display
                 // when the LLM is inside an Update group.
                 let in_update_group = Arc::new(AtomicBool::new(false));
-                let in_update_for_tool = in_update_group.clone();
 
                 // Tool execution loop: send request → process stream → if tool calls,
                 // execute locally and send results back → repeat until text response.
@@ -516,534 +864,34 @@ pub fn run_repl(
                         crate::api::session::SessionKind::Chat,
                     );
                     let result = rt.block_on(async {
-                        backend.stream_chat(
-                            conversation.messages(),
-                            tool_defs_arg,
-                            &chat_session_id,
-                            cancel_for_stream.clone(),
-                            // on_token — no-op: text is accumulated silently (not
-                            // displayed per-token), so the animation should keep
-                            // running to provide visual feedback. It will be stopped
-                            // by on_tool_complete, the ToolCalls handler, or
-                            // post-loop cleanup. The animation thread handles stdin.
-                            |_token| {},
-                            // on_tool_requested — record args; don't stop animation
-                            // (animation keeps running until something needs to display)
-                            //
-                            // Keyed by tool_id (not tool_name) so multiple invocations of the
-                            // same tool in one turn don't overwrite each other's arguments.
-                            |tool_id, tool_name, args| {
-                                // Record args for later pairing with on_tool_complete
-                                if let Ok(mut map) = pending_args_for_tool.lock() {
-                                    map.insert(tool_id.to_string(), args.clone());
-                                }
-                                // Track Update grouping flag for the execution loop
-                                if tool_name == "Update" {
-                                    in_update_for_tool.store(true, Ordering::Relaxed);
-                                } else if tool_name != "Shell"
-                                    || !in_update_for_tool.load(Ordering::Relaxed)
-                                {
-                                    // Non-Shell (or Shell outside Update) clears the flag
-                                    if tool_name != "Shell" {
-                                        in_update_for_tool.store(false, Ordering::Relaxed);
-                                    }
-                                }
-                            },
-                            // on_tool_start — no-op; animation keeps running
-                            |_tool_id, _tool_name| {},
-                            // on_tool_complete — show grouped summary for server-side tools
-                            |tool_id, tool_name, duration, result: Option<&str>| {
-                                // Stop animation: prefer ptw (later iterations), fall back
-                                // to initial animation (first iteration).
-                                let had_ptw = if let Ok(mut guard) = ptw_for_complete.lock() {
-                                    if let Some((ptw_anim, _)) = guard.take() {
-                                        ptw_anim.finish();
-                                        true
-                                    } else {
-                                        false
-                                    }
-                                } else {
-                                    false
-                                };
-                                if !had_ptw && !anim_cleared_for_complete.load(Ordering::Relaxed) {
-                                    stop_and_clear_animation(&stop_flag_for_token);
-                                    anim_cleared_for_complete.store(true, Ordering::Relaxed);
-                                }
-                                // Show server-side tool result
-                                {
-                                    let _term = lock_term();
-                                    erase_input_frame();
-                                    let args = pending_args_for_complete
-                                        .lock()
-                                        .ok()
-                                        .and_then(|mut map| map.remove(tool_id))
-                                        .unwrap_or_default();
-                                    if is_expanded_output() {
-                                        print_tool_call_expanded(
-                                            tool_name,
-                                            &args,
-                                            duration,
-                                            result,
-                                        );
-                                    } else {
-                                        crate::ui::prompt::print_tool_call_summary(
-                                            tool_name,
-                                            &args,
-                                            Some(duration),
-                                        );
-                                        println!();
-                                    }
-                                    if let Ok(mut events) = turn_events_for_complete.lock() {
-                                        events.push(DisplayEvent::ToolCall {
-                                            tool_name: tool_name.to_string(),
-                                            arguments: args,
-                                            duration,
-                                            result: result.map(|s| s.to_string()),
-                                        });
-                                    }
-                                }
-                                // Start "Thinking" animation to fill gap until next event
-                                let (wave_anim, wave_stop) = {
-                                    let _term = lock_term();
-                                    WaveAnimation::start(
-                                        "Thinking",
-                                        vec![],
-                                        input_buf_for_complete.clone(),
-                                        Some(cancel_for_complete.clone()),
-                                    )
-                                };
-                                if let Ok(mut guard) = ptw_for_complete.lock() {
-                                    *guard = Some((wave_anim, wave_stop));
-                                }
-                                prepare_input_line(
-                                    &input_buf_for_complete,
-                                    Some(&cancel_for_complete),
-                                );
-                            },
-                            // on_usage
-                            |prompt_tokens, completion_tokens| {
-                                set_status_bar_tokens(prompt_tokens, completion_tokens);
-                                update_status_bar();
-                                if let Ok(mut events) = turn_events_for_usage.lock() {
-                                    events.push(DisplayEvent::Usage {
-                                        prompt_tokens,
-                                        completion_tokens,
-                                    });
-                                }
-                            },
-                            // on_raw_event — capture for stream panel and
-                            // record progress_token → tool_id so an incoming
-                            // aura.progress can be steered onto the right
-                            // active tool's running line.
-                            |event_name, event_data| {
-                                push_sse_event(event_name, event_data);
-                                if event_name == "aura.tool_start"
-                                    && let Ok(val) =
-                                        serde_json::from_str::<serde_json::Value>(event_data)
-                                    && let Some(tool_id) =
-                                        val.get("tool_id").and_then(|v| v.as_str())
-                                    && let Some(token) = val.get("progress_token")
-                                    && !token.is_null()
-                                {
-                                    crate::ui::prompt::record_tool_progress_token(
-                                        tool_id,
-                                        &token.to_string(),
-                                    );
-                                }
-                            },
-                            // on_orchestrator_event — display orchestrator events in chat
-                            |event_name, val| {
-                                // Handle aura.progress — prefer to attach the
-                                // message to the active orchestrator tool whose
-                                // progress_token matches; fall back to the
-                                // global "Thinking" sub-line when there's no
-                                // active tool to attach it to (single-agent
-                                // mode, or progress for a tool we never saw a
-                                // tool_start for).
-                                if event_name == "aura.progress" {
-                                    if let Some(message) = val.get("message").and_then(|v| v.as_str()) {
-                                        let token = val.get("progress_token").map(|t| t.to_string());
-                                        let attached = token
-                                            .as_deref()
-                                            .map(|t| {
-                                                crate::ui::prompt::set_orch_tool_progress_by_token(
-                                                    t, message,
-                                                )
-                                            })
-                                            .unwrap_or(false);
-                                        if !attached {
-                                            crate::ui::prompt::set_agent_reasoning(message);
-                                        }
-                                    }
-                                    return;
-                                }
-
-                                // Reflect the worker's current phase
-                                // (`Planning`/`Executing`/`Analyzing`) in the
-                                // task header. Overwrites in-place; the
-                                // task_completed handler later replaces this
-                                // with `done`.
-                                if event_name == "aura.worker_phase" {
-                                    let task_id = val.get("task_id").and_then(|v| v.as_str()).unwrap_or("");
-                                    let phase = val.get("phase").and_then(|v| v.as_str()).unwrap_or("");
-                                    if task_id.is_empty() || phase.is_empty() {
-                                        return;
-                                    }
-                                    let mut chars = phase.chars();
-                                    let phase_label: String = match chars.next() {
-                                        Some(c) => c.to_uppercase().chain(chars).collect(),
-                                        None => return,
-                                    };
-                                    let header_info = if let Ok(os) = orch_for_cb.lock() {
-                                        os.tasks
-                                            .get(task_id)
-                                            .map(|t| (t.header_line_num, t.worker_id.clone()))
-                                    } else {
-                                        None
-                                    };
-                                    if let Some((header_line, worker_id)) = header_info {
-                                        crate::ui::prompt::overwrite_orch_task_header(
-                                            header_line,
-                                            task_id,
-                                            &worker_id,
-                                            &phase_label,
-                                        );
-                                    }
-                                    return;
-                                }
-
-                                let sub = event_name.strip_prefix("aura.orchestrator.").unwrap_or(event_name);
-                                if event_name == "aura.session_info" || sub == event_name {
-                                    return;
-                                }
-
-
-                                // Stop current animation
-                                let had_ptw = if let Ok(mut guard) = ptw_for_orch.lock() {
-                                    if let Some((ptw_anim, _)) = guard.take() {
-                                        ptw_anim.finish();
-                                        true
-                                    } else {
-                                        false
-                                    }
-                                } else {
-                                    false
-                                };
-                                if !had_ptw && !anim_cleared_for_orch.load(Ordering::Relaxed) {
-                                    stop_and_clear_animation(&stop_flag_for_orch);
-                                    anim_cleared_for_orch.store(true, Ordering::Relaxed);
-                                }
-                                {
-                                let _term = lock_term();
-                                erase_input_frame();
-
-                                // Emit a deferred blank line from a previous
-                                // tool_call_completed — but only if this event
-                                // isn't another tool starting directly after.
-                                if needs_blank_for_cb.swap(false, Ordering::Relaxed) && sub != "tool_call_started" {
-                                    println!();
-                                    crate::ui::prompt::increment_orch_scrollback();
-                                }
-
-                                // Helpers
-                                let get_str = |v: &serde_json::Value, field: &str| -> String {
-                                    let f = v.get(field)
-                                        .or_else(|| v.get("data").and_then(|d| d.get(field)));
-                                    match f {
-                                        Some(serde_json::Value::String(s)) => s.clone(),
-                                        Some(serde_json::Value::Number(n)) => n.to_string(),
-                                        Some(serde_json::Value::Bool(b)) => b.to_string(),
-                                        _ => String::new(),
-                                    }
-                                };
-                                let get_u64 = |v: &serde_json::Value, field: &str| -> u64 {
-                                    v.get(field)
-                                        .or_else(|| v.get("data").and_then(|d| d.get(field)))
-                                        .and_then(|f| f.as_u64())
-                                        .unwrap_or(0)
-                                };
-                                let fields: BTreeMap<String, serde_json::Value> = match val.as_object() {
-                                    Some(obj) => obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
-                                    None => BTreeMap::new(),
-                                };
-                                let parse_args = |v: &serde_json::Value| -> Option<serde_json::Map<String, serde_json::Value>> {
-                                    v.get("arguments")
-                                        .or_else(|| v.get("data").and_then(|d| d.get("arguments")))
-                                        .and_then(|a| match a {
-                                            serde_json::Value::Object(obj) => Some(obj.clone()),
-                                            serde_json::Value::String(s) => serde_json::from_str(s).ok(),
-                                            _ => None,
-                                        })
-                                };
-
-                                // Per-orchestrator-entity bullet color. Keyed by task_id
-                                // (or `__orchestrator__` for coordinator-level events:
-                                // plan_created, synthesizing, iteration_complete).
-                                // Resolved through the active theme — switching themes
-                                // repaints automatically; no colors are persisted.
-                                let event_task_id = get_str(val, "task_id");
-                                let color_key: String = if !event_task_id.is_empty() {
-                                    event_task_id.clone()
-                                } else {
-                                    "__orchestrator__".to_string()
-                                };
-                                let bullet_color = task_color_for(&color_key);
-
-                                match sub {
-                                    "plan_created" => {
-                                        let goal = get_str(val, "goal");
-                                        // New plan resets reasoning
-                                        crate::ui::prompt::clear_agent_reasoning();
-                                        println!(
-                                            "{} {}",
-                                            "●".with(bullet_color).attribute(crossterm::style::Attribute::Bold),
-                                            format!("Plan - {goal}").attribute(crossterm::style::Attribute::Bold),
-                                        );
-                                        crate::ui::prompt::increment_orch_scrollback();
-                                        if is_expanded_output() {
-                                            // Count lines that print_fields_tree will emit
-                                            let field_lines = fields.values().map(|v| {
-                                                if let serde_json::Value::Object(obj) = v { 1 + obj.len() } else { 1 }
-                                            }).sum::<usize>();
-                                            print_fields_tree(&fields);
-                                            for _ in 0..field_lines {
-                                                crate::ui::prompt::increment_orch_scrollback();
-                                            }
-                                        }
-                                        println!();
-                                        crate::ui::prompt::increment_orch_scrollback();
-                                        push_display_event(DisplayEvent::OrchestratorPlanCreated { goal, fields });
-                                    }
-                                    "task_started" => {
-                                        let worker_id = get_str(val, "worker_id");
-                                        let task_id = get_str(val, "task_id");
-                                        let description = get_str(val, "description");
-                                        // Bullet color resolved per-task at render time —
-                                        // `task_color_for(&task_id)` returns the color the
-                                        // generic block (above) already computed via
-                                        // `bullet_color`, so reuse that directly.
-                                        crate::ui::prompt::set_agent_reasoning(&description);
-                                        let header_line = crate::ui::prompt::current_orch_scrollback();
-                                        println!(
-                                            "{} {} {} {}",
-                                            "●".with(bullet_color).attribute(crossterm::style::Attribute::Bold),
-                                            format!("Task {task_id}").attribute(crossterm::style::Attribute::Bold),
-                                            "-".themed(AuraStyle::Muted),
-                                            format!("Worker: {worker_id}").themed(AuraStyle::Muted),
-                                        );
-                                        crate::ui::prompt::increment_orch_scrollback();
-                                        // No blank line – tool calls follow directly
-                                        if let Ok(mut os) = orch_for_cb.lock() {
-                                            os.tasks.insert(task_id.clone(), OrchTaskInfo {
-                                                header_line_num: header_line,
-                                                worker_id: worker_id.clone(),
-                                                tools: Vec::new(),
-                                            });
-                                        }
-                                        push_display_event(DisplayEvent::OrchestratorTaskStarted {
-                                            worker_id, task_id, description, fields,
-                                        });
-                                    }
-                                    "tool_call_started" => {
-                                        let tool_name = get_str(val, "tool_name");
-                                        let tool_initiator_id = get_str(val, "tool_initiator_id");
-                                        let tool_call_id = get_str(val, "tool_call_id");
-                                        let task_id_str = get_str(val, "task_id");
-                                        let display_name = snake_to_pascal_case(&tool_name);
-                                        let args_obj = parse_args(val);
-                                        let args_summary = args_obj.as_ref()
-                                            .map(|obj| {
-                                                obj.iter()
-                                                    .filter(|(k, v)| {
-                                                        !k.starts_with('_')
-                                                            && !matches!(v, serde_json::Value::Null)
-                                                            && !matches!(v, serde_json::Value::String(s) if s.is_empty() || s == "null")
-                                                    })
-                                                    .take(3)
-                                                    .map(|(k, v)| {
-                                                        let val_str = match v {
-                                                            serde_json::Value::String(s) => {
-                                                                if s.chars().count() > 20 {
-                                                                    let prefix: String = s.chars().take(17).collect();
-                                                                    format!("\"{prefix}...\"")
-                                                                } else {
-                                                                    format!("\"{s}\"")
-                                                                }
-                                                            }
-                                                            other => {
-                                                                let s = other.to_string();
-                                                                if s.chars().count() > 20 {
-                                                                    let prefix: String = s.chars().take(17).collect();
-                                                                    format!("{prefix}...")
-                                                                } else {
-                                                                    s
-                                                                }
-                                                            }
-                                                        };
-                                                        format!("{k}: {val_str}")
-                                                    })
-                                                    .collect::<Vec<_>>()
-                                                    .join(", ")
-                                            })
-                                            .unwrap_or_default();
-                                        let reasoning = args_obj.as_ref()
-                                            .and_then(|obj| obj.get("_aura_reasoning").and_then(|v| v.as_str()));
-                                        // Set reasoning in the Thinking animation sub-line
-                                        if let Some(text) = reasoning {
-                                            crate::ui::prompt::set_agent_reasoning(text);
-                                        }
-                                        // Print tool line indented under the task with live duration
-                                        let tool_display = format!("{display_name}({args_summary})");
-                                        // Use tool_call_id as primary key, fall back to tool_initiator_id
-                                        let match_id = if !tool_call_id.is_empty() { &tool_call_id } else { &tool_initiator_id };
-                                        crate::ui::prompt::register_orch_tool(
-                                            match_id,
-                                            &task_id_str,
-                                            &tool_display,
-                                            std::time::Instant::now(),
-                                            &fields,
-                                        );
-                                        // Track tool under its task
-                                        if let Ok(mut os) = orch_for_cb.lock() {
-                                            if let Some(task) = os.tasks.get_mut(&task_id_str) {
-                                                task.tools.push(tool_display);
-                                            } else if let Some(task) = os.tasks.get_mut(&tool_initiator_id) {
-                                                task.tools.push(tool_display);
-                                            }
-                                        }
-                                        push_display_event(DisplayEvent::OrchestratorToolCallStarted {
-                                            tool_name, tool_initiator_id, fields,
-                                        });
-                                    }
-                                    "tool_call_completed" => {
-                                        let tool_name = get_str(val, "tool_name");
-                                        let tool_initiator_id = get_str(val, "tool_initiator_id");
-                                        let tool_call_id = get_str(val, "tool_call_id");
-                                        let duration_ms_val = val.get("duration_ms")
-                                            .or_else(|| val.get("data").and_then(|d| d.get("duration_ms")))
-                                            .and_then(|v| v.as_u64());
-                                        let result_text = val.get("result")
-                                            .or_else(|| val.get("data").and_then(|d| d.get("result")))
-                                            .and_then(|v| v.as_str());
-                                        // Use tool_call_id as primary key, fall back to tool_initiator_id
-                                        let match_id = if !tool_call_id.is_empty() { &tool_call_id } else { &tool_initiator_id };
-                                        // Finalize tool display (solid color + completed duration + live result lines in /expand)
-                                        crate::ui::prompt::finalize_orch_tool(
-                                            match_id,
-                                            duration_ms_val,
-                                            result_text,
-                                        );
-                                        needs_blank_for_cb.store(true, Ordering::Relaxed);
-                                        push_display_event(DisplayEvent::OrchestratorToolCallCompleted {
-                                            tool_name, tool_initiator_id,
-                                            duration_ms: duration_ms_val, fields,
-                                        });
-                                    }
-                                    "task_completed" => {
-                                        let worker_id = get_str(val, "worker_id");
-                                        let task_id = get_str(val, "task_id");
-                                        let result = get_str(val, "result");
-                                        // Look up task info and overwrite the header line in-place
-                                        let task_info = if let Ok(mut os) = orch_for_cb.lock() {
-                                            os.tasks.remove(&task_id)
-                                        } else {
-                                            None
-                                        };
-                                        if let Some(info) = &task_info {
-                                            overwrite_orch_task_header_unlocked(
-                                                info.header_line_num,
-                                                &task_id,
-                                                &worker_id,
-                                                "done",
-                                            );
-                                        }
-                                        crate::ui::prompt::clear_orch_task_tools(&task_id);
-                                        // Blank line to separate from next task
-                                        println!();
-                                        crate::ui::prompt::increment_orch_scrollback();
-                                        push_display_event(DisplayEvent::OrchestratorTaskCompleted {
-                                            worker_id, task_id, result, fields,
-                                        });
-                                    }
-                                    "synthesizing" => {
-                                        crate::ui::prompt::clear_agent_reasoning();
-                                        push_display_event(DisplayEvent::OrchestratorSynthesizing);
-                                    }
-                                    "iteration_complete" => {
-                                        let iteration = get_u64(val, "iteration");
-                                        let quality_score = get_str(val, "quality_score");
-                                        let expanded = is_expanded_output();
-                                        let has_fields = expanded && !fields.is_empty();
-                                        crate::ui::prompt::clear_agent_reasoning();
-                                        println!(
-                                            "{} {}",
-                                            "●".with(bullet_color).attribute(crossterm::style::Attribute::Bold),
-                                            "Iteration complete".attribute(crossterm::style::Attribute::Bold),
-                                        );
-                                        crate::ui::prompt::increment_orch_scrollback();
-                                        println!(
-                                            "{} iteration: {}",
-                                            "├─".themed(AuraStyle::Connector),
-                                            iteration.to_string().as_str().themed(AuraStyle::Muted),
-                                        );
-                                        crate::ui::prompt::increment_orch_scrollback();
-                                        let quality_connector = if has_fields { "├─" } else { "└─" };
-                                        println!(
-                                            "{} quality: {}",
-                                            quality_connector.themed(AuraStyle::Connector),
-                                            quality_score.as_str().themed(AuraStyle::Muted),
-                                        );
-                                        crate::ui::prompt::increment_orch_scrollback();
-                                        if has_fields {
-                                            let field_lines = fields.values().map(|v| {
-                                                if let serde_json::Value::Object(obj) = v { 1 + obj.len() } else { 1 }
-                                            }).sum::<usize>();
-                                            print_fields_tree(&fields);
-                                            for _ in 0..field_lines {
-                                                crate::ui::prompt::increment_orch_scrollback();
-                                            }
-                                        }
-                                        println!();
-                                        crate::ui::prompt::increment_orch_scrollback();
-                                        push_display_event(DisplayEvent::OrchestratorIterationComplete {
-                                            iteration, quality_score, fields,
-                                        });
-                                    }
-                                    "scratchpad_usage" => {
-                                        let tokens_intercepted = get_u64(val, "tokens_intercepted");
-                                        let tokens_extracted = get_u64(val, "tokens_extracted");
-                                        crate::ui::prompt::add_scratchpad_usage(tokens_intercepted, tokens_extracted);
-                                        update_status_bar_unlocked();
-                                        push_display_event(DisplayEvent::OrchestratorScratchpadSavings {
-                                            tokens_intercepted, tokens_extracted,
-                                        });
-                                    }
-                                    _ => {}
-                                }
-                                } // drop _term lock
-
-                                // Restart animation
-                                let anim_label = if sub == "synthesizing" { "Synthesizing" } else { "Thinking" };
-                                let (wave_anim, wave_stop) = {
-                                    let _term = lock_term();
-                                    WaveAnimation::start(
-                                        anim_label,
-                                        vec![],
-                                        input_buf_for_orch.clone(),
-                                        Some(cancel_for_orch.clone()),
-                                    )
-                                };
-                                if let Ok(mut guard) = ptw_for_orch.lock() {
-                                    *guard = Some((wave_anim, wave_stop));
-                                }
-                                prepare_input_line(
-                                    &input_buf_for_orch,
-                                    Some(&cancel_for_orch),
-                                );
-                            },
-                        )
-                        .await
+                        let mut handler = ReplStreamHandler {
+                            pending_args: pending_args.clone(),
+                            turn_events: turn_events.clone(),
+                            live_reasoning: live_reasoning.clone(),
+                            stop_flag: stop_flag.clone(),
+                            anim_cleared: anim_cleared.clone(),
+                            cancel: cancel_flag.clone(),
+                            post_tool_wave: post_tool_wave.clone(),
+                            input_buf: input_buf.clone(),
+                            orch_state: orch_state.clone(),
+                            needs_blank: needs_blank.clone(),
+                            in_update_group: in_update_group.clone(),
+                        };
+                        backend
+                            .stream_chat(
+                                conversation.messages(),
+                                tool_defs_arg,
+                                &chat_session_id,
+                                cancel_for_stream.clone(),
+                                &mut handler,
+                            )
+                            .await
                     });
+
+                    // Close any live reasoning block left open by the stream
+                    // (e.g., reasoning was the last thing the model emitted
+                    // before the stream ended without a usage/tool event).
+                    flush_live_reasoning(&live_reasoning);
 
                     // Check for cancellation
                     if cancel_flag.load(Ordering::Relaxed) {
@@ -2006,4 +1854,879 @@ pub fn run_repl(
 
     println!();
     Ok(())
+}
+
+/// Streaming event handler for the interactive REPL: drives the live
+/// "Thinking" animation, tool-call rendering, reasoning blocks, and the
+/// orchestrator task tree. State is shared via `Arc` so each turn's stream
+/// mutates the same terminal-display state the REPL reads between turns.
+struct ReplStreamHandler {
+    pending_args:
+        Arc<Mutex<std::collections::HashMap<String, BTreeMap<String, serde_json::Value>>>>,
+    turn_events: Arc<Mutex<Vec<DisplayEvent>>>,
+    live_reasoning: Arc<Mutex<Option<LiveReasoning>>>,
+    stop_flag: Arc<AtomicBool>,
+    anim_cleared: Arc<AtomicBool>,
+    cancel: Arc<AtomicBool>,
+    #[allow(clippy::type_complexity)]
+    post_tool_wave: Arc<Mutex<Option<(WaveAnimation, Arc<AtomicBool>)>>>,
+    input_buf: Arc<Mutex<String>>,
+    orch_state: Arc<Mutex<OrchDisplayState>>,
+    needs_blank: Arc<AtomicBool>,
+    in_update_group: Arc<AtomicBool>,
+}
+
+impl StreamHandler for ReplStreamHandler {
+    // on_token / on_tool_start stay no-ops (trait defaults): text is
+    // accumulated silently and the animation keeps running until a later
+    // event needs to display.
+
+    fn on_tool_requested(
+        &mut self,
+        tool_id: &str,
+        tool_name: &str,
+        args: &BTreeMap<String, serde_json::Value>,
+    ) {
+        // Record args for later pairing with on_tool_complete
+        if let Ok(mut map) = self.pending_args.lock() {
+            map.insert(tool_id.to_string(), args.clone());
+        }
+        // Track Update grouping flag for the execution loop
+        if tool_name == "Update" {
+            self.in_update_group.store(true, Ordering::Relaxed);
+        } else if tool_name != "Shell" || !self.in_update_group.load(Ordering::Relaxed) {
+            // Non-Shell (or Shell outside Update) clears the flag
+            if tool_name != "Shell" {
+                self.in_update_group.store(false, Ordering::Relaxed);
+            }
+        }
+    }
+
+    fn on_tool_complete(
+        &mut self,
+        tool_id: &str,
+        tool_name: &str,
+        duration: std::time::Duration,
+        result: Option<&str>,
+    ) {
+        flush_live_reasoning(&self.live_reasoning);
+        // Stop animation: prefer ptw (later iterations), fall back
+        // to initial animation (first iteration).
+        let had_ptw = if let Ok(mut guard) = self.post_tool_wave.lock() {
+            if let Some((ptw_anim, _)) = guard.take() {
+                ptw_anim.finish();
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if !had_ptw && !self.anim_cleared.load(Ordering::Relaxed) {
+            stop_and_clear_animation(&self.stop_flag);
+            self.anim_cleared.store(true, Ordering::Relaxed);
+        }
+        // Show server-side tool result
+        {
+            let _term = lock_term();
+            erase_input_frame();
+            let args = self
+                .pending_args
+                .lock()
+                .ok()
+                .and_then(|mut map| map.remove(tool_id))
+                .unwrap_or_default();
+            if is_expanded_output() {
+                print_tool_call_expanded(tool_name, &args, duration, result);
+            } else {
+                crate::ui::prompt::print_tool_call_summary(tool_name, &args, Some(duration));
+                println!();
+            }
+            if let Ok(mut events) = self.turn_events.lock() {
+                events.push(DisplayEvent::ToolCall {
+                    tool_name: tool_name.to_string(),
+                    arguments: args,
+                    duration,
+                    result: result.map(|s| s.to_string()),
+                });
+            }
+        }
+        // Start "Thinking" animation to fill gap until next event
+        let (wave_anim, wave_stop) = {
+            let _term = lock_term();
+            WaveAnimation::start(
+                "Thinking",
+                vec![],
+                self.input_buf.clone(),
+                Some(self.cancel.clone()),
+            )
+        };
+        if let Ok(mut guard) = self.post_tool_wave.lock() {
+            *guard = Some((wave_anim, wave_stop));
+        }
+        prepare_input_line(&self.input_buf, Some(&self.cancel));
+    }
+
+    fn on_usage(&mut self, prompt_tokens: u64, completion_tokens: u64) {
+        set_status_bar_tokens(prompt_tokens, completion_tokens);
+        update_status_bar();
+        if let Ok(mut events) = self.turn_events.lock() {
+            events.push(DisplayEvent::Usage {
+                prompt_tokens,
+                completion_tokens,
+            });
+        }
+    }
+
+    fn on_reasoning(
+        &mut self,
+        content: &str,
+        agent_id: &str,
+        fields: &BTreeMap<String, serde_json::Value>,
+    ) {
+        if content.is_empty() {
+            return;
+        }
+
+        let parent_agent_id = fields
+            .get("parent_agent_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        // Switching agents closes the previous block.
+        let agent_changed = match self.live_reasoning.lock() {
+            Ok(g) => g.as_ref().is_some_and(|s| s.agent_id != agent_id),
+            Err(_) => false,
+        };
+        if agent_changed {
+            flush_live_reasoning(&self.live_reasoning);
+        }
+
+        // Initialize the live block on the first chunk.
+        let need_init = match self.live_reasoning.lock() {
+            Ok(g) => g.is_none(),
+            Err(_) => return,
+        };
+        if need_init {
+            let is_worker = parent_agent_id.is_some();
+            let task_id = if is_worker {
+                self.orch_state.lock().ok().and_then(|os| {
+                    os.tasks
+                        .iter()
+                        .find(|(_, info)| info.worker_id == agent_id)
+                        .map(|(tid, _)| tid.clone())
+                })
+            } else {
+                None
+            };
+            // No matching task means we can't insert
+            // into the tree — fall back to top-level
+            // rendering so the reasoning isn't lost.
+            let effective_worker = is_worker && task_id.is_some();
+
+            // Stop the running animation and erase
+            // the input frame BEFORE printing any
+            // new scrollback rows — both top-level
+            // (`open_top_level_reasoning_block`) and
+            // worker (`open_worker_reasoning_block`
+            // → `register_orch_reasoning_in_tree`)
+            // emit `println!` rows. If we skip this,
+            // the println lands at the InputLine
+            // and the old anim/frame rows above are
+            // left stale in scrollback (the doubled
+            // "● Thinking" + duplicate body bug).
+            let had_ptw = if let Ok(mut guard) = self.post_tool_wave.lock() {
+                if let Some((ptw_anim, _)) = guard.take() {
+                    ptw_anim.finish();
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+            if !had_ptw && !self.anim_cleared.load(Ordering::Relaxed) {
+                stop_and_clear_animation(&self.stop_flag);
+                self.anim_cleared.store(true, Ordering::Relaxed);
+            }
+
+            let mut new_state = LiveReasoning {
+                agent_id: agent_id.to_string(),
+                parent_agent_id: parent_agent_id.clone(),
+                task_id: task_id.clone(),
+                combined: String::new(),
+                fields: fields.clone(),
+                started: false,
+                body_line_num: 0,
+                body_line_text: String::new(),
+                body_visual_rows: 1,
+                is_worker: effective_worker,
+            };
+            {
+                let _term = lock_term();
+                erase_input_frame();
+                if effective_worker {
+                    let tid = task_id.as_deref().unwrap_or("");
+                    open_worker_reasoning_block(&mut new_state, tid);
+                } else {
+                    open_top_level_reasoning_block(&mut new_state, agent_id);
+                }
+            }
+            // Restart the Thinking spinner so it
+            // stays visible while reasoning chunks
+            // stream in. `WaveAnimation::start`
+            // prints the anim overlay BELOW the
+            // body row, so the `MoveUp(3)` tick and
+            // the `(total_sb + 3) - body_line_num`
+            // in-place body rewrite both target
+            // rows below the body — body is safe.
+            let (wave_anim, wave_stop) = {
+                let _term = lock_term();
+                WaveAnimation::start(
+                    "Thinking",
+                    vec![],
+                    self.input_buf.clone(),
+                    Some(self.cancel.clone()),
+                )
+            };
+            if let Ok(mut guard) = self.post_tool_wave.lock() {
+                *guard = Some((wave_anim, wave_stop));
+            }
+            prepare_input_line(&self.input_buf, Some(&self.cancel));
+            // Animation is live again — the orch
+            // handler's "stop if not cleared"
+            // check needs to fire on the next
+            // event to finish this wave.
+            self.anim_cleared
+                .store(false, std::sync::atomic::Ordering::Relaxed);
+            if let Ok(mut guard) = self.live_reasoning.lock() {
+                *guard = Some(new_state);
+            }
+        }
+
+        // For top-level reasoning, decide whether
+        // this chunk grows the body row-count
+        // BEFORE we update state — extension needs
+        // to release the live_reasoning lock so
+        // the animation halt+restart can re-acquire
+        // it safely.
+        let extend_by: u32 = {
+            if let Ok(guard) = self.live_reasoning.lock() {
+                if let Some(state) = guard.as_ref() {
+                    if state.is_worker {
+                        0
+                    } else {
+                        let mut candidate = state.body_line_text.clone();
+                        candidate.push_str(content);
+                        let lines = top_level_reasoning_body_for_terminal(&candidate);
+                        let required = lines.len() as u32;
+                        required.saturating_sub(state.body_visual_rows)
+                    }
+                } else {
+                    0
+                }
+            } else {
+                0
+            }
+        };
+
+        if extend_by > 0 {
+            // Halt anim, extend scrollback by
+            // `extend_by` rows (overwriting the
+            // current trailing-blank separator with
+            // body content + appending a new
+            // separator at the end), restart anim.
+            // Same halt-restart shape as
+            // `tool_call_started`; spinner only
+            // pauses for the extension itself, not
+            // for the chunk.
+            let had_ptw = if let Ok(mut guard) = self.post_tool_wave.lock() {
+                if let Some((ptw_anim, _)) = guard.take() {
+                    ptw_anim.finish();
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+            if !had_ptw && !self.anim_cleared.load(Ordering::Relaxed) {
+                stop_and_clear_animation(&self.stop_flag);
+                self.anim_cleared.store(true, Ordering::Relaxed);
+            }
+            {
+                let _term = lock_term();
+                erase_input_frame();
+                // After `erase_input_frame`, the
+                // cursor sits where the frame's
+                // top border was — exactly one row
+                // below the existing trailing
+                // separator. Println `extend_by`
+                // blank rows from here: each
+                // println commits one new
+                // scrollback row below the prior
+                // separator. The old separator
+                // (still blank at its row) becomes
+                // the first new body row when
+                // `rewrite_top_level_reasoning_body_inplace`
+                // fills the expanded body region;
+                // the LAST println becomes the
+                // new trailing separator.
+                //
+                // Do NOT `MoveUp(1) + Clear` here:
+                // that overwrites the existing
+                // separator row WITHOUT committing
+                // a new scrollback row, but still
+                // increments the counter, leaving
+                // it ahead by 1 and making the
+                // next body rewrite's `MoveUp`
+                // land on the header.
+                for _ in 0..extend_by {
+                    println!();
+                    crate::ui::prompt::increment_orch_scrollback();
+                }
+            }
+            let (wave_anim, wave_stop) = {
+                let _term = lock_term();
+                WaveAnimation::start(
+                    "Thinking",
+                    vec![],
+                    self.input_buf.clone(),
+                    Some(self.cancel.clone()),
+                )
+            };
+            if let Ok(mut guard) = self.post_tool_wave.lock() {
+                *guard = Some((wave_anim, wave_stop));
+            }
+            prepare_input_line(&self.input_buf, Some(&self.cancel));
+            self.anim_cleared
+                .store(false, std::sync::atomic::Ordering::Relaxed);
+
+            if let Ok(mut guard) = self.live_reasoning.lock()
+                && let Some(s) = guard.as_mut()
+            {
+                s.body_visual_rows += extend_by;
+            }
+        }
+
+        if let Ok(mut guard) = self.live_reasoning.lock() {
+            let Some(state) = guard.as_mut() else {
+                return;
+            };
+            let _term = lock_term();
+            apply_reasoning_chunk(state, content);
+            if state.is_worker {
+                // Keep `ORCH_LAST_TOOL_LINES` in sync
+                // so the next tool's upgrade redraws
+                // the body with the latest content.
+                if let Some(tid) = state.task_id.clone() {
+                    let body = worker_reasoning_body_for_terminal(&state.body_line_text);
+                    crate::ui::orchestrator::update_orch_last_tool_duration_text(&tid, &body);
+                }
+            }
+        }
+    }
+
+    fn on_raw_event(&mut self, event_name: &str, event_data: &str) {
+        push_sse_event(event_name, event_data);
+        if event_name == event_names::TOOL_START
+            && let Ok(val) = serde_json::from_str::<serde_json::Value>(event_data)
+            && let Some(tool_id) = val.get("tool_id").and_then(|v| v.as_str())
+            && let Some(token) = val.get("progress_token")
+            && !token.is_null()
+        {
+            crate::ui::prompt::record_tool_progress_token(tool_id, &token.to_string());
+        }
+    }
+
+    fn on_orchestrator_event(&mut self, event_name: &str, val: &serde_json::Value) {
+        // Handle aura.progress — prefer to attach the
+        // message to the active orchestrator tool whose
+        // progress_token matches; fall back to the
+        // global "Thinking" sub-line when there's no
+        // active tool to attach it to (single-agent
+        // mode, or progress for a tool we never saw a
+        // tool_start for).
+        //
+        // These transient events (progress, worker_phase,
+        // session_info, non-orchestrator-prefixed) update
+        // the spinner sub-line or task header in-place —
+        // they don't add to scrollback, so they must NOT
+        // flush the live reasoning block. Flushing here
+        // would slice multi-chunk reasoning into multiple
+        // `● Reasoning - <agent>` blocks every time a
+        // worker phase changes.
+        if event_name == event_names::PROGRESS {
+            if let Some(message) = val.get("message").and_then(|v| v.as_str()) {
+                let token = val.get("progress_token").map(|t| t.to_string());
+                let attached = token
+                    .as_deref()
+                    .map(|t| crate::ui::prompt::set_orch_tool_progress_by_token(t, message))
+                    .unwrap_or(false);
+                if !attached {
+                    crate::ui::prompt::set_agent_reasoning(message);
+                }
+            }
+            return;
+        }
+
+        // Reflect the worker's current phase
+        // (`Planning`/`Executing`/`Analyzing`) in the
+        // task header. Overwrites in-place; the
+        // task_completed handler later replaces this
+        // with `done`.
+        if event_name == event_names::WORKER_PHASE {
+            let task_id = val.get("task_id").and_then(|v| v.as_str()).unwrap_or("");
+            let phase = val.get("phase").and_then(|v| v.as_str()).unwrap_or("");
+            if task_id.is_empty() || phase.is_empty() {
+                return;
+            }
+            let mut chars = phase.chars();
+            let phase_label: String = match chars.next() {
+                Some(c) => c.to_uppercase().chain(chars).collect(),
+                None => return,
+            };
+            let header_info = if let Ok(os) = self.orch_state.lock() {
+                os.tasks
+                    .get(task_id)
+                    .map(|t| (t.header_line_num, t.worker_id.clone()))
+            } else {
+                None
+            };
+            if let Some((header_line, worker_id)) = header_info {
+                crate::ui::prompt::overwrite_orch_task_header(
+                    header_line,
+                    task_id,
+                    &worker_id,
+                    &phase_label,
+                );
+            }
+            return;
+        }
+
+        // Scratchpad savings ride in on the base `aura.scratchpad_usage`
+        // event (not orchestrator-namespaced), so handle it here, before the
+        // orchestrator-prefix guard below. Accumulate into the status bar and
+        // record a DisplayEvent for history replay.
+        if event_name == event_names::SCRATCHPAD_USAGE {
+            let tokens_intercepted = val
+                .get("tokens_intercepted")
+                .or_else(|| val.get("data").and_then(|d| d.get("tokens_intercepted")))
+                .and_then(|f| f.as_u64())
+                .unwrap_or(0);
+            let tokens_extracted = val
+                .get("tokens_extracted")
+                .or_else(|| val.get("data").and_then(|d| d.get("tokens_extracted")))
+                .and_then(|f| f.as_u64())
+                .unwrap_or(0);
+            crate::ui::prompt::add_scratchpad_usage(tokens_intercepted, tokens_extracted);
+            update_status_bar_unlocked();
+            push_display_event(DisplayEvent::OrchestratorScratchpadSavings {
+                tokens_intercepted,
+                tokens_extracted,
+            });
+            return;
+        }
+
+        // Everything below acts only on `aura.orchestrator.*` events; bail
+        // out for anything else (e.g. session_info).
+        if !event_name.starts_with("aura.orchestrator.") {
+            return;
+        }
+
+        // The server emits `aura.orchestrator.worker_reasoning`
+        // alongside every `aura.reasoning` delta from a
+        // worker. We already render the reasoning via
+        // the dedicated `on_reasoning` path (which has
+        // the worker's agent_id and richer correlation
+        // context), and processing the orch mirror here
+        // would call `erase_input_frame` mid-stream and
+        // corrupt the running `● Reasoning - <agent>`
+        // block. Drop it before any frame work runs.
+        if event_name == event_names::WORKER_REASONING {
+            return;
+        }
+
+        // Non-printable orch subs (synthesizing and any
+        // future no-print subs) need their side effects but
+        // must NOT disturb the input frame mid-reasoning.
+        // Handle them inline and bail out before the
+        // `erase_input_frame` machinery runs.
+        if !orch_event_prints_scrollback(event_name) {
+            if event_name == event_names::SYNTHESIZING {
+                crate::ui::prompt::clear_agent_reasoning();
+                push_display_event(DisplayEvent::OrchestratorSynthesizing);
+            }
+            return;
+        }
+
+        // Past this point: event_name is in
+        // `orch_event_prints_scrollback`, so close the
+        // live reasoning block before the event lands.
+        // The block's trailing blank (committed in
+        // `open_top_level_reasoning_block`) is the
+        // separator — no extra println needed here.
+        let _ = flush_live_reasoning(&self.live_reasoning);
+
+        // Stop current animation
+        let had_ptw = if let Ok(mut guard) = self.post_tool_wave.lock() {
+            if let Some((ptw_anim, _)) = guard.take() {
+                ptw_anim.finish();
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if !had_ptw && !self.anim_cleared.load(Ordering::Relaxed) {
+            stop_and_clear_animation(&self.stop_flag);
+            self.anim_cleared.store(true, Ordering::Relaxed);
+        }
+        {
+            let _term = lock_term();
+            erase_input_frame();
+
+            // Emit a deferred blank line from a previous
+            // tool_call_completed — but only if this event
+            // isn't another tool starting directly after.
+            if self.needs_blank.swap(false, Ordering::Relaxed)
+                && event_name != event_names::TOOL_CALL_STARTED
+            {
+                println!();
+                crate::ui::prompt::increment_orch_scrollback();
+            }
+
+            // Helpers
+            let get_str = |v: &serde_json::Value, field: &str| -> String {
+                let f = v
+                    .get(field)
+                    .or_else(|| v.get("data").and_then(|d| d.get(field)));
+                match f {
+                    Some(serde_json::Value::String(s)) => s.clone(),
+                    Some(serde_json::Value::Number(n)) => n.to_string(),
+                    Some(serde_json::Value::Bool(b)) => b.to_string(),
+                    _ => String::new(),
+                }
+            };
+            let get_u64 = |v: &serde_json::Value, field: &str| -> u64 {
+                v.get(field)
+                    .or_else(|| v.get("data").and_then(|d| d.get(field)))
+                    .and_then(|f| f.as_u64())
+                    .unwrap_or(0)
+            };
+            let fields: BTreeMap<String, serde_json::Value> = match val.as_object() {
+                Some(obj) => obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+                None => BTreeMap::new(),
+            };
+            let parse_args =
+                |v: &serde_json::Value| -> Option<serde_json::Map<String, serde_json::Value>> {
+                    v.get("arguments")
+                        .or_else(|| v.get("data").and_then(|d| d.get("arguments")))
+                        .and_then(|a| match a {
+                            serde_json::Value::Object(obj) => Some(obj.clone()),
+                            serde_json::Value::String(s) => serde_json::from_str(s).ok(),
+                            _ => None,
+                        })
+                };
+
+            // Per-orchestrator-entity bullet color. Keyed by task_id
+            // (or `__orchestrator__` for coordinator-level events:
+            // plan_created, synthesizing, iteration_complete).
+            // Resolved through the active theme — switching themes
+            // repaints automatically; no colors are persisted.
+            let event_task_id = get_str(val, "task_id");
+            let color_key: String = if !event_task_id.is_empty() {
+                event_task_id.clone()
+            } else {
+                "__orchestrator__".to_string()
+            };
+            let bullet_color = task_color_for(&color_key);
+
+            match event_name {
+                event_names::PLAN_CREATED => {
+                    let goal = get_str(val, "goal");
+                    // New plan resets reasoning
+                    crate::ui::prompt::clear_agent_reasoning();
+                    println!(
+                        "{} {}",
+                        "●"
+                            .with(bullet_color)
+                            .attribute(crossterm::style::Attribute::Bold),
+                        format!("Plan - {goal}").attribute(crossterm::style::Attribute::Bold),
+                    );
+                    crate::ui::prompt::increment_orch_scrollback();
+                    if is_expanded_output() {
+                        // Count lines that print_fields_tree will emit
+                        let field_lines = fields
+                            .values()
+                            .map(|v| {
+                                if let serde_json::Value::Object(obj) = v {
+                                    1 + obj.len()
+                                } else {
+                                    1
+                                }
+                            })
+                            .sum::<usize>();
+                        print_fields_tree(&fields);
+                        for _ in 0..field_lines {
+                            crate::ui::prompt::increment_orch_scrollback();
+                        }
+                    }
+                    println!();
+                    crate::ui::prompt::increment_orch_scrollback();
+                    push_display_event(DisplayEvent::OrchestratorPlanCreated { goal, fields });
+                }
+                event_names::TASK_STARTED => {
+                    let worker_id = get_str(val, "worker_id");
+                    let task_id = get_str(val, "task_id");
+                    let description = get_str(val, "description");
+                    // Bullet color resolved per-task at render time —
+                    // `task_color_for(&task_id)` returns the color the
+                    // generic block (above) already computed via
+                    // `bullet_color`, so reuse that directly.
+                    crate::ui::prompt::set_agent_reasoning(&description);
+                    let header_line = crate::ui::prompt::current_orch_scrollback();
+                    println!(
+                        "{} {} {} {}",
+                        "●"
+                            .with(bullet_color)
+                            .attribute(crossterm::style::Attribute::Bold),
+                        format!("Task {task_id}").attribute(crossterm::style::Attribute::Bold),
+                        "-".themed(AuraStyle::Muted),
+                        format!("Worker: {worker_id}").themed(AuraStyle::Muted),
+                    );
+                    crate::ui::prompt::increment_orch_scrollback();
+                    // No blank line – tool calls follow directly
+                    if let Ok(mut os) = self.orch_state.lock() {
+                        os.tasks.insert(
+                            task_id.clone(),
+                            OrchTaskInfo {
+                                header_line_num: header_line,
+                                worker_id: worker_id.clone(),
+                                tools: Vec::new(),
+                            },
+                        );
+                    }
+                    push_display_event(DisplayEvent::OrchestratorTaskStarted {
+                        worker_id,
+                        task_id,
+                        description,
+                        fields,
+                    });
+                }
+                event_names::TOOL_CALL_STARTED => {
+                    let tool_name = get_str(val, "tool_name");
+                    let tool_initiator_id = get_str(val, "tool_initiator_id");
+                    let tool_call_id = get_str(val, "tool_call_id");
+                    let task_id_str = get_str(val, "task_id");
+                    let display_name = snake_to_pascal_case(&tool_name);
+                    let args_obj = parse_args(val);
+                    let args_summary = args_obj.as_ref()
+                                            .map(|obj| {
+                                                obj.iter()
+                                                    .filter(|(k, v)| {
+                                                        !k.starts_with('_')
+                                                            && !matches!(v, serde_json::Value::Null)
+                                                            && !matches!(v, serde_json::Value::String(s) if s.is_empty() || s == "null")
+                                                    })
+                                                    .take(3)
+                                                    .map(|(k, v)| {
+                                                        let val_str = match v {
+                                                            serde_json::Value::String(s) => {
+                                                                if s.chars().count() > 20 {
+                                                                    let prefix: String = s.chars().take(17).collect();
+                                                                    format!("\"{prefix}...\"")
+                                                                } else {
+                                                                    format!("\"{s}\"")
+                                                                }
+                                                            }
+                                                            other => {
+                                                                let s = other.to_string();
+                                                                if s.chars().count() > 20 {
+                                                                    let prefix: String = s.chars().take(17).collect();
+                                                                    format!("{prefix}...")
+                                                                } else {
+                                                                    s
+                                                                }
+                                                            }
+                                                        };
+                                                        format!("{k}: {val_str}")
+                                                    })
+                                                    .collect::<Vec<_>>()
+                                                    .join(", ")
+                                            })
+                                            .unwrap_or_default();
+                    let reasoning = args_obj
+                        .as_ref()
+                        .and_then(|obj| obj.get("_aura_reasoning").and_then(|v| v.as_str()));
+                    // Set reasoning in the Thinking animation sub-line
+                    if let Some(text) = reasoning {
+                        crate::ui::prompt::set_agent_reasoning(text);
+                    }
+                    // Print tool line indented under the task with live duration
+                    let tool_display = format!("{display_name}({args_summary})");
+                    // Use tool_call_id as primary key, fall back to tool_initiator_id
+                    let match_id = if !tool_call_id.is_empty() {
+                        &tool_call_id
+                    } else {
+                        &tool_initiator_id
+                    };
+                    crate::ui::prompt::register_orch_tool(
+                        match_id,
+                        &task_id_str,
+                        &tool_display,
+                        std::time::Instant::now(),
+                        &fields,
+                    );
+                    // Track tool under its task
+                    if let Ok(mut os) = self.orch_state.lock() {
+                        if let Some(task) = os.tasks.get_mut(&task_id_str) {
+                            task.tools.push(tool_display);
+                        } else if let Some(task) = os.tasks.get_mut(&tool_initiator_id) {
+                            task.tools.push(tool_display);
+                        }
+                    }
+                    push_display_event(DisplayEvent::OrchestratorToolCallStarted {
+                        tool_name,
+                        tool_initiator_id,
+                        fields,
+                    });
+                }
+                event_names::TOOL_CALL_COMPLETED => {
+                    let tool_name = get_str(val, "tool_name");
+                    let tool_initiator_id = get_str(val, "tool_initiator_id");
+                    let tool_call_id = get_str(val, "tool_call_id");
+                    let duration_ms_val = val
+                        .get("duration_ms")
+                        .or_else(|| val.get("data").and_then(|d| d.get("duration_ms")))
+                        .and_then(|v| v.as_u64());
+                    let result_text = val
+                        .get("result")
+                        .or_else(|| val.get("data").and_then(|d| d.get("result")))
+                        .and_then(|v| v.as_str());
+                    // Use tool_call_id as primary key, fall back to tool_initiator_id
+                    let match_id = if !tool_call_id.is_empty() {
+                        &tool_call_id
+                    } else {
+                        &tool_initiator_id
+                    };
+                    // Finalize tool display (solid color + completed duration + live result lines in /expand)
+                    crate::ui::prompt::finalize_orch_tool(match_id, duration_ms_val, result_text);
+                    self.needs_blank.store(true, Ordering::Relaxed);
+                    push_display_event(DisplayEvent::OrchestratorToolCallCompleted {
+                        tool_name,
+                        tool_initiator_id,
+                        duration_ms: duration_ms_val,
+                        fields,
+                    });
+                }
+                event_names::TASK_COMPLETED => {
+                    let worker_id = get_str(val, "worker_id");
+                    let task_id = get_str(val, "task_id");
+                    let result = get_str(val, "result");
+                    // Look up task info and overwrite the header line in-place
+                    let task_info = if let Ok(mut os) = self.orch_state.lock() {
+                        os.tasks.remove(&task_id)
+                    } else {
+                        None
+                    };
+                    if let Some(info) = &task_info {
+                        overwrite_orch_task_header_unlocked(
+                            info.header_line_num,
+                            &task_id,
+                            &worker_id,
+                            "done",
+                        );
+                    }
+                    crate::ui::prompt::clear_orch_task_tools(&task_id);
+                    // Blank line to separate from next task
+                    println!();
+                    crate::ui::prompt::increment_orch_scrollback();
+                    push_display_event(DisplayEvent::OrchestratorTaskCompleted {
+                        worker_id,
+                        task_id,
+                        result,
+                        fields,
+                    });
+                }
+                // `synthesizing` / `scratchpad_usage` /
+                // `worker_reasoning` are handled above
+                // the frame machinery so they don't
+                // disturb in-flight reasoning blocks.
+                event_names::ITERATION_COMPLETE => {
+                    let iteration = get_u64(val, "iteration");
+                    let quality_score = get_str(val, "quality_score");
+                    let expanded = is_expanded_output();
+                    let has_fields = expanded && !fields.is_empty();
+                    crate::ui::prompt::clear_agent_reasoning();
+                    println!(
+                        "{} {}",
+                        "●"
+                            .with(bullet_color)
+                            .attribute(crossterm::style::Attribute::Bold),
+                        "Iteration complete".attribute(crossterm::style::Attribute::Bold),
+                    );
+                    crate::ui::prompt::increment_orch_scrollback();
+                    println!(
+                        "{} iteration: {}",
+                        "├─".themed(AuraStyle::Connector),
+                        iteration.to_string().as_str().themed(AuraStyle::Muted),
+                    );
+                    crate::ui::prompt::increment_orch_scrollback();
+                    let quality_connector = if has_fields { "├─" } else { "└─" };
+                    println!(
+                        "{} quality: {}",
+                        quality_connector.themed(AuraStyle::Connector),
+                        quality_score.as_str().themed(AuraStyle::Muted),
+                    );
+                    crate::ui::prompt::increment_orch_scrollback();
+                    if has_fields {
+                        let field_lines = fields
+                            .values()
+                            .map(|v| {
+                                if let serde_json::Value::Object(obj) = v {
+                                    1 + obj.len()
+                                } else {
+                                    1
+                                }
+                            })
+                            .sum::<usize>();
+                        print_fields_tree(&fields);
+                        for _ in 0..field_lines {
+                            crate::ui::prompt::increment_orch_scrollback();
+                        }
+                    }
+                    println!();
+                    crate::ui::prompt::increment_orch_scrollback();
+                    push_display_event(DisplayEvent::OrchestratorIterationComplete {
+                        iteration,
+                        quality_score,
+                        fields,
+                    });
+                }
+                _ => {}
+            }
+        } // drop _term lock
+
+        // Restart animation
+        let anim_label = if event_name == event_names::SYNTHESIZING {
+            "Synthesizing"
+        } else {
+            "Thinking"
+        };
+        let (wave_anim, wave_stop) = {
+            let _term = lock_term();
+            WaveAnimation::start(
+                anim_label,
+                vec![],
+                self.input_buf.clone(),
+                Some(self.cancel.clone()),
+            )
+        };
+        if let Ok(mut guard) = self.post_tool_wave.lock() {
+            *guard = Some((wave_anim, wave_stop));
+        }
+        prepare_input_line(&self.input_buf, Some(&self.cancel));
+    }
 }

--- a/crates/aura-cli/src/ui/event_replay.rs
+++ b/crates/aura-cli/src/ui/event_replay.rs
@@ -17,6 +17,7 @@ use crossterm::terminal;
 use crate::api::types::{DisplayEvent, snake_to_pascal_case};
 use crate::tools;
 use crate::ui::markdown::render_markdown;
+use crate::ui::text::truncate_with_ellipsis;
 
 use super::orchestrator::{
     TREE_END_BULLET, TREE_END_DURATION, TREE_MID_BULLET, TREE_MID_DURATION, format_orch_duration_ms,
@@ -329,13 +330,24 @@ pub fn replay_event_log_global() {
                 description,
                 ..
             } => {
-                #[allow(clippy::type_complexity)]
-                let mut task_tools: Vec<(
-                    String,
-                    BTreeMap<String, serde_json::Value>,
-                    Option<u64>,
-                    Option<String>,
-                )> = Vec::new();
+                // Collect every entry that belongs inside this task tree:
+                // tool calls and worker-reasoning blocks (whose `agent_id`
+                // matches the task's `worker_id`). Reasoning for a different
+                // agent ends the inner walk so the outer loop can render it
+                // separately.
+                enum TaskEntry {
+                    Tool {
+                        label: String,
+                        fields: BTreeMap<String, serde_json::Value>,
+                        duration_ms: Option<u64>,
+                        result: Option<String>,
+                    },
+                    Reasoning {
+                        content: String,
+                        fields: BTreeMap<String, serde_json::Value>,
+                    },
+                }
+                let mut entries: Vec<TaskEntry> = Vec::new();
                 let mut last_reasoning: Option<String> = None;
                 let mut j = i + 1;
                 while j < events.len() {
@@ -345,7 +357,12 @@ pub fn replay_event_log_global() {
                         } => {
                             let dn = snake_to_pascal_case(tool_name);
                             let args = format_orch_args_summary(fields);
-                            task_tools.push((format!("{dn}({args})"), fields.clone(), None, None));
+                            entries.push(TaskEntry::Tool {
+                                label: format!("{dn}({args})"),
+                                fields: fields.clone(),
+                                duration_ms: None,
+                                result: None,
+                            });
                             if let Some(r) = extract_aura_reasoning(fields) {
                                 last_reasoning = Some(r);
                             }
@@ -356,14 +373,37 @@ pub fn replay_event_log_global() {
                             fields,
                             ..
                         } => {
-                            if let Some(last) = task_tools.last_mut() {
-                                last.2 = *duration_ms;
-                                last.3 = fields.get("result").and_then(|v| match v {
+                            if let Some(TaskEntry::Tool {
+                                duration_ms: dm,
+                                result: r,
+                                ..
+                            }) = entries.last_mut()
+                            {
+                                *dm = *duration_ms;
+                                *r = fields.get("result").and_then(|v| match v {
                                     serde_json::Value::String(s) => Some(s.clone()),
                                     _ => None,
                                 });
                             }
                             j += 1;
+                        }
+                        DisplayEvent::Reasoning {
+                            content,
+                            agent_id,
+                            fields,
+                        } if agent_id == worker_id => {
+                            entries.push(TaskEntry::Reasoning {
+                                content: content.clone(),
+                                fields: fields.clone(),
+                            });
+                            last_reasoning = Some(content.clone());
+                            j += 1;
+                        }
+                        DisplayEvent::Reasoning { .. } => {
+                            // Reasoning for a different agent — bail so the
+                            // outer loop renders it separately. Don't advance
+                            // past the task_completed event yet either.
+                            break;
                         }
                         DisplayEvent::OrchestratorTaskCompleted { .. } => {
                             j += 1;
@@ -380,11 +420,7 @@ pub fn replay_event_log_global() {
                         Some(description.as_str())
                     });
                     if let Some(text) = reasoning_text {
-                        let display = if text.len() > 120 {
-                            format!("{}...", &text[..117])
-                        } else {
-                            text.to_string()
-                        };
+                        let display = truncate_with_ellipsis(text, 120);
                         println!(
                             "{} {}",
                             "●".with(bc).attribute(Attribute::Bold),
@@ -402,68 +438,110 @@ pub fn replay_event_log_global() {
                     "-".themed(AuraStyle::Muted),
                     "done".themed(AuraStyle::Muted),
                 );
-                let tool_count = task_tools.len();
-                for (idx, (tool_label, tool_fields, duration_ms, result_text)) in
-                    task_tools.iter().enumerate()
-                {
-                    let is_last_tool = idx == tool_count - 1;
-                    let (b_prefix, cont_prefix) = if is_last_tool {
+                let entry_count = entries.len();
+                for (idx, entry) in entries.iter().enumerate() {
+                    let is_last = idx == entry_count - 1;
+                    let (b_prefix, cont_prefix) = if is_last {
                         (TREE_END_BULLET, TREE_END_DURATION)
                     } else {
                         (TREE_MID_BULLET, TREE_MID_DURATION)
                     };
-                    println!(
-                        "{}{} {}",
-                        b_prefix.themed(AuraStyle::Connector),
-                        "●".with(bc),
-                        tool_label.as_str().themed(AuraStyle::Primary),
-                    );
-                    if expanded {
-                        let has_duration = duration_ms.is_some();
-                        let has_fields = !tool_fields.is_empty();
-                        if let Some(ms) = duration_ms {
-                            let dur_str = format_orch_duration_ms(*ms);
-                            let item_prefix = if has_fields { "├─" } else { "└─" };
+                    match entry {
+                        TaskEntry::Tool {
+                            label,
+                            fields: tool_fields,
+                            duration_ms,
+                            result,
+                        } => {
+                            println!(
+                                "{}{} {}",
+                                b_prefix.themed(AuraStyle::Connector),
+                                "●".with(bc),
+                                label.as_str().themed(AuraStyle::Primary),
+                            );
+                            if expanded {
+                                let has_duration = duration_ms.is_some();
+                                let has_fields = !tool_fields.is_empty();
+                                if let Some(ms) = duration_ms {
+                                    let dur_str = format_orch_duration_ms(*ms);
+                                    let item_prefix = if has_fields { "├─" } else { "└─" };
+                                    println!(
+                                        "{}{} {}",
+                                        cont_prefix.themed(AuraStyle::Connector),
+                                        item_prefix.themed(AuraStyle::Connector),
+                                        format!("completed in {dur_str}")
+                                            .as_str()
+                                            .themed(AuraStyle::Muted),
+                                    );
+                                }
+                                if has_fields {
+                                    super::orchestrator::print_fields_tree_indented(
+                                        tool_fields,
+                                        cont_prefix,
+                                        has_duration,
+                                    );
+                                }
+                                if let Some(text) = result.as_deref()
+                                    && !text.is_empty()
+                                {
+                                    let normalized = crate::tools::normalize_tool_result_text(text);
+                                    println!();
+                                    for line in normalized.lines() {
+                                        println!(
+                                            "{}  {}",
+                                            cont_prefix.themed(AuraStyle::Connector),
+                                            line.themed(AuraStyle::Muted),
+                                        );
+                                    }
+                                    println!();
+                                }
+                            } else if let Some(ms) = duration_ms {
+                                let dur_str = format_orch_duration_ms(*ms);
+                                println!(
+                                    "{}{} {}",
+                                    cont_prefix.themed(AuraStyle::Connector),
+                                    "⎿".themed(AuraStyle::Connector),
+                                    format!("completed in {dur_str}")
+                                        .as_str()
+                                        .themed(AuraStyle::Muted),
+                                );
+                            }
+                        }
+                        TaskEntry::Reasoning {
+                            content,
+                            fields: reasoning_fields,
+                        } => {
+                            println!(
+                                "{}{} {}",
+                                b_prefix.themed(AuraStyle::Connector),
+                                "●".with(bc),
+                                "Reasoning".themed(AuraStyle::Primary),
+                            );
+                            // Worker reasoning body is a single line in the
+                            // live display; flatten whitespace and truncate
+                            // for replay so we match what the user saw.
+                            let flattened: String =
+                                content.split_whitespace().collect::<Vec<_>>().join(" ");
+                            let display = if flattened.chars().count() > 200 {
+                                let prefix: String = flattened.chars().take(197).collect();
+                                format!("{prefix}...")
+                            } else {
+                                flattened
+                            };
                             println!(
                                 "{}{} {}",
                                 cont_prefix.themed(AuraStyle::Connector),
-                                item_prefix.themed(AuraStyle::Connector),
-                                format!("completed in {dur_str}")
-                                    .as_str()
-                                    .themed(AuraStyle::Muted),
+                                "⎿".themed(AuraStyle::Connector),
+                                display.as_str().themed(AuraStyle::Muted),
                             );
-                        }
-                        if has_fields {
-                            super::orchestrator::print_fields_tree_indented(
-                                tool_fields,
-                                cont_prefix,
-                                has_duration,
-                            );
-                        }
-                        if let Some(text) = result_text.as_deref()
-                            && !text.is_empty()
-                        {
-                            let normalized = crate::tools::normalize_tool_result_text(text);
-                            println!();
-                            for line in normalized.lines() {
-                                println!(
-                                    "{}  {}",
-                                    cont_prefix.themed(AuraStyle::Connector),
-                                    line.themed(AuraStyle::Muted),
+                            if expanded && !reasoning_fields.is_empty() {
+                                super::orchestrator::print_fields_tree_indented(
+                                    reasoning_fields,
+                                    cont_prefix,
+                                    false,
                                 );
                             }
-                            println!();
                         }
-                    } else if let Some(ms) = duration_ms {
-                        let dur_str = format_orch_duration_ms(*ms);
-                        println!(
-                            "{}{} {}",
-                            cont_prefix.themed(AuraStyle::Connector),
-                            "⎿".themed(AuraStyle::Connector),
-                            format!("completed in {dur_str}")
-                                .as_str()
-                                .themed(AuraStyle::Muted),
-                        );
                     }
                 }
                 println!();
@@ -479,6 +557,58 @@ pub fn replay_event_log_global() {
                 i += 1;
             }
             DisplayEvent::OrchestratorSynthesizing => {
+                i += 1;
+            }
+            DisplayEvent::Reasoning {
+                content,
+                agent_id,
+                fields,
+            } => {
+                let trimmed = content.trim();
+                if !trimmed.is_empty() {
+                    let bc = task_color_for(if agent_id.is_empty() {
+                        "__orchestrator__"
+                    } else {
+                        agent_id.as_str()
+                    });
+                    let header = if agent_id == "main" || agent_id.is_empty() {
+                        "Reasoning".to_string()
+                    } else {
+                        format!("Reasoning - {agent_id}")
+                    };
+                    println!(
+                        "{} {}",
+                        "●".with(bc).attribute(Attribute::Bold),
+                        header
+                            .as_str()
+                            .themed(AuraStyle::Primary)
+                            .attribute(Attribute::Bold),
+                    );
+                    if expanded {
+                        // Show wire-level fields under the header (agent_id,
+                        // content, parent_agent_id, session_id, trace_id) so
+                        // /expand mirrors how other orchestrator events render
+                        // their fields. `content` in the tree is the full
+                        // accumulated reasoning text — we override the map's
+                        // value here just in case the persisted entry only
+                        // captured a single delta.
+                        let mut tree = fields.clone();
+                        tree.insert(
+                            "content".to_string(),
+                            serde_json::Value::String(content.clone()),
+                        );
+                        print_fields_tree(&tree);
+                    } else {
+                        for line in trimmed.lines() {
+                            println!(
+                                "{} {}",
+                                "│".themed(AuraStyle::Connector),
+                                line.themed(AuraStyle::Muted),
+                            );
+                        }
+                    }
+                    println!();
+                }
                 i += 1;
             }
             DisplayEvent::OrchestratorIterationComplete {

--- a/crates/aura-cli/src/ui/mod.rs
+++ b/crates/aura-cli/src/ui/mod.rs
@@ -13,3 +13,4 @@ pub(crate) mod orchestrator;
 pub(crate) mod state;
 pub(crate) mod status_bar;
 pub(crate) mod stream_panel;
+pub(crate) mod text;

--- a/crates/aura-cli/src/ui/orchestrator.rs
+++ b/crates/aura-cli/src/ui/orchestrator.rs
@@ -158,6 +158,77 @@ pub fn register_orch_tool(
     }
 }
 
+/// Register a "Reasoning" entry inside a worker's task tree.
+///
+/// Prints `└─ ● Reasoning` plus an initial empty `   ⎿ ` body line, just
+/// like a tool call. The body line number is yielded to the caller via
+/// `on_lines` so subsequent reasoning chunks can rewrite it in place. The
+/// entry is recorded in `ORCH_LAST_TOOL_LINES` so the next tool call's
+/// `upgrade_last_tool_to_mid` upgrades reasoning's connector from `└─` to
+/// `├─` automatically.
+///
+/// `on_lines(bullet_line_num, body_line_num)` runs while the orchestrator
+/// state lock is held — the caller should record the line numbers into its
+/// own `LiveReasoning` state without doing additional terminal I/O.
+pub fn register_orch_reasoning_in_tree(task_id: &str, on_lines: impl FnOnce(u32, u32)) {
+    upgrade_last_tool_to_mid(task_id);
+
+    let display = "Reasoning";
+    let bullet_text = format!("{}● {}", TREE_END_BULLET, display);
+    let bullet_rows = visual_row_count(&bullet_text);
+    let bullet_line = ORCH_SCROLLBACK_COUNTER.fetch_add(bullet_rows, Ordering::Relaxed);
+    println!(
+        "{}{} {}",
+        TREE_END_BULLET.themed(AuraStyle::Connector),
+        "●".themed(AuraStyle::Muted),
+        display.themed(AuraStyle::Primary),
+    );
+
+    // Initial body row: empty. The reasoning callback will rewrite this
+    // in-place as chunks arrive.
+    let body_text = format!("{}⎿ ", TREE_END_DURATION);
+    let body_rows = visual_row_count(&body_text);
+    let body_line = ORCH_SCROLLBACK_COUNTER.fetch_add(body_rows, Ordering::Relaxed);
+    println!(
+        "{}{} ",
+        TREE_END_DURATION.themed(AuraStyle::Connector),
+        "⎿".themed(AuraStyle::Connector),
+    );
+
+    // Insert into the per-task "last entry" map so the next tool registration
+    // upgrades reasoning's `└─` to `├─`. We mirror tool semantics: the
+    // `tool_display` we record is just "Reasoning" (used by
+    // `upgrade_last_tool_to_mid` to repaint the bullet line), and
+    // `duration_text` stays empty initially (the reasoning callback owns
+    // updating it as content streams in).
+    if let Ok(mut guard) = ORCH_LAST_TOOL_LINES.lock() {
+        guard.insert(
+            task_id.to_string(),
+            OrchLastToolInfo {
+                bullet_line_num: bullet_line,
+                duration_line_num: body_line,
+                tool_display: display.to_string(),
+                duration_text: String::new(),
+                has_content_below: false,
+            },
+        );
+    }
+
+    on_lines(bullet_line, body_line);
+}
+
+/// Update the recorded `duration_text` of the last entry under a task so
+/// that any subsequent `upgrade_last_tool_to_mid` redraws the line with the
+/// latest reasoning content (otherwise the upgrade would repaint the body
+/// with an empty string, blanking out the live update).
+pub fn update_orch_last_tool_duration_text(task_id: &str, text: &str) {
+    if let Ok(mut guard) = ORCH_LAST_TOOL_LINES.lock()
+        && let Some(info) = guard.get_mut(task_id)
+    {
+        info.duration_text = text.to_string();
+    }
+}
+
 /// Update the previous last tool under a task from └─ to ├─.
 fn upgrade_last_tool_to_mid(task_id: &str) {
     let prev = if let Ok(guard) = ORCH_LAST_TOOL_LINES.lock() {

--- a/crates/aura-cli/src/ui/prompt.rs
+++ b/crates/aura-cli/src/ui/prompt.rs
@@ -17,8 +17,8 @@ pub use super::state::{
     push_display_event, push_mid_stream_history, random_bullet_color, reset_input_geometry,
     reset_task_colors, restore_style_preview_original, set_expanded_output, set_mid_stream_history,
     set_pending_command, set_pretty, set_processing, set_queued_input, set_selected_model,
-    set_welcome_state, take_pending_command, take_queued_input, task_color_for, text_lines,
-    with_event_log, with_event_log_mut,
+    set_welcome_state, take_pending_command, take_queued_input, task_color_for, term_size,
+    text_lines, with_event_log, with_event_log_mut,
 };
 
 // Re-export from status_bar.rs

--- a/crates/aura-cli/src/ui/state.rs
+++ b/crates/aura-cli/src/ui/state.rs
@@ -35,7 +35,7 @@ pub(crate) fn lock_term() -> std::sync::MutexGuard<'static, ()> {
     TERM_WRITE.lock().unwrap_or_else(|e| e.into_inner())
 }
 
-pub(crate) fn term_size() -> (u16, u16) {
+pub fn term_size() -> (u16, u16) {
     crossterm::terminal::size().unwrap_or((80, 24))
 }
 

--- a/crates/aura-cli/src/ui/stream_panel.rs
+++ b/crates/aura-cli/src/ui/stream_panel.rs
@@ -17,6 +17,7 @@ use super::state::{
     CURSOR_ROW, EXPANDED_OUTPUT, FRAME_LINES, STREAM_CONV_DIR, STREAM_PANEL, STREAM_PANEL_DIRTY,
     term_size,
 };
+use crate::event_names;
 use crate::theme::{AuraStyle, Style, Themed, theme};
 
 /// Resolve the per-event-type style for a stream panel row.
@@ -94,20 +95,18 @@ fn extract_display_id(event_name: &str, data: &str) -> Option<String> {
     };
 
     match event_name {
-        "aura.tool_requested" | "aura.tool_start" | "aura.tool_complete" => {
+        event_names::TOOL_REQUESTED | event_names::TOOL_START | event_names::TOOL_COMPLETE => {
             try_field(&val, "tool_id")
         }
-        "aura.usage" | "aura.session_info" => try_field(&val, "session_id"),
+        event_names::USAGE | event_names::SESSION_INFO => try_field(&val, "session_id"),
         "message" => try_field(&val, "id"),
-        "aura.orchestrator.tool_call_started" | "aura.orchestrator.tool_call_completed" => {
+        event_names::TOOL_CALL_STARTED | event_names::TOOL_CALL_COMPLETED => {
             try_field(&val, "tool_call_id")
         }
-        "aura.orchestrator.task_started" | "aura.orchestrator.task_completed" => {
-            try_field(&val, "task_id")
+        event_names::TASK_STARTED | event_names::TASK_COMPLETED => try_field(&val, "task_id"),
+        event_names::PLAN_CREATED | event_names::ITERATION_COMPLETE | event_names::SYNTHESIZING => {
+            try_field(&val, "session_id")
         }
-        "aura.orchestrator.plan_created"
-        | "aura.orchestrator.iteration_complete"
-        | "aura.orchestrator.synthesizing" => try_field(&val, "session_id"),
         _ => try_field(&val, "id")
             .or_else(|| try_field(&val, "session_id"))
             .or_else(|| try_field(&val, "tool_id")),

--- a/crates/aura-cli/src/ui/text.rs
+++ b/crates/aura-cli/src/ui/text.rs
@@ -1,0 +1,61 @@
+//! Grapheme-aware text helpers for terminal display.
+
+use unicode_segmentation::UnicodeSegmentation;
+
+/// Truncate `text` to at most `max` grapheme clusters, appending `...` when
+/// truncation occurs (so the result stays within `max` clusters).
+///
+/// Counts and splits on grapheme cluster boundaries, not `char`s, so
+/// multi-scalar glyphs — ZWJ emoji sequences (👨‍👩‍👧), skin-tone modifiers
+/// (👋🏽), and regional-indicator flags (🇯🇵) — are never cut mid-glyph.
+pub fn truncate_with_ellipsis(text: &str, max: usize) -> String {
+    if text.graphemes(true).count() <= max {
+        return text.to_string();
+    }
+    // Reserve three clusters for the ellipsis so the result fits in `max`.
+    let keep = max.saturating_sub(3);
+    let prefix: String = text.graphemes(true).take(keep).collect();
+    format!("{prefix}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_text_is_unchanged() {
+        assert_eq!(truncate_with_ellipsis("hello", 120), "hello");
+    }
+
+    #[test]
+    fn long_ascii_is_truncated_with_ellipsis() {
+        let s = "a".repeat(200);
+        let out = truncate_with_ellipsis(&s, 120);
+        assert_eq!(out.graphemes(true).count(), 120);
+        assert!(out.ends_with("..."));
+    }
+
+    #[test]
+    fn does_not_split_zwj_emoji() {
+        // Family emoji is a single grapheme made of multiple scalars.
+        let family = "👨‍👩‍👧";
+        // Pad with enough families to force truncation at a boundary.
+        let s = family.repeat(50);
+        let out = truncate_with_ellipsis(&s, 10);
+        // Truncation point keeps 7 whole families + "...". Crucially, the
+        // output must still be valid and contain only whole families.
+        let body = out.strip_suffix("...").unwrap();
+        assert_eq!(body, family.repeat(7));
+        assert_eq!(out, format!("{}...", family.repeat(7)));
+    }
+
+    #[test]
+    fn does_not_split_skin_tone_or_flag() {
+        let wave = "👋🏽"; // base + skin-tone modifier
+        let flag = "🇯🇵"; // two regional indicators
+        let s = format!("{}{}", wave.repeat(8), flag.repeat(8));
+        let out = truncate_with_ellipsis(&s, 6);
+        // 3 kept clusters + ellipsis; all kept clusters are whole waves.
+        assert_eq!(out, format!("{}...", wave.repeat(3)));
+    }
+}

--- a/crates/aura-events/src/event_names.rs
+++ b/crates/aura-events/src/event_names.rs
@@ -1,0 +1,16 @@
+//! SSE event-name constants for the base `aura.*` namespace.
+//!
+//! Orchestration events are kept separate in
+//! [`crate::orchestration::event_names`] under the `aura.orchestrator.*`
+//! namespace.
+
+pub const SESSION_INFO: &str = "aura.session_info";
+pub const TOOL_REQUESTED: &str = "aura.tool_requested";
+pub const TOOL_START: &str = "aura.tool_start";
+pub const TOOL_COMPLETE: &str = "aura.tool_complete";
+pub const REASONING: &str = "aura.reasoning";
+pub const PROGRESS: &str = "aura.progress";
+pub const WORKER_PHASE: &str = "aura.worker_phase";
+pub const TOOL_USAGE: &str = "aura.tool_usage";
+pub const USAGE: &str = "aura.usage";
+pub const SCRATCHPAD_USAGE: &str = "aura.scratchpad_usage";

--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -13,6 +13,7 @@
 //! Both enums derive `Serialize + Deserialize` so they can be used for
 //! producing SSE (server) and parsing SSE (client) with the same types.
 
+pub mod event_names;
 pub mod orchestration;
 
 use serde::{Deserialize, Serialize};
@@ -296,16 +297,16 @@ impl AuraStreamEvent {
     /// Get the SSE event name for this event type.
     pub fn event_name(&self) -> &'static str {
         match self {
-            Self::SessionInfo { .. } => "aura.session_info",
-            Self::ToolRequested { .. } => "aura.tool_requested",
-            Self::ToolStart { .. } => "aura.tool_start",
-            Self::ToolComplete { .. } => "aura.tool_complete",
-            Self::Reasoning { .. } => "aura.reasoning",
-            Self::Progress { .. } => "aura.progress",
-            Self::WorkerPhase { .. } => "aura.worker_phase",
-            Self::ToolUsage { .. } => "aura.tool_usage",
-            Self::Usage { .. } => "aura.usage",
-            Self::ScratchpadUsage { .. } => "aura.scratchpad_usage",
+            Self::SessionInfo { .. } => event_names::SESSION_INFO,
+            Self::ToolRequested { .. } => event_names::TOOL_REQUESTED,
+            Self::ToolStart { .. } => event_names::TOOL_START,
+            Self::ToolComplete { .. } => event_names::TOOL_COMPLETE,
+            Self::Reasoning { .. } => event_names::REASONING,
+            Self::Progress { .. } => event_names::PROGRESS,
+            Self::WorkerPhase { .. } => event_names::WORKER_PHASE,
+            Self::ToolUsage { .. } => event_names::TOOL_USAGE,
+            Self::Usage { .. } => event_names::USAGE,
+            Self::ScratchpadUsage { .. } => event_names::SCRATCHPAD_USAGE,
         }
     }
 

--- a/crates/aura-web-server/Cargo.toml
+++ b/crates/aura-web-server/Cargo.toml
@@ -77,3 +77,4 @@ rig-core = { workspace = true }
 futures-util = "0.3"
 uuid = { version = "1.0", features = ["v4"] }
 aura-test-utils = { path = "../aura-test-utils" }
+aura-events = { path = "../aura-events" }

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -1297,7 +1297,8 @@ fn build_final_chunk(ctx: &TurnContext, state: &TurnState) -> Vec<Bytes> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aura::stream_events::{AgentContext, CorrelationContext, event_names};
+    use aura::stream_events::{AgentContext, CorrelationContext};
+    use aura_events::event_names;
 
     /// Verify handle_tool_call does NOT emit aura.tool_requested events directly.
     /// The aura.tool_requested event is emitted via StreamingRequestHook → tool_event_rx channel

--- a/crates/aura-web-server/tests/aura_events_test.rs
+++ b/crates/aura-web-server/tests/aura_events_test.rs
@@ -12,7 +12,7 @@
 //! - `aura.reasoning` - Emitted for LLM reasoning (requires AURA_EMIT_REASONING=true)
 //!
 
-use aura::stream_events::event_names;
+use aura_events::event_names;
 use aura_test_utils::server_urls::AURA_SERVER;
 use aura_test_utils::sse::{SseEvent, events_by_type, parse_sse_stream};
 use serde_json::{Value, json};

--- a/crates/aura-web-server/tests/orchestration_events_test.rs
+++ b/crates/aura-web-server/tests/orchestration_events_test.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "integration-orchestration")]
 
 use aura::orchestration::event_names;
-use aura::stream_events::event_names as aura_event_names;
+use aura_events::event_names as aura_event_names;
 use aura_test_utils::server_urls::AURA_SERVER;
 use aura_test_utils::sse::{SseEvent, events_by_type, parse_sse_stream};
 use serde_json::{Value, json};

--- a/crates/aura-web-server/tests/scratchpad_test.rs
+++ b/crates/aura-web-server/tests/scratchpad_test.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "integration-scratchpad")]
 
 use aura::orchestration::event_names as orch_event_names;
-use aura::stream_events::event_names;
+use aura_events::event_names;
 use aura_test_utils::server_urls::AURA_SERVER;
 use aura_test_utils::sse::{SseEvent, events_by_type, parse_sse_stream};
 use serde_json::{Value, json};

--- a/crates/aura/src/stream_events.rs
+++ b/crates/aura/src/stream_events.rs
@@ -36,27 +36,10 @@ impl CorrelationContextExt for CorrelationContext {
     }
 }
 
-/// Constants for SSE event names on the base `aura.*` namespace.
-///
-/// Import these in tests or downstream consumers instead of hard-coding the
-/// string literals. Orchestration-specific events live in
-/// `orchestration::stream_events::event_names` under `aura.orchestrator.*`.
-pub mod event_names {
-    pub const SESSION_INFO: &str = "aura.session_info";
-    pub const TOOL_REQUESTED: &str = "aura.tool_requested";
-    pub const TOOL_START: &str = "aura.tool_start";
-    pub const TOOL_COMPLETE: &str = "aura.tool_complete";
-    pub const REASONING: &str = "aura.reasoning";
-    pub const PROGRESS: &str = "aura.progress";
-    pub const WORKER_PHASE: &str = "aura.worker_phase";
-    pub const TOOL_USAGE: &str = "aura.tool_usage";
-    pub const USAGE: &str = "aura.usage";
-    pub const SCRATCHPAD_USAGE: &str = "aura.scratchpad_usage";
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aura_events::event_names;
 
     #[test]
     fn test_agent_context_single_agent() {


### PR DESCRIPTION
Shows "Reasoning: ..." output both at the top-level of the output, for the coordinator, and in-line with a given task for worker reasoning.

Here is an example of running against an orchestration enabled AURA config using Anthropic `claude-sonnet-4-6` model.

<img width="1265" height="1241" alt="image" src="https://github.com/user-attachments/assets/78decdca-b5f9-426d-a58e-5b2b03b348c5" />

Here is an example of running against a single-agent AURA config using Anthropic `claude-sonnet-4-6` model.

<img width="1265" height="781" alt="image" src="https://github.com/user-attachments/assets/2af69bf8-96fa-459f-86de-7cd3f57ca024" />

Additionally, event names are consolidated to a single source of truth.

Base aura.* event-name constants now live solely in aura-events::event_names, beside the existing orchestration::event_names (kept as separate modules). The duplicate copy in aura/src/stream_events.rs was removed, and AuraStreamEvent::event_name() returns these consts rather than inline literals.

aura-cli no longer hard-codes "aura.*" strings: the dispatch match, REPL handlers, and stream panel reference the consts via a local event_names re-export. The orchestrator handler now matches full event names directly instead of stripping the "aura.orchestrator." prefix and comparing the tail.

aura-web-server consumers import event_names straight from aura-events rather than the aura facade re-export, so the base names have one definition and one import path.

Ref: GH-114