### PR TITLE
feat: webhook to launch an investigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "rig-core",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -364,6 +365,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-opentelemetry",
+ "url",
  "uuid",
 ]
 

--- a/crates/aura-web-server/Cargo.toml
+++ b/crates/aura-web-server/Cargo.toml
@@ -31,6 +31,10 @@ async-trait = "0.1.89"
 a2a = { package = "a2a-lf", git = "https://github.com/a2aproject/a2a-rs.git", tag = "a2a-server-lf-v0.3.1" }
 a2a-server = { package = "a2a-server-lf", git = "https://github.com/a2aproject/a2a-rs.git", tag = "a2a-server-lf-v0.3.1" }
 
+reqwest = { version = "0.12", features = ["json"] }
+thiserror = { workspace = true }
+url = "2.5.8"
+
 [features]
 default = ["otel"]
 otel = ["aura/otel", "dep:tracing-opentelemetry", "dep:opentelemetry"]

--- a/crates/aura-web-server/src/investigation.rs
+++ b/crates/aura-web-server/src/investigation.rs
@@ -1,0 +1,31 @@
+//! Webhook-triggered investigation pipeline.
+//!
+//! - `handler` exposes `POST /v1/launch_investigation`. Validates auth headers,
+//!   creates an investigation record in ai-history-service, returns 202, and
+//!   spawns the runner.
+//! - `runner` drives the Aura streaming agent (single-agent mode) with the
+//!   `finalize_investigation` tool attached, PATCHing ai-history-service as
+//!   state advances.
+//! - `client` is a thin reqwest wrapper for the ai-history-service `internal/investigation` API.
+
+pub mod client;
+pub mod finalize;
+pub mod handler;
+pub mod runner;
+
+pub use client::{
+    AiHistoryClient, AiHistoryError, CreateInvestigationRequest, InvestigationRecord,
+    UpdateInvestigationRequest,
+};
+pub use finalize::{FinalizeArguments, parse_finalize_tail};
+pub use handler::launch_investigation;
+pub use runner::run_investigation;
+
+/// Five auth headers the webhook requires; all forwarded as-is to ai-history-service.
+pub const REQUIRED_AUTH_HEADERS: &[&str] = &[
+    "x-auth-subject-id",
+    "x-auth-subject-email",
+    "x-auth-account-id",
+    "x-auth-account-short-id",
+    "x-auth-account-plan",
+];

--- a/crates/aura-web-server/src/investigation/client.rs
+++ b/crates/aura-web-server/src/investigation/client.rs
@@ -1,0 +1,250 @@
+//! HTTP client for the ai-history-service `/internal/investigation` API.
+
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Investigation state transitions, mirrors `INVESTIGATION_STATUS` in ai-history-service (`lib/constants.js`).
+///
+/// Failed investigations are still considered completed `InvestigationStatus::Completed`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InvestigationState {
+    Triggered,
+    Investigating,
+    Completed,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateInvestigationRequest {
+    pub trigger_source: String,
+    pub linked_alert_id: String,
+    pub evidence_refs: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<InvestigationState>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdateInvestigationRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<InvestigationState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence_score: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested_resolution: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution_status: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct InvestigationRecord {
+    pub id: String,
+    #[serde(default)]
+    pub state: Option<InvestigationState>,
+    #[serde(flatten)]
+    pub rest: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct InvestigationEnvelope {
+    data: InvestigationRecord,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AiHistoryError {
+    #[error("invalid auth header name '{}'", .0)]
+    BadHeaderName(String),
+    #[error("invalid auth header value for '{}'", .0)]
+    BadHeaderValue(String),
+    #[error("ai-history-service returned HTTP {}: {}", .status, .body)]
+    Http { status: u16, body: String },
+    #[error("ai-history-service request failed: {}", .0)]
+    Transport(#[from] reqwest::Error),
+    #[error("ai-history-service returned malformed JSON: {}", .0)]
+    Json(serde_json::Error),
+}
+
+#[derive(Clone)]
+pub struct AiHistoryClient {
+    http: reqwest::Client,
+    base_url: url::Url,
+}
+
+impl AiHistoryClient {
+    pub fn new(http: reqwest::Client, base_url: url::Url) -> Self {
+        Self { http, base_url }
+    }
+
+    pub async fn create(
+        &self,
+        auth_headers: &HashMap<String, String>,
+        body: &CreateInvestigationRequest,
+    ) -> Result<InvestigationRecord, AiHistoryError> {
+        let mut endpoint = self.base_url.clone();
+
+        {
+            let mut path = endpoint
+                .path_segments_mut()
+                .expect("Endpoint cannot be relative");
+
+            path.push("internal");
+            path.push("investigation");
+        }
+
+        let headers = build_auth_header_map(auth_headers)?;
+
+        let response = self
+            .http
+            .post(endpoint)
+            .headers(headers)
+            .json(body)
+            .send()
+            .await?;
+
+        decode_envelope(response).await
+    }
+
+    pub async fn update(
+        &self,
+        auth_headers: &HashMap<String, String>,
+        investigation_id: &str,
+        body: &UpdateInvestigationRequest,
+    ) -> Result<InvestigationRecord, AiHistoryError> {
+        let mut endpoint = self.base_url.clone();
+
+        {
+            let mut path = endpoint
+                .path_segments_mut()
+                .expect("Endpoint cannot be relative");
+
+            path.push("internal");
+            path.push("investigation");
+            path.push(investigation_id);
+        }
+
+        let headers = build_auth_header_map(auth_headers)?;
+
+        let reponse = self
+            .http
+            .patch(endpoint)
+            .headers(headers)
+            .json(body)
+            .send()
+            .await?;
+
+        decode_envelope(reponse).await
+    }
+}
+
+/// Build a HeaderMap from the forwarded `x-auth-*` headers plus the JSON content type.
+/// Returns a typed error if any header name/value is invalid (callers can render 502).
+fn build_auth_header_map(
+    auth_headers: &HashMap<String, String>,
+) -> Result<HeaderMap, AiHistoryError> {
+    let mut headers = HeaderMap::new();
+
+    for (key, value) in auth_headers {
+        let name = HeaderName::from_bytes(key.as_bytes())
+            .map_err(|_| AiHistoryError::BadHeaderName(key.clone()))?;
+
+        let value = HeaderValue::from_str(value)
+            .map_err(|_| AiHistoryError::BadHeaderValue(key.clone()))?;
+
+        headers.insert(name, value);
+    }
+
+    headers.insert(
+        reqwest::header::ACCEPT,
+        HeaderValue::from_static("application/json"),
+    );
+
+    Ok(headers)
+}
+
+async fn decode_envelope(
+    response: reqwest::Response,
+) -> Result<InvestigationRecord, AiHistoryError> {
+    let status = response.status();
+    let body_bytes = response.bytes().await?;
+
+    if !status.is_success() {
+        let body = String::from_utf8_lossy(&body_bytes).into_owned();
+
+        return Err(AiHistoryError::Http {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    let envelope: InvestigationEnvelope =
+        serde_json::from_slice(&body_bytes).map_err(AiHistoryError::Json)?;
+
+    Ok(envelope.data)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::investigation::client::InvestigationState;
+
+    use super::{
+        AiHistoryError, CreateInvestigationRequest, HashMap, UpdateInvestigationRequest,
+        build_auth_header_map,
+    };
+
+    #[test]
+    fn create_request_serializes_with_state_omitted_when_none() {
+        let request = CreateInvestigationRequest {
+            trigger_source: "pipeline".into(),
+            linked_alert_id: "alert-1".into(),
+            evidence_refs: "stuff happened".into(),
+            state: None,
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+
+        assert!(!json.contains("state"));
+        assert!(json.contains("\"trigger_source\":\"pipeline\""));
+    }
+
+    #[test]
+    fn update_request_omits_none_fields() {
+        let request = UpdateInvestigationRequest {
+            state: Some(InvestigationState::Completed),
+            confidence_score: None,
+            suggested_resolution: None,
+            resolution_status: Some("resolved".into()),
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+
+        assert!(json.contains("\"state\":\"completed\""));
+        assert!(json.contains("\"resolution_status\":\"resolved\""));
+
+        assert!(!json.contains("confidence_score"));
+        assert!(!json.contains("suggested_resolution"));
+    }
+
+    #[test]
+    fn build_auth_headers_includes_only_provided() {
+        let mut headers = HashMap::new();
+        headers.insert("x-auth-subject-id".into(), "abc".into());
+        headers.insert("x-auth-account-id".into(), "def".into());
+
+        let map = build_auth_header_map(&headers).unwrap();
+
+        assert_eq!(map.get("x-auth-subject-id").unwrap(), "abc");
+        assert_eq!(map.get("x-auth-account-id").unwrap(), "def");
+        assert_eq!(map.get("accept").unwrap(), "application/json");
+    }
+
+    #[test]
+    fn invalid_header_name_rejected() {
+        let mut headers = HashMap::new();
+        headers.insert("bad header\n".into(), "value".into());
+
+        let error = build_auth_header_map(&headers).unwrap_err();
+
+        assert!(matches!(error, AiHistoryError::BadHeaderName(_)));
+    }
+}

--- a/crates/aura-web-server/src/investigation/finalize.rs
+++ b/crates/aura-web-server/src/investigation/finalize.rs
@@ -1,0 +1,192 @@
+//! Tail-extracted structured conclusions for investigations.
+//!
+//! The agent's prompt asks it to end its final assistant message with a
+//! fenced ```json ... ``` block carrying its conclusions. After the stream
+//! terminates, [`parse_finalize_tail`] looks for that block in the final
+//! assistant text. If present and valid, the arguments populate the PATCH to
+//! ai-history-service; otherwise the investigation is recorded as
+//! `resolution_status="failed"`.
+//!
+//! This is a prompt-only contract — there is no schema-side enforcement.
+//! If the model forgets the block, emits malformed JSON, or hallucinates
+//! field names, the parser returns `None` and the runner falls back to
+//! the failure path.
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FinalizeArguments {
+    #[serde(deserialize_with = "deserialize_confidence_score")]
+    pub confidence_score: f64,
+    #[serde(deserialize_with = "not_empty_or_whitespace")]
+    pub suggested_resolution: String,
+    #[serde(deserialize_with = "not_empty_or_whitespace")]
+    pub resolution_status: String,
+}
+
+fn deserialize_confidence_score<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<f64, D::Error> {
+    let v = f64::deserialize(deserializer)?;
+
+    if (0.0..=1.0).contains(&v) {
+        Ok(v)
+    } else {
+        Err(serde::de::Error::invalid_value(
+            serde::de::Unexpected::Float(v),
+            &"`confidence_score` must be between 0.0..=1.0",
+        ))
+    }
+}
+
+fn not_empty_or_whitespace<'de, D: Deserializer<'de>>(deserializer: D) -> Result<String, D::Error> {
+    let v = String::deserialize(deserializer)?.trim().to_owned();
+
+    if !v.is_empty() {
+        Ok(v)
+    } else {
+        Err(serde::de::Error::invalid_value(
+            serde::de::Unexpected::Str(&v),
+            &"value cannot be empty/whitespace-only",
+        ))
+    }
+}
+
+const FENCE_OPEN: &str = "```json";
+const FENCE_CLOSE: &str = "```";
+
+/// Tries to parse the last ```` ```json { ... }``` ```` block from `text`
+///
+/// Returns `None` if:
+/// - no trailing ```json``` fence is present
+/// - the JSON body fails to parse as `FinalizeArguments`
+/// - `confidence_score` is outside `[0.0, 1.0]`
+/// - `suggested_resolution` or `resolution_status` is empty/whitespace
+///
+/// Tolerates trailing whitespace after the closing fence.
+pub fn parse_finalize_tail(text: &str) -> Option<(FinalizeArguments, String)> {
+    // find the last closing piece, as determined by `FENCE_CLOSE`.
+    let trimmed = text.trim_end();
+
+    if !trimmed.ends_with(FENCE_CLOSE) {
+        return None;
+    }
+
+    // now we walk back and try to find the closest `FENCE_OPEN` to our `FENCE_CLOSE`.
+    // since `end` is the beginning of a valid `&str`, we know that our `text` up until
+    // `end` is also valid UTF-8.
+    let before_close = &trimmed[..trimmed.len() - FENCE_CLOSE.len()];
+
+    let open_at = before_close.rfind(FENCE_OPEN)?;
+
+    let body = before_close[open_at + FENCE_OPEN.len()..].trim();
+
+    let finalize_arguments: FinalizeArguments = serde_json::from_str(body).ok()?;
+
+    let stripped = text[..open_at].trim_end().to_string();
+
+    Some((finalize_arguments, stripped))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn happy_path() {
+        let text = "Here is my analysis.\n\n```json\n{\"confidence_score\": 0.8, \"suggested_resolution\": \"Restart\", \"resolution_status\": \"mitigated\"}\n```";
+        let (arguments, stripped) = parse_finalize_tail(text).expect("should parse");
+        assert_eq!(arguments.confidence_score, 0.8);
+        assert_eq!(&*arguments.suggested_resolution, "Restart");
+        assert_eq!(&*arguments.resolution_status, "mitigated");
+        assert_eq!(stripped, "Here is my analysis.");
+    }
+
+    #[test]
+    fn tolerates_trailing_whitespace() {
+        let text = "Done.\n```json\n{\"confidence_score\": 0.5, \"suggested_resolution\": \"x\", \"resolution_status\": \"y\"}\n```\n\n  ";
+        assert!(parse_finalize_tail(text).is_some());
+    }
+
+    #[test]
+    fn missing_tail_returns_none() {
+        let text = "I looked at things but I have no conclusion to share.";
+        assert!(parse_finalize_tail(text).is_none());
+    }
+
+    #[test]
+    fn malformed_json_returns_none() {
+        let text = "Done.\n```json\n{this is not json}\n```";
+        assert!(parse_finalize_tail(text).is_none());
+    }
+
+    #[test]
+    fn missing_required_fields_returns_none() {
+        let text = "Done.\n```json\n{\"confidence_score\": 0.5}\n```";
+        assert!(parse_finalize_tail(text).is_none());
+    }
+
+    #[test]
+    fn confidence_out_of_range_high_rejected() {
+        let text = "Done.\n```json\n{\"confidence_score\": 1.5, \"suggested_resolution\": \"x\", \"resolution_status\": \"y\"}\n```";
+        assert!(parse_finalize_tail(text).is_none());
+    }
+
+    #[test]
+    fn confidence_out_of_range_low_rejected() {
+        let text = "Done.\n```json\n{\"confidence_score\": -0.1, \"suggested_resolution\": \"x\", \"resolution_status\": \"y\"}\n```";
+        assert!(parse_finalize_tail(text).is_none());
+    }
+
+    #[test]
+    fn nan_confidence_rejected() {
+        // serde_json doesn't parse NaN by default, so this is effectively belt-and-braces.
+        let text = "Done.\n```json\n{\"confidence_score\": 0.0, \"suggested_resolution\": \"x\", \"resolution_status\": \"y\"}\n```";
+        // sanity: 0.0 is allowed
+        assert!(parse_finalize_tail(text).is_some());
+    }
+
+    #[test]
+    fn empty_resolution_rejected() {
+        let text = "Done.\n```json\n{\"confidence_score\": 0.5, \"suggested_resolution\": \"   \", \"resolution_status\": \"y\"}\n```";
+        assert!(parse_finalize_tail(text).is_none());
+    }
+
+    #[test]
+    fn empty_status_rejected() {
+        let text = "Done.\n```json\n{\"confidence_score\": 0.5, \"suggested_resolution\": \"x\", \"resolution_status\": \"\"}\n```";
+        assert!(parse_finalize_tail(text).is_none());
+    }
+
+    #[test]
+    fn multiple_blocks_last_one_wins() {
+        let text = concat!(
+            "First attempt:\n",
+            "```json\n",
+            "{\"confidence_score\": 0.1, \"suggested_resolution\": \"old\", \"resolution_status\": \"a\"}\n",
+            "```\n",
+            "Revised conclusion:\n",
+            "```json\n",
+            "{\"confidence_score\": 0.9, \"suggested_resolution\": \"new\", \"resolution_status\": \"b\"}\n",
+            "```",
+        );
+        let (arguments, _) = parse_finalize_tail(text).expect("should parse");
+        assert_eq!(arguments.confidence_score, 0.9);
+        assert_eq!(&*arguments.suggested_resolution, "new");
+    }
+
+    #[test]
+    fn stripped_text_excludes_block() {
+        let text = "Conclusion narrative.\n\n```json\n{\"confidence_score\": 0.5, \"suggested_resolution\": \"x\", \"resolution_status\": \"y\"}\n```";
+        let (_, stripped) = parse_finalize_tail(text).unwrap();
+        assert!(!stripped.contains("```json"));
+        assert!(!stripped.contains("confidence_score"));
+        assert_eq!(stripped, "Conclusion narrative.");
+    }
+
+    #[test]
+    fn tail_without_open_fence_returns_none() {
+        let text = "Done.\n{\"confidence_score\": 0.5, \"suggested_resolution\": \"x\", \"resolution_status\": \"y\"}";
+        assert!(parse_finalize_tail(text).is_none());
+    }
+}

--- a/crates/aura-web-server/src/investigation/handler.rs
+++ b/crates/aura-web-server/src/investigation/handler.rs
@@ -1,0 +1,267 @@
+//! `POST /v1/launch_investigation`: the webhook entry point.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::{Json, extract::State};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::{error, info};
+use uuid::Uuid;
+
+use crate::investigation::client::CreateInvestigationRequest;
+use crate::investigation::runner::{InvestigationRunnerContext, run_investigation};
+use crate::investigation::{REQUIRED_AUTH_HEADERS, client::InvestigationState};
+use crate::types::AppState;
+
+/// Webhook payload. `error` is permissive for now: any string or JSON value.
+/// We might narrow that down in the future.
+#[derive(Debug, Deserialize)]
+pub struct LaunchInvestigationRequest {
+    pub source: String,
+    pub error: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct LaunchInvestigationResponse {
+    investigation_id: String,
+    task_id: String,
+    state: InvestigationState,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    error: String,
+}
+
+/// ai-history-service caps `trigger_source` at 254 and `evidence_refs` at 100k.
+const TRIGGER_SOURCE_MAX: usize = 254;
+const EVIDENCE_REFS_MAX: usize = 100_000;
+
+#[tracing::instrument(name = "launch_investigation", skip(state, request, headers), fields(otel.kind = "server"))]
+pub async fn launch_investigation(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<LaunchInvestigationRequest>,
+) -> Response {
+    // To validate: which headers do we take in
+    // How to differentiate between internal and external callers
+    let auth_headers = match extract_auth_headers(&headers) {
+        Ok(hashmap) => hashmap,
+        Err(missing) => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorBody {
+                    error: format!("missing required auth header(s): {}", missing.join(", ")),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    // TODO do we want to move this validation to the schema?
+    if request.source.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorBody {
+                error: "`source` must not be empty".to_owned(),
+            }),
+        )
+            .into_response();
+    }
+
+    // TODO do we want to move this validation to the schema?
+    let evidence = match request.error {
+        Value::String(s) => s,
+        Value::Null => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorBody {
+                    error: "`error` must not be null".to_owned(),
+                }),
+            )
+                .into_response();
+        }
+        other => serde_json::to_string(&other).unwrap_or_default(),
+    };
+
+    // TODO do we want to move this validation to the schema?
+    if evidence.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorBody {
+                error: "`error` must not be empty".to_owned(),
+            }),
+        )
+            .into_response();
+    }
+
+    let create_body = CreateInvestigationRequest {
+        trigger_source: truncate(&request.source, TRIGGER_SOURCE_MAX),
+        linked_alert_id: Uuid::new_v4().to_string(),
+        evidence_refs: truncate(&evidence, EVIDENCE_REFS_MAX),
+        state: Some(InvestigationState::Triggered),
+    };
+
+    let record = match state
+        .ai_history_client
+        .create(&auth_headers, &create_body)
+        .await
+    {
+        Ok(record) => record,
+        Err(error) => {
+            error!(%error, "Failed to create investigation in ai-history-service");
+
+            // TODO what error do we want to give here?
+            // exposing the fact that we have an `ai-history-service` really is an implementation detail.
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(ErrorBody {
+                    error: format!("ai-history-service create failed: {}", error),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let investigation_id = record.id.clone();
+
+    // Reuse the same task store as the A2A executor so investigations surface
+    // through GET /a2a/v1/tasks/{investigation_id}.
+    let task_store = state.a2a_task_store.clone();
+
+    let runner_ctx = InvestigationRunnerContext {
+        investigation_id: investigation_id.clone(),
+        source: request.source,
+        error_text: evidence,
+        auth_headers,
+        task_store,
+    };
+
+    info!(
+        investigation_id = %investigation_id,
+        "Investigation created; spawning runner"
+    );
+
+    tokio::spawn(run_investigation(state.clone(), runner_ctx));
+
+    (
+        StatusCode::ACCEPTED,
+        Json(LaunchInvestigationResponse {
+            investigation_id: investigation_id.clone(),
+            task_id: investigation_id,
+            state: InvestigationState::Triggered,
+        }),
+    )
+        .into_response()
+}
+
+/// Returns the auth-header map on success, or the list of missing header names on failure.
+fn extract_auth_headers(headers: &HeaderMap) -> Result<HashMap<String, String>, Vec<&'static str>> {
+    let mut out = HashMap::with_capacity(REQUIRED_AUTH_HEADERS.len());
+
+    let mut missing: Vec<&'static str> = Vec::new();
+
+    for name in REQUIRED_AUTH_HEADERS {
+        match headers.get(*name).and_then(|v| v.to_str().ok()) {
+            Some(v) if !v.is_empty() => {
+                out.insert((*name).to_owned(), v.to_owned());
+            }
+            _ => missing.push(name),
+        }
+    }
+
+    if missing.is_empty() {
+        Ok(out)
+    } else {
+        Err(missing)
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_owned()
+    } else {
+        // Truncate on a char boundary to keep UTF-8 well-formed.
+        let end = s.floor_char_boundary(max);
+        s[..end].to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HeaderMap, extract_auth_headers, truncate};
+    use axum::http::HeaderValue;
+
+    fn make_headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                axum::http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        h
+    }
+
+    #[test]
+    fn extract_auth_headers_happy_path() {
+        let h = make_headers(&[
+            ("x-auth-subject-id", "sub"),
+            ("x-auth-subject-email", "e@x"),
+            ("x-auth-account-id", "acc"),
+            ("x-auth-account-short-id", "short"),
+            ("x-auth-account-plan", "pro7"),
+        ]);
+        let out = extract_auth_headers(&h).unwrap();
+        assert_eq!(out.len(), 5);
+        assert_eq!(
+            out.get("x-auth-subject-id").map(String::as_str),
+            Some("sub")
+        );
+    }
+
+    #[test]
+    fn extract_auth_headers_missing_reported() {
+        let h = make_headers(&[
+            ("x-auth-subject-id", "sub"),
+            // missing email
+            ("x-auth-account-id", "acc"),
+            ("x-auth-account-short-id", "short"),
+            ("x-auth-account-plan", "pro7"),
+        ]);
+        let err = extract_auth_headers(&h).unwrap_err();
+        assert_eq!(err, vec!["x-auth-subject-email"]);
+    }
+
+    #[test]
+    fn extract_auth_headers_empty_value_counted_as_missing() {
+        let h = make_headers(&[
+            ("x-auth-subject-id", ""),
+            ("x-auth-subject-email", "e@x"),
+            ("x-auth-account-id", "acc"),
+            ("x-auth-account-short-id", "short"),
+            ("x-auth-account-plan", "pro7"),
+        ]);
+        let err = extract_auth_headers(&h).unwrap_err();
+        assert_eq!(err, vec!["x-auth-subject-id"]);
+    }
+
+    #[test]
+    fn truncate_handles_ascii() {
+        assert_eq!(truncate("hello", 10), "hello");
+        assert_eq!(truncate("hello world", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_keeps_utf8_well_formed() {
+        // 'é' is 2 bytes in UTF-8.
+        let s = "héllo";
+        // Cap of 2 lands inside the multi-byte char; truncate must back off to a boundary.
+        let out = truncate(s, 2);
+        assert!(out.is_char_boundary(out.len()));
+        assert_eq!(out, "h");
+    }
+}

--- a/crates/aura-web-server/src/investigation/runner.rs
+++ b/crates/aura-web-server/src/investigation/runner.rs
@@ -1,0 +1,354 @@
+//! Background task driving the Aura agent for one investigation.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use a2a::{Message, Part, Role as A2ARole, StreamResponse, TaskState};
+use a2a_server::{AgentExecutor, ExecutorContext};
+use futures_util::StreamExt;
+use tracing::{Level, event};
+
+use crate::investigation::client::UpdateInvestigationRequest;
+use crate::investigation::finalize::{FinalizeArguments, parse_finalize_tail};
+use crate::types::AppState;
+use crate::{
+    a2a::{AuraAgentExecutor, SharedTaskStore},
+    investigation::client::InvestigationState,
+};
+
+/// Inputs the spawned task needs.
+pub struct InvestigationRunnerContext {
+    pub investigation_id: String,
+    pub source: String,
+    pub error_text: String,
+    pub auth_headers: HashMap<String, String>,
+    pub task_store: SharedTaskStore,
+}
+
+/// Decide the final PATCH payload based on what the agent produced.
+///
+/// - `finalize_arguments` is `Some` when the agent emitted a parseable JSON-tail conclusion.
+/// - `terminal_state` is the last status the A2A stream emitted.
+/// - `last_text` and `failure_message` are fallback sources of human-readable context for the no-finalize branch.
+pub fn decide_update(
+    terminal_state: Option<TaskState>,
+    finalize_arguments: Option<FinalizeArguments>,
+    last_text: Option<String>,
+    failure_message: Option<String>,
+) -> UpdateInvestigationRequest {
+    let _ = terminal_state; // TODO where do we patch the A2a's store?
+
+    match finalize_arguments {
+        Some(arguments) => UpdateInvestigationRequest {
+            state: Some(InvestigationState::Completed),
+            confidence_score: Some(arguments.confidence_score),
+            suggested_resolution: Some(arguments.suggested_resolution),
+            resolution_status: Some(arguments.resolution_status),
+        },
+        None => {
+            let resolution_text = failure_message.or(last_text).unwrap_or_else(|| {
+                "Investigation ended without producing a structured conclusion.".into()
+            });
+
+            UpdateInvestigationRequest {
+                state: Some(InvestigationState::Completed),
+                confidence_score: None,
+                suggested_resolution: Some(resolution_text),
+                resolution_status: Some("failed".into()),
+            }
+        }
+    }
+}
+
+/// Build the prompt text the agent will receive as the user message of the A2A task.
+fn build_prompt(source: &str, error_text: &str) -> String {
+    format!(
+        "An alert requires investigation.\n\
+         Source: {}\n\
+         Evidence:\n\
+         {}\n\
+         \n\
+         Investigate the issue using your available tools. When you are confident in your \
+         conclusions, end your response with EXACTLY one fenced JSON block of the following \
+         form, and emit nothing after the closing fence:\n\
+         \n\
+         ```json\n\
+         {{\n  \
+         \"confidence_score\": <number between 0.0 and 1.0>,\n  \
+         \"suggested_resolution\": \"<natural-language recommendation>\",\n  \
+         \"resolution_status\": \"<short label, e.g. resolved | mitigated | needs_escalation | no_action_required>\"\n\
+         }}\n\
+         ```",
+        source, error_text
+    )
+}
+
+/// Drive one investigation to completion/failure and report to ai-history-service
+/// with the outcome.
+pub async fn run_investigation(state: Arc<AppState>, context: InvestigationRunnerContext) {
+    let investigation_id = context.investigation_id;
+
+    event!(
+        Level::INFO,
+        %investigation_id,
+        source = %context.source,
+        "Investigation runner starting"
+    );
+
+    // Mark the record as investigating before kicking off the agent.
+    // Best-effort, if this fails, we can still continue and try and update the service with our final result.
+    if let Err(error) = state
+        .ai_history_client
+        .update(
+            &context.auth_headers,
+            &investigation_id,
+            &UpdateInvestigationRequest {
+                state: Some(InvestigationState::Investigating),
+                ..Default::default()
+            },
+        )
+        .await
+    {
+        event!(
+            Level::WARN,
+            %investigation_id,
+            %error,
+            "Failed to notify ai-history-service"
+        );
+    }
+
+    let service_params: HashMap<String, Vec<String>> = context
+        .auth_headers
+        .iter()
+        .map(|(key, value)| (key.clone(), vec![value.clone()]))
+        .collect();
+
+    let prompt = build_prompt(&context.source, &context.error_text);
+
+    let executor_context = ExecutorContext {
+        message: Some(Message::new(A2ARole::User, vec![Part::text(prompt)])),
+        task_id: investigation_id.clone(),
+        stored_task: None,
+        context_id: investigation_id.clone(),
+        metadata: None,
+        user: None,
+        service_params,
+        tenant: None,
+    };
+
+    let executor = AuraAgentExecutor::new(state.clone(), context.task_store.clone());
+    let mut stream = executor.execute(executor_context);
+
+    let mut last_text: Option<String> = None;
+    let mut terminal_state: Option<TaskState> = None;
+    let mut failure_message: Option<String> = None;
+
+    // We deliberately only react to "start & end": the terminal status and the
+    // final response artifact. Intermediate events (Working pings, in-progress
+    // messages, chunked/appended artifacts) are drained but ignored, because the
+    // ai-history-service only cares about the final outcome of the investigation.
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(StreamResponse::StatusUpdate(update_event)) => match update_event.status.state {
+                TaskState::Working => {}
+                state @ (TaskState::Completed | TaskState::Canceled | TaskState::Failed) => {
+                    terminal_state = Some(state);
+
+                    if let Some(message) = update_event.status.message {
+                        let collected = message
+                            .parts
+                            .iter()
+                            .filter_map(|p| {
+                                // TODO once the A2a agent emits JSON we need to patch this
+                                match &p.content {
+                                    a2a::PartContent::Text(t) => Some(t.as_str()),
+                                    _ => None,
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+
+                        if !collected.is_empty() {
+                            failure_message = Some(collected);
+                        }
+                    }
+
+                    break;
+                }
+                _ => {}
+            },
+            Ok(StreamResponse::ArtifactUpdate(update_event)) => {
+                if update_event.artifact.artifact_id == "response"
+                    || update_event.artifact.artifact_id == "final"
+                {
+                    let text = update_event
+                        .artifact
+                        .parts
+                        .iter()
+                        .filter_map(|p| {
+                            // TODO once the A2a agent emits JSON we need to patch this
+                            match &p.content {
+                                a2a::PartContent::Text(t) => Some(t.as_str()),
+                                _ => None,
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join("");
+
+                    if !text.is_empty() {
+                        last_text = Some(text);
+                    }
+                }
+            }
+            Ok(_) => {}
+            Err(error) => {
+                event!(
+                    Level::ERROR,
+                    investigation_id = %investigation_id,
+                    error = %error,
+                    "A2A stream error"
+                );
+
+                failure_message = Some(error.to_string());
+                terminal_state = Some(TaskState::Failed);
+
+                break;
+            }
+        }
+    }
+
+    // Parse a structured tail from the final assistant text. As part of prompt we instruct a certain return format.
+    let (finalize_arguments, cleaned_text) =
+        match last_text.as_deref().and_then(parse_finalize_tail) {
+            Some((arguments, stripped)) => {
+                (Some(arguments), (!stripped.is_empty()).then_some(stripped))
+            }
+            None => (None, last_text),
+        };
+
+    let update = decide_update(
+        terminal_state,
+        finalize_arguments,
+        cleaned_text,
+        failure_message,
+    );
+
+    if let Err(error) = state
+        .ai_history_client
+        .update(&context.auth_headers, &investigation_id, &update)
+        .await
+    {
+        event!(
+            Level::ERROR,
+            %investigation_id,
+            %error,
+            "Failed to PATCH final investigation state"
+        );
+    } else {
+        event!(
+            Level::INFO,
+            %investigation_id,
+            "Investigation runner finished"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::investigation::client::InvestigationState;
+
+    use super::{FinalizeArguments, TaskState, build_prompt, decide_update};
+
+    #[test]
+    fn prompt_includes_source_and_evidence() {
+        let prompt = build_prompt("pipeline", "Service XXXX returning 400s");
+
+        assert!(prompt.contains("Source: pipeline"));
+        assert!(prompt.contains("Service XXXX returning 400s"));
+        assert!(prompt.contains("```json"));
+        assert!(prompt.contains("confidence_score"));
+    }
+
+    fn good_finalize() -> FinalizeArguments {
+        FinalizeArguments {
+            confidence_score: 0.9,
+            suggested_resolution: "Roll back v42".to_owned(),
+            resolution_status: "mitigated".to_owned(),
+        }
+    }
+
+    #[test]
+    fn finalize_arguments_carry_through_on_completed() {
+        let update = decide_update(
+            Some(TaskState::Completed),
+            Some(good_finalize()),
+            None,
+            None,
+        );
+        assert_eq!(update.state, Some(InvestigationState::Completed));
+        assert_eq!(update.confidence_score, Some(0.9));
+        assert_eq!(
+            update.suggested_resolution.as_deref(),
+            Some("Roll back v42")
+        );
+        assert_eq!(update.resolution_status.as_deref(), Some("mitigated"));
+    }
+
+    #[test]
+    fn finalize_arguments_carry_through_even_on_failed_stream() {
+        // Tail parsed successfully but stream terminated abnormally — still trust the conclusions.
+        let update = decide_update(
+            Some(TaskState::Failed),
+            Some(good_finalize()),
+            Some("partial text".into()),
+            Some("stream error".into()),
+        );
+        assert_eq!(update.state, Some(InvestigationState::Completed));
+        assert_eq!(update.resolution_status.as_deref(), Some("mitigated"));
+    }
+
+    #[test]
+    fn no_finalize_falls_back_to_failure_message() {
+        let update = decide_update(
+            Some(TaskState::Failed),
+            None,
+            Some("last assistant text".into()),
+            Some("agent error: model returned 429".into()),
+        );
+        assert_eq!(update.state, Some(InvestigationState::Completed));
+        assert_eq!(update.resolution_status.as_deref(), Some("failed"));
+        assert_eq!(
+            update.suggested_resolution.as_deref(),
+            Some("agent error: model returned 429")
+        );
+        assert!(update.confidence_score.is_none());
+    }
+
+    #[test]
+    fn no_finalize_falls_back_to_last_text_when_no_failure() {
+        let udpate = decide_update(
+            Some(TaskState::Completed),
+            None,
+            Some("here's what I found...".into()),
+            None,
+        );
+        assert_eq!(udpate.resolution_status.as_deref(), Some("failed"));
+        assert_eq!(
+            udpate.suggested_resolution.as_deref(),
+            Some("here's what I found...")
+        );
+    }
+
+    #[test]
+    fn no_finalize_and_no_text_uses_default() {
+        let update = decide_update(None, None, None, None);
+        assert_eq!(update.resolution_status.as_deref(), Some("failed"));
+        assert!(
+            update
+                .suggested_resolution
+                .as_deref()
+                .unwrap()
+                .contains("structured conclusion")
+        );
+    }
+}

--- a/crates/aura-web-server/src/lib.rs
+++ b/crates/aura-web-server/src/lib.rs
@@ -2,5 +2,6 @@
 
 pub mod a2a;
 pub mod handlers;
+pub mod investigation;
 pub mod streaming;
 pub mod types;

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -15,10 +15,13 @@ use tokio_util::sync::CancellationToken;
 use tower_http::trace::TraceLayer;
 use tracing::{error, info};
 
-use aura_web_server::a2a::{AuraAgentExecutor, AuraRequestHandler, SharedTaskStore};
-use aura_web_server::handlers;
 use aura_web_server::streaming;
 use aura_web_server::types;
+use aura_web_server::{
+    a2a::{AuraAgentExecutor, AuraRequestHandler, SharedTaskStore},
+    investigation,
+};
+use aura_web_server::{handlers, investigation::AiHistoryClient};
 
 use streaming::ToolResultMode;
 use types::{ActiveRequestTracker, AppState, ErrorDetail, ErrorResponse};
@@ -131,6 +134,10 @@ struct Args {
     /// /.well-known/agent-card.json. Disabled by default.
     #[arg(long, env = "AURA_ENABLE_A2A", action = clap::ArgAction::SetTrue)]
     enable_a2a: bool,
+
+    /// Base URL of the ai-history-service.
+    #[arg(long, env = "AI_HISTORY_URL", default_value = "http://localhost:3000")]
+    ai_history_url: url::Url,
 }
 
 /// Resolve the externally-advertised base URL for the A2A agent card.
@@ -234,6 +241,12 @@ async fn run() -> std::io::Result<()> {
 
     let shutdown_timeout_secs = args.shutdown_timeout_secs;
 
+    // forcing an in-memory store for now. TBD: a resilient location
+    let task_store = SharedTaskStore::new();
+
+    info!("ai-history-service base URL: {}", args.ai_history_url);
+    let ai_history_client = AiHistoryClient::new(reqwest::Client::new(), args.ai_history_url);
+
     let app_state = Arc::new(AppState {
         configs: configs_arc,
         tool_result_mode: args.tool_result_mode,
@@ -248,6 +261,8 @@ async fn run() -> std::io::Result<()> {
         active_requests: active_requests.clone(),
         default_agent: args.default_agent.clone(),
         additional_tools: Arc::new(Vec::new),
+        ai_history_client,
+        a2a_task_store: task_store.clone(),
     });
 
     info!(
@@ -259,6 +274,10 @@ async fn run() -> std::io::Result<()> {
         .route("/health", get(handlers::health))
         .route("/v1/models", get(handlers::list_models))
         .route("/v1/chat/completions", post(handlers::chat_completions))
+        .route(
+            "/v1/launch_investigation",
+            post(investigation::launch_investigation),
+        )
         .layer(TraceLayer::new_for_http())
         .layer(middleware::from_fn_with_state(
             app_state.clone(),
@@ -272,8 +291,6 @@ async fn run() -> std::io::Result<()> {
     // REST at /a2a/v1/message:send, /a2a/v1/tasks/
     // Agent card at /.well-known/agent-card.json
     let app = if args.enable_a2a {
-        // forcing an in-memory store for now. TBD: a resilient location
-        let task_store = SharedTaskStore::new();
         let executor = AuraAgentExecutor::new(app_state.clone(), task_store.clone());
         let base_url = advertised_base_url(args.server_url.as_deref(), &args.host, args.port);
         let agent_card = executor.build_agent_card(&base_url);

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -5,6 +5,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
+use crate::a2a::SharedTaskStore;
+use crate::investigation::AiHistoryClient;
 use crate::streaming::ToolResultMode;
 
 /// Tracks in-flight request count for graceful shutdown.
@@ -99,6 +101,11 @@ pub struct AppState {
     /// Factory for additional tools to register on every agent (e.g., CLI tools in standalone mode).
     /// Called once per request to produce fresh tool instances. Returns empty vec for the web server.
     pub additional_tools: Arc<dyn Fn() -> Vec<Box<dyn aura::ToolDyn>> + Send + Sync>,
+    /// ai-history-service client used by the investigation webhook.
+    pub ai_history_client: AiHistoryClient,
+    /// Shared A2A task store. Reused by the investigation runner so investigations
+    /// surface through `GET /a2a/v1/tasks/{investigation_id}`.
+    pub a2a_task_store: SharedTaskStore,
 }
 
 /// OpenAI-compatible message role

--- a/crates/aura-web-server/tests/investigation_client_test.rs
+++ b/crates/aura-web-server/tests/investigation_client_test.rs
@@ -1,0 +1,244 @@
+//! Integration test for `AiHistoryClient` against a stub HTTP server that
+//! plays the shape of the ai-history-service `/internal/investigation` API.
+//!
+//! Verifies:
+//! - POST body shape and serialization
+//! - PATCH body omits None fields
+//! - Auth headers forwarded verbatim
+//! - Envelope `{ data: ... }` decoded into `InvestigationRecord`
+//! - HTTP error paths surface as `AiHistoryError::Http { status, body }`
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use aura_web_server::investigation::{
+    AiHistoryClient, AiHistoryError, CreateInvestigationRequest, UpdateInvestigationRequest,
+    client::InvestigationState,
+};
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::{patch, post};
+use axum::{Json, Router};
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+
+#[derive(Default)]
+struct Recorded {
+    create_body: Option<Value>,
+    create_headers: HashMap<String, String>,
+    update_body: Option<Value>,
+    update_headers: HashMap<String, String>,
+    fail_create: bool,
+}
+
+type SharedRecorded = Arc<Mutex<Recorded>>;
+
+async fn handle_create(
+    State(recorded): State<SharedRecorded>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> axum::response::Response {
+    let mut guard = recorded.lock().await;
+
+    guard.create_body = Some(body);
+    guard.create_headers = headers
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or_default().to_string()))
+        .collect();
+    if guard.fail_create {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Body::from("downstream exploded"),
+        )
+            .into_response();
+    }
+    (
+        StatusCode::CREATED,
+        Json(json!({
+            "meta": { "type": "ai-investigation" },
+            "data": {
+                "id": "60c1234567890abcdef01234",
+                "state": "triggered",
+                "trigger_source": "pipeline"
+            }
+        })),
+    )
+        .into_response()
+}
+
+async fn handle_update(
+    State(recorded): State<SharedRecorded>,
+    Path(id): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> axum::response::Response {
+    let mut guard = recorded.lock().await;
+
+    guard.update_body = Some(body);
+    guard.update_headers = headers
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or_default().to_string()))
+        .collect();
+    (
+        StatusCode::OK,
+        Json(json!({
+            "meta": { "type": "ai-investigation" },
+            "data": {
+                "id": id,
+                "state": "completed"
+            }
+        })),
+    )
+        .into_response()
+}
+
+async fn spawn_stub(rec: SharedRecorded) -> url::Url {
+    let app = Router::new()
+        .route("/internal/investigation", post(handle_create))
+        .route(
+            "/internal/investigation/{investigation_id}",
+            patch(handle_update),
+        )
+        .with_state(rec);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    format!("http://{}", address).parse().unwrap()
+}
+
+fn auth_headers() -> HashMap<String, String> {
+    [
+        ("x-auth-subject-id".to_string(), "sub-1".to_string()),
+        (
+            "x-auth-subject-email".to_string(),
+            "u@example.com".to_string(),
+        ),
+        ("x-auth-account-id".to_string(), "acc-1".to_string()),
+        ("x-auth-account-short-id".to_string(), "short1".to_string()),
+        ("x-auth-account-plan".to_string(), "pro7".to_string()),
+    ]
+    .into_iter()
+    .collect::<HashMap<_, _>>()
+}
+
+#[tokio::test]
+async fn create_posts_correct_body_and_forwards_headers() {
+    let recorded = Arc::new(Mutex::new(Recorded::default()));
+
+    let base = spawn_stub(recorded.clone()).await;
+
+    let client = AiHistoryClient::new(reqwest::Client::new(), base);
+
+    let result = client
+        .create(
+            &auth_headers(),
+            &CreateInvestigationRequest {
+                trigger_source: "pipeline".to_string(),
+                linked_alert_id: "alert-1".to_string(),
+                evidence_refs: "stuff went wrong".to_string(),
+                state: Some(InvestigationState::Triggered),
+            },
+        )
+        .await
+        .expect("create should succeed");
+
+    assert_eq!(result.id, "60c1234567890abcdef01234");
+    assert_eq!(result.state, Some(InvestigationState::Triggered));
+
+    let guard = recorded.lock().await;
+    let body = guard.create_body.as_ref().unwrap();
+    assert_eq!(body["trigger_source"], "pipeline");
+    assert_eq!(body["linked_alert_id"], "alert-1");
+    assert_eq!(body["evidence_refs"], "stuff went wrong");
+    assert_eq!(body["state"], "triggered");
+
+    // Auth headers forwarded verbatim (the server normalizes names to lowercase).
+    assert_eq!(
+        guard
+            .create_headers
+            .get("x-auth-subject-id")
+            .map(String::as_str),
+        Some("sub-1")
+    );
+    assert_eq!(
+        guard
+            .create_headers
+            .get("x-auth-account-id")
+            .map(String::as_str),
+        Some("acc-1")
+    );
+    assert_eq!(
+        guard
+            .create_headers
+            .get("x-auth-account-short-id")
+            .map(String::as_str),
+        Some("short1")
+    );
+}
+
+#[tokio::test]
+async fn update_patches_only_provided_fields() {
+    let recorded = Arc::new(Mutex::new(Recorded::default()));
+    let base = spawn_stub(recorded.clone()).await;
+    let client = AiHistoryClient::new(reqwest::Client::new(), base);
+
+    client
+        .update(
+            &auth_headers(),
+            "60c1234567890abcdef01234",
+            &UpdateInvestigationRequest {
+                state: Some(InvestigationState::Completed),
+                confidence_score: Some(0.42),
+                suggested_resolution: None,
+                resolution_status: Some("failed".to_string()),
+            },
+        )
+        .await
+        .expect("update should succeed");
+
+    let guard = recorded.lock().await;
+    let body = guard.update_body.as_ref().unwrap();
+
+    assert_eq!(body["state"], "completed");
+    assert_eq!(body["confidence_score"], 0.42);
+    assert_eq!(body["resolution_status"], "failed");
+    assert!(body.get("suggested_resolution").is_none());
+}
+
+#[tokio::test]
+async fn http_error_surfaces_as_typed_error() {
+    let recorded = Arc::new(Mutex::new(Recorded {
+        fail_create: true,
+        ..Default::default()
+    }));
+    let base = spawn_stub(recorded.clone()).await;
+    let client = AiHistoryClient::new(reqwest::Client::new(), base);
+
+    let error = client
+        .create(
+            &auth_headers(),
+            &CreateInvestigationRequest {
+                trigger_source: "x".to_string(),
+                linked_alert_id: "y".to_string(),
+                evidence_refs: "z".to_string(),
+                state: None,
+            },
+        )
+        .await
+        .expect_err("create should fail");
+
+    match error {
+        AiHistoryError::Http { status, body } => {
+            assert_eq!(status, 500);
+            assert!(body.contains("downstream exploded"));
+        }
+        other => panic!("expected AiHistoryError::Http, got: {:?}", other),
+    }
+}


### PR DESCRIPTION
Returns the investigation id so it can be queried with the A2a API as well.

There are a couple of TODOs in the code that I'd like to address before marking this PR as final.

REF: LOG-23644
