### PR TITLE
docs(readme): add slack, license, rust, and mcp badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # AURA
 
+[![Slack](https://img.shields.io/badge/Slack-Join%20the%20community-4A154B?logo=slack&logoColor=white)](https://mezmo.com/r/slack-aura)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue)](LICENSE)
+[![Rust](https://img.shields.io/badge/Rust-1.85%2B-orange?logo=rust)](https://www.rust-lang.org)
+[![MCP](https://img.shields.io/badge/MCP-compatible-green)](https://modelcontextprotocol.io)
+
 AURA is an agentic harness that turns an LLM model into a reliable, autonomous service capable of executing real SRE work. AURA provides the guardrails, API servers, state management, authentication, streaming, error handling, and tool integrations necessary to run AI SRE agents safely in production.
 
 Key capabilities:


### PR DESCRIPTION
Adds a row of badges below the README title: a Slack community invite (https://mezmo.com/r/slack-aura), the Apache-2.0 license, the minimum Rust version, and MCP compatibility. Documentation-only change with no code impact.