### PR TITLE
fix(make): wire test target to cargo test

### DIFF
--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -1,6 +1,7 @@
 lint:: lint-rust fmt-rust
 clean:: clean-rust clean-node clean-report
 build:: build-rust
+test:: test-rust
 
 CARGO_BIN_DIR ?= .bin
 NEXTEST_BIN = $(CARGO_BIN_DIR)/cargo-nextest
@@ -18,6 +19,10 @@ $(REPORT_DIR):
 .PHONY:build-rust
 build-rust: $(DOCKER_ENV) ## Build all rust targets
 	$(RUN) cargo build --workspace $(if $(AURA_RELEASE),--release,) $(if $(IS_CI),--quiet,)
+
+.PHONY:test-rust
+test-rust: $(DOCKER_ENV) ## Run unit tests across the workspace
+	$(RUN) cargo test --workspace $(if $(IS_CI),--quiet,)
 
 .PHONY:coverage
 coverage: $(DOCKER_ENV) $(REPORT_DIR) $(GRCOV_BIN) ## Run the local test suite with code coverage


### PR DESCRIPTION
## What

`make test` was declared in the Makefile (`test::`, help text "Run all tests targets") but no `.makefiles/*.mk` module contributed to the double-colon target — it exited 0 without running a single test. Since `make ci` chains `fmt-check test lint`, its test leg was also a silent no-op.

This adds a `test-rust` target to `.makefiles/rust.mk` and hooks it into `test::`, following the existing module pattern (`lint:: lint-rust`, `build:: build-rust`):

```makefile
test:: test-rust

.PHONY:test-rust
test-rust: $(DOCKER_ENV) ## Run unit tests across the workspace
	$(RUN) cargo test --workspace $(if $(IS_CI),--quiet,)
```

## Why this command

- `cargo test --workspace` is exactly what CONTRIBUTING.md documents as the local test command, so `make test` and the documented manual flow now agree.
- Integration tests are feature-gated behind `--features integration`, so this stays safe on a fresh clone with no Docker or API keys.
- The existing `nextest` target is deliberately **not** wired in: it compiles with `--features integration` and expects the compose infrastructure that `make test-integration-local` provides.

## Testing

- `make -n test` resolves to `cargo test --workspace`
- `make test` runs the full workspace unit suite and passes (exit 0)