### PR TITLE
docs(compose): correct stale mock-mcp stub comments

### DIFF
--- a/compose/scratchpad.yml
+++ b/compose/scratchpad.yml
@@ -27,8 +27,8 @@
 
 services:
   # Stub out mock-mcp from base.yml — scratchpad tests don't use it.
-  # Override with a minimal container so the stack doesn't need the external
-  # aura-mock-mcp:local image (which requires `make mock-mcp-build`).
+  # Override with a minimal container so the stack doesn't pull the
+  # mezmo/aura-mock-mcp image it would otherwise require.
   mock-mcp:
     image: alpine:latest
     command: ["sleep", "infinity"]

--- a/compose/sre-orchestration.yml
+++ b/compose/sre-orchestration.yml
@@ -10,8 +10,8 @@
 
 services:
   # Stub out mock-mcp from base.yml — SRE orchestration tests don't use it.
-  # Override with a minimal container so the stack doesn't need the external
-  # aura-mock-mcp:local image (which requires `make mock-mcp-build`).
+  # Override with a minimal container so the stack doesn't pull the
+  # mezmo/aura-mock-mcp image it would otherwise require.
   mock-mcp:
     image: alpine:latest
     command: ["sleep", "infinity"]


### PR DESCRIPTION
These comments referenced a `make mock-mcp-build` target that no longer exists - the stub just avoids pulling the public mezmo/aura-mock-mcp image.