### PR TITLE
feat(mcp): surface and report failed MCP server connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,11 +76,12 @@ aura/
 - **STDIO Transport**: Tool discovery
 - **Header Forwarding**: `headers_from_request` mappings with static TOML `headers` as fallback
 - **Cancellation**: `notifications/cancelled` propagation on client disconnect
+- **Status reporting**: per-server connection state (`Connected`/`Failed(reason)`/`NotAttempted`) is tracked in `McpManager::server_info` and projected to clients via the `aura.mcp_status` SSE event. Transport/auth failures bubble as errors.
 
 ### Streaming
 - OpenAI-compatible SSE streaming (`/v1/chat/completions`)
 - Custom `aura.*` events (opt-in via `AURA_CUSTOM_EVENTS=true`):
-  - `aura.session_info`, `aura.tool_requested`, `aura.tool_start`, `aura.tool_complete`, `aura.reasoning`, `aura.progress`, `aura.worker_phase`, `aura.tool_usage`, `aura.usage`, `aura.scratchpad_usage`
+  - `aura.session_info`, `aura.mcp_status`, `aura.tool_requested`, `aura.tool_start`, `aura.tool_complete`, `aura.reasoning`, `aura.progress`, `aura.worker_phase`, `aura.tool_usage`, `aura.usage`, `aura.scratchpad_usage`
 - Request cancellation on timeout or client disconnect
 - Two-phase graceful shutdown: new requests rejected immediately (503), in-flight streams get configurable grace period (`SHUTDOWN_TIMEOUT_SECS`, default 30s)
 

--- a/crates/aura-cli/src/api/mcp_status.rs
+++ b/crates/aura-cli/src/api/mcp_status.rs
@@ -1,0 +1,302 @@
+//! Shared rendering of the `aura.mcp_status` SSE event into user-facing
+//! notices.
+//!
+//! Both the REPL (status area, styled) and one-shot mode (stderr) surface MCP
+//! connection problems. This module centralises the parsing and message
+//! wording so the two stay consistent — callers only decide presentation
+//! (color/prefix vs. plain stderr line).
+
+/// Marker the `aura` transport layer prepends to an HTTP status in the failure
+/// reason (e.g. `"server returned HTTP 404 Not Found"`). Shared from
+/// [`aura_events`] so producer and consumer match on a single source of truth —
+/// because it's **our** string and not a Rig/rmcp error format, it's stable
+/// across Rig fork bumps. The only upstream-owned fragment we parse is reqwest's
+/// `HTTP status ... (<status>)` `Display` output, used as a fallback in
+/// [`extract_http_status`].
+use aura_events::HTTP_STATUS_MARKER;
+
+/// A single user-facing notice derived from an `aura.mcp_status` event.
+///
+/// The variant carries the severity; the payload is the human-readable message
+/// body, which does **not** include an `error:`/`warning:` prefix — each caller
+/// adds its own prefix and styling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpNotice {
+    Error(String),
+    Warning(String),
+}
+
+impl McpNotice {
+    /// The message body, regardless of severity.
+    pub fn message(&self) -> &str {
+        match self {
+            McpNotice::Error(message) | McpNotice::Warning(message) => message,
+        }
+    }
+}
+
+/// Human-friendly label for an MCP transport identifier from the event.
+fn transport_display(transport: &str) -> &str {
+    match transport {
+        "http_streamable" => "HTTP",
+        "sse" => "SSE",
+        "stdio" => "STDIO",
+        other => other,
+    }
+}
+
+/// Extract a concise HTTP status (e.g. "404 Not Found") from a verbose error
+/// chain, if one is present.
+///
+/// The server collapses the transport error chain into the reason string, which
+/// for an HTTP failure looks like:
+///   "... server returned HTTP 404 Not Found: Failed to establish ...
+///    Client error: HTTP status client error (404 Not Found) for url (...)"
+///
+/// We prefer the `server returned HTTP <status>` fragment (injected by AURA at
+/// the transport layer, so it's clean), then fall back to reqwest's
+/// `HTTP status ... (<status>)` form.
+fn extract_http_status(reason: &str) -> Option<String> {
+    if let Some(idx) = reason.find(HTTP_STATUS_MARKER) {
+        let rest = &reason[idx + HTTP_STATUS_MARKER.len()..];
+        // The status runs up to the next chain separator (": ").
+        let end = rest.find(": ").unwrap_or(rest.len());
+        let status = rest[..end].trim();
+        if !status.is_empty() {
+            return Some(status.to_string());
+        }
+    }
+    // Fallback: reqwest's "HTTP status client error (404 Not Found)".
+    if let Some(idx) = reason.find("HTTP status ") {
+        let rest = &reason[idx..];
+        if let (Some(open), Some(close)) = (rest.find('('), rest.find(')'))
+            && open < close
+        {
+            let status = rest[open + 1..close].trim();
+            if !status.is_empty() {
+                return Some(status.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Build a one-line failure summary for a degraded MCP server.
+///
+/// Prefers signal over completeness: when the (often very verbose) reason chain
+/// carries an HTTP status, collapse to just `<transport> MCP server '<name>':
+/// <status>` (e.g. "HTTP MCP server 'github': 404 Not Found"). The full chain
+/// is still available in the SSE stream panel for debugging.
+///
+/// Otherwise the reason is usually self-describing (e.g. the 401 auth message),
+/// so it's shown verbatim once the redundant "Connection failed: " prefix is
+/// stripped; the server name/transport are prepended only when the reason
+/// doesn't already name the server.
+fn failure_summary(transport_display: &str, name: &str, reason: &str) -> String {
+    let reason = reason
+        .strip_prefix("Connection failed: ")
+        .unwrap_or(reason)
+        .trim();
+    if let Some(status) = extract_http_status(reason) {
+        format!("{transport_display} MCP server '{name}': {status}")
+    } else if reason.is_empty() {
+        format!("Failed to connect to {transport_display} MCP server '{name}'")
+    } else if reason.contains(name) {
+        reason.to_string()
+    } else {
+        format!("{transport_display} MCP server '{name}': {reason}")
+    }
+}
+
+/// Parse an `aura.mcp_status` event payload into user-facing notices.
+///
+/// Emits at most one notice per server:
+/// - a failed server → an error notice carrying the failure reason;
+/// - a connected server exposing zero tools → a warning notice;
+/// - everything else (connected with tools, not attempted) → nothing.
+///
+/// A failed server never also produces a "no tools" warning — the connection
+/// failure is the actionable problem and no tools are expected when it fails.
+pub fn notices_from_event(val: &serde_json::Value) -> Vec<McpNotice> {
+    let Some(servers) = val.get("servers").and_then(|s| s.as_array()) else {
+        return Vec::new();
+    };
+
+    servers
+        .iter()
+        .filter_map(|s| {
+            let name = s
+                .get("server_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let transport = s
+                .get("transport")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let status = s.get("status").and_then(|v| v.as_str()).unwrap_or_default();
+            let tools = s
+                .get("tools_count")
+                .and_then(|v| v.as_u64())
+                .unwrap_or_default();
+            let disp = transport_display(transport);
+
+            if status == "failed" {
+                let reason = s.get("reason").and_then(|v| v.as_str()).unwrap_or_default();
+                Some(McpNotice::Error(failure_summary(disp, name, reason)))
+            } else if status == "connected" && tools == 0 {
+                Some(McpNotice::Warning(format!(
+                    "{disp} MCP server '{name}' connected but reported no tools available"
+                )))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn event(servers: serde_json::Value) -> serde_json::Value {
+        json!({ "servers": servers, "session_id": "s1" })
+    }
+
+    #[test]
+    fn failed_server_yields_error_with_reason_and_no_tools_warning() {
+        let notices = notices_from_event(&event(json!([{
+            "server_name": "github",
+            "transport": "http_streamable",
+            "status": "failed",
+            "tools_count": 0,
+            "reason": "Connection failed: HTTP MCP server 'github' authentication failed (401 Unauthorized)."
+        }])));
+        // Exactly one notice: the error. No redundant "no tools" warning.
+        assert_eq!(notices.len(), 1);
+        assert!(matches!(notices[0], McpNotice::Error(_)));
+        // "Connection failed: " prefix stripped; reason shown verbatim (it
+        // already names the server, so no duplicate prefix is added).
+        assert_eq!(
+            notices[0].message(),
+            "HTTP MCP server 'github' authentication failed (401 Unauthorized)."
+        );
+    }
+
+    #[test]
+    fn failed_server_without_name_in_reason_gets_prefixed() {
+        let notices = notices_from_event(&event(json!([{
+            "server_name": "kb",
+            "transport": "sse",
+            "status": "failed",
+            "tools_count": 0,
+            "reason": "Connection failed: transport closed"
+        }])));
+        assert_eq!(
+            notices[0].message(),
+            "SSE MCP server 'kb': transport closed"
+        );
+    }
+
+    #[test]
+    fn failed_server_without_reason_falls_back_to_generic() {
+        let notices = notices_from_event(&event(json!([{
+            "server_name": "kb",
+            "transport": "stdio",
+            "status": "failed",
+            "tools_count": 0
+        }])));
+        assert_eq!(
+            notices[0].message(),
+            "Failed to connect to STDIO MCP server 'kb'"
+        );
+    }
+
+    #[test]
+    fn connected_empty_server_yields_warning_only() {
+        let notices = notices_from_event(&event(json!([{
+            "server_name": "mezmo",
+            "transport": "http_streamable",
+            "status": "connected",
+            "tools_count": 0
+        }])));
+        assert_eq!(notices.len(), 1);
+        assert!(matches!(notices[0], McpNotice::Warning(_)));
+        assert_eq!(
+            notices[0].message(),
+            "HTTP MCP server 'mezmo' connected but reported no tools available"
+        );
+    }
+
+    #[test]
+    fn connected_with_tools_and_missing_servers_yield_nothing() {
+        let connected = notices_from_event(&event(json!([{
+            "server_name": "mezmo",
+            "transport": "http_streamable",
+            "status": "connected",
+            "tools_count": 7
+        }])));
+        assert!(connected.is_empty());
+        assert!(notices_from_event(&json!({ "session_id": "s1" })).is_empty());
+    }
+
+    #[test]
+    fn verbose_http_status_chain_is_condensed_to_signal() {
+        // The exact verbose reason a real 404 produces — should collapse to the
+        // status alone, not echo the whole transport chain.
+        let reason = "Connection failed: MCP initialization error: Failed to connect to \
+             HTTP MCP server 'github': server returned HTTP 404 Not Found: Failed to \
+             establish MCP client connection: Send message error Transport [...] error: \
+             Client error: HTTP status client error (404 Not Found) for url \
+             (https://api.githubcopilot.com/mcpz), when send initialize request";
+        let notices = notices_from_event(&event(json!([{
+            "server_name": "github",
+            "transport": "http_streamable",
+            "status": "failed",
+            "tools_count": 0,
+            "reason": reason,
+        }])));
+        assert_eq!(notices.len(), 1);
+        assert!(matches!(notices[0], McpNotice::Error(_)));
+        assert_eq!(
+            notices[0].message(),
+            "HTTP MCP server 'github': 404 Not Found"
+        );
+    }
+
+    #[test]
+    fn http_status_extracted_via_reqwest_fallback() {
+        // No "server returned HTTP" marker (e.g. a discover-tools failure) —
+        // fall back to reqwest's parenthesised status.
+        let reason = "Connection failed: Failed to discover tools from server 'gh': \
+             Client error: HTTP status client error (403 Forbidden) for url (https://x/y)";
+        let notices = notices_from_event(&event(json!([{
+            "server_name": "gh",
+            "transport": "http_streamable",
+            "status": "failed",
+            "tools_count": 0,
+            "reason": reason,
+        }])));
+        assert_eq!(notices[0].message(), "HTTP MCP server 'gh': 403 Forbidden");
+    }
+
+    #[test]
+    fn auth_401_message_is_left_verbatim() {
+        // The friendly 401 message has no HTTP-status marker, so it should pass
+        // through unchanged rather than being collapsed.
+        let reason = "Connection failed: HTTP MCP server 'github' authentication failed \
+             (401 Unauthorized). Check that your forwarded headers and credentials are correct.";
+        let notices = notices_from_event(&event(json!([{
+            "server_name": "github",
+            "transport": "http_streamable",
+            "status": "failed",
+            "tools_count": 0,
+            "reason": reason,
+        }])));
+        assert_eq!(
+            notices[0].message(),
+            "HTTP MCP server 'github' authentication failed (401 Unauthorized). \
+             Check that your forwarded headers and credentials are correct."
+        );
+    }
+}

--- a/crates/aura-cli/src/api/mod.rs
+++ b/crates/aura-cli/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod mcp_status;
 pub mod session;
 pub mod stream;
 pub mod types;

--- a/crates/aura-cli/src/api/stream.rs
+++ b/crates/aura-cli/src/api/stream.rs
@@ -266,7 +266,10 @@ where
                 }
                 _ => {
                     // aura.orchestrator.*, aura.session_info, aura.progress,
-                    // aura.worker_phase, and any future events
+                    // aura.worker_phase, aura.mcp_status, and any future events.
+                    // Consumers (REPL status notices, one-shot stderr) handle
+                    // these via the orchestrator-event callback; on_raw_event
+                    // above also captures them into the stream panel.
                     if let Ok(val) = serde_json::from_str::<serde_json::Value>(&event.data) {
                         handler.on_orchestrator_event(event_name, &val);
                     }

--- a/crates/aura-cli/src/oneshot.rs
+++ b/crates/aura-cli/src/oneshot.rs
@@ -24,13 +24,35 @@ use std::sync::atomic::AtomicBool;
 use anyhow::Result;
 use tokio::runtime::Runtime;
 
-use crate::api::stream::{NoopHandler, StreamResult};
+use crate::api::mcp_status::{McpNotice, notices_from_event};
+use crate::api::stream::{StreamHandler, StreamResult};
 use crate::api::types::ToolCallInfo;
 use crate::backend::Backend;
 use crate::config::AppConfig;
 use crate::repl::history::ConversationHistory;
 use crate::tools;
 use crate::ui::prompt::set_selected_model;
+
+/// One-shot [`StreamHandler`] that ignores every event except
+/// `aura.mcp_status`, which it renders to **stderr** so degraded MCP servers
+/// are visible without polluting stdout (reserved for the assistant response
+/// per the output contract).
+struct OneshotStreamHandler;
+
+impl StreamHandler for OneshotStreamHandler {
+    fn on_orchestrator_event(&mut self, event_name: &str, value: &serde_json::Value) {
+        if event_name != "aura.mcp_status" {
+            return;
+        }
+        for notice in notices_from_event(value) {
+            let (prefix, message) = match &notice {
+                McpNotice::Error(message) => ("error:", message),
+                McpNotice::Warning(message) => ("warning:", message),
+            };
+            eprintln!("{prefix} {message}");
+        }
+    }
+}
 
 /// `rt` is the CLI's process-wide tokio runtime, owned by `main`. We
 /// don't build our own here — sharing the runtime with `main`'s OTel
@@ -78,8 +100,9 @@ pub fn run_oneshot(
         crate::api::session::SessionKind::Chat,
     );
 
-    // Tool execution loop. One-shot ignores every stream event — stdout is
-    // reserved for the final assistant text — so a NoopHandler suffices.
+    // Tool execution loop. One-shot ignores nearly every stream event —
+    // stdout is reserved for the final assistant text — but degraded MCP
+    // servers are surfaced on stderr via `OneshotStreamHandler`.
     let result: Result<()> = loop {
         let stream_result = rt.block_on(async {
             backend
@@ -88,7 +111,7 @@ pub fn run_oneshot(
                     tool_defs_arg,
                     &chat_session_id,
                     Arc::new(AtomicBool::new(false)),
-                    &mut NoopHandler,
+                    &mut OneshotStreamHandler,
                 )
                 .await
         });

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::runtime::Runtime;
 
+use crate::api::mcp_status::McpNotice;
 use crate::api::stream::{StreamHandler, StreamResult};
 use crate::api::types::{DisplayEvent, ShellCallDetail, ToolCallInfo, snake_to_pascal_case};
 use crate::backend::Backend;
@@ -721,6 +722,9 @@ pub fn run_repl(
                 set_processing(true);
                 crate::ui::prompt::clear_agent_reasoning();
                 crate::ui::prompt::reset_orch_tools();
+                // Per-turn status notices (e.g. MCP connection errors/warnings)
+                // are scoped to the current request; clear last turn's set.
+                crate::ui::prompt::clear_turn_notices();
 
                 // Per-turn event recording state
                 let pending_args: Arc<
@@ -2240,6 +2244,74 @@ impl StreamHandler for ReplStreamHandler {
     }
 
     fn on_orchestrator_event(&mut self, event_name: &str, val: &serde_json::Value) {
+        // Per-turn MCP connection status. Surfaced two ways:
+        //  1. Persistent status notices below the token line, rendered when
+        //     this turn's frame is redrawn at turn end (data-only).
+        //  2. Immediately in the scrollback, so the user can react — e.g. stop
+        //     a doomed run — without waiting for the turn to finish.
+        if event_name == event_names::MCP_STATUS {
+            let notices = crate::api::mcp_status::notices_from_event(val);
+            if notices.is_empty() {
+                return;
+            }
+
+            // (1) Persistent status section.
+            for notice in &notices {
+                // Prefixes are padded so message text aligns
+                // ("error:   " / "warning: ").
+                let (style, line) = match notice {
+                    McpNotice::Error(message) => (AuraStyle::Error, format!("error:   {message}")),
+                    McpNotice::Warning(message) => {
+                        (AuraStyle::Warning, format!("warning: {message}"))
+                    }
+                };
+                crate::ui::prompt::add_turn_notice(style, line);
+            }
+
+            // (2) Immediate scrollback line(s). Mirror the on_tool_complete
+            // dance: stop the spinner, print above the frame, then restart
+            // "Thinking" so feedback continues until the next event/response.
+            let had_ptw = if let Ok(mut guard) = self.post_tool_wave.lock() {
+                guard.take().map(|(a, _)| a.finish()).is_some()
+            } else {
+                false
+            };
+            if !had_ptw && !self.anim_cleared.load(Ordering::Relaxed) {
+                stop_and_clear_animation(&self.stop_flag);
+                self.anim_cleared.store(true, Ordering::Relaxed);
+            }
+            {
+                let _term = lock_term();
+                erase_input_frame();
+                for notice in &notices {
+                    let (style, label, message) = match notice {
+                        McpNotice::Error(message) => (AuraStyle::Error, "Error", message),
+                        McpNotice::Warning(message) => (AuraStyle::Warning, "Warning", message),
+                    };
+                    // Theme the whole line, not just the marker/label.
+                    let line = format!("⏺ {label} - {message}");
+                    println!("{}", line.themed(style));
+                    crate::ui::prompt::increment_orch_scrollback();
+                }
+                println!();
+                crate::ui::prompt::increment_orch_scrollback();
+            }
+            let (wave_anim, wave_stop) = {
+                let _term = lock_term();
+                WaveAnimation::start(
+                    "Thinking",
+                    vec![],
+                    self.input_buf.clone(),
+                    Some(self.cancel.clone()),
+                )
+            };
+            if let Ok(mut guard) = self.post_tool_wave.lock() {
+                *guard = Some((wave_anim, wave_stop));
+            }
+            prepare_input_line(&self.input_buf, Some(&self.cancel));
+            return;
+        }
+
         // Handle aura.progress — prefer to attach the
         // message to the active orchestrator tool whose
         // progress_token matches; fall back to the

--- a/crates/aura-cli/src/ui/input_frame.rs
+++ b/crates/aura-cli/src/ui/input_frame.rs
@@ -14,11 +14,11 @@ use crate::theme::{AuraStyle, Themed};
 use super::animation::render_queued_wave;
 use super::state::{
     CURSOR_ROW, FORCE_REPAINT, FRAME_LINES, INPUT_LINES, LAST_TERM_WIDTH, PROCESSING, QUEUED_INPUT,
-    QUEUED_WAVE_POS, lock_term, status_rows, term_size,
+    QUEUED_WAVE_POS, STATUS_ROWS, lock_term, status_rows, term_size,
 };
 use super::status_bar::{
-    get_effective_status, is_hint_active, print_status_line, set_status_bar,
-    set_status_with_right_text,
+    desired_status_rows, get_effective_status, print_status_line, set_status_bar,
+    set_status_with_right_text, status_is_prestyled,
 };
 use super::stream_panel::{render_stream_panel_in_place, stream_panel_rows};
 
@@ -124,7 +124,7 @@ fn adjust_frame_for_line_change(old_lines: u16, new_lines: u16, old_cursor_row: 
     let _ = execute!(stdout, terminal::Clear(terminal::ClearType::CurrentLine));
     print!("{styled_border}");
 
-    let hint_active = is_hint_active();
+    let hint_active = status_is_prestyled();
 
     for i in 0..sr as usize {
         let _ = execute!(stdout, cursor::MoveDown(1), cursor::MoveToColumn(0));
@@ -177,12 +177,16 @@ pub fn redraw_input_frame() {
     LAST_TERM_WIDTH.store(width, Ordering::Relaxed);
     let border: String = "─".repeat(width as usize);
     let styled_border = border.themed(AuraStyle::Connector);
+    // Size the status area to fit any per-turn notices (and hint overlay).
+    // A full repaint, so it's safe to (re)derive and store the row count here;
+    // this is what surfaces notices collected during a turn once it finishes.
+    let sr = desired_status_rows();
+    STATUS_ROWS.store(sr, Ordering::Relaxed);
     let status_lines = get_effective_status();
-    let hint_active = is_hint_active();
+    let hint_active = status_is_prestyled();
     let queued = QUEUED_INPUT.lock().map(|g| g.clone()).unwrap_or_default();
     let show_queued = PROCESSING.load(Ordering::Relaxed) && !queued.is_empty();
 
-    let sr = status_rows();
     println!("{styled_border}");
     println!();
     println!("{styled_border}");
@@ -327,7 +331,7 @@ pub fn handle_resize_frame(old_width: u16) {
     print!("{styled_border}");
 
     let status_lines = get_effective_status();
-    let hint_active = is_hint_active();
+    let hint_active = status_is_prestyled();
     let queued = QUEUED_INPUT.lock().map(|g| g.clone()).unwrap_or_default();
     let show_queued = PROCESSING.load(Ordering::Relaxed) && !queued.is_empty();
 
@@ -359,7 +363,7 @@ pub fn resize_status_area(old_sr: u16, new_sr: u16) {
     let n = FRAME_LINES.load(Ordering::Relaxed);
     let r = CURSOR_ROW.load(Ordering::Relaxed);
     let status_lines = get_effective_status();
-    let hint_active = is_hint_active();
+    let hint_active = status_is_prestyled();
     let queued = QUEUED_INPUT.lock().map(|g| g.clone()).unwrap_or_default();
     let show_queued = PROCESSING.load(Ordering::Relaxed) && !queued.is_empty();
 
@@ -485,7 +489,7 @@ pub(crate) fn collapse_two_lines_above_frame() {
     let border: String = "─".repeat(width as usize);
     let styled_border = border.themed(AuraStyle::Connector);
     let status_lines = get_effective_status();
-    let hint_active = is_hint_active();
+    let hint_active = status_is_prestyled();
     let queued = QUEUED_INPUT.lock().map(|g| g.clone()).unwrap_or_default();
     let show_queued = PROCESSING.load(Ordering::Relaxed) && !queued.is_empty();
 

--- a/crates/aura-cli/src/ui/input_hint.rs
+++ b/crates/aura-cli/src/ui/input_hint.rs
@@ -18,7 +18,7 @@ use super::state::{
     STREAM_CONV_DIR, STYLE_MATCHES, get_tab_select_index, lock_term, random_bullet_color,
     status_rows, term_size,
 };
-use super::status_bar::update_status_bar;
+use super::status_bar::{notice_status_rows, update_status_bar};
 use crate::theme::{AuraStyle, STYLE_NAMES, Themed, theme};
 
 /// Update the model cache from a successful fetch.
@@ -386,9 +386,11 @@ pub fn update_input_hint(line: &str) {
         }
         vec![]
     };
-    // Compute new status row count and handle resizing
+    // Compute new status row count and handle resizing. When no hint is
+    // showing, fall back to the notice-aware baseline so any per-turn notices
+    // stay visible.
     let new_sr = if hint.is_empty() {
-        3u16
+        notice_status_rows()
     } else {
         (hint.len() as u16 + 1).max(3)
     };
@@ -422,10 +424,13 @@ pub fn clear_input_hint() {
     if let Ok(mut guard) = STATUS_HINT.lock() {
         guard.clear();
     }
-    if old_sr != 3 {
+    // Shrink back to the notice-aware baseline (3 when no notices), so notices
+    // collected this turn reappear once the command hint is dismissed.
+    let target = notice_status_rows();
+    if old_sr != target {
         let _term = lock_term();
-        STATUS_ROWS.store(3, Ordering::Relaxed);
-        resize_status_area(old_sr, 3);
+        STATUS_ROWS.store(target, Ordering::Relaxed);
+        resize_status_area(old_sr, target);
     }
 }
 

--- a/crates/aura-cli/src/ui/prompt.rs
+++ b/crates/aura-cli/src/ui/prompt.rs
@@ -24,9 +24,9 @@ pub use super::state::{
 // Re-export from status_bar.rs
 pub(crate) use super::status_bar::update_status_bar_unlocked;
 pub use super::status_bar::{
-    add_scratchpad_usage, get_cumulative_tokens, handle_ctrlc, reset_ctrlc_state,
-    reset_status_bar_tokens, seed_status_bar_tokens, set_auto_compact_ceiling, set_status_bar,
-    set_status_bar_tokens, update_status_bar,
+    add_scratchpad_usage, add_turn_notice, clear_turn_notices, get_cumulative_tokens, handle_ctrlc,
+    reset_ctrlc_state, reset_status_bar_tokens, seed_status_bar_tokens, set_auto_compact_ceiling,
+    set_status_bar, set_status_bar_tokens, update_status_bar,
 };
 
 // Re-export from input_frame.rs

--- a/crates/aura-cli/src/ui/state.rs
+++ b/crates/aura-cli/src/ui/state.rs
@@ -45,6 +45,18 @@ pub fn term_size() -> (u16, u16) {
 
 pub(crate) static STATUS_BAR: Mutex<String> = Mutex::new(String::new());
 pub(crate) static STATUS_HINT: Mutex<Vec<String>> = Mutex::new(Vec::new());
+/// Per-turn status notices (pre-styled error/warning lines) shown below the
+/// token line in the status area while the REPL is idle. Populated during a
+/// turn (e.g. from `aura.mcp_status`) and cleared at the start of the next
+/// request. Hidden while a request is processing and while a hint overlay is
+/// active — this is the *persistent* surface that sticks after the turn ends.
+///
+/// For *immediate* visibility during the turn (so the user can react before it
+/// finishes), notices are also printed into the scrollback as `⏺ Error/Warning`
+/// lines when the event arrives — see the `aura.mcp_status` handler in
+/// `repl::loop`. The two surfaces are complementary: scrollback = immediate,
+/// status area = sticky.
+pub(crate) static TURN_NOTICES: Mutex<Vec<String>> = Mutex::new(Vec::new());
 pub(crate) static CUMULATIVE_PROMPT: Mutex<u64> = Mutex::new(0);
 pub(crate) static CUMULATIVE_COMPLETION: Mutex<u64> = Mutex::new(0);
 pub(crate) static CUMULATIVE_SCRATCHPAD_INTERCEPTED: Mutex<u64> = Mutex::new(0);

--- a/crates/aura-cli/src/ui/status_bar.rs
+++ b/crates/aura-cli/src/ui/status_bar.rs
@@ -18,7 +18,7 @@ use super::state::{
     AUTO_COMPACT_CEILING, CTRLC_HINT_VISIBLE, CTRLC_RESET_SKIP, CUMULATIVE_COMPLETION,
     CUMULATIVE_PROMPT, CUMULATIVE_SCRATCHPAD_EXTRACTED, CUMULATIVE_SCRATCHPAD_INTERCEPTED,
     CURSOR_ROW, FRAME_LINES, LAST_CTRLC, PROCESSING, QUEUED_INPUT, QUEUED_WAVE_POS, STATUS_BAR,
-    STATUS_HINT, lock_term, status_rows, term_size,
+    STATUS_HINT, STATUS_ROWS, TURN_NOTICES, lock_term, status_rows, term_size,
 };
 
 /// Format a number with comma separators (e.g. 1234 -> "1,234").
@@ -55,29 +55,107 @@ pub(crate) fn is_hint_active() -> bool {
     STATUS_HINT.lock().map(|g| !g.is_empty()).unwrap_or(false)
 }
 
+/// Whether per-turn notices should currently be shown. Notices are hidden
+/// while a request is processing (the status area shows "esc to stop") and
+/// while a hint overlay is active.
+fn notices_visible() -> bool {
+    !PROCESSING.load(Ordering::Relaxed)
+        && !is_hint_active()
+        && TURN_NOTICES.lock().map(|g| !g.is_empty()).unwrap_or(false)
+}
+
+/// Whether the status lines are already styled (hint overlay or per-turn
+/// notices) and must therefore be printed verbatim rather than re-coloured
+/// `Muted` by the render sites.
+pub(crate) fn status_is_prestyled() -> bool {
+    is_hint_active() || notices_visible()
+}
+
+/// Number of status rows the notices require when idle: token line + a blank
+/// separator + one row per notice + a trailing (reserved) row. Returns the
+/// legacy default of 3 when no notices are visible.
+pub(crate) fn notice_status_rows() -> u16 {
+    let n = if !PROCESSING.load(Ordering::Relaxed) {
+        TURN_NOTICES.lock().map(|g| g.len()).unwrap_or(0)
+    } else {
+        0
+    };
+    if n == 0 { 3 } else { n as u16 + 3 }
+}
+
+/// Desired status-row count given the current hint and notice state. The hint
+/// overlay takes precedence over notices (it replaces the status area).
+pub(crate) fn desired_status_rows() -> u16 {
+    let hint_len = STATUS_HINT.lock().map(|g| g.len()).unwrap_or(0);
+    if hint_len > 0 {
+        return (hint_len as u16 + 1).max(3);
+    }
+    notice_status_rows()
+}
+
 /// Return the lines to display in the status area.
 pub(crate) fn get_effective_status() -> Vec<String> {
     let hint = STATUS_HINT.lock().map(|g| g.clone()).unwrap_or_default();
     if !hint.is_empty() {
         return hint;
     }
-    if PROCESSING.load(Ordering::Relaxed) {
-        return vec!["esc to stop".to_string()];
+
+    let first = if PROCESSING.load(Ordering::Relaxed) {
+        "esc to stop".to_string()
+    } else {
+        let bar = get_status_bar();
+        if !bar.is_empty() {
+            bar
+        } else {
+            "? for help".to_string()
+        }
+    };
+
+    if !notices_visible() {
+        return vec![first];
     }
-    let bar = get_status_bar();
-    if !bar.is_empty() {
-        return vec![bar];
-    }
-    vec!["? for help".to_string()]
+
+    // Notices are present and idle: the whole status area renders verbatim
+    // (status_is_prestyled() is true), so pre-style the leading line as Muted
+    // to match its normal appearance, then a blank separator, then the
+    // already-styled notice lines.
+    let notices = TURN_NOTICES.lock().map(|g| g.clone()).unwrap_or_default();
+    let mut lines = Vec::with_capacity(notices.len() + 2);
+    lines.push(first.themed(AuraStyle::Muted).to_string());
+    lines.push(String::new());
+    lines.extend(notices);
+    lines
 }
 
-/// Print a status line: hints are pre-styled, others get DarkGrey.
-pub(crate) fn print_status_line(line: &str, hint_active: bool) {
-    if hint_active {
+/// Print a status line: pre-styled lines (hints / notices) are emitted as-is,
+/// others get the Muted style.
+pub(crate) fn print_status_line(line: &str, prestyled: bool) {
+    if prestyled {
         print!("{line}");
     } else {
         print!("{}", line.themed(AuraStyle::Muted));
     }
+}
+
+/// Append a per-turn status notice (error/warning) shown below the token line
+/// while idle. The `style` colours the whole line. The notice is data-only
+/// here — it becomes visible the next time the input frame is redrawn (i.e.
+/// once the in-flight request finishes), so this is safe to call mid-stream.
+pub fn add_turn_notice(style: AuraStyle, message: impl AsRef<str>) {
+    let styled = message.as_ref().themed(style).to_string();
+    if let Ok(mut g) = TURN_NOTICES.lock() {
+        g.push(styled);
+    }
+}
+
+/// Clear all per-turn notices and reflow the status area back to its baseline
+/// size. Called at the start of each request, after the previous frame has
+/// already been erased, so a plain store (no in-place reflow) is sufficient.
+pub fn clear_turn_notices() {
+    if let Ok(mut g) = TURN_NOTICES.lock() {
+        g.clear();
+    }
+    STATUS_ROWS.store(notice_status_rows(), Ordering::Relaxed);
 }
 
 /// Update the status bar rows in place (dynamically sized).
@@ -89,7 +167,7 @@ pub fn update_status_bar() {
 /// Inner implementation — caller must already hold `TERM_WRITE`.
 pub(crate) fn update_status_bar_unlocked() {
     let lines = get_effective_status();
-    let hint_active = is_hint_active();
+    let hint_active = status_is_prestyled();
     let queued = QUEUED_INPUT.lock().map(|g| g.clone()).unwrap_or_default();
     let show_queued = PROCESSING.load(Ordering::Relaxed) && !queued.is_empty();
     let sr = status_rows() as usize;

--- a/crates/aura-events/src/event_names.rs
+++ b/crates/aura-events/src/event_names.rs
@@ -5,6 +5,7 @@
 //! namespace.
 
 pub const SESSION_INFO: &str = "aura.session_info";
+pub const MCP_STATUS: &str = "aura.mcp_status";
 pub const TOOL_REQUESTED: &str = "aura.tool_requested";
 pub const TOOL_START: &str = "aura.tool_start";
 pub const TOOL_COMPLETE: &str = "aura.tool_complete";

--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -136,6 +136,35 @@ impl CorrelationContext {
     }
 }
 
+/// Marker the `aura` crate prepends to an HTTP status when an MCP transport
+/// fails (e.g. `"server returned HTTP 404 Not Found"`), surfaced in
+/// [`McpServerStatus::reason`].
+///
+/// Defined here, in the shared wire crate, so the producer (`aura`'s transport
+/// layer) and consumers (the CLI, which condenses the reason for display) match
+/// on a single source of truth rather than duplicated literals. Note the
+/// trailing space — callers format `"{HTTP_STATUS_MARKER}{status}"`.
+pub const HTTP_STATUS_MARKER: &str = "server returned HTTP ";
+
+/// Connection status of a single configured MCP server.
+///
+/// Wire projection of the aura crate's `ConnectionStatus`/`ServerInfo`. Kept as
+/// plain primitives so this lightweight crate stays free of agent/MCP deps.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpServerStatus {
+    /// Configured server name (e.g. "pagerduty").
+    pub server_name: String,
+    /// Transport kind: "http_streamable", "sse", or "stdio".
+    pub transport: String,
+    /// Connection outcome: "connected", "failed", or "not_attempted".
+    pub status: String,
+    /// Number of tools discovered (0 for failed or genuinely empty servers).
+    pub tools_count: usize,
+    /// Failure reason when `status == "failed"`; omitted otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
 /// Worker phase for multi-agent orchestration.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -291,6 +320,17 @@ pub enum AuraStreamEvent {
         #[serde(flatten)]
         correlation: CorrelationContext,
     },
+    /// Emitted at stream start with the connection status of every configured
+    /// MCP server. Lets clients distinguish between "server connected", "server has no tools"
+    /// "server is configured but unavailable", (auth failure, connection refused), etc...
+    ///
+    /// Placed last in the enum: its unique required `servers` field keeps
+    /// `#[serde(untagged)]` deserialization unambiguous regardless of order.
+    McpStatus {
+        servers: Vec<McpServerStatus>,
+        #[serde(flatten)]
+        correlation: CorrelationContext,
+    },
 }
 
 impl AuraStreamEvent {
@@ -307,6 +347,7 @@ impl AuraStreamEvent {
             Self::ToolUsage { .. } => event_names::TOOL_USAGE,
             Self::Usage { .. } => event_names::USAGE,
             Self::ScratchpadUsage { .. } => event_names::SCRATCHPAD_USAGE,
+            Self::McpStatus { .. } => event_names::MCP_STATUS,
         }
     }
 
@@ -468,6 +509,14 @@ impl AuraStreamEvent {
         }
     }
 
+    /// Create an McpStatus event (emitted at stream start).
+    pub fn mcp_status(servers: Vec<McpServerStatus>, correlation: CorrelationContext) -> Self {
+        Self::McpStatus {
+            servers,
+            correlation,
+        }
+    }
+
     /// Create a ScratchpadUsage event.
     pub fn scratchpad_usage(
         tokens_intercepted: usize,
@@ -529,6 +578,49 @@ mod tests {
                 assert_eq!(completion_tokens, 50);
             }
             other => panic!("expected Usage, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn mcp_status_roundtrip_and_event_name() {
+        let event = AuraStreamEvent::mcp_status(
+            vec![
+                McpServerStatus {
+                    server_name: "pagerduty".to_string(),
+                    transport: "http_streamable".to_string(),
+                    status: "failed".to_string(),
+                    tools_count: 0,
+                    reason: Some("authentication failed (401 Unauthorized)".to_string()),
+                },
+                McpServerStatus {
+                    server_name: "mezmo".to_string(),
+                    transport: "http_streamable".to_string(),
+                    status: "connected".to_string(),
+                    tools_count: 7,
+                    reason: None,
+                },
+            ],
+            CorrelationContext::new("s1", None),
+        );
+        assert_eq!(event.event_name(), "aura.mcp_status");
+
+        let sse = event.format_sse();
+        assert!(sse.starts_with("event: aura.mcp_status\n"));
+        // A connected server omits the reason field entirely.
+        assert!(sse.contains("\"status\":\"connected\""));
+        assert!(sse.contains("\"reason\":\"authentication failed (401 Unauthorized)\""));
+
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: AuraStreamEvent = serde_json::from_str(&json).unwrap();
+        match parsed {
+            AuraStreamEvent::McpStatus { servers, .. } => {
+                assert_eq!(servers.len(), 2);
+                assert_eq!(servers[0].server_name, "pagerduty");
+                assert_eq!(servers[0].status, "failed");
+                assert_eq!(servers[1].tools_count, 7);
+                assert_eq!(servers[1].reason, None);
+            }
+            other => panic!("expected McpStatus, got {:?}", other),
         }
     }
 

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -343,6 +343,9 @@ impl AgentExecutor for AuraAgentExecutor {
                     Ok(StreamItem::OrchestratorEvent(_)) => {
                         event!(Level::DEBUG, request_id, "orchestration event");
                     }
+                    Ok(StreamItem::McpStatus(_)) => {
+                        event!(Level::DEBUG, request_id, "mcp status");
+                    }
                     Ok(StreamItem::StreamUserItem(_)) => {
                         event!(Level::DEBUG, request_id, "stream user item");
                     }

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -134,6 +134,24 @@ where
             callbacks.model_name,
             context_limit
         );
+
+        // Emit aura.mcp_status so clients can distinguish degraded/unavailable and available
+        // MCP servers. Skipped when no servers are configured (single-agent without MCP,
+        // orchestrator).
+        let mcp_servers = callbacks.agent.mcp_server_status();
+        if !mcp_servers.is_empty() {
+            let failed = mcp_servers.iter().filter(|s| s.status == "failed").count();
+            let mcp_status = AuraStreamEvent::mcp_status(mcp_servers, ctx.correlation.clone());
+            if tx
+                .send(Ok(Bytes::from(mcp_status.format_sse())))
+                .await
+                .is_err()
+            {
+                tracing::info!("Client disconnected during mcp_status emit");
+                return StreamTermination::Disconnected;
+            }
+            tracing::debug!("Emitted aura.mcp_status: {} failed server(s)", failed);
+        }
     }
 
     // Safety net timeout
@@ -628,6 +646,22 @@ fn handle_stream_item(
                 agent_ctx,
                 ctx.correlation.clone(),
             );
+            vec![Bytes::from(event.format_sse())]
+        }
+        StreamItem::McpStatus(servers) => {
+            // Orchestration emits this mid-stream once its shared McpManager is
+            // built; the single-agent path emits the same event at stream start.
+            // Gated on custom events to match that path.
+            if !config.emit_custom_events {
+                return vec![];
+            }
+
+            let count = servers.len();
+            let failed = servers.iter().filter(|s| s.status == "failed").count();
+            tracing::debug!(
+                "aura.mcp_status (orchestration): {failed} failed server connections for {count} total servers"
+            );
+            let event = AuraStreamEvent::mcp_status(servers.clone(), ctx.correlation.clone());
             vec![Bytes::from(event.format_sse())]
         }
     }

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -1479,6 +1479,13 @@ impl StreamingAgent for Agent {
     fn context_window(&self) -> Option<u64> {
         self.context_window
     }
+
+    fn mcp_server_status(&self) -> Vec<aura_events::McpServerStatus> {
+        self.mcp_manager
+            .as_ref()
+            .map(|m| m.server_status_snapshot())
+            .unwrap_or_default()
+    }
 }
 
 /// Build the appropriate streaming agent based on configuration.

--- a/crates/aura/src/mcp.rs
+++ b/crates/aura/src/mcp.rs
@@ -5,7 +5,7 @@ use rmcp::transport::streamable_http_client::StreamableHttpClient;
 use serde_json::Value;
 use sse_stream::{Sse, SseStream};
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tracing::{debug, info, warn};
 
 /// Simple error type for tool execution
@@ -36,18 +36,48 @@ impl From<&str> for ToolExecutionError {
     }
 }
 
-/// Custom HTTP client that supports Bearer token authentication
+/// Custom HTTP client that captures the underlying HTTP status when a request
+/// fails.
+///
+/// rmcp's streamable-HTTP transport runs in a background worker: when a request
+/// fails (e.g. 404/401), the worker logs the `reqwest` error and closes the
+/// channel, so `serve_client` only sees "channel closed" — the status code is
+/// lost. By implementing `StreamableHttpClient` ourselves we record the status
+/// into `first_error` *at the layer it occurs*, then read it back after the
+/// connection fails to produce a precise reason.
 #[derive(Clone, Default)]
 pub struct CustomHttpClient {
     client: reqwest::Client,
-    auth_token: Option<String>,
+    /// First failing HTTP status observed on this client, if any. Shared across
+    /// clones (the transport worker clones the client) via `Arc`.
+    first_error: Arc<Mutex<Option<String>>>,
 }
 
 impl CustomHttpClient {
-    pub fn new(auth_token: Option<String>) -> Self {
+    /// Wrap an existing `reqwest::Client` (already carrying any forwarded
+    /// headers, including auth) so transport HTTP errors can be captured.
+    pub fn from_reqwest(client: reqwest::Client) -> Self {
         Self {
-            client: reqwest::Client::new(),
-            auth_token,
+            client,
+            first_error: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Shared handle to the first captured failing HTTP status, if any.
+    pub fn first_error(&self) -> Arc<Mutex<Option<String>>> {
+        Arc::clone(&self.first_error)
+    }
+
+    /// Record the first non-success HTTP status seen (first error wins, so the
+    /// root cause isn't overwritten by any follow-on failures).
+    fn record_http_status(&self, status: reqwest::StatusCode) {
+        if status.is_success() {
+            return;
+        }
+        if let Ok(mut guard) = self.first_error.lock()
+            && guard.is_none()
+        {
+            *guard = Some(format!("{}{status}", aura_events::HTTP_STATUS_MARKER));
         }
     }
 }
@@ -60,14 +90,14 @@ impl StreamableHttpClient for CustomHttpClient {
         uri: Arc<str>,
         session_id: Arc<str>,
         last_event_id: Option<String>,
-        _auth_token: Option<String>, // We use our own auth_token field
+        _auth_token: Option<String>, // auth flows through the client's default headers
     ) -> Result<
         BoxStream<'static, Result<Sse, sse_stream::Error>>,
         rmcp::transport::streamable_http_client::StreamableHttpError<Self::Error>,
     > {
         use reqwest::header::ACCEPT;
         use rmcp::transport::common::http_header::{
-            EVENT_STREAM_MIME_TYPE, HEADER_LAST_EVENT_ID, HEADER_SESSION_ID,
+            EVENT_STREAM_MIME_TYPE, HEADER_LAST_EVENT_ID, HEADER_SESSION_ID, JSON_MIME_TYPE,
         };
 
         let mut request_builder = self
@@ -80,25 +110,28 @@ impl StreamableHttpClient for CustomHttpClient {
             request_builder = request_builder.header(HEADER_LAST_EVENT_ID, last_event_id);
         }
 
-        // Add Bearer token authentication if available
-        if let Some(ref auth_header) = self.auth_token {
-            request_builder = request_builder.bearer_auth(auth_header);
-        }
-
         let response = request_builder
             .send()
             .await
             .map_err(rmcp::transport::streamable_http_client::StreamableHttpError::Client)?;
         if response.status() == reqwest::StatusCode::METHOD_NOT_ALLOWED {
+            // Not a failure — the server just doesn't support the SSE GET.
             return Err(rmcp::transport::streamable_http_client::StreamableHttpError::ServerDoesNotSupportSse);
         }
+        self.record_http_status(response.status());
         let response = response
             .error_for_status()
             .map_err(rmcp::transport::streamable_http_client::StreamableHttpError::Client)?;
 
         match response.headers().get(reqwest::header::CONTENT_TYPE) {
             Some(ct) => {
-                if !ct.as_bytes().starts_with(EVENT_STREAM_MIME_TYPE.as_bytes()) {
+                // Accept both `text/event-stream` and `application/json`, matching
+                // rmcp's reference reqwest client — a server may answer the GET
+                // stream with either. Rejecting JSON here would mark an otherwise
+                // healthy server as `Failed`.
+                if !ct.as_bytes().starts_with(EVENT_STREAM_MIME_TYPE.as_bytes())
+                    && !ct.as_bytes().starts_with(JSON_MIME_TYPE.as_bytes())
+                {
                     return Err(rmcp::transport::streamable_http_client::StreamableHttpError::UnexpectedContentType(Some(
                         String::from_utf8_lossy(ct.as_bytes()).to_string(),
                     )));
@@ -117,18 +150,13 @@ impl StreamableHttpClient for CustomHttpClient {
         &self,
         uri: Arc<str>,
         session: Arc<str>,
-        _auth_token: Option<String>, // We use our own auth_token field
+        _auth_token: Option<String>, // auth flows through the client's default headers
     ) -> Result<(), rmcp::transport::streamable_http_client::StreamableHttpError<Self::Error>> {
         use rmcp::transport::common::http_header::HEADER_SESSION_ID;
 
-        let mut request_builder = self.client.delete(uri.as_ref());
-
-        // Add Bearer token authentication if available
-        if let Some(ref auth_header) = self.auth_token {
-            request_builder = request_builder.bearer_auth(auth_header);
-        }
-
-        let response = request_builder
+        let response = self
+            .client
+            .delete(uri.as_ref())
             .header(HEADER_SESSION_ID, session.as_ref())
             .send()
             .await
@@ -147,13 +175,13 @@ impl StreamableHttpClient for CustomHttpClient {
         &self,
         uri: Arc<str>,
         message: rmcp::model::ClientJsonRpcMessage,
-        _session_id: Option<Arc<str>>,
-        _auth_token: Option<String>, // We use our own auth_token field
+        session_id: Option<Arc<str>>,
+        _auth_token: Option<String>, // auth flows through the client's default headers
     ) -> Result<
         rmcp::transport::streamable_http_client::StreamableHttpPostResponse,
         rmcp::transport::streamable_http_client::StreamableHttpError<Self::Error>,
     > {
-        use rmcp::transport::common::http_header::JSON_MIME_TYPE;
+        use rmcp::transport::common::http_header::{HEADER_SESSION_ID, JSON_MIME_TYPE};
 
         let mut request_builder = self
             .client
@@ -162,21 +190,46 @@ impl StreamableHttpClient for CustomHttpClient {
             .header(
                 reqwest::header::ACCEPT,
                 "application/json, text/event-stream",
-            )
-            .json(&message);
+            );
 
-        // Add Bearer token authentication if available
-        if let Some(ref auth_header) = self.auth_token {
-            request_builder = request_builder.bearer_auth(auth_header);
+        // Forward the negotiated session id on every post after `initialize`.
+        // The server returns the id in the initialize response and requires it
+        // on subsequent requests (`notifications/initialized`, tool calls, …);
+        // dropping it makes the server reject them (FastMCP: 400, rmcp: 422),
+        // which the transport worker then collapses into "channel closed".
+        if let Some(session_id) = session_id {
+            request_builder = request_builder.header(HEADER_SESSION_ID, session_id.as_ref());
         }
 
         let response = request_builder
+            .json(&message)
             .send()
             .await
             .map_err(rmcp::transport::streamable_http_client::StreamableHttpError::Client)?;
+        // Capture the status before error_for_status consumes the response — this
+        // is the initialize/JSON-RPC POST, where auth (401) and endpoint (404)
+        // failures surface, and where the transport worker would otherwise hide
+        // them behind a "channel closed" error.
+        let status = response.status();
+        self.record_http_status(status);
         let response = response
             .error_for_status()
             .map_err(rmcp::transport::streamable_http_client::StreamableHttpError::Client)?;
+
+        // A notification/response-less POST (e.g. `notifications/initialized`)
+        // comes back as 202 Accepted / 204 No Content with an empty body. Some
+        // servers (FastMCP) still tag the empty body `application/json`; parsing
+        // it as a JSON-RPC message fails and the worker reports "channel closed".
+        // Short-circuit on these statuses before touching the body, matching
+        // rmcp's reference reqwest client.
+        if matches!(
+            status,
+            reqwest::StatusCode::ACCEPTED | reqwest::StatusCode::NO_CONTENT
+        ) {
+            return Ok(
+                rmcp::transport::streamable_http_client::StreamableHttpPostResponse::Accepted,
+            );
+        }
 
         // Extract session ID from headers before consuming response
         let session_id = response
@@ -185,13 +238,15 @@ impl StreamableHttpClient for CustomHttpClient {
             .and_then(|h| h.to_str().ok())
             .map(|s| s.to_string());
 
-        // Check response content type to determine how to handle it
-        let content_type = response.headers().get(reqwest::header::CONTENT_TYPE);
+        // Snapshot the content type as an owned string before consuming the
+        // response body in the branches below.
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .map(|ct| String::from_utf8_lossy(ct.as_bytes()).to_string());
 
-        if let Some(ct) = content_type {
-            let ct_str = ct.to_str().unwrap_or("");
-            if ct_str.starts_with("application/json") {
-                // Parse JSON response
+        match content_type.as_deref() {
+            Some(ct) if ct.starts_with("application/json") => {
                 let json_text = response.text().await.map_err(
                     rmcp::transport::streamable_http_client::StreamableHttpError::Client,
                 )?;
@@ -199,29 +254,35 @@ impl StreamableHttpClient for CustomHttpClient {
                     serde_json::from_str(&json_text).map_err(
                         rmcp::transport::streamable_http_client::StreamableHttpError::Deserialize,
                     )?;
-
-                return Ok(
+                Ok(
                     rmcp::transport::streamable_http_client::StreamableHttpPostResponse::Json(
                         json_message,
                         session_id,
                     ),
-                );
-            } else if ct_str.starts_with("text/event-stream") {
-                // Handle SSE stream - convert response to stream
+                )
+            }
+            Some(ct) if ct.starts_with("text/event-stream") => {
                 let event_stream =
                     sse_stream::SseStream::from_byte_stream(response.bytes_stream()).boxed();
-
-                return Ok(
+                Ok(
                     rmcp::transport::streamable_http_client::StreamableHttpPostResponse::Sse(
                         event_stream,
                         session_id,
                     ),
-                );
+                )
             }
+            // A 2xx body that is neither JSON nor SSE (or carries no content
+            // type) is unexpected for a JSON-RPC request — the response-less
+            // 202/204 acks are already handled above. Surface it as an error
+            // like rmcp's reference client rather than silently reporting
+            // `Accepted`, which would drop the real response and hang the
+            // request until it times out.
+            other => Err(
+                rmcp::transport::streamable_http_client::StreamableHttpError::UnexpectedContentType(
+                    other.map(|s| s.to_string()),
+                ),
+            ),
         }
-
-        // Fallback to Accepted for other content types
-        Ok(rmcp::transport::streamable_http_client::StreamableHttpPostResponse::Accepted)
     }
 }
 
@@ -247,6 +308,8 @@ pub struct ServerInfo {
     pub description: Option<String>,
     pub tools_count: usize,
     pub status: ConnectionStatus,
+    /// Transport kind for this server: `"http_streamable"`, `"sse"`, or `"stdio"`.
+    pub transport: String,
 }
 
 #[derive(Debug, Clone)]
@@ -293,6 +356,7 @@ impl McpManager {
         for (server_name, server_config) in &mcp_config.servers {
             info!("Connecting to MCP server: {}", server_name);
 
+            let transport = Self::transport_label(server_config).to_string();
             match manager
                 .connect_and_discover_tools(server_name, server_config)
                 .await
@@ -305,6 +369,7 @@ impl McpManager {
                             description: manager.get_server_description(server_config),
                             tools_count,
                             status: ConnectionStatus::Connected,
+                            transport,
                         },
                     );
                     info!(
@@ -321,6 +386,7 @@ impl McpManager {
                             description: manager.get_server_description(server_config),
                             tools_count: 0,
                             status: ConnectionStatus::Failed(error_msg.clone()),
+                            transport,
                         },
                     );
                     warn!("{} - {}", server_name, error_msg);
@@ -396,17 +462,20 @@ impl McpManager {
                 Ok(tools_count)
             }
             Err(e) => {
-                // Check if this is an authentication error
+                // Auth failures get a clearer, actionable message. Every other
+                // failure (connection refused, timeout, closed transport,
+                // unexpected content type, non-401 HTTP status, tool-discovery
+                // errors) bubbles up as an error so the server is recorded as
+                // `Failed`. A genuine empty server is represented by `Ok(0)`
+                // only after `discover_tools()` succeeds with an empty tool list.
                 if e.to_string().contains("401 Unauthorized")
                     || e.to_string().contains("HTTP status client error (401")
                 {
                     Err(BuilderError::McpInitError(format!(
-                        "HTTP MCP server '{server_name}' authentication failed (401 Unauthorized). Check that your forwarded headers and credentials are correct."
+                        "HTTP MCP server '{server_name}' authentication failed (401 Unauthorized). Check that your headers, forwarded headers, and/or credentials are correct."
                     )))
                 } else {
-                    warn!("  HTTP Streamable MCP connection failed: {}", e);
-                    // Continue without this server for now
-                    Ok(0)
+                    Err(e)
                 }
             }
         }
@@ -426,12 +495,14 @@ impl McpManager {
             info!("  Forwarding {} headers to MCP client", headers.len());
         }
 
-        // Use McpClient
+        // Use McpClient. Render with `{e:#}` so anyhow's full cause chain (e.g.
+        // the captured HTTP status → transport error) is included, not just the
+        // outermost context.
         let client = McpClient::new(url.to_string(), headers)
             .await
             .map_err(|e| {
                 BuilderError::McpInitError(format!(
-                    "Failed to connect to HTTP MCP server '{server_name}': {e}"
+                    "Failed to connect to HTTP MCP server '{server_name}': {e:#}"
                 ))
             })?;
 
@@ -444,7 +515,7 @@ impl McpManager {
         info!("  🔍 Discovering tools from server '{}'...", server_name);
         let tools = client.discover_tools().await.map_err(|e| {
             BuilderError::McpInitError(format!(
-                "Failed to discover tools from server '{server_name}': {e}"
+                "Failed to discover tools from server '{server_name}': {e:#}"
             ))
         })?;
 
@@ -488,11 +559,11 @@ impl McpManager {
                     || e.to_string().contains("HTTP status client error (401")
                 {
                     Err(BuilderError::McpInitError(format!(
-                        "SSE MCP server '{server_name}' authentication failed (401 Unauthorized). Check that your forwarded headers and credentials are correct."
+                        "SSE MCP server '{server_name}' authentication failed (401 Unauthorized). Check that your headers, forwarded headers, and/or credentials are correct."
                     )))
                 } else {
-                    warn!("  SSE MCP connection failed: {}", e);
-                    Ok(0)
+                    // Bubble the failure so the server is recorded as `Failed`.
+                    Err(e)
                 }
             }
         }
@@ -515,7 +586,7 @@ impl McpManager {
             .await
             .map_err(|e| {
                 BuilderError::McpInitError(format!(
-                    "Failed to establish SSE MCP connection to '{server_name}': {e}"
+                    "Failed to establish SSE MCP connection to '{server_name}': {e:#}"
                 ))
             })?;
 
@@ -523,7 +594,7 @@ impl McpManager {
 
         let tools = client.discover_tools().await.map_err(|e| {
             BuilderError::McpInitError(format!(
-                "Failed to discover tools from SSE server '{server_name}': {e}"
+                "Failed to discover tools from SSE server '{server_name}': {e:#}"
             ))
         })?;
 
@@ -560,8 +631,8 @@ impl McpManager {
             }
             Err(e) => {
                 warn!("  STDIO MCP connection failed: {}", e);
-                // Continue without this server
-                Ok(0)
+                // Bubble the failure so the server is recorded as `Failed`.
+                Err(e)
             }
         }
     }
@@ -821,6 +892,45 @@ impl McpManager {
             | McpServerConfig::Sse { description, .. }
             | McpServerConfig::Stdio { description, .. } => description.clone(),
         }
+    }
+
+    /// Stable transport label for a server config (used in status reporting).
+    fn transport_label(server_config: &McpServerConfig) -> &'static str {
+        match server_config {
+            McpServerConfig::HttpStreamable { .. } => "http_streamable",
+            McpServerConfig::Sse { .. } => "sse",
+            McpServerConfig::Stdio { .. } => "stdio",
+        }
+    }
+
+    /// Project the per-server connection state into wire-friendly status
+    /// records for the `aura.mcp_status` SSE event.
+    ///
+    /// This is a thin projection of `server_info` — the same state that drives
+    /// `log_summary()` — so degraded servers surface to the user with the same
+    /// reason string recorded at connection time. Sorted by server name for
+    /// deterministic output (the underlying map is unordered).
+    pub fn server_status_snapshot(&self) -> Vec<aura_events::McpServerStatus> {
+        let mut statuses: Vec<aura_events::McpServerStatus> = self
+            .server_info
+            .values()
+            .map(|info| {
+                let (status, reason) = match &info.status {
+                    ConnectionStatus::Connected => ("connected", None),
+                    ConnectionStatus::Failed(reason) => ("failed", Some(reason.clone())),
+                    ConnectionStatus::NotAttempted => ("not_attempted", None),
+                };
+                aura_events::McpServerStatus {
+                    server_name: info.name.clone(),
+                    transport: info.transport.clone(),
+                    status: status.to_string(),
+                    tools_count: info.tools_count,
+                    reason,
+                }
+            })
+            .collect();
+        statuses.sort_by(|a, b| a.server_name.cmp(&b.server_name));
+        statuses
     }
 
     /// Log the summary of MCP connections and tools
@@ -1468,8 +1578,234 @@ impl RigTool for FallbackHttpMcpTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{McpConfig, McpServerConfig};
     use serde_json::json;
     use std::collections::HashMap;
+
+    // ========================================
+    // Connection Status Tests
+    // ========================================
+
+    /// An unreachable HTTP-streamable server must be recorded as `Failed`, not
+    /// as a connected zero-tool server. This is the regression guard for the
+    /// bug where transport failures were swallowed into `Ok(0)` and logged as
+    /// "Connected successfully, 0 tools discovered".
+    #[tokio::test]
+    async fn unreachable_http_server_is_recorded_as_failed() {
+        let mut servers = HashMap::new();
+        servers.insert(
+            "pagerduty".to_string(),
+            McpServerConfig::HttpStreamable {
+                // Port 1 on loopback refuses connections immediately, so this
+                // exercises the transport/connection-error path deterministically.
+                url: "http://127.0.0.1:1/mcp".to_string(),
+                headers: HashMap::new(),
+                description: None,
+                headers_from_request: HashMap::new(),
+                scratchpad: HashMap::new(),
+            },
+        );
+        let config = McpConfig {
+            sanitize_schemas: true,
+            servers,
+        };
+
+        let manager = McpManager::initialize_from_config(&config)
+            .await
+            .expect("initialize_from_config should succeed even when a server fails");
+
+        let info = manager
+            .server_info
+            .get("pagerduty")
+            .expect("pagerduty server_info should be present");
+        assert!(
+            matches!(info.status, ConnectionStatus::Failed(_)),
+            "unreachable server should be Failed, got {:?}",
+            info.status
+        );
+        assert_eq!(info.tools_count, 0);
+        assert_eq!(info.transport, "http_streamable");
+
+        // The status snapshot (what the aura.mcp_status event projects) must
+        // surface the failure with a reason, distinct from an empty server.
+        let snapshot = manager.server_status_snapshot();
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].server_name, "pagerduty");
+        assert_eq!(snapshot[0].status, "failed");
+        assert_eq!(snapshot[0].transport, "http_streamable");
+        assert!(
+            snapshot[0].reason.is_some(),
+            "failed server should carry a reason"
+        );
+    }
+
+    /// `post_message` must (a) forward the negotiated `mcp-session-id` header on
+    /// every post after `initialize`, and (b) treat a `202 Accepted` /
+    /// `204 No Content` response as `Accepted` *without* parsing the (empty)
+    /// body — even when the server tags that empty body `application/json`
+    /// (FastMCP does).
+    ///
+    /// Both are regression guards for the `notifications/initialized` post:
+    /// dropping the session id makes the server reject it (FastMCP 400, rmcp
+    /// 422); parsing the empty 202 body as JSON-RPC fails to deserialize. Either
+    /// bug collapses into a generic "channel closed" and the whole server is
+    /// recorded as `Failed`, so no tools are available.
+    #[tokio::test]
+    async fn post_message_forwards_session_id_and_accepts_empty_202() {
+        use std::sync::{Arc, Mutex};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Capture the raw request bytes the server received so the test can
+        // assert the session-id header was actually sent on the wire.
+        let seen_request = Arc::new(Mutex::new(String::new()));
+        let seen_for_server = Arc::clone(&seen_request);
+
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let n = sock.read(&mut buf).await.unwrap();
+            *seen_for_server.lock().unwrap() = String::from_utf8_lossy(&buf[..n]).to_string();
+            // FastMCP-style ack: 202 Accepted, application/json content-type,
+            // and an empty body.
+            sock.write_all(
+                b"HTTP/1.1 202 Accepted\r\ncontent-type: application/json\r\ncontent-length: 0\r\n\r\n",
+            )
+            .await
+            .unwrap();
+            let _ = sock.flush().await;
+        });
+
+        let client = CustomHttpClient::from_reqwest(reqwest::Client::new());
+        let uri: Arc<str> = format!("http://{addr}/mcp").into();
+        let message: rmcp::model::ClientJsonRpcMessage = serde_json::from_value(
+            json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        )
+        .unwrap();
+        let session: Arc<str> = "test-session-abc123".into();
+
+        let result = client
+            .post_message(uri, message, Some(Arc::clone(&session)), None)
+            .await;
+
+        server.await.unwrap();
+
+        // (b) Empty 202 → Accepted, not a deserialize error.
+        assert!(
+            matches!(
+                result,
+                Ok(rmcp::transport::streamable_http_client::StreamableHttpPostResponse::Accepted)
+            ),
+            "empty 202 should yield Accepted, got {result:?}"
+        );
+
+        // (a) The session id was forwarded as the mcp-session-id header.
+        let request = seen_request.lock().unwrap();
+        let lowered = request.to_lowercase();
+        assert!(
+            lowered.contains("mcp-session-id: test-session-abc123"),
+            "post_message must forward the session id header; request was:\n{request}"
+        );
+    }
+
+    /// A server that responds with an HTTP error status must surface that
+    /// status in the failure reason — not the generic "Failed to establish MCP
+    /// client connection". Guards the `CustomHttpClient` status-capture path
+    /// (Level 2a): rmcp's transport worker would otherwise hide the 404 behind
+    /// a "channel closed" error.
+    #[tokio::test]
+    async fn http_error_status_surfaces_in_reason() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Minimal server: reply 404 to every request, then close. Loops so the
+        // transport worker sees a 404 on whatever request it makes first.
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut buf = [0u8; 2048];
+                let _ = sock.read(&mut buf).await;
+                let _ = sock
+                    .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+                    .await;
+                let _ = sock.flush().await;
+            }
+        });
+
+        let mut servers = HashMap::new();
+        servers.insert(
+            "ghost".to_string(),
+            McpServerConfig::HttpStreamable {
+                url: format!("http://{addr}/mcp"),
+                headers: HashMap::new(),
+                description: None,
+                headers_from_request: HashMap::new(),
+                scratchpad: HashMap::new(),
+            },
+        );
+        let config = McpConfig {
+            sanitize_schemas: true,
+            servers,
+        };
+
+        let manager = McpManager::initialize_from_config(&config).await.unwrap();
+        server.abort();
+
+        let info = manager.server_info.get("ghost").unwrap();
+        let reason = match &info.status {
+            ConnectionStatus::Failed(reason) => reason.clone(),
+            other => panic!("expected Failed, got {other:?}"),
+        };
+        assert!(
+            reason.contains("404"),
+            "reason should include the HTTP status code, got: {reason}"
+        );
+    }
+
+    /// A connected server with no tools projects as `connected` (status), not
+    /// `failed` — the distinction the issue asks us to preserve.
+    #[test]
+    fn snapshot_distinguishes_connected_empty_from_failed() {
+        let mut manager = McpManager::with_sanitization(true);
+        manager.server_info.insert(
+            "empty".to_string(),
+            ServerInfo {
+                name: "empty".to_string(),
+                description: None,
+                tools_count: 0,
+                status: ConnectionStatus::Connected,
+                transport: "http_streamable".to_string(),
+            },
+        );
+        manager.server_info.insert(
+            "down".to_string(),
+            ServerInfo {
+                name: "down".to_string(),
+                description: None,
+                tools_count: 0,
+                status: ConnectionStatus::Failed("connection refused".to_string()),
+                transport: "sse".to_string(),
+            },
+        );
+
+        let snapshot = manager.server_status_snapshot();
+        // Sorted by name: "down", then "empty".
+        assert_eq!(snapshot[0].server_name, "down");
+        assert_eq!(snapshot[0].status, "failed");
+        assert_eq!(snapshot[0].reason.as_deref(), Some("connection refused"));
+        assert_eq!(snapshot[1].server_name, "empty");
+        assert_eq!(snapshot[1].status, "connected");
+        assert_eq!(snapshot[1].tools_count, 0);
+        assert_eq!(snapshot[1].reason, None);
+    }
 
     // ========================================
     // Tool Conversion Tests

--- a/crates/aura/src/mcp_streamable_http.rs
+++ b/crates/aura/src/mcp_streamable_http.rs
@@ -150,15 +150,31 @@ impl McpClient {
             .build()
             .context("Failed to build HTTP client")?;
 
+        // Use our own StreamableHttpClient so a failing HTTP status (404/401/…)
+        // is captured at the transport layer. rmcp's worker otherwise collapses
+        // it into a generic "channel closed", losing the actionable detail.
+        let custom_client = crate::mcp::CustomHttpClient::from_reqwest(http_client);
+        let captured_status = custom_client.first_error();
+
         let transport = StreamableHttpClientTransport::with_client(
-            http_client,
+            custom_client,
             StreamableHttpClientTransportConfig {
                 uri: server_url.clone().into(),
                 ..Default::default()
             },
         );
 
-        let client = Self::from_transport(transport, server_url.clone()).await?;
+        let client = match Self::from_transport(transport, server_url.clone()).await {
+            Ok(client) => client,
+            Err(e) => {
+                // Surface the real HTTP status when the transport captured one,
+                // as the outermost context so it leads the rendered chain.
+                if let Some(status) = captured_status.lock().ok().and_then(|mut g| g.take()) {
+                    return Err(e.context(status));
+                }
+                return Err(e);
+            }
+        };
 
         info!(
             "Successfully established streamable HTTP MCP client: {}",

--- a/crates/aura/src/orchestration/factory.rs
+++ b/crates/aura/src/orchestration/factory.rs
@@ -76,9 +76,16 @@ impl OrchestratorFactory {
                 // are visible to the streaming handler (UsageState is Arc-backed).
                 orchestrator.usage_state = usage_state;
 
-                // Set MCP request ID for progress notification routing
+                // Set MCP request ID for progress notification routing, and
+                // surface per-server connection status so degraded/unavailable
+                // MCP servers are visible in orchestration mode too (workers
+                // share this one manager).
                 if let Some(ref mcp_manager) = orchestrator.mcp_manager {
                     mcp_manager.set_current_request(&request_id).await;
+                    let snapshot = mcp_manager.server_status_snapshot();
+                    if !snapshot.is_empty() {
+                        let _ = event_tx.send(Ok(StreamItem::McpStatus(snapshot))).await;
+                    }
                 }
 
                 // Forward tool call events from workers to SSE stream

--- a/crates/aura/src/provider_agent.rs
+++ b/crates/aura/src/provider_agent.rs
@@ -400,6 +400,14 @@ pub enum StreamItem {
         /// Tokens extracted from scratchpad back into context.
         tokens_extracted: usize,
     },
+    /// MCP server connection status snapshot.
+    ///
+    /// Emitted once near the start of an orchestration run (after the shared
+    /// `McpManager` is initialized) so clients can see degraded/unavailable
+    /// servers. The web server handler converts this to an `aura.mcp_status`
+    /// SSE event — the same event single-agent mode emits at stream start —
+    /// filling in correlation context from the request.
+    McpStatus(Vec<aura_events::McpServerStatus>),
 }
 
 /// Final response information.

--- a/crates/aura/src/stream_events.rs
+++ b/crates/aura/src/stream_events.rs
@@ -6,8 +6,8 @@
 
 // Re-export everything from aura-events so existing consumers don't break
 pub use aura_events::{
-    AgentContext, AuraStreamEvent, CorrelationContext, NumberOrString, ProgressToken, WorkerPhase,
-    format_named_sse,
+    AgentContext, AuraStreamEvent, CorrelationContext, McpServerStatus, NumberOrString,
+    ProgressToken, WorkerPhase, format_named_sse,
 };
 
 // Re-export orchestration event types

--- a/crates/aura/src/streaming.rs
+++ b/crates/aura/src/streaming.rs
@@ -130,6 +130,16 @@ pub trait StreamingAgent: Send + Sync {
         None
     }
 
+    /// Snapshot the connection status of every configured MCP server.
+    ///
+    /// Used by the streaming handler to emit an `aura.mcp_status` event at
+    /// stream start so clients can distinguish degraded/unavailable/available servers.
+    /// Defaults to empty (no MCP servers, or an implementor without MCP — e.g. the orchestrator,
+    /// whose workers own their own managers).
+    fn mcp_server_status(&self) -> Vec<aura_events::McpServerStatus> {
+        Vec::new()
+    }
+
     /// Whether this agent is an orchestrator (emits per-phase LLM spans).
     ///
     /// Returned `true` by the multi-agent `OrchestratorFactory`. The web-server

--- a/docs/streaming-api-guide.md
+++ b/docs/streaming-api-guide.md
@@ -67,6 +67,7 @@ AURA_CUSTOM_EVENTS=true cargo run --bin aura-web-server
 | `aura.reasoning` | LLM reasoning content (requires `AURA_EMIT_REASONING=true`) | ✅ Implemented |
 | `aura.progress` | MCP progress notifications during long-running tools | ✅ Implemented |
 | `aura.session_info` | Session metadata (model, context window) emitted at stream start | ✅ Implemented |
+| `aura.mcp_status` | Per-server MCP connection status emitted at stream start (connected/failed/not_attempted, with failure reason) | ✅ Implemented |
 | `aura.worker_phase` | Worker phase transitions in multi-agent mode (planning/executing/analyzing) | ✅ Implemented |
 | `aura.tool_usage` | Usage snapshot after tool execution (associates tool IDs with token counts) | ✅ Implemented |
 | `aura.usage` | Final token usage emitted at stream end (prompt/completion/total) | ✅ Implemented |
@@ -214,6 +215,36 @@ data:
 ```
 
 Note: `aura.session_info` includes only `CorrelationContext` fields (`session_id`, `trace_id`) — no `agent_id`. `model_context_limit` comes from the `context_window` field in the `[agent.llm]` TOML config section (or `[orchestration.worker.<name>.llm]` for per-worker overrides). If `context_window` is not set, `model_context_limit` is omitted from the event.
+
+**MCP status** (emitted once when at least one MCP server is configured — at stream start in single-agent mode, or just after the shared manager connects in orchestration mode):
+```
+event: aura.mcp_status
+data:
+```
+```json
+{
+  "servers": [
+    {
+      "server_name": "mezmo",
+      "transport": "http_streamable",
+      "status": "connected",
+      "tools_count": 7
+    },
+    {
+      "server_name": "pagerduty",
+      "transport": "http_streamable",
+      "status": "failed",
+      "tools_count": 0,
+      "reason": "Connection failed: HTTP MCP server 'pagerduty' authentication failed (401 Unauthorized). Check that your headers, forwarded headers. and/or credentials are correct."
+    }
+  ],
+  "session_id": "sess_xyz"
+}
+```
+
+Note: `status` is one of `connected`, `failed`, or `not_attempted`. This lets a client distinguish a server that is configured but unavailable (`failed`, with a `reason`) from one that connected and legitimately exposes no tools (`connected`, `tools_count: 0`). `reason` is present only for failed servers. The event is omitted entirely when no servers are configured. `aura.mcp_status` includes only `CorrelationContext` fields (`session_id`, `trace_id`) — no `agent_id`.
+
+In orchestration mode all workers share a single `McpManager`, so one `aura.mcp_status` reports the whole run's server status. The wire shape is identical to single-agent mode; it just arrives slightly later (after the manager connects, before planning) rather than at stream start. Requires `AURA_CUSTOM_EVENTS=true` in both modes.
 
 **Worker phase** (phase transitions in multi-agent mode):
 ```


### PR DESCRIPTION
MCP connection failures were swallowed as Ok(0) and logged as "Connected successfully, 0 tools discovered", hiding degraded servers.

- mcp: bubble transport/discovery errors instead of Ok(0); record per-server status (Connected/Failed/NotAttempted) with reason
- capture the real HTTP status (404/401) in CustomHttpClient so the reason is precise, not a generic "channel closed"
- render the full anyhow cause chain ({e:#}) for richer reasons
- events: add aura.mcp_status SSE event projecting server status; emit at stream start (single-agent) and after the shared manager connects (orchestration, via StreamItem::McpStatus)
- cli: show failed/empty servers in a persistent status section and immediately in scrollback (themed ⏺ Error/Warning); condense verbose HTTP chains to "HTTP MCP server 'x': 404 Not Found"; warn on stderr in one-shot mode
- tests + streaming-api-guide docs

Ref: GH-154