### PR TITLE
fix(aura-cli): display reasoning events in single-agent mode

### DIFF
--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -712,6 +712,13 @@ pub fn run_repl(
                                     return;
                                 }
 
+                                if event_name == "aura.reasoning" {
+                                    if let Some(content) = val.get("content").and_then(|v| v.as_str()) {
+                                        crate::ui::prompt::set_agent_reasoning(content);
+                                    }
+                                    return;
+                                }
+
                                 let sub = event_name.strip_prefix("aura.orchestrator.").unwrap_or(event_name);
                                 if event_name == "aura.session_info" || sub == event_name {
                                     return;


### PR DESCRIPTION
## Summary
- `aura.reasoning` SSE events were silently dropped in single-agent mode because the orchestrator event handler early-returns for any event without the `aura.orchestrator.` prefix
- Adds early dispatch for `aura.reasoning` (same pattern as `aura.progress` and `aura.worker_phase`) so the thinking animation sub-line shows reasoning content regardless of mode

## Test plan
- [ ] Run CLI against an OpenRouter reasoning model (e.g. `arcee-ai/trinity-large-thinking`) and verify thinking animation displays reasoning text
- [ ] Verify orchestration mode reasoning still works (no regression)
- [ ] `cargo clippy -p aura-cli`