### PR TITLE
ci: pin contributor-assistant/github-action to a commit SHA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret


### PR DESCRIPTION
## Summary

Pins the third-party action used by the CLA Assistant workflow to an immutable commit SHA.

`.github/workflows/cla.yml` runs on `pull_request_target` and hands `secrets.GITHUB_TOKEN` (write) and `secrets.CLA_GITHUB_TOKEN` (a repo-scoped PAT) to `contributor-assistant/github-action`, which was pinned to the mutable `v2.6.1` tag. A mutable tag can be repointed, and if the upstream action repository were compromised, that credential handoff would run attacker-controlled code on any externally-opened pull request.

This change pins the action to the commit the `v2.6.1` tag currently resolves to:

- Before: `uses: contributor-assistant/github-action@v2.6.1`
- After: `uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1`

`v2.6.1` is the latest stable release of `contributor-assistant/github-action`, so pinning the SHA loses no version currency. The trailing `# v2.6.1` comment keeps the human-readable version visible and supports update tooling such as Dependabot.

## Scope

Single-line change. The `permissions:` block is unchanged — `actions: write` is intentionally retained: the action's `issue_comment`-triggered recheck / sign flow re-runs the CLA status check and requires it, and it appears in the action's own recommended permissions block at the pinned SHA.

This workflow does not check out or run pull-request-author code, so the classic "pwn request" RCE path is not present. This change is preventive hardening of the credential-handoff surface.

## Verification

- Tag-to-commit resolution confirmed via the GitHub git-refs API: `v2.6.1` resolves to `ca4a40a7d1004f18d9960b404b97e5f30a505a08`.
- `cla.yml` still parses as valid YAML (`yamllint` syntax rules — clean).
- Diff is exactly one line.

## Notes

No CHANGELOG entry: CI workflow hardening, no user-facing or product behavior change.

Contact: Sven Delmas.
