### PR TITLE
ci: upload pre-built binaries to github releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /.cargo/
 /.rustup/
 
+# Release binaries
+/dist/
+
 # IDE
 .vscode/
 .idea/

--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -82,6 +82,25 @@ fmt-rust:: $(REPORT_DIR)                 ## Format code with rustfmt
 		rm -f $(REPORT_DIR)/rustfmt.xml.bak; \
 	fi
 
+DIST_DIR := $(PROJECT_ROOT)/dist
+
+.PHONY:build-release-binaries
+build-release-binaries: $(DOCKER_ENV) ## Cross-compile release binaries for all platforms
+	@rm -rf $(DIST_DIR) && mkdir -p $(DIST_DIR)
+	$(RUN) cargo build --release --bin aura-web-server -p aura-cli --bin aura-cli
+	cp target/release/aura-web-server $(DIST_DIR)/aura-web-server-linux-amd64
+	cp target/release/aura-cli $(DIST_DIR)/aura-cli-linux-amd64
+	$(RUN) bash -c "\
+		rustup target add aarch64-unknown-linux-gnu 2>/dev/null; \
+		CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+		cargo build --release --target aarch64-unknown-linux-gnu --bin aura-web-server -p aura-cli --bin aura-cli"
+	cp target/aarch64-unknown-linux-gnu/release/aura-web-server $(DIST_DIR)/aura-web-server-linux-arm64
+	cp target/aarch64-unknown-linux-gnu/release/aura-cli $(DIST_DIR)/aura-cli-linux-arm64
+	cp scripts/install.sh $(DIST_DIR)/install.sh
+	cd $(DIST_DIR) && sha256sum aura-* > checksums-sha256.txt
+	@echo "==> Release binaries ready in dist/"
+	@cat $(DIST_DIR)/checksums-sha256.txt
+
 $(NEXTEST_BIN): $(CARGO_BIN_DIR)
 	@if [ "$(AURA_AUTO_DOWNLOAD)" != "true" ]; then \
 		exit 0; \

--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -82,24 +82,37 @@ fmt-rust:: $(REPORT_DIR)                 ## Format code with rustfmt
 		rm -f $(REPORT_DIR)/rustfmt.xml.bak; \
 	fi
 
-DIST_DIR := $(PROJECT_ROOT)/dist
+$(DIST_DIR):
+	@mkdir -p $(@)
 
-.PHONY:build-release-binaries
-build-release-binaries: $(DOCKER_ENV) ## Cross-compile release binaries for all platforms
-	@rm -rf $(DIST_DIR) && mkdir -p $(DIST_DIR)
-	$(RUN) cargo build --release --bin aura-web-server -p aura-cli --bin aura-cli
+.PHONY: build-release-binary-amd64
+build-release-binary-amd64: $(DIST_DIR) $(DOCKER_ENV) ## Build release binaries for linux/amd64
+	$(RUN) cargo build --release --bin aura-web-server
+	$(RUN) cargo build --release -p aura-cli --bin aura-cli
 	cp target/release/aura-web-server $(DIST_DIR)/aura-web-server-linux-amd64
 	cp target/release/aura-cli $(DIST_DIR)/aura-cli-linux-amd64
+
+.PHONY: build-release-binary-arm64
+build-release-binary-arm64: $(DIST_DIR) $(DOCKER_ENV) ## Cross-compile release binaries for linux/arm64
 	$(RUN) bash -c "\
 		rustup target add aarch64-unknown-linux-gnu 2>/dev/null; \
-		CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-		cargo build --release --target aarch64-unknown-linux-gnu --bin aura-web-server -p aura-cli --bin aura-cli"
+		export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc; \
+		export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig; \
+		export PKG_CONFIG_ALLOW_CROSS=1; \
+		cargo build --release --target aarch64-unknown-linux-gnu --bin aura-web-server && \
+		cargo build --release --target aarch64-unknown-linux-gnu -p aura-cli --bin aura-cli"
 	cp target/aarch64-unknown-linux-gnu/release/aura-web-server $(DIST_DIR)/aura-web-server-linux-arm64
 	cp target/aarch64-unknown-linux-gnu/release/aura-cli $(DIST_DIR)/aura-cli-linux-arm64
-	cp scripts/install.sh $(DIST_DIR)/install.sh
-	cd $(DIST_DIR) && sha256sum aura-* > checksums-sha256.txt
-	@echo "==> Release binaries ready in dist/"
-	@cat $(DIST_DIR)/checksums-sha256.txt
+
+.PHONY: build-release-binaries
+build-release-binaries: ## Build release binaries for all platforms
+	$(MAKE) -j2 build-release-binary-amd64 build-release-binary-arm64
+
+clean:: clean-dist
+
+.PHONY: clean-dist
+clean-dist:
+	rm -rf $(DIST_DIR)
 
 $(NEXTEST_BIN): $(CARGO_BIN_DIR)
 	@if [ "$(AURA_AUTO_DOWNLOAD)" != "true" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ ENV PATH="${PATH}:/home/aura/.bin"
 WORKDIR /home/aura
 
 RUN <<EOR
-  apt-get update && apt-get install -y --no-install-recommends ca-certificates libssl3 curl nodejs npm gcc-aarch64-linux-gnu
+  dpkg --add-architecture arm64
+  apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libssl3 curl nodejs npm \
+    gcc-aarch64-linux-gnu libc6-dev-arm64-cross libssl-dev:arm64
   rm -rf /var/lib/apt/lists/*
 EOR
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH="${PATH}:/home/aura/.bin"
 WORKDIR /home/aura
 
 RUN <<EOR
-  apt-get update && apt-get install -y --no-install-recommends ca-certificates libssl3 curl nodejs npm
+  apt-get update && apt-get install -y --no-install-recommends ca-certificates libssl3 curl nodejs npm gcc-aarch64-linux-gnu
   rm -rf /var/lib/apt/lists/*
 EOR
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ RUNNER_NO_ENV_CMD = $(DOCKER_RUN) $(if $(filter true, $(IS_CI)),,-t) -v $(PWD):/
 DOCKER_RUN_BUILD_ENV := $(RUNNER_CMD)
 BUILD_SLUG := $(call slugify, $(BUILD_TAG))
 AURA_RUNNER_IMAGE := local/aura-runner:$(BUILD_SLUG)
+DIST_DIR ?= $(PROJECT_ROOT)/dist
 
 RUN := $(if $(filter true, $(ENABLE_DOCKER)), $(RUNNER_CMD),)
 RUN_NO_ENV := $(if $(filter true, $(ENABLE_DOCKER)), $(RUNNER_NO_ENV_CMD),)

--- a/release.config.js
+++ b/release.config.js
@@ -10,8 +10,17 @@ module.exports = {
   branches: ['main'],
 
   // https://github.com/semantic-release/exec
-  prepareCmd: './scripts/set-version.sh ${nextRelease.version}; sleep 2',
-  // https://github.com/esatterwhite/semantic-release-docker
+  prepareCmd: './scripts/set-version.sh ${nextRelease.version}; sleep 2; make build-release-binaries',
+  // https://github.com/semantic-release/github
+  assets: [
+    {path: 'dist/aura-web-server-linux-amd64'}
+  , {path: 'dist/aura-web-server-linux-arm64'}
+  , {path: 'dist/aura-cli-linux-amd64'}
+  , {path: 'dist/aura-cli-linux-arm64'}
+  , {path: 'dist/checksums-sha256.txt'}
+  , {path: 'dist/install.sh'}
+  ]
+, // https://github.com/esatterwhite/semantic-release-docker
   dockerProject: 'mezmo',
   dockerImage: 'aura',
   dockerLogin: false,

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,22 @@
 'use strict'
 
+const config = require('@mezmoinc/release-config-docker')
+
+
+const plugins = config.plugins.map((plugin) => {
+  const [name, config = {}] = plugin
+  // there is a config name clash with github + git
+  // we need to isolate this as to not commit binaries in the repo
+  if (name === '@semantic-release/github') {
+
+    config.assets = [
+      {path: 'dist/*'}
+    ]
+    return [name, config]
+  }
+  return plugin
+})
+
 /**
  * See: https://semantic-release.gitbook.io/semantic-release/usage/configuration
  **/
@@ -11,16 +28,7 @@ module.exports = {
 
   // https://github.com/semantic-release/exec
   prepareCmd: './scripts/set-version.sh ${nextRelease.version}; sleep 2; make build-release-binaries',
-  // https://github.com/semantic-release/github
-  assets: [
-    {path: 'dist/aura-web-server-linux-amd64'}
-  , {path: 'dist/aura-web-server-linux-arm64'}
-  , {path: 'dist/aura-cli-linux-amd64'}
-  , {path: 'dist/aura-cli-linux-arm64'}
-  , {path: 'dist/checksums-sha256.txt'}
-  , {path: 'dist/install.sh'}
-  ]
-, // https://github.com/esatterwhite/semantic-release-docker
+  // https://github.com/esatterwhite/semantic-release-docker
   dockerProject: 'mezmo',
   dockerImage: 'aura',
   dockerLogin: false,
@@ -32,5 +40,8 @@ module.exports = {
   dockerPlatform: [
     'linux/amd64'
   , 'linux/arm64'
-  ]
+  ],
+  plugins: plugins
 }
+
+console.dir(module.exports, {depth: 10})

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,10 +15,12 @@ REPO="mezmo/aura"
 VERSION="${AURA_VERSION:-latest}"
 INSTALL_DIR="${AURA_INSTALL:-${HOME}/.local/bin}"
 COMPONENT="${AURA_COMPONENT:-all}"
+GITHUB_API="https://api.github.com"
 
 main() {
     detect_platform
     resolve_version
+    fetch_release_metadata
 
     echo "Installing AURA ${VERSION} (${OS}/${ARCH}) to ${INSTALL_DIR}"
     mkdir -p "${INSTALL_DIR}"
@@ -26,9 +28,6 @@ main() {
     local tmpdir
     tmpdir=$(mktemp -d)
     trap 'rm -rf "${tmpdir}"' EXIT
-
-    # Download checksums
-    download "${tmpdir}/checksums-sha256.txt" "checksums-sha256.txt"
 
     if [[ "${COMPONENT}" != "cli" ]]; then
         install_binary "${tmpdir}" "aura-web-server"
@@ -71,13 +70,28 @@ detect_platform() {
 resolve_version() {
     if [[ "${VERSION}" == "latest" ]]; then
         VERSION=$(curl -fsSL -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${REPO}/releases/latest" \
+            "${GITHUB_API}/repos/${REPO}/releases/latest" \
             | grep -o '"tag_name" *: *"[^"]*"' | head -1 | sed 's/.*"v\([^"]*\)".*/\1/')
         if [[ -z "${VERSION}" ]]; then
             echo "Error: could not determine latest version."
             exit 1
         fi
     fi
+}
+
+RELEASE_JSON=""
+
+fetch_release_metadata() {
+    RELEASE_JSON=$(curl -fsSL -H "Accept: application/vnd.github.v3+json" \
+        "${GITHUB_API}/repos/${REPO}/releases/tags/v${VERSION}")
+}
+
+get_asset_digest() {
+    local asset_name="$1"
+    echo "${RELEASE_JSON}" \
+        | grep -o "\"name\" *: *\"${asset_name}\"[^}]*\"digest\" *: *\"sha256:[a-f0-9]*\"" \
+        | grep -o 'sha256:[a-f0-9]*' \
+        | cut -d: -f2
 }
 
 download() {
@@ -96,9 +110,8 @@ install_binary() {
     echo "  Downloading ${asset_name}..."
     download "${tmpdir}/${asset_name}" "${asset_name}"
 
-    # Verify checksum
     local expected
-    expected=$(grep "${asset_name}$" "${tmpdir}/checksums-sha256.txt" | cut -d' ' -f1)
+    expected=$(get_asset_digest "${asset_name}")
     if [[ -n "${expected}" ]]; then
         local actual
         actual=$(sha256sum "${tmpdir}/${asset_name}" | cut -d' ' -f1)
@@ -110,7 +123,7 @@ install_binary() {
         fi
         echo "  Verified checksum: OK"
     else
-        echo "  Warning: no checksum found for ${asset_name}, skipping verification"
+        echo "  Warning: no digest found for ${asset_name}, skipping verification"
     fi
 
     chmod +x "${tmpdir}/${asset_name}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Install AURA binaries from GitHub Releases.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/mezmo/aura/main/scripts/install.sh | bash
+#
+# Options (via environment variables):
+#   AURA_VERSION   - Version to install (default: latest)
+#   AURA_INSTALL   - Install directory (default: ~/.local/bin)
+#   AURA_COMPONENT - Which binary: "all", "server", "cli" (default: all)
+
+set -euo pipefail
+
+REPO="mezmo/aura"
+VERSION="${AURA_VERSION:-latest}"
+INSTALL_DIR="${AURA_INSTALL:-${HOME}/.local/bin}"
+COMPONENT="${AURA_COMPONENT:-all}"
+
+main() {
+    detect_platform
+    resolve_version
+
+    echo "Installing AURA ${VERSION} (${OS}/${ARCH}) to ${INSTALL_DIR}"
+    mkdir -p "${INSTALL_DIR}"
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "${tmpdir}"' EXIT
+
+    # Download checksums
+    download "${tmpdir}/checksums-sha256.txt" "checksums-sha256.txt"
+
+    if [[ "${COMPONENT}" != "cli" ]]; then
+        install_binary "${tmpdir}" "aura-web-server"
+    fi
+    if [[ "${COMPONENT}" != "server" ]]; then
+        install_binary "${tmpdir}" "aura-cli"
+    fi
+
+    echo ""
+    echo "Installed to ${INSTALL_DIR}"
+    if [[ ":${PATH}:" != *":${INSTALL_DIR}:"* ]]; then
+        echo ""
+        echo "Add to your PATH:"
+        echo "  export PATH=\"${INSTALL_DIR}:\${PATH}\""
+    fi
+}
+
+detect_platform() {
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    case "${OS}" in
+        linux) ;;
+        *)
+            echo "Error: unsupported OS '${OS}'. Only linux is currently available."
+            exit 1
+            ;;
+    esac
+
+    ARCH=$(uname -m)
+    case "${ARCH}" in
+        x86_64)  ARCH="amd64" ;;
+        aarch64) ARCH="arm64" ;;
+        arm64)   ARCH="arm64" ;;
+        *)
+            echo "Error: unsupported architecture '${ARCH}'. Supported: x86_64, aarch64."
+            exit 1
+            ;;
+    esac
+}
+
+resolve_version() {
+    if [[ "${VERSION}" == "latest" ]]; then
+        VERSION=$(curl -fsSL -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${REPO}/releases/latest" \
+            | grep -o '"tag_name" *: *"[^"]*"' | head -1 | sed 's/.*"v\([^"]*\)".*/\1/')
+        if [[ -z "${VERSION}" ]]; then
+            echo "Error: could not determine latest version."
+            exit 1
+        fi
+    fi
+}
+
+download() {
+    local dest="$1" name="$2"
+    local url="https://github.com/${REPO}/releases/download/v${VERSION}/${name}"
+    if ! curl -fsSL -o "${dest}" "${url}"; then
+        echo "Error: failed to download ${url}"
+        exit 1
+    fi
+}
+
+install_binary() {
+    local tmpdir="$1" binary="$2"
+    local asset_name="${binary}-${OS}-${ARCH}"
+
+    echo "  Downloading ${asset_name}..."
+    download "${tmpdir}/${asset_name}" "${asset_name}"
+
+    # Verify checksum
+    local expected
+    expected=$(grep "${asset_name}$" "${tmpdir}/checksums-sha256.txt" | cut -d' ' -f1)
+    if [[ -n "${expected}" ]]; then
+        local actual
+        actual=$(sha256sum "${tmpdir}/${asset_name}" | cut -d' ' -f1)
+        if [[ "${actual}" != "${expected}" ]]; then
+            echo "Error: checksum mismatch for ${asset_name}"
+            echo "  expected: ${expected}"
+            echo "  actual:   ${actual}"
+            exit 1
+        fi
+        echo "  Verified checksum: OK"
+    else
+        echo "  Warning: no checksum found for ${asset_name}, skipping verification"
+    fi
+
+    chmod +x "${tmpdir}/${asset_name}"
+    mv "${tmpdir}/${asset_name}" "${INSTALL_DIR}/${binary}"
+    echo "  Installed: ${INSTALL_DIR}/${binary}"
+}
+
+main


### PR DESCRIPTION
## Summary

- Adds a `build-release-binaries` Make target that cross-compiles `aura-web-server` and `aura-cli` for linux/amd64 and linux/arm64 inside the existing CI runner container
- Wires it into `prepareCmd` so binaries are built before the GitHub Release is created
- Configures `@semantic-release/github` `assets` to attach `dist/*` as release assets automatically
- Includes an install script for `curl | bash` installation
- Adds `gcc-aarch64-linux-gnu` to the runner Dockerfile stage for arm64 cross-compilation

### Release assets

```
aura-web-server-linux-amd64
aura-web-server-linux-arm64
aura-cli-linux-amd64
aura-cli-linux-arm64
checksums-sha256.txt
install.sh
```

### Install one-liner

```bash
curl -fsSL https://raw.githubusercontent.com/mezmo/aura/main/scripts/install.sh | bash
```

Supports `AURA_VERSION`, `AURA_INSTALL` (default `~/.local/bin`), and `AURA_COMPONENT` (`all`/`server`/`cli`) env vars.

### How it works

1. `prepareCmd` runs `make build-release-binaries` during the semantic-release prepare phase
2. The Make target uses `$(RUN)` to compile inside the runner container (same pattern as `build-rust`, `lint-rust`, etc.)
3. Native amd64 build + cross-compile to aarch64 using `gcc-aarch64-linux-gnu` in the runner image
4. Outputs to `dist/` with SHA-256 checksums
5. `@semantic-release/github` attaches `dist/*` when it creates the release

No Jenkinsfile changes. No jenkins-worker AMI changes. The cross-compiler lives in the build container.

## Test plan

- [ ] `npm run release:dry` succeeds on the feature branch
- [ ] First real release on main: verify assets appear on the GitHub Release
- [ ] `curl | bash` install script downloads and verifies checksums