### PR TITLE
fix(a2a): publish absolute urls in agent card

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Core server options:
 | `--config`                   | `CONFIG_PATH`              | `config.toml` | Path to TOML config file or directory |
 | `--host`                     | `HOST`                     | `127.0.0.1`   | Bind host                           |
 | `--port`                     | `PORT`                     | `8080`        | Bind port                           |
+| `--server-url`               | `AURA_SERVER_URL`          | host/port     | Canonical public origin published in the A2A agent card (see below) |
 | `--streaming-timeout-secs`   | `STREAMING_TIMEOUT_SECS`   | `900`         | Max SSE request duration            |
 | `--first-chunk-timeout-secs` | `FIRST_CHUNK_TIMEOUT_SECS` | `30`          | Max time to first provider chunk    |
 | `--streaming-buffer-size`    | `STREAMING_BUFFER_SIZE`    | `400`         | SSE backpressure buffer             |
@@ -195,7 +196,9 @@ curl -X POST http://localhost:8080/a2a/v1/rpc \
   -d '{"jsonrpc": "2.0", "method": "SendMessage", "params": {"message": {"messageId": "msg-002", "role": "ROLE_USER", "parts": [{"text": "Hello"}]}}, "id": 1}'
 ```
 
-A2A endpoints, transport modes, task lifecycle, and testing examples are documented in [docs/a2a-implementation.md](docs/a2a-implementation.md).
+> **Set `AURA_SERVER_URL` when running behind a proxy, load balancer, or in Kubernetes.** The agent card must advertise **absolute** endpoint URLs, and A2A clients use those URLs directly — a relative or wrong-host URL makes `message:send` fail even though the card itself loads. Aura builds the card's URLs from `AURA_SERVER_URL` (or `--server-url`); set it to the externally-reachable origin clients use (e.g. `https://aura.example.com`). When unset, it falls back to the bind host/port, which is only correct for direct local access.
+
+A2A endpoints, transport modes, the agent card URL, task lifecycle, and testing examples are documented in [docs/a2a-implementation.md](docs/a2a-implementation.md).
 
 ### Client-Side Tools
 

--- a/compose/base.yml
+++ b/compose/base.yml
@@ -50,6 +50,10 @@ services:
       # Server configuration
       HOST: 0.0.0.0
       PORT: 8080
+      # AURA_SERVER_URL (the canonical origin published in the A2A agent card) is
+      # set per-topology in the test.yml / dev.yml overlays so it matches the URL
+      # the test runner actually reaches the server on. Unset here, the server
+      # falls back to http://127.0.0.1:8080 for ad-hoc base-only runs.
       CONFIG_PATH: /app/config/test-config.toml
       # MCP server hostname (Docker service name)
       MCP_MOCK_HOST: mock-mcp

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -25,3 +25,6 @@ services:
     environment:
       # More verbose logging for development
       - RUST_LOG=info,aura=debug
+      # Publish the host-reachable origin so the A2A agent card's absolute URLs
+      # match where host-run tests connect (AURA_SERVER default: http://localhost:8080).
+      - AURA_SERVER_URL=http://localhost:8080

--- a/compose/test.yml
+++ b/compose/test.yml
@@ -16,6 +16,11 @@ services:
     attach: false
     logging:
       driver: "none"
+    environment:
+      # Publish the in-network address the test runner reaches us on, so the
+      # A2A agent card carries absolute URLs that resolve inside the compose
+      # network. Must match the test runner's AURA_SERVER_URL below.
+      AURA_SERVER_URL: http://aura-web-server:8080
 
   aura-integration-test:
     build:

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -60,7 +60,14 @@ impl AuraAgentExecutor {
         self.app_state.configs.first().cloned()
     }
 
-    pub fn build_agent_card(&self) -> AgentCard {
+    /// Build the A2A agent card.
+    ///
+    /// `base_url` is the externally-reachable origin (e.g. `https://aura.example.com`)
+    /// used to make the interface endpoints absolute. The A2A spec requires absolute
+    /// interface URLs — clients pass them straight to their HTTP layer, which rejects
+    /// relative paths.
+    pub fn build_agent_card(&self, base_url: &str) -> AgentCard {
+        let base = base_url.trim_end_matches('/');
         let config = self.resolve_config();
         let name = config
             .as_ref()
@@ -94,8 +101,8 @@ impl AuraAgentExecutor {
                 extended_agent_card: None,
             },
             supported_interfaces: vec![
-                AgentInterface::new("/a2a/v1", TRANSPORT_PROTOCOL_HTTP_JSON),
-                AgentInterface::new("/a2a/v1/rpc", TRANSPORT_PROTOCOL_JSONRPC),
+                AgentInterface::new(format!("{base}/a2a/v1"), TRANSPORT_PROTOCOL_HTTP_JSON),
+                AgentInterface::new(format!("{base}/a2a/v1/rpc"), TRANSPORT_PROTOCOL_JSONRPC),
             ],
             skills: vec![AgentSkill {
                 id: "chat".to_owned(),

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -115,6 +115,33 @@ struct Args {
     /// Not required when only one configuration is loaded via CONFIG_PATH.
     #[arg(long, env = "DEFAULT_AGENT")]
     default_agent: Option<String>,
+
+    /// Canonical, externally-reachable base URL of this server (e.g.
+    /// `https://aura.example.com`). It is published in the A2A agent card's
+    /// interface endpoints — A2A clients require absolute URLs and pass them
+    /// straight to their HTTP layer. When unset, this is derived from
+    /// --host/--port (0.0.0.0 / :: mapped to 127.0.0.1), which is fine for local
+    /// use but should be set explicitly behind a proxy or in K8s. Integration
+    /// tests reuse this same value to know where to reach the server.
+    #[arg(long, env = "AURA_SERVER_URL")]
+    server_url: Option<String>,
+}
+
+/// Resolve the externally-advertised base URL for the A2A agent card.
+///
+/// A2A clients reject relative interface URLs, so the card must carry an absolute
+/// origin. Prefer an explicit `--server-url`; otherwise derive one from the bind
+/// host/port, mapping wildcard binds to a loopback address since `0.0.0.0` is not
+/// a routable destination.
+fn advertised_base_url(server_url: Option<&str>, host: &str, port: u16) -> String {
+    if let Some(url) = server_url {
+        return url.trim_end_matches('/').to_string();
+    }
+    let host = match host {
+        "0.0.0.0" | "::" | "[::]" => "127.0.0.1",
+        other => other,
+    };
+    format!("http://{host}:{port}")
 }
 
 /// Middleware that rejects new requests with 503 when shutdown_token is cancelled.
@@ -230,7 +257,8 @@ async fn run() -> std::io::Result<()> {
     // forcing an in-memory store for now. TBD: a resilient location
     let task_store = SharedTaskStore::new();
     let executor = AuraAgentExecutor::new(app_state.clone(), task_store.clone());
-    let agent_card = executor.build_agent_card();
+    let base_url = advertised_base_url(args.server_url.as_deref(), &args.host, args.port);
+    let agent_card = executor.build_agent_card(&base_url);
     let a2a_handler = Arc::new(AuraRequestHandler::new(executor, task_store));
     let card_producer = Arc::new(StaticAgentCard::new(agent_card));
 

--- a/crates/aura-web-server/tests/a2a_test.rs
+++ b/crates/aura-web-server/tests/a2a_test.rs
@@ -1,4 +1,4 @@
-//#![cfg(feature = "integration-a2a")]
+#![cfg(feature = "integration-a2a")]
 
 //! Integration tests for Aura invocation of A2A tools via the a2a-rs-server crate.
 //!
@@ -35,12 +35,12 @@ async fn test_a2a_agent_card() {
       "version": "1.0",
       "supportedInterfaces": [
         {
-          "url": "/a2a/v1",
+          "url": format!("{}/a2a/v1", AURA_SERVER),
           "protocolBinding": "HTTP+JSON",
           "protocolVersion": "1.0"
         },
         {
-          "url": "/a2a/v1/rpc",
+          "url": format!("{}/a2a/v1/rpc", AURA_SERVER),
           "protocolBinding": "JSONRPC",
           "protocolVersion": "1.0"
         }

--- a/deployment/helm/aura/templates/deployment.yaml
+++ b/deployment/helm/aura/templates/deployment.yaml
@@ -63,6 +63,11 @@ spec:
               value: {{ .Values.server.host | quote }}
             - name: PORT
               value: {{ .Values.server.httpPort | quote }}
+            {{- if .Values.server.publicUrl }}
+            # Canonical public origin for the A2A agent card's absolute URLs
+            - name: AURA_SERVER_URL
+              value: {{ .Values.server.publicUrl | quote }}
+            {{- end }}
             - name: CONFIG_PATH
               value: "/etc/aura/"
             {{- if .Values.server.defaultAgent }}

--- a/deployment/helm/aura/values-prod.yaml
+++ b/deployment/helm/aura/values-prod.yaml
@@ -11,6 +11,14 @@ replicaCount: 3
 imagePullSecrets:
   - name: gcr
 
+server:
+  # Externally-reachable origin clients use to reach this deployment (your
+  # Ingress/load-balancer host). Required for the A2A agent card to advertise
+  # absolute, reachable URLs — without it the card falls back to the pod's
+  # bind host/port (0.0.0.0:8080), which no external A2A client can reach.
+  # CHANGE THIS WHEN READY TO SERVE A2A TRAFFIC, AND SET IT TO YOUR DEPLOYMENT'S PUBLIC ORIGIN
+  publicUrl: ""
+
 # Use existing secrets from production
 secrets:
   existingSecret: "aura-secrets"

--- a/deployment/helm/aura/values.yaml
+++ b/deployment/helm/aura/values.yaml
@@ -49,6 +49,13 @@ server:
   host: "0.0.0.0"
   # -- HTTP port for the container
   httpPort: 8080
+  # -- Externally-reachable origin published in the A2A agent card (AURA_SERVER_URL).
+  # A2A clients require absolute interface URLs and use them directly, so set this
+  # to the URL clients reach the server on (via the Service, Ingress, or load
+  # balancer): scheme + host + optional port, no path — e.g. "https://aura.example.com".
+  # When empty, Aura derives it from host/port, which is wrong behind a proxy or
+  # Service (host binds 0.0.0.0). Required for A2A to work from outside the cluster.
+  publicUrl: ""
   # -- Log level
   loglevel: info
   # -- Default agent name or alias when multiple configs are loaded via config.configs.

--- a/docs/a2a-implementation.md
+++ b/docs/a2a-implementation.md
@@ -22,6 +22,35 @@ This module wires the [A2A RC 1.0](https://github.com/a2a-protocol) protocol int
 
 `AuraRequestHandler` forces `return_immediately = true` on every `message:send` request. The HTTP response returns as soon as the task is queued in `Working` state, without waiting for the agent to finish. Poll `GET /a2a/v1/tasks/{id}` or subscribe via `message:stream` / `tasks/{id}:subscribe` to track completion.
 
+## Agent card URL (`AURA_SERVER_URL`)
+
+The agent card's `supportedInterfaces[].url` fields **must be absolute** (per the A2A spec). A2A clients read these URLs from the card and pass them straight to their HTTP layer, which rejects relative paths — so a client that fetches the card successfully will still fail on `message:send` if the advertised URLs are relative.
+
+Aura builds the interface URLs from a single canonical origin, configured via:
+
+| Flag | Env var | Default |
+|------|---------|---------|
+| `--server-url` | `AURA_SERVER_URL` | derived from `--host` / `--port` |
+
+When `AURA_SERVER_URL` is unset, the origin is derived from the bind host/port, with a wildcard bind (`0.0.0.0` / `::`) mapped to `127.0.0.1`. That default is fine for local development but **wrong whenever the server is reached at a different address than it binds** — behind a reverse proxy, load balancer, Kubernetes Service/Ingress, or when the container port is remapped. In those cases set `AURA_SERVER_URL` to the externally-reachable origin clients actually use (scheme + host + optional port, **no path**):
+
+```bash
+AURA_SERVER_URL=https://aura.example.com cargo run --bin aura-web-server
+```
+
+The card then advertises absolute endpoints under that origin:
+
+```jsonc
+{
+  "supportedInterfaces": [
+    { "url": "https://aura.example.com/a2a/v1",     "protocolBinding": "HTTP+JSON", "protocolVersion": "1.0" },
+    { "url": "https://aura.example.com/a2a/v1/rpc", "protocolBinding": "JSONRPC",   "protocolVersion": "1.0" }
+  ]
+}
+```
+
+A trailing slash on `AURA_SERVER_URL` is trimmed before the paths are appended.
+
 ## Testing with curl
 
 Assumes the server is running on `localhost:8080`.


### PR DESCRIPTION
A2A clients read the agent card's interface URLs and pass them straight to their HTTP layer, which rejects relative paths. The card advertised "/a2a/v1" and "/a2a/v1/rpc", so message/send failed with a reqwest "builder error" while the card fetch worked.

Build the interface URLs from a canonical base. Add the --server-url flag (AURA_SERVER_URL), falling back to host/port with 0.0.0.0 mapped to 127.0.0.1.

Re-enable the integration-a2a cfg gate on a2a_test (it was commented out, leaking the card test into suites with a different agent name) and update its expected URLs to absolute.

Wire AURA_SERVER_URL per topology in compose so the server publishes the address the test runner reaches it on: aura-web-server:8080 in CI, localhost:8080 for local dev.

Ref: LOG-23822