### PR TITLE
fix(a2a): propagate mcp notifications/cancelled and gate completed yield

### DIFF
--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -9,7 +9,7 @@ use a2a::{
     TaskStatusUpdateEvent, VERSION,
 };
 use a2a_server::{AgentExecutor, ExecutorContext, TaskStore};
-use aura::{StreamItem, StreamedAssistantContent};
+use aura::{RequestCancellation, StreamItem, StreamedAssistantContent, StreamingAgent};
 use aura_config::RigBuilder;
 use futures_util::StreamExt;
 use futures_util::stream::BoxStream;
@@ -18,14 +18,23 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::{Level, event};
 
-use crate::{a2a::SharedTaskStore, types::AppState};
+use crate::{
+    a2a::SharedTaskStore,
+    types::{ActiveRequestGuard, AppState},
+};
 
 const PLAIN_TEXT: &str = "text/plain";
 
 pub struct AuraAgentExecutor {
     app_state: Arc<AppState>,
     task_store: SharedTaskStore,
-    task_cancel_tokens: Arc<Mutex<HashMap<String, CancellationToken>>>,
+    task_cancel_state: Arc<Mutex<HashMap<String, TaskCancelEntry>>>,
+}
+
+struct TaskCancelEntry {
+    token: CancellationToken,
+    agent: Arc<dyn StreamingAgent>,
+    request_id: String,
 }
 
 impl AuraAgentExecutor {
@@ -33,7 +42,7 @@ impl AuraAgentExecutor {
         Self {
             app_state,
             task_store,
-            task_cancel_tokens: Arc::new(Mutex::new(HashMap::new())),
+            task_cancel_state: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -114,7 +123,7 @@ impl AgentExecutor for AuraAgentExecutor {
     ) -> BoxStream<'static, Result<StreamResponse, A2AError>> {
         let config = self.resolve_config();
         let stream_shutdown_token = self.app_state.stream_shutdown_token.clone();
-        let task_cancel_tokens = self.task_cancel_tokens.clone();
+        let task_cancel_state = self.task_cancel_state.clone();
         let active_request_tracker = self.app_state.active_requests.clone();
         let task_store = self.task_store.clone();
 
@@ -165,33 +174,50 @@ impl AgentExecutor for AuraAgentExecutor {
             let history = get_history_for_context(task_store.clone(), &request_id, &context_id, &task_id).await?;
 
             let cancel_token = stream_shutdown_token.child_token();
+            // Register with the global cancellation registry for parity with the OpenAI handler
+            // and to let any future code address this request by id.
+            RequestCancellation::register(request_id.clone());
             {
-                // keep track of this cancel token in case the a2a framework
-                // receives a cancel call and we need to propagate
-                let mut cancel_map = task_cancel_tokens.lock().await;
-                cancel_map.insert(task_id.clone(), cancel_token.clone());
+                let mut cancel_map = task_cancel_state.lock().await;
+                cancel_map.insert(task_id.clone(), TaskCancelEntry {
+                    token: cancel_token.clone(),
+                    agent: agent.clone(),
+                    request_id: request_id.clone(),
+                });
             }
 
-            let mut stream = match agent.stream(&text, history, cancel_token, &request_id).await {
+            let mut stream = match agent.stream(&text, history, cancel_token.clone(), &request_id).await {
                 Ok(s) => s,
                 Err(e) => {
-                    // processing never started, so we can remove the cancel token from tracking
-                    let mut cancel_map = task_cancel_tokens.lock().await;
-                    cancel_map.remove(&task_id);
+                    {
+                        let mut cancel_map = task_cancel_state.lock().await;
+                        cancel_map.remove(&task_id);
+                    }
+                    RequestCancellation::unregister(&request_id);
 
                     yield Ok(fail_status(&task_id, &context_id, &e.to_string()));
                     return;
                 }
             };
 
-            // let the main state machinery know we've got a job in progress
-            active_request_tracker.increment();
+            // RAII guard: drop on any generator exit (loop break, early return, panic,
+            // consumer drop) produces exactly one decrement. Replaces the manual
+            // increment/decrement pair that previously raced with cancel() — a fast
+            // cancel before this line, or a cancel mid-loop followed by natural
+            // loop-exit cleanup, could double-decrement and wrap the counter.
+            let _request_guard = ActiveRequestGuard::new(active_request_tracker);
 
             let mut first_chunk = true;
             let mut success = true; // assume everything is successful
 
             let mut reasoning_num = 0;
-            while let Some(item) = stream.next().await {
+            loop {
+                let next = tokio::select! {
+                    biased;
+                    _ = cancel_token.cancelled() => break,
+                    next = stream.next() => next,
+                };
+                let Some(item) = next else { break };
                 match item {
                     Ok(StreamItem::StreamAssistantItem(StreamedAssistantContent::Text(t))) => {
                         event!(Level::DEBUG, request_id, t, "stream content received");
@@ -330,17 +356,41 @@ impl AgentExecutor for AuraAgentExecutor {
                 }
             }
 
-            // processing done, remove the token from the map, no longer need to track
-            {
-                let mut cancel_map = task_cancel_tokens.lock().await;
-                cancel_map.remove(&task_id);
+            // If cancel_token fired but our entry is still in the map, the cancel came
+            // from the parent stream_shutdown_token (server shutdown), not from our
+            // cancel() hook — cancel() removes its entry before firing the token.
+            // In that case the executor has to drive MCP cleanup itself and emit a
+            // terminal Canceled status (the OpenAI handler does the equivalent in its
+            // Shutdown post-loop arm).
+            let entry_still_present = {
+                let mut cancel_map = task_cancel_state.lock().await;
+                cancel_map.remove(&task_id).is_some()
+            };
+            let shutdown_initiated_cancel = cancel_token.is_cancelled() && entry_still_present;
+            RequestCancellation::unregister(&request_id);
+
+            if shutdown_initiated_cancel {
+                agent
+                    .cancel_and_close_mcp(&request_id, "server shutdown")
+                    .await;
+
+                yield Ok(StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+                    task_id: task_id.clone(),
+                    context_id: context_id.clone(),
+                    status: TaskStatus {
+                        state: TaskState::Canceled,
+                        message: None,
+                        timestamp: Some(chrono::Utc::now()),
+                    },
+                    metadata: None,
+                }));
             }
 
-            // let the main state machinery know we've completed this particular job
-            active_request_tracker.decrement();
+            // _request_guard drops at end of generator scope → exactly one decrement.
 
-            // if successful (hit either finalizer), mark the task as such.
-            if success {
+            // Skip Completed if cancel() or the shutdown path already emitted Canceled —
+            // yielding here would clobber it.
+            if success && !cancel_token.is_cancelled() {
                 yield Ok(StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
                     task_id,
                     context_id,
@@ -358,19 +408,28 @@ impl AgentExecutor for AuraAgentExecutor {
     fn cancel(&self, ctx: ExecutorContext) -> BoxStream<'static, Result<StreamResponse, A2AError>> {
         let task_id = ctx.task_id.clone();
         let context_id = ctx.context_id.clone();
-        let task_cancel_tokens = self.task_cancel_tokens.clone();
-        let active_request_tracker = self.app_state.active_requests.clone();
+        let task_cancel_state = self.task_cancel_state.clone();
 
         Box::pin(futures_util::stream::once(async move {
-            // a2a got a cancel call, so make sure rig cancels as well
-            // and remove the token from tracking
-            let mut cancel_map = task_cancel_tokens.lock().await;
-            if let Some(token) = cancel_map.remove(&task_id) {
-                token.cancel();
-            }
+            let entry = {
+                let mut cancel_map = task_cancel_state.lock().await;
+                cancel_map.remove(&task_id)
+            };
 
-            // let the main state machinery know this task is effectively complete
-            active_request_tracker.decrement();
+            // Token-cancel wakes execute()'s select! → loop breaks → generator drops
+            // → ActiveRequestGuard drops → exactly one decrement. cancel() never
+            // touches the tracker directly, which closes the prior double-decrement
+            // / underflow race.
+            if let Some(entry) = entry {
+                // Send notifications/cancelled to in-flight MCP tool calls. No-op in
+                // orchestration mode (workers manage their own MCP cancellation).
+                entry
+                    .agent
+                    .cancel_and_close_mcp(&entry.request_id, "A2A cancelTask")
+                    .await;
+                entry.token.cancel();
+                RequestCancellation::unregister(&entry.request_id);
+            }
 
             Ok(StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
                 task_id,

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -24,25 +24,6 @@ use crate::streaming::{
 };
 use crate::types::*;
 
-/// RAII guard that increments the active request counter on creation and
-/// decrements it on drop, notifying the shutdown task when the count hits zero.
-struct ActiveRequestGuard {
-    tracker: Arc<ActiveRequestTracker>,
-}
-
-impl ActiveRequestGuard {
-    fn new(tracker: Arc<ActiveRequestTracker>) -> Self {
-        tracker.increment();
-        Self { tracker }
-    }
-}
-
-impl Drop for ActiveRequestGuard {
-    fn drop(&mut self) {
-        self.tracker.decrement();
-    }
-}
-
 /// RAII guard for request-scoped subscriptions. Ensures cleanup even on panic.
 struct RequestResourceGuard {
     request_id: String,

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -52,6 +52,27 @@ impl ActiveRequestTracker {
     }
 }
 
+/// RAII guard that increments the active request counter on creation and
+/// decrements it on drop. Pair with one construction per logical request so
+/// every code path (normal completion, early return, panic, consumer drop)
+/// produces exactly one decrement.
+pub struct ActiveRequestGuard {
+    tracker: Arc<ActiveRequestTracker>,
+}
+
+impl ActiveRequestGuard {
+    pub fn new(tracker: Arc<ActiveRequestTracker>) -> Self {
+        tracker.increment();
+        Self { tracker }
+    }
+}
+
+impl Drop for ActiveRequestGuard {
+    fn drop(&mut self) {
+        self.tracker.decrement();
+    }
+}
+
 /// Application state
 pub struct AppState {
     pub configs: Arc<Vec<aura_config::Config>>,

--- a/crates/aura-web-server/tests/a2a_test.rs
+++ b/crates/aura-web-server/tests/a2a_test.rs
@@ -646,6 +646,65 @@ async fn test_cancel_task() {
         "TASK_STATE_CANCELED", response_body["status"]["state"],
         "The task is cancelled"
     );
+
+    // Poll until the task quiesces — same (state, artifact_count) across two
+    // consecutive reads. This is self-tuning (returns immediately on a fast box,
+    // waits only as long as needed on a slow one) and is the actual regression
+    // check: a buggy executor that keeps yielding past cancel will keep growing
+    // the artifact count, never reach stability, and trip the deadline. State
+    // is asserted Canceled on every poll so a Completed-clobber is caught the
+    // instant it happens, not just on the final read.
+    let client = reqwest::Client::new();
+    let get_task = || async {
+        let resp = client
+            .get(format!("{}/a2a/v1/tasks/{}", AURA_SERVER, task_id))
+            .header("A2A-Version", "1.0")
+            .timeout(TEST_TIMEOUT)
+            .send()
+            .await
+            .expect("Failed to GET task after cancel");
+        let body = resp.text().await.expect("Failed to read GetTask body");
+        serde_json::from_str::<Task>(&body).expect("GetTask body not valid JSON")
+    };
+    let artifact_count = |t: &Task| t.artifacts.as_ref().map(|a| a.len()).unwrap_or(0);
+
+    let poll_interval = Duration::from_millis(250);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+
+    let mut prev = get_task().await;
+    assert_eq!(
+        prev.status.state,
+        TaskState::Canceled,
+        "Task state was {:?} on first read after cancel — Completed yield clobbered the cancel",
+        prev.status.state
+    );
+
+    let stable = loop {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Task never quiesced after cancel — executor is still emitting (last state: {:?}, last artifact count: {})",
+            prev.status.state,
+            artifact_count(&prev)
+        );
+        tokio::time::sleep(poll_interval).await;
+        let curr = get_task().await;
+        assert_eq!(
+            curr.status.state,
+            TaskState::Canceled,
+            "Task state regressed to {:?} after cancel — execute() yielded a terminal state past the cancel",
+            curr.status.state
+        );
+        if curr.status.state == prev.status.state && artifact_count(&curr) == artifact_count(&prev)
+        {
+            break curr;
+        }
+        prev = curr;
+    };
+
+    println!(
+        "Task quiesced at {} artifact(s) in Canceled state",
+        artifact_count(&stable)
+    );
 }
 
 // validates that two sequential messages sent with the same contextId result in two tasks


### PR DESCRIPTION
The cancel hook cancels a token that nothing observes: `Agent::stream(...)` accepts the token as `_cancel_token` and ignores it, and the real MCP cancellation path is keyed off `request_id` and triggered by an explicit `agent.cancel_and_close_mcp(request_id, reason)` — which the executor never called from either the cancel hook or the server- shutdown post-loop. Result: CancelTask returned `Canceled` but the agent kept streaming, in-flight MCP tool calls on remote servers never received `notifications/cancelled` (whether the trigger was a client cancel or a graceful shutdown), and the trailing `if success { yield Completed }` block could clobber the Canceled state back to Completed. The executor also hand-rolled increment/decrement of ActiveRequestTracker in two places, which could double-decrement (or decrement before increment on a fast cancel) and underflow the counter, breaking shutdown drain.

Cancellation propagation:
- Register the per-task `request_id` with `aura::RequestCancellation` for parity with the OpenAI handler, and unregister on every exit path.
- Stash an `Arc<dyn StreamingAgent>` in the per-task cancellation entry so `cancel()` can call `agent.cancel_and_close_mcp(...)` to send `notifications/cancelled` to in-flight MCP tool calls.
- Wrap `stream.next()` in `tokio::select!` against `cancel_token.cancelled()` so the executor stops emitting artifacts the moment cancel fires.
- Gate the final `Completed` yield on `!cancel_token.is_cancelled()` so a cancel that lands while the stream is producing its final chunk doesn't get overwritten.
- Drive MCP cleanup on server shutdown. `cancel_token` is a child of `stream_shutdown_token`, so shutdown wakes the select! and breaks the loop — but nothing was notifying MCP. 
  - The post-loop now distinguishes the two cancel sources by checking whether the cancel-map entry is still present (cancel() removes its entry before firing the token, so a still-present entry means the parent shutdown token fired), calls `agent.cancel_and_close_mcp(request_id, "server shutdown")` in that branch, and yields a terminal `Canceled` status so the client sees a clean end instead of a silent stream close. 
  - Mirrors the OpenAI handler's `StreamTermination::Shutdown` arm.

Active-request tracking (closes underflow race):
- Extract `ActiveRequestGuard` from `handlers.rs` (private) to `types.rs` (`pub`) so both handlers can share it. No behavior change on the OpenAI side — the local duplicate is removed in favor of the shared type.
- Replace the manual `active_request_tracker.increment()` / `.decrement()` pairs in the A2A executor with the RAII guard. Drop on generator exit (loop break, early return, panic, consumer drop) produces exactly one decrement, regardless of which side initiates termination.
- `cancel()` no longer touches the tracker — it only fires the token and cleans up the cancel-map entry. The in-flight execute() loop catches the cancel via select!, breaks, drops the guard, decrements once.

Test:
- Extend `test_cancel_task` to poll `GetTask` until the task quiesces (same state + artifact count across two reads). State is asserted `Canceled` on every poll, so a Completed-clobber is caught the instant it happens; an executor that keeps emitting past cancel never stabilizes and trips the 10s deadline.

Ref: LOG-23822