### PR TITLE
feat(quickstart): default to cli-driven orchestrator mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,14 @@ Key capabilities:
 ## Quick Start
 
 ```bash
-cp .env.example .env          # set your LLM provider, model, and API key
-docker compose up -d           # starts Aura + LibreChat + Phoenix
+cp .env.example .env            # set your LLM provider, model, and API key
+docker compose up -d            # starts Aura (orchestrator mode) + LibreChat + Phoenix
+docker exec -it aura ./aura-cli # chat with the orchestrator from your terminal
 ```
 
-Open <http://localhost:3080> to chat, <http://localhost:6006> to inspect traces.
+Aura boots in **orchestrator mode**: a coordinator routes each request — answering simple ones directly and decomposing complex ones across specialized workers. The bundled `aura-cli` connects to the in-container server automatically and renders the coordinator's plan and worker activity as it streams.
+
+Prefer a browser? Open <http://localhost:3080> to chat in LibreChat, or <http://localhost:6006> to inspect traces in Phoenix.
 
 **[Full quickstart guide](docs/quickstart.md)** — provider setup (OpenAI, Anthropic, Ollama, llama-server), adding MCP tools, enabling vector search, serving multiple agents, and troubleshooting.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,11 @@ services:
       PORT: "8080"
       CONFIG_PATH: "/app/config/quickstart.toml"
 
-      # Streaming — custom events disabled because LibreChat's SSE
-      # parser doesn't skip unknown event types (aura.session_info, etc.)
-      AURA_CUSTOM_EVENTS: "false"
+      # Streaming — custom events enabled so aura-cli can render the
+      # orchestrator's plan/worker events. Safe for LibreChat as of v0.8.6,
+      # whose SSE parser skips unknown event types (aura.session_info, etc.)
+      # instead of crashing on them (danny-avila/LibreChat#12919).
+      AURA_CUSTOM_EVENTS: "true"
       AURA_EMIT_REASONING: "false"
       TOOL_RESULT_MODE: "none"
 
@@ -47,7 +49,7 @@ services:
       - aura-quickstart
 
   librechat:
-    image: ghcr.io/danny-avila/librechat:v0.7.8
+    image: ghcr.io/danny-avila/librechat:v0.8.6
     container_name: aura-qs-librechat
     ports:
       - "3080:3080"

--- a/docs/ollama-guide.md
+++ b/docs/ollama-guide.md
@@ -36,6 +36,8 @@ Known handled styles include:
 
 This improves tool reliability with local models that do not consistently emit structured function-calling payloads.
 
+> **Orchestration limitation.** `fallback_tool_parsing` applies only to single-agent mode (`[orchestration].enabled = false`). In orchestration mode the coordinator and workers are built with fallback parsing **disabled**, so a local model that can't emit native tool calls may fail to drive worker tools. Run such models in single-agent mode, or use a model with reliable native tool-calling for orchestration.
+
 ## Practical Guidance
 
 - Prefer instruction-tuned variants (`*-instruct`) when you need reliable tool execution.

--- a/docs/ollama-guide.md
+++ b/docs/ollama-guide.md
@@ -36,7 +36,7 @@ Known handled styles include:
 
 This improves tool reliability with local models that do not consistently emit structured function-calling payloads.
 
-> **Orchestration limitation.** `fallback_tool_parsing` applies only to single-agent mode (`[orchestration].enabled = false`). In orchestration mode the coordinator and workers are built with fallback parsing **disabled**, so a local model that can't emit native tool calls may fail to drive worker tools. Run such models in single-agent mode, or use a model with reliable native tool-calling for orchestration.
+> **Known issue (orchestration).** `fallback_tool_parsing` is currently honored only in single-agent mode. In orchestration mode the coordinator and workers are built with fallback parsing **disabled** — a bug, not intended behavior, tracked in [#193](https://github.com/mezmo/aura/issues/193). Until it's fixed, a local model that emits tool calls as text instead of native `tool_calls` can stall in orchestration (the coordinator never registers a routing decision). Workaround: run such models in single-agent mode (`[orchestration].enabled = false`), or use a model with reliable native tool-calling.
 
 ## Practical Guidance
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -101,7 +101,7 @@ LLM_BASE_URL=http://host.docker.internal:11434
 
 Also uncomment the `base_url` line in `quickstart.toml`.
 
-> **Ollama + orchestration:** the quickstart defaults to orchestration mode, which builds its coordinator and workers *without* `fallback_tool_parsing`. A local model that relies on fallback parsing (tool calls emitted as text rather than native tool calls) may fail to drive the workers. If your model needs it, run the quickstart in single-agent mode — set `[orchestration].enabled = false` and uncomment `fallback_tool_parsing = true` in `quickstart.toml`. Models with reliable native tool-calling work as-is in the default orchestrated mode. See the [Ollama guide](ollama-guide.md) for details.
+> **Ollama + orchestration (known issue):** the quickstart defaults to orchestration mode, where `fallback_tool_parsing` is currently *not* applied to the coordinator or workers — a bug tracked in [#193](https://github.com/mezmo/aura/issues/193). Until it's fixed, a local model that relies on fallback parsing (tool calls emitted as text rather than native tool calls) can stall in orchestration. Workaround: run the quickstart in single-agent mode — set `[orchestration].enabled = false` and uncomment `fallback_tool_parsing = true` in `quickstart.toml`. Models with reliable native tool-calling work as-is. See the [Ollama guide](ollama-guide.md) for details.
 
 **[llama-server](https://github.com/ggml-org/llama.cpp/tree/master/tools/server)** (llama.cpp, local, no API key):
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # AURA Quickstart
 
-Get a fully working AI agent stack running in under a minute — AURA, a chat UI, and a trace viewer — all from the repo root.
+Get a fully working AI agent stack running in under a minute — AURA in **orchestrator mode**, a chat UI, and a trace viewer — all from the repo root.
 
 **Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and an LLM API key (OpenAI, Anthropic, or a local [Ollama](https://ollama.com) instance).
 
@@ -24,7 +24,21 @@ LLM_API_KEY=sk-...            # your API key (use "unused" for Ollama/llama-serv
 docker compose up -d
 ```
 
-## 3. Open the UIs
+AURA boots in orchestrator mode: a coordinator routes each request — answering simple ones directly and decomposing complex ones across the `researcher` and `writer` workers defined in `quickstart.toml`.
+
+## 3. Chat with your agent
+
+The [AURA CLI](../crates/aura-cli/README.md) ships in the same Docker image and connects to the in-container server automatically. Exec into the running container:
+
+```bash
+docker exec -it aura ./aura-cli
+```
+
+It renders the coordinator's plan and worker activity as the response streams.
+
+> **Tip:** Check startup progress with `docker compose logs -f aura`.
+
+### Or use a browser
 
 | Service | URL | Description |
 |---------|-----|-------------|
@@ -32,19 +46,11 @@ docker compose up -d
 | Phoenix | <http://localhost:6006> | Inspect LLM traces |
 | AURA API | <http://localhost:8080> | OpenAI-compatible API |
 
-**LibreChat first-time setup:** Create your user account on the signup page. The agent model is pre-configured as "AURA Assistant".
+**LibreChat first-time setup:** Create your user account on the signup page. The agent model is pre-configured as "Aura Orchestrator".
 
-> **Tip:** Check startup progress with `docker compose logs -f aura`.
+### Build the CLI from source
 
-### Use the CLI instead
-
-Prefer a terminal? The [AURA CLI](../crates/aura-cli/README.md) ships in the same Docker image. Exec into the running container:
-
-```bash
-docker exec -it aura ./aura-cli
-```
-
-Or build from source and connect to the quickstart server:
+Prefer to build locally instead of using the bundled binary? Connect to the quickstart server:
 
 ```bash
 cargo build -p aura-cli --release
@@ -62,7 +68,7 @@ See the [CLI README](../crates/aura-cli/README.md) for the full feature set.
 
 ## Customize Your Agent
 
-Edit `quickstart.toml` to change agent behavior, add tools, or enable vector search.
+Edit `quickstart.toml` to change coordinator routing and worker behavior, add tools, or enable vector search.
 Edit `.env` to switch LLM providers. Then apply changes:
 
 ```bash
@@ -93,7 +99,9 @@ LLM_API_KEY=unused
 LLM_BASE_URL=http://host.docker.internal:11434
 ```
 
-Also uncomment the `base_url` and `fallback_tool_parsing` lines in `quickstart.toml`.
+Also uncomment the `base_url` line in `quickstart.toml`.
+
+> **Ollama + orchestration:** the quickstart defaults to orchestration mode, which builds its coordinator and workers *without* `fallback_tool_parsing`. A local model that relies on fallback parsing (tool calls emitted as text rather than native tool calls) may fail to drive the workers. If your model needs it, run the quickstart in single-agent mode — set `[orchestration].enabled = false` and uncomment `fallback_tool_parsing = true` in `quickstart.toml`. Models with reliable native tool-calling work as-is in the default orchestrated mode. See the [Ollama guide](ollama-guide.md) for details.
 
 **[llama-server](https://github.com/ggml-org/llama.cpp/tree/master/tools/server)** (llama.cpp, local, no API key):
 
@@ -123,12 +131,16 @@ url = "http://host.docker.internal:9000/mcp"
 
 Use `host.docker.internal` to reach services running on your host machine.
 
+Then scope the tools per worker: set `mcp_filter` on each worker that should use them (see [Customize orchestration](#customize-orchestration)). A worker with no `mcp_filter` receives **all** MCP tools, so set it explicitly on every tool-using worker and keep tool-free workers (like the default `writer`) on a non-matching pattern.
+
 ### Add vector search
 
 Uncomment the `[[vector_stores]]` section in `quickstart.toml`. Options:
 
 - **Qdrant** (self-hosted): add a Qdrant instance to the compose file or point at an external one. Embeddings can be generated via OpenAI or AWS Bedrock.
 - **AWS Bedrock Knowledge Base** (managed): set `type = "bedrock_kb"` with a `knowledge_base_id` and `region`. No embedding model needed — the KB manages embeddings internally.
+
+Registering a store under `[[vector_stores]]` only defines it — no agent can query it until you attach it. Add the store's `name` to a worker's `vector_stores` list (e.g. `vector_stores = ["docs"]`), or to `[orchestration].coordinator_vector_stores` to give the coordinator access.
 
 See [`examples/reference.toml`](../examples/reference.toml) for both.
 
@@ -159,11 +171,9 @@ Restart with `docker compose up -d`. Clients that support model selection (Libre
 > appropriate keys to your `.env` — they're automatically loaded into the container
 > via `env_file`. See `.env.example` for the full list.
 
-### Enable orchestration mode
+### Customize orchestration
 
-Orchestration mode routes requests through a **coordinator** that decomposes problems into tasks and dispatches them to **workers** — each with access to a filtered subset of MCP tools.
-
-Add these sections to `quickstart.toml` (below the `[agent]` block):
+`quickstart.toml` ships with orchestration enabled: a coordinator and two tool-free workers (`researcher` and `writer`) that reason with the LLM alone. The coordinator's routing is controlled by the `[orchestration]` block:
 
 ```toml
 [orchestration]
@@ -172,7 +182,11 @@ max_planning_cycles = 2
 allow_direct_answers = true    # simple queries answered without workers
 allow_clarification = true     # vague requests prompt follow-up questions
 tools_in_planning = "summary"  # coordinator sees tool names during planning
+```
 
+Each `[orchestration.worker.<name>]` block defines a worker. Give a worker tools by configuring an MCP server (see [Add MCP tool servers](#add-mcp-tool-servers) above) and listing matching tool globs in its `mcp_filter`, or point it at a vector store via `vector_stores`:
+
+```toml
 [orchestration.worker.operations]
 description = "Operational analysis and diagnostics"
 preamble = """
@@ -188,14 +202,18 @@ preamble = """
 You are a knowledge specialist completing one assigned task.
 Search available documentation to answer the question.
 """
-mcp_filter = []
-vector_stores = ["docs"]       # this worker uses vector search instead of MCP tools
+mcp_filter = ["__none__"]      # non-matching pattern: no MCP tools, vector search only
+vector_stores = ["docs"]
 turn_depth = 5
 ```
 
+> **Note:** a worker whose `mcp_filter` is omitted or empty (`[]`) is granted **every** MCP tool, not none. Set an explicit `mcp_filter` on each worker once an MCP server is configured, and use a non-matching pattern (e.g. `["__none__"]`) for any worker you want to keep tool-free.
+
 Each worker inherits the agent's LLM by default. To run a worker on a different model, add a complete `[orchestration.worker.<name>.llm]` block — see the [orchestration config reference](../README.md#orchestration) for all fields.
 
-Restart with `docker compose restart aura` and try asking a multi-step question. Watch the coordinator plan and dispatch in Phoenix at <http://localhost:6006>.
+Restart with `docker compose restart aura` and try asking a multi-step question. Watch the coordinator plan and dispatch in the CLI's event panel, or in Phoenix at <http://localhost:6006>.
+
+To run a single agent instead of orchestration, set `[orchestration].enabled = false` and configure a single `[agent]` — see [`examples/reference.toml`](../examples/reference.toml).
 
 For a fully self-contained orchestration example with a math MCP server, see the [Orchestration — Math MCP quickstart](../examples/quickstart-orchestration-math/README.md).
 
@@ -216,7 +234,9 @@ Once the basic quickstart is running, try these more advanced setups:
 ```mermaid
 graph TD
     Browser -->|":3080"| LibreChat
+    Terminal -->|"docker exec"| CLI["aura-cli"]
     LibreChat <-->|"/v1/chat/completions"| AURA
+    CLI <-->|"/v1/chat/completions"| AURA
     AURA -->|"OTel gRPC :4317"| Phoenix
     AURA <-->|"API calls"| LLM["LLM Provider<br/>(OpenAI, etc.)"]
     AURA <-->|"MCP"| MCP["MCP Tool Servers"]
@@ -225,15 +245,17 @@ graph TD
 
     subgraph compose["docker compose"]
         LibreChat[":3080 LibreChat"]
-        AURA[":8080 AURA"]
+        AURA[":8080 AURA (orchestrator)"]
         Phoenix[":6006 Phoenix"]
+        CLI
         MongoDB
     end
 ```
 
+- **aura-cli** runs inside the AURA container (`docker exec`) and talks to the same OpenAI-compatible `/v1/chat/completions` endpoint, rendering coordinator and worker events as they stream.
 - **LibreChat** sends chat requests to AURA's OpenAI-compatible `/v1/chat/completions` endpoint. MongoDB is used by LibreChat internally for user accounts and conversation history — AURA does not use it.
-- **AURA** calls the configured LLM provider, executes MCP tools, and streams responses back.
-- **Phoenix** receives OpenTelemetry traces from AURA so you can inspect every step.
+- **AURA** runs the coordinator that routes each request, dispatches workers, executes MCP tools, calls the configured LLM provider, and streams responses back.
+- **Phoenix** receives OpenTelemetry traces from AURA so you can inspect every coordinator and worker step.
 
 ## Troubleshooting
 

--- a/quickstart.toml
+++ b/quickstart.toml
@@ -1,34 +1,95 @@
 # Aura Quickstart Configuration
 #
-# Customize this file to change your agent's behavior, tools, and
-# knowledge bases. Changes take effect after: docker compose restart aura
+# Boots Aura in ORCHESTRATOR mode: a coordinator routes each request —
+# answering simple ones directly, decomposing complex ones across the
+# workers defined below, or asking for clarification when a request is vague.
+#
+# Customize this file to change routing, workers, tools, and knowledge
+# bases. Changes take effect after: docker compose restart aura
 #
 # For all available options, see: examples/reference.toml
 
-# ── Agent ───────────────────────────────────────────────────────────
+# ── Coordinator ─────────────────────────────────────────────────────
+# In orchestration mode, [agent].system_prompt is the COORDINATOR prompt.
+# It provides domain context and routing guidance, not worker behavior.
 
 [agent]
-name = "Aura Assistant"
+name = "Aura Orchestrator"
 # alias = "aura"  # optional: stable identifier for model selection by clients
 system_prompt = """
-You are a helpful assistant with access to external tools and
-knowledge bases. Use them to provide accurate, grounded answers.
+You are a coordinator that turns user requests into results by delegating
+to specialized workers.
+
+ROUTING GUIDANCE:
+- Simple, single-step questions: answer directly.
+- Multi-step or mixed requests: create a plan and delegate to the workers.
+- Vague requests: ask a brief clarifying question.
+
+Delegate research and analysis to the `researcher` worker, and delegate
+drafting and final write-up to the `writer` worker. Consolidate their
+outputs into a single, coherent answer.
 """
-# Maximum tool-calling rounds per user turn
+# Maximum tool-calling rounds per worker turn
 turn_depth = 5
 
 # ── LLM Provider ────────────────────────────────────────────────────
 # Provider, model, and API key are set in .env — no changes needed here.
+# Workers inherit this LLM unless they declare their own [.llm] override.
 
 [agent.llm]
 provider = "{{ env.LLM_PROVIDER }}"
 api_key = "{{ env.LLM_API_KEY }}"
 model = "{{ env.LLM_MODEL }}"
 # base_url = "{{ env.LLM_BASE_URL }}"    # Uncomment for Ollama or llama-server
-# fallback_tool_parsing = true            # Uncomment for Ollama
+# fallback_tool_parsing = true            # Ollama only — takes effect in single-agent
+#                                         # mode ([orchestration].enabled = false); it is
+#                                         # NOT applied to orchestration coordinator/workers
+
+# ── Orchestration ───────────────────────────────────────────────────
+
+[orchestration]
+enabled = true
+max_planning_cycles = 2
+allow_direct_answers = true
+allow_clarification = true
+tools_in_planning = "summary"
+# Where plan state and worker artifacts are persisted (must be writable).
+memory_dir = "/tmp/aura-orchestration"
+
+# Workers reason with the LLM alone until you enable an MCP server below.
+#
+# IMPORTANT: a worker whose `mcp_filter` is omitted or empty (`[]`) is granted
+# *every* MCP tool. Once you add an MCP server, set an explicit `mcp_filter` on
+# each tool-using worker. The `writer` below ships with a non-matching filter so
+# it stays tool-free; see the per-worker notes for details.
+
+[orchestration.worker.researcher]
+description = "Research and analysis: break a request into parts, gather facts, and reason through the details"
+preamble = """
+You are a Research Specialist. Decompose the task, reason step by step,
+and report clear, well-organized findings for the coordinator to use.
+"""
+# With an MCP server enabled, scope this worker to the tools it needs:
+# mcp_filter = ["my_tool_*"]
+
+[orchestration.worker.writer]
+description = "Drafting and synthesis: turn findings into a clear, well-structured final answer"
+preamble = """
+You are a Writing Specialist. Take the coordinator's goal and any research
+findings and produce a concise, well-structured response.
+"""
+# The writer synthesizes text and needs no tools. This non-matching pattern
+# keeps it tool-free even after you enable an MCP server (an omitted/empty
+# filter would otherwise grant it every tool). Leave it as-is.
+mcp_filter = ["__none__"]
 
 # ── MCP Tool Servers (optional) ─────────────────────────────────────
-# Uncomment and configure to give your agent access to external tools.
+# To give your workers external tools:
+#   1. Uncomment and configure the [mcp] section below.
+#   2. Uncomment `mcp_filter` in the `researcher` block above and set it to the
+#      tools that worker should use. A worker with no `mcp_filter` receives ALL
+#      MCP tools, so scope every tool-using worker explicitly. The `writer`
+#      already has an active no-tool filter and needs no change.
 #
 # [mcp]
 # sanitize_schemas = true
@@ -39,7 +100,8 @@ model = "{{ env.LLM_MODEL }}"
 # description = "My MCP tool server"
 
 # ── Vector Search (optional) ─────────────────────────────────────────
-# Uncomment to enable vector search with Qdrant.
+# Uncomment to enable vector search with Qdrant, then add the store name
+# to a worker's `vector_stores` list.
 #
 # [[vector_stores]]
 # name = "docs"

--- a/quickstart.toml
+++ b/quickstart.toml
@@ -41,9 +41,10 @@ provider = "{{ env.LLM_PROVIDER }}"
 api_key = "{{ env.LLM_API_KEY }}"
 model = "{{ env.LLM_MODEL }}"
 # base_url = "{{ env.LLM_BASE_URL }}"    # Uncomment for Ollama or llama-server
-# fallback_tool_parsing = true            # Ollama only — takes effect in single-agent
-#                                         # mode ([orchestration].enabled = false); it is
-#                                         # NOT applied to orchestration coordinator/workers
+# fallback_tool_parsing = true            # Ollama only. Known issue: currently applied in
+#                                         # single-agent mode ([orchestration].enabled =
+#                                         # false) only, not the orchestration coordinator/
+#                                         # workers — a bug tracked in mezmo/aura#193.
 
 # ── Orchestration ───────────────────────────────────────────────────
 

--- a/quickstart/librechat.yaml
+++ b/quickstart/librechat.yaml
@@ -10,10 +10,10 @@ endpoints:
       baseURL: "http://aura:8080/v1"
       models:
         default:
-          - "Aura Assistant"
+          - "Aura Orchestrator"
         fetch: true
       titleConvo: true
-      titleModel: "Aura Assistant"
+      titleModel: "Aura Orchestrator"
       summarize: false
       forcePrompt: false
       modelDisplayLabel: "Aura"


### PR DESCRIPTION
- The quick start now leads with the bundled CLI (`docker exec -it aura ./aura-cli`)
- the default `quickstart.toml` ships in orchestration mode with a coordinator plus `researcher`/`writer` workers. The writer stays tool-free via a non-matching `mcp_filter` (an omitted/empty filter would grant all tools).
- `docker-compose.yml` enables `AURA_CUSTOM_EVENTS` so the CLI renders plan/worker events
- bumps LibreChat v0.7.8 → v0.8.6, which skips unknown SSE event types instead of crashing on them (danny-avila/LibreChat#12919); 
- `quickstart/librechat.yaml` points the default model at "Aura Orchestrator". 
- The docs (`docs/quickstart.md`, `docs/ollama-guide.md`) are aligned to the CLI-first orchestrator flow and now state that vector stores must be attached to a worker or coordinator to be queryable, and that `fallback_tool_parsing` applies only in single-agent mode. 
- The orchestration `fallback_tool_parsing` gap is tracked in #193.