### PR TITLE
refactor: consolidate slash-command handling into one registry

### DIFF
--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -21,11 +21,12 @@ use crate::repl::commands;
 use crate::repl::conversations::ConversationStore;
 use crate::repl::history::ConversationHistory;
 use crate::repl::input_reader::{self, HISTORY_COUNT, HISTORY_DEPTH, LAST_READLINE_INPUT};
+use crate::repl::registry::{self, CommandContext, CommandOutcome};
 use crate::tools;
 use crate::ui::markdown::render_markdown;
 use crate::ui::prompt::{
-    PendingCommand, WaveAnimation, cleanup_terminal, clear_display_events, clear_input_hint,
-    drain_stdin, erase_input_frame, extend_display_events, frame_lines, get_cumulative_tokens,
+    WaveAnimation, cleanup_terminal, clear_display_events, clear_input_hint, drain_stdin,
+    erase_input_frame, extend_display_events, frame_lines, get_cumulative_tokens,
     get_selected_model, handle_ctrlc, install_sigint_handler, is_expanded_output,
     last_mid_stream_history_entry, load_and_restore_sse_events, lock_term,
     overwrite_orch_task_header_unlocked, prepare_input_line, print_fields_tree,
@@ -625,62 +626,27 @@ pub fn run_repl(
                     reset_input_geometry();
                 }
 
-                if input == "/quit" || input == "/exit" {
-                    // Save before exiting, or delete if conversation was never started
-                    if let Some(ref store) = conv_store {
-                        if conversation.messages().len() > 1 {
-                            with_event_log(|log| {
-                                store.save_all(conversation.messages(), log, is_expanded_output())
-                            });
-                        } else {
-                            store.delete();
+                if input.starts_with('/') {
+                    let mut ctx = CommandContext {
+                        conversation: &mut conversation,
+                        conv_store: &mut conv_store,
+                        input_reader: &mut input_reader,
+                    };
+                    match registry::dispatch(&input, &mut ctx) {
+                        Some(CommandOutcome::Exit) => break,
+                        Some(CommandOutcome::Reinject(new_input)) => {
+                            initial_input = new_input;
+                            continue;
+                        }
+                        Some(CommandOutcome::Handled) => continue,
+                        None => {
+                            // Unknown command — don't send to API
+                            println!("Unknown command: {}", input);
+                            println!("Type /help for available commands.");
+                            redraw_input_frame();
+                            continue;
                         }
                     }
-                    break;
-                } else if input == "/clear" {
-                    commands::handle_clear(&mut conversation, &mut conv_store, &mut input_reader);
-                    continue;
-                } else if input == "/help" {
-                    commands::handle_help();
-                    continue;
-                } else if input == "/expand" {
-                    commands::handle_expand(&conversation, &conv_store);
-                    continue;
-                } else if input == "/stream" {
-                    commands::handle_stream();
-                    continue;
-                } else if input == "/conversations" {
-                    commands::handle_conversations();
-                    continue;
-                } else if let Some(arg) = input.strip_prefix("/rename") {
-                    commands::handle_rename(arg.trim(), &conv_store);
-                    continue;
-                } else if let Some(arg) = input.strip_prefix("/resume") {
-                    // In-REPL resume ignores CLI --model and --system-prompt;
-                    // uses whatever the resumed conversation had saved.
-                    if let Some(new_input) = commands::handle_resume(
-                        arg.trim(),
-                        &mut conversation,
-                        &mut conv_store,
-                        &mut input_reader,
-                        None,
-                    ) {
-                        initial_input = new_input;
-                    }
-                    continue;
-                } else if let Some(filter) = input.strip_prefix("/model") {
-                    let filter = filter.trim();
-                    commands::handle_model(filter, &conv_store);
-                    continue;
-                } else if let Some(arg) = input.strip_prefix("/style") {
-                    commands::handle_style(arg.trim());
-                    continue;
-                } else if input.starts_with('/') {
-                    // Unknown command — don't send to API
-                    println!("Unknown command: {}", input);
-                    println!("Type /help for available commands.");
-                    redraw_input_frame();
-                    continue;
                 }
 
                 // Append compaction hint to user message if pending
@@ -1725,54 +1691,21 @@ pub fn run_repl(
                 // Done processing — restore status bar to token counts / default
                 set_processing(false);
 
-                // Check for pending commands set by mid-stream slash commands
-                if let Some(cmd) = take_pending_command() {
-                    match cmd {
-                        PendingCommand::Quit => {
-                            // Save before exiting, or delete if conversation was never started
-                            if let Some(ref store) = conv_store {
-                                if conversation.messages().len() > 1 {
-                                    with_event_log(|log| {
-                                        store.save_all(
-                                            conversation.messages(),
-                                            log,
-                                            is_expanded_output(),
-                                        )
-                                    });
-                                } else {
-                                    store.delete();
-                                }
-                            }
-                            break;
-                        }
-                        PendingCommand::Clear => {
-                            commands::handle_clear(
-                                &mut conversation,
-                                &mut conv_store,
-                                &mut input_reader,
-                            );
+                // Run any command deferred from mid-stream input through the
+                // same registry dispatch the prompt uses.
+                if let Some(pending) = take_pending_command() {
+                    let mut ctx = CommandContext {
+                        conversation: &mut conversation,
+                        conv_store: &mut conv_store,
+                        input_reader: &mut input_reader,
+                    };
+                    match (pending.command.handler)(&mut ctx, &pending.args) {
+                        CommandOutcome::Exit => break,
+                        CommandOutcome::Reinject(new_input) => {
+                            initial_input = new_input;
                             continue;
                         }
-                        PendingCommand::Resume(filter) => {
-                            let arg = filter.trim();
-                            if arg.is_empty() {
-                                // No argument — just continue normally
-                                redraw_input_frame();
-                                continue;
-                            }
-                            // In-REPL resume ignores CLI --model and --system-prompt
-                            if let Some(new_input) = commands::handle_resume(
-                                arg,
-                                &mut conversation,
-                                &mut conv_store,
-                                &mut input_reader,
-                                None,
-                            ) {
-                                initial_input = new_input;
-                            }
-                            redraw_input_frame();
-                            continue;
-                        }
+                        CommandOutcome::Handled => continue,
                     }
                 }
 

--- a/crates/aura-cli/src/repl/mod.rs
+++ b/crates/aura-cli/src/repl/mod.rs
@@ -3,3 +3,4 @@ pub mod conversations;
 pub mod history;
 pub mod input_reader;
 pub mod r#loop;
+pub mod registry;

--- a/crates/aura-cli/src/repl/registry.rs
+++ b/crates/aura-cli/src/repl/registry.rs
@@ -1,0 +1,364 @@
+//! Slash-command registry. [`COMMANDS`] is the list of REPL commands that
+//! dispatch (`repl/loop.rs`), Enter-validation (`ui/input_hint.rs`), `/help`
+//! (`ui/event_replay.rs`), and autocomplete all read from.
+//!
+//! Each [`Command`] carries its name, help text, a [`CommandFn`] handler, and
+//! an optional submission gate. A handler takes a [`CommandContext`] and the
+//! argument string and returns a [`CommandOutcome`] directing the REPL loop.
+
+use rustyline::Editor;
+use rustyline::history::DefaultHistory;
+
+use super::commands;
+use super::conversations::ConversationStore;
+use super::history::ConversationHistory;
+use super::input_reader::AuraHelper;
+use crate::ui::prompt::{is_expanded_output, with_event_log};
+use crate::ui::state::{MODEL_MATCHES, RESUME_MATCHES, STYLE_MATCHES, get_tab_select_index};
+
+/// Mutable per-session state passed to each command handler.
+pub(crate) struct CommandContext<'a> {
+    pub conversation: &'a mut ConversationHistory,
+    pub conv_store: &'a mut Option<ConversationStore>,
+    pub input_reader: &'a mut Editor<AuraHelper, DefaultHistory>,
+}
+
+/// What the REPL loop should do after a command handler returns.
+pub(crate) enum CommandOutcome {
+    /// Command handled itself (drew its own output); read the next input.
+    Handled,
+    /// Pre-fill the next readline with this text (e.g. a resumed
+    /// conversation's pending input).
+    Reinject(String),
+    /// Tear down and leave the REPL loop.
+    Exit,
+}
+
+/// A command resolved against [`COMMANDS`], paired with its argument string,
+/// ready to run without re-parsing. Used to hand a command typed mid-stream to
+/// the main loop, where the full session state needed to run it is available.
+pub(crate) struct PendingCommand {
+    pub command: &'static Command,
+    pub args: String,
+}
+
+/// Uniform handler signature. `args` is the trimmed remainder after the
+/// (resolved) command word.
+pub(crate) type CommandFn = fn(&mut CommandContext, &str) -> CommandOutcome;
+
+/// Optional per-command Enter-submission gate. Receives the resolved, trimmed
+/// input line. Returns `false` to keep rustyline from submitting (e.g. an
+/// ambiguous `/resume` filter). Commands without a gate are always
+/// submittable.
+pub(crate) type ValidateFn = fn(&str) -> bool;
+
+/// How a command behaves when typed while a response is streaming.
+pub(crate) enum MidStream {
+    /// Run immediately without interrupting the stream. The handler receives
+    /// the post-command argument string and touches only global display state.
+    Live(fn(&str)),
+    /// Cancel the stream and re-run the command line in the main loop, where
+    /// the full session state (and `handler`) is available.
+    Defer,
+}
+
+/// A single REPL slash command.
+pub(crate) struct Command {
+    pub name: &'static str,
+    pub description: &'static str,
+    /// Argument placeholder for `/help` (e.g. `"<filter>"`); `None` for
+    /// commands that take no argument.
+    pub usage_hint: Option<&'static str>,
+    pub handler: CommandFn,
+    pub validate: Option<ValidateFn>,
+    pub mid_stream: MidStream,
+}
+
+/// The command an interrupt (Ctrl-C / SIGINT) defers to tear down the REPL.
+/// Named so those sites can take a direct `&'static` reference to it (via
+/// const promotion) instead of a fallible name lookup.
+pub(crate) const QUIT_COMMAND: Command = Command {
+    name: "/quit",
+    description: "Exit the REPL",
+    usage_hint: None,
+    handler: cmd_exit,
+    validate: None,
+    mid_stream: MidStream::Defer,
+};
+
+pub(crate) const COMMANDS: &[Command] = &[
+    QUIT_COMMAND,
+    Command {
+        name: "/exit",
+        description: "Exit the REPL",
+        usage_hint: None,
+        handler: cmd_exit,
+        validate: None,
+        mid_stream: MidStream::Defer,
+    },
+    Command {
+        name: "/clear",
+        description: "Start a new conversation",
+        usage_hint: None,
+        handler: cmd_clear,
+        validate: None,
+        mid_stream: MidStream::Defer,
+    },
+    Command {
+        name: "/help",
+        description: "Show this help message",
+        usage_hint: None,
+        handler: cmd_help,
+        validate: None,
+        mid_stream: MidStream::Live(crate::ui::mid_stream::live_help),
+    },
+    Command {
+        name: "/expand",
+        description: "Toggle expanded/compact tool call view",
+        usage_hint: None,
+        handler: cmd_expand,
+        validate: None,
+        mid_stream: MidStream::Live(crate::ui::mid_stream::live_expand),
+    },
+    Command {
+        name: "/stream",
+        description: "Toggle SSE event stream panel",
+        usage_hint: None,
+        handler: cmd_stream,
+        validate: None,
+        mid_stream: MidStream::Live(crate::ui::mid_stream::live_stream),
+    },
+    Command {
+        name: "/conversations",
+        description: "List saved conversations",
+        usage_hint: None,
+        handler: cmd_conversations,
+        validate: None,
+        mid_stream: MidStream::Live(crate::ui::mid_stream::live_conversations),
+    },
+    Command {
+        name: "/resume",
+        description: "Resume a saved conversation (by ID or name)",
+        usage_hint: Some("<filter>"),
+        handler: cmd_resume,
+        validate: Some(validate_resume),
+        mid_stream: MidStream::Defer,
+    },
+    Command {
+        name: "/rename",
+        description: "Rename the current conversation",
+        usage_hint: Some("<name>"),
+        handler: cmd_rename,
+        validate: None,
+        mid_stream: MidStream::Defer,
+    },
+    Command {
+        name: "/model",
+        description: "Select a model for LLM requests",
+        usage_hint: Some("<filter>"),
+        handler: cmd_model,
+        validate: Some(validate_model),
+        mid_stream: MidStream::Live(crate::ui::mid_stream::live_model),
+    },
+    Command {
+        name: "/style",
+        description: "Switch the visual style",
+        usage_hint: Some("<name>"),
+        handler: cmd_style,
+        validate: Some(validate_style),
+        mid_stream: MidStream::Live(crate::ui::mid_stream::live_style),
+    },
+];
+
+/// Look up a command by its exact, fully-resolved name.
+pub(crate) fn lookup(name: &str) -> Option<&'static Command> {
+    COMMANDS.iter().find(|c| c.name == name)
+}
+
+/// Split a resolved command line into its command word (the leading
+/// whitespace-delimited token) and the trimmed argument remainder.
+pub(crate) fn split_command(resolved: &str) -> (&str, &str) {
+    let word = resolved.split_whitespace().next().unwrap_or(resolved);
+    let args = resolved.strip_prefix(word).map(str::trim).unwrap_or("");
+    (word, args)
+}
+
+/// Run a command line through its handler, returning the outcome. `None` means
+/// the line names no known command.
+pub(crate) fn dispatch(line: &str, ctx: &mut CommandContext) -> Option<CommandOutcome> {
+    let (word, args) = split_command(line);
+    Some((lookup(word)?.handler)(ctx, args))
+}
+
+fn cmd_exit(ctx: &mut CommandContext, _args: &str) -> CommandOutcome {
+    // Save before exiting, or delete if the conversation was never started.
+    if let Some(store) = ctx.conv_store.as_ref() {
+        if ctx.conversation.messages().len() > 1 {
+            with_event_log(|log| {
+                store.save_all(ctx.conversation.messages(), log, is_expanded_output())
+            });
+        } else {
+            store.delete();
+        }
+    }
+    CommandOutcome::Exit
+}
+
+fn cmd_clear(ctx: &mut CommandContext, _args: &str) -> CommandOutcome {
+    commands::handle_clear(ctx.conversation, ctx.conv_store, ctx.input_reader);
+    CommandOutcome::Handled
+}
+
+fn cmd_help(_ctx: &mut CommandContext, _args: &str) -> CommandOutcome {
+    commands::handle_help();
+    CommandOutcome::Handled
+}
+
+fn cmd_expand(ctx: &mut CommandContext, _args: &str) -> CommandOutcome {
+    commands::handle_expand(ctx.conversation, ctx.conv_store);
+    CommandOutcome::Handled
+}
+
+fn cmd_stream(_ctx: &mut CommandContext, _args: &str) -> CommandOutcome {
+    commands::handle_stream();
+    CommandOutcome::Handled
+}
+
+fn cmd_conversations(_ctx: &mut CommandContext, _args: &str) -> CommandOutcome {
+    commands::handle_conversations();
+    CommandOutcome::Handled
+}
+
+fn cmd_resume(ctx: &mut CommandContext, args: &str) -> CommandOutcome {
+    // In-REPL resume ignores CLI --model/--system-prompt and uses whatever the
+    // resumed conversation had saved.
+    match commands::handle_resume(
+        args,
+        ctx.conversation,
+        ctx.conv_store,
+        ctx.input_reader,
+        None,
+    ) {
+        Some(new_input) => CommandOutcome::Reinject(new_input),
+        None => CommandOutcome::Handled,
+    }
+}
+
+fn cmd_rename(ctx: &mut CommandContext, args: &str) -> CommandOutcome {
+    commands::handle_rename(args, ctx.conv_store);
+    CommandOutcome::Handled
+}
+
+fn cmd_model(ctx: &mut CommandContext, args: &str) -> CommandOutcome {
+    commands::handle_model(args, ctx.conv_store);
+    CommandOutcome::Handled
+}
+
+fn cmd_style(_ctx: &mut CommandContext, args: &str) -> CommandOutcome {
+    commands::handle_style(args);
+    CommandOutcome::Handled
+}
+
+/// Block Enter while a command's argument is still ambiguous against the live
+/// autocomplete match state.
+fn validate_resume(_input: &str) -> bool {
+    if get_tab_select_index().is_some() {
+        return true;
+    }
+    RESUME_MATCHES.lock().map(|g| g.len()).unwrap_or(0) == 1
+}
+
+fn validate_model(input: &str) -> bool {
+    if get_tab_select_index().is_some() {
+        return true;
+    }
+    let filter = input.trim().strip_prefix("/model").unwrap_or("").trim();
+    if filter.is_empty() {
+        MODEL_MATCHES.lock().map(|g| g.len()).unwrap_or(0) == 1
+    } else {
+        true
+    }
+}
+
+fn validate_style(input: &str) -> bool {
+    if get_tab_select_index().is_some() {
+        return true;
+    }
+    let filter = input.trim().strip_prefix("/style").unwrap_or("").trim();
+    let count = STYLE_MATCHES.lock().map(|g| g.len()).unwrap_or(0);
+    !filter.is_empty() && count == 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_look_up() {
+        for cmd in COMMANDS {
+            assert!(lookup(cmd.name).is_some(), "{} not found", cmd.name);
+        }
+    }
+
+    #[test]
+    fn ungated_commands_submit() {
+        for cmd in COMMANDS.iter().filter(|c| c.validate.is_none()) {
+            assert!(
+                crate::ui::input_hint::validate_command_input(cmd.name),
+                "{} is not submittable",
+                cmd.name
+            );
+        }
+    }
+
+    #[test]
+    fn lookup_is_exact() {
+        assert!(lookup("/he").is_none());
+        assert!(lookup("/nope").is_none());
+    }
+
+    #[test]
+    fn resume_gate() {
+        crate::ui::state::set_tab_select_index(None);
+        RESUME_MATCHES.lock().unwrap().clear();
+        assert!(!validate_resume("/resume foo"));
+        *RESUME_MATCHES.lock().unwrap() = vec![("id".into(), "name".into())];
+        assert!(validate_resume("/resume foo"));
+        RESUME_MATCHES.lock().unwrap().clear();
+    }
+
+    #[test]
+    fn style_gate() {
+        crate::ui::state::set_tab_select_index(None);
+        *STYLE_MATCHES.lock().unwrap() = vec!["dark".into()];
+        assert!(validate_style("/style dark"));
+        assert!(!validate_style("/style")); // no filter
+        STYLE_MATCHES.lock().unwrap().clear();
+        assert!(!validate_style("/style dark")); // no match
+    }
+
+    #[test]
+    fn model_gate() {
+        use crate::ui::input_hint::validate_command_input;
+        crate::ui::state::set_tab_select_index(None);
+        // Empty filter requires exactly one match.
+        MODEL_MATCHES.lock().unwrap().clear();
+        assert!(!validate_model("/model"));
+        *MODEL_MATCHES.lock().unwrap() = vec!["gpt-4".into()];
+        assert!(validate_model("/model"));
+        // The gate is reached through validate_command_input by exact name.
+        assert!(validate_command_input("/model"));
+        MODEL_MATCHES.lock().unwrap().clear();
+        assert!(!validate_command_input("/model"));
+        // A non-empty filter always submits.
+        assert!(validate_model("/model gpt-4"));
+    }
+
+    #[test]
+    fn splits_word_and_args() {
+        assert_eq!(split_command("/clear"), ("/clear", ""));
+        assert_eq!(split_command("/resume foo"), ("/resume", "foo"));
+        assert_eq!(split_command("/model   gpt-4"), ("/model", "gpt-4"));
+        assert_eq!(split_command("/rename my chat"), ("/rename", "my chat"));
+    }
+}

--- a/crates/aura-cli/src/ui/event_replay.rs
+++ b/crates/aura-cli/src/ui/event_replay.rs
@@ -883,16 +883,20 @@ pub fn print_tool_call_expanded(
 }
 
 pub fn print_help() {
+    use crate::repl::registry::COMMANDS;
     println!("Available commands:");
-    println!("  /help            — Show this help message");
-    println!("  /clear           — Start a new conversation");
-    println!("  /expand          — Toggle expanded/compact tool call view");
-    println!("  /conversations   — List saved conversations");
-    println!("  /resume <filter> — Resume a saved conversation (by ID or name)");
-    println!("  /rename <name>   — Rename the current conversation");
-    println!("  /model <filter>  — Select a model for LLM requests");
-    println!("  /quit            — Exit the REPL");
-    println!("  /exit            — Exit the REPL");
+    let width = COMMANDS
+        .iter()
+        .map(|c| c.name.len() + c.usage_hint.map_or(0, |h| h.len() + 1))
+        .max()
+        .unwrap_or(0);
+    for cmd in COMMANDS {
+        let cell = match cmd.usage_hint {
+            Some(hint) => format!("{} {}", cmd.name, hint),
+            None => cmd.name.to_string(),
+        };
+        println!("  {cell:<width$} — {}", cmd.description);
+    }
 }
 
 pub fn list_conversations() {

--- a/crates/aura-cli/src/ui/input_hint.rs
+++ b/crates/aura-cli/src/ui/input_hint.rs
@@ -10,10 +10,11 @@ use std::time::Duration;
 use crossterm::style::Stylize;
 
 use crate::repl::conversations::ConversationStore;
+use crate::repl::registry::{COMMANDS, Command, lookup, split_command};
 
 use super::input_frame::resize_status_area;
 use super::state::{
-    COMMANDS, CTRLC_HINT_VISIBLE, LAST_HINT_LINE, MODEL_CACHE, MODEL_ERROR, MODEL_FETCH_CONFIG,
+    CTRLC_HINT_VISIBLE, LAST_HINT_LINE, MODEL_CACHE, MODEL_ERROR, MODEL_FETCH_CONFIG,
     MODEL_FETCH_IN_PROGRESS, MODEL_MATCHES, RESUME_MATCHES, STATUS_HINT, STATUS_ROWS,
     STREAM_CONV_DIR, STYLE_MATCHES, get_tab_select_index, lock_term, random_bullet_color,
     status_rows, term_size,
@@ -357,24 +358,29 @@ pub fn update_input_hint(line: &str) {
         if let Ok(mut guard) = RESUME_MATCHES.lock() {
             guard.clear();
         }
-        let matching: Vec<(&str, &str)> = COMMANDS
+        let matching: Vec<&Command> = COMMANDS
             .iter()
-            .filter(|(name, _)| name[1..].starts_with(prefix))
-            .copied()
+            .filter(|c| {
+                c.name
+                    .strip_prefix('/')
+                    .unwrap_or(c.name)
+                    .starts_with(prefix)
+            })
             .collect();
         if matching.is_empty() {
             vec![]
         } else if matching.len() == 1 {
             vec![format!(
                 "{}",
-                format!("{} — {}", matching[0].0, matching[0].1).themed(AuraStyle::Muted)
+                format!("{} — {}", matching[0].name, matching[0].description)
+                    .themed(AuraStyle::Muted)
             )]
         } else {
             vec![format!(
                 "{}",
                 matching
                     .iter()
-                    .map(|(name, _)| *name)
+                    .map(|c| c.name)
                     .collect::<Vec<_>>()
                     .join("  ")
                     .themed(AuraStyle::Muted)
@@ -435,66 +441,46 @@ pub fn clear_input_hint() {
 }
 
 /// Returns whether Enter should submit the current input line.
+///
+/// Enter always submits, except for a known command whose submission gate
+/// holds it back (e.g. an ambiguous `/resume` argument). Unknown or partial
+/// commands submit too, so dispatch can report them as unknown rather than
+/// Enter doing nothing.
 pub fn validate_command_input(line: &str) -> bool {
     let trimmed = line.trim();
     if trimmed.is_empty() || !trimmed.starts_with('/') {
         return true;
     }
-    // Tab selection active -> allow Enter for /model and /resume
-    let tab_active = get_tab_select_index().is_some();
-    if trimmed == "/resume" || trimmed.starts_with("/resume ") {
-        if tab_active {
-            return true;
-        }
-        let count = RESUME_MATCHES.lock().map(|g| g.len()).unwrap_or(0);
-        return count == 1;
+    let (word, _) = split_command(trimmed);
+    match lookup(word) {
+        Some(cmd) => cmd.validate.is_none_or(|gate| gate(trimmed)),
+        None => true,
     }
-    if trimmed == "/model" || trimmed.starts_with("/model ") {
-        if tab_active {
-            return true;
-        }
-        let filter = trimmed.strip_prefix("/model").unwrap_or("").trim();
-        if filter.is_empty() {
-            let count = MODEL_MATCHES.lock().map(|g| g.len()).unwrap_or(0);
-            return count == 1;
-        }
-        return true;
-    }
-    if trimmed == "/style" || trimmed.starts_with("/style ") {
-        if tab_active {
-            return true;
-        }
-        let filter = trimmed.strip_prefix("/style").unwrap_or("").trim();
-        let count = STYLE_MATCHES.lock().map(|g| g.len()).unwrap_or(0);
-        // No-arg `/style` lists current + options (no selection to commit).
-        // Single match with a filter: Enter applies it.
-        return !filter.is_empty() && count == 1;
-    }
-    let cmd_word = trimmed.split_whitespace().next().unwrap_or(trimmed);
-    let resolved = resolve_command_prefix(cmd_word);
-    COMMANDS.iter().any(|(name, _)| *name == resolved)
 }
 
-/// Resolve a possibly-abbreviated slash command to its full form (used by validate).
-fn resolve_command_prefix(input: &str) -> String {
-    if COMMANDS.iter().any(|(name, _)| *name == input) {
-        return input.to_string();
+#[cfg(test)]
+mod tests {
+    use super::validate_command_input;
+
+    #[test]
+    fn plain_text_submits() {
+        assert!(validate_command_input(""));
+        assert!(validate_command_input("   "));
+        assert!(validate_command_input("hello there"));
+        assert!(validate_command_input("what is /help"));
     }
-    let (cmd_part, args_part) = match input.find(' ') {
-        Some(pos) => (&input[..pos], Some(&input[pos..])),
-        None => (input, None),
-    };
-    let matches: Vec<&str> = COMMANDS
-        .iter()
-        .filter(|(name, _)| name.starts_with(cmd_part))
-        .map(|(name, _)| *name)
-        .collect();
-    if matches.len() == 1 {
-        match args_part {
-            Some(args) => format!("{}{}", matches[0], args),
-            None => matches[0].to_string(),
-        }
-    } else {
-        input.to_string()
+
+    #[test]
+    fn known_commands_submit() {
+        assert!(validate_command_input("/help"));
+        assert!(validate_command_input("/clear"));
+    }
+
+    #[test]
+    fn unknown_commands_submit() {
+        assert!(validate_command_input("/zzz"));
+        assert!(validate_command_input("/he"));
+        assert!(validate_command_input("/conv"));
+        assert!(validate_command_input("/e"));
     }
 }

--- a/crates/aura-cli/src/ui/mid_stream.rs
+++ b/crates/aura-cli/src/ui/mid_stream.rs
@@ -14,7 +14,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use super::event_replay::{list_conversations, print_help, replay_event_log_global};
 use super::input_frame::{erase_input_frame, redraw_input_frame};
 use super::input_hint::update_input_hint;
-use super::state::{COMMANDS, PendingCommand};
 use super::state::{
     CTRLC_HINT_VISIBLE, EXPANDED_OUTPUT, LAST_ANIM_LINES, MID_STREAM_HISTORY,
     MID_STREAM_HISTORY_POS, MID_STREAM_SAVED_INPUT, PROCESSING, QUEUED_INPUT, RESUME_MATCHES,
@@ -29,6 +28,7 @@ use super::stream_panel::{
     scroll_stream_page_up, scroll_stream_up, set_stream_show_all, toggle_stream_expand,
     toggle_stream_panel,
 };
+use crate::repl::registry::{MidStream, PendingCommand, QUIT_COMMAND, lookup, split_command};
 
 const PROMPT_COLS: usize = 2; // "❯ " occupies 2 display columns
 
@@ -57,137 +57,108 @@ enum ImmediateResult {
     NotHandled,
 }
 
-/// Resolve a possibly-abbreviated slash command to its full form.
-fn resolve_command_prefix(input: &str) -> String {
-    if COMMANDS.iter().any(|(name, _)| *name == input) {
-        return input.to_string();
+/// Handle a slash command typed while a response streams: run live commands
+/// now, defer the rest to the main loop. Non-commands return `NotHandled` so
+/// the caller queues them as the next message.
+fn execute_immediate_command(input: &str) -> ImmediateResult {
+    if !input.starts_with('/') {
+        return ImmediateResult::NotHandled;
     }
-    let (cmd_part, args_part) = match input.find(' ') {
-        Some(pos) => (&input[..pos], Some(&input[pos..])),
-        None => (input, None),
-    };
-    let matches: Vec<&str> = COMMANDS
-        .iter()
-        .filter(|(name, _)| name.starts_with(cmd_part))
-        .map(|(name, _)| *name)
-        .collect();
-    if matches.len() == 1 {
-        match args_part {
-            Some(args) => format!("{}{}", matches[0], args),
-            None => matches[0].to_string(),
-        }
-    } else {
-        input.to_string()
+    let (word, args) = split_command(input);
+    match lookup(word) {
+        Some(cmd) => match cmd.mid_stream {
+            MidStream::Live(run) => {
+                run(args);
+                ImmediateResult::Handled
+            }
+            MidStream::Defer => {
+                set_pending_command(PendingCommand {
+                    command: cmd,
+                    args: args.to_string(),
+                });
+                ImmediateResult::HandledCancel
+            }
+        },
+        None => ImmediateResult::NotHandled,
     }
 }
 
-/// Execute a command immediately during processing.
-fn execute_immediate_command(input: &str) -> ImmediateResult {
-    let resolved = resolve_command_prefix(input);
-    match resolved.as_str() {
-        "/stream" => {
-            clear_stream_panel_in_place();
-            toggle_stream_panel();
-            erase_input_frame();
-            redraw_input_frame();
-            ImmediateResult::Handled
-        }
-        "/expand" => {
-            let expanded = !EXPANDED_OUTPUT.load(Ordering::Relaxed);
-            EXPANDED_OUTPUT.store(expanded, Ordering::Relaxed);
-            set_stream_show_all(expanded);
-            replay_event_log_global();
-            reprint_cached_anim_lines();
-            redraw_input_frame();
-            ImmediateResult::Handled
-        }
-        "/help" => {
-            replay_event_log_global();
-            print_help();
-            reprint_cached_anim_lines();
-            redraw_input_frame();
-            ImmediateResult::Handled
-        }
-        "/conversations" => {
-            replay_event_log_global();
-            list_conversations();
-            reprint_cached_anim_lines();
-            redraw_input_frame();
-            ImmediateResult::Handled
-        }
-        "/quit" | "/exit" => {
-            set_pending_command(PendingCommand::Quit);
-            ImmediateResult::HandledCancel
-        }
-        "/clear" => {
-            set_pending_command(PendingCommand::Clear);
-            ImmediateResult::HandledCancel
-        }
-        _ if input.starts_with("/resume") => {
-            let arg = input
-                .strip_prefix("/resume")
-                .unwrap_or("")
-                .trim()
-                .to_string();
-            set_pending_command(PendingCommand::Resume(arg));
-            ImmediateResult::HandledCancel
-        }
-        _ if input == "/model" || input.starts_with("/model ") => {
-            replay_event_log_global();
-            let current = get_selected_model();
-            match current {
-                Some(m) => println!("Current model: {}", m),
-                None => println!("No model selected (using server default)"),
+pub(crate) fn live_stream(_args: &str) {
+    clear_stream_panel_in_place();
+    toggle_stream_panel();
+    erase_input_frame();
+    redraw_input_frame();
+}
+
+pub(crate) fn live_expand(_args: &str) {
+    let expanded = !EXPANDED_OUTPUT.load(Ordering::Relaxed);
+    EXPANDED_OUTPUT.store(expanded, Ordering::Relaxed);
+    set_stream_show_all(expanded);
+    replay_event_log_global();
+    reprint_cached_anim_lines();
+    redraw_input_frame();
+}
+
+pub(crate) fn live_help(_args: &str) {
+    replay_event_log_global();
+    print_help();
+    reprint_cached_anim_lines();
+    redraw_input_frame();
+}
+
+pub(crate) fn live_conversations(_args: &str) {
+    replay_event_log_global();
+    list_conversations();
+    reprint_cached_anim_lines();
+    redraw_input_frame();
+}
+
+pub(crate) fn live_model(_args: &str) {
+    replay_event_log_global();
+    match get_selected_model() {
+        Some(m) => println!("Current model: {}", m),
+        None => println!("No model selected (using server default)"),
+    }
+    reprint_cached_anim_lines();
+    redraw_input_frame();
+}
+
+pub(crate) fn live_style(args: &str) {
+    // A tab pick (set by the Tab handler in `drain_stdin`) wins over a typed
+    // arg; with neither, the in-progress animation is left untouched. Tab
+    // cycling already applied a live preview, so Enter just commits by
+    // dropping the captured revert target.
+    let tab_pick = get_tab_select_index()
+        .and_then(|i| STYLE_MATCHES.lock().ok().and_then(|g| g.get(i).cloned()));
+    set_tab_select_index(None);
+    clear_style_preview_original();
+    let chosen: Option<String> = tab_pick.or_else(|| {
+        if args.is_empty() {
+            None
+        } else {
+            let lower = args.to_ascii_lowercase();
+            let matches: Vec<&&str> = crate::theme::STYLE_NAMES
+                .iter()
+                .filter(|n| n.starts_with(&lower))
+                .collect();
+            if matches.len() == 1 {
+                Some((*matches[0]).to_string())
+            } else {
+                Some(args.to_string())
             }
-            reprint_cached_anim_lines();
-            redraw_input_frame();
-            ImmediateResult::Handled
         }
-        _ if input == "/style" || input.starts_with("/style ") => {
-            // Mid-stream theme switching is fully client-side. A tab pick
-            // (set by the Tab handler in `drain_stdin`) wins over a typed
-            // arg; with no pick and no arg we leave the in-progress
-            // animation untouched. Tab cycling already applied a live preview
-            // — Enter just commits by dropping the captured "revert target".
-            let arg = input.strip_prefix("/style").unwrap_or("").trim();
-            let tab_pick = get_tab_select_index()
-                .and_then(|i| STYLE_MATCHES.lock().ok().and_then(|g| g.get(i).cloned()));
-            set_tab_select_index(None);
-            clear_style_preview_original();
-            let chosen: Option<String> = tab_pick.or_else(|| {
-                if arg.is_empty() {
-                    None
-                } else {
-                    let lower = arg.to_ascii_lowercase();
-                    let matches: Vec<&&str> = crate::theme::STYLE_NAMES
-                        .iter()
-                        .filter(|n| n.starts_with(&lower))
-                        .collect();
-                    if matches.len() == 1 {
-                        Some((*matches[0]).to_string())
-                    } else {
-                        Some(arg.to_string())
-                    }
-                }
-            });
-            if let Some(name) = chosen
-                && let Some(t) = crate::theme::theme_by_name(&name)
-            {
-                crate::theme::set_theme(t);
-                replay_event_log_global();
-                reprint_cached_anim_lines();
-                redraw_input_frame();
-                // Persist mid-stream commits too. Failure prints a warning
-                // to stderr; never goes through `push_display_event` so it
-                // stays out of the saved chat log.
-                let public_name = crate::theme::theme_public_name(crate::theme::theme());
-                if let Err(e) = crate::config::save_style_to_global_cli_toml(public_name) {
-                    eprintln!("warning: could not persist style to ~/.aura/cli.toml: {e}");
-                }
-            }
-            ImmediateResult::Handled
+    });
+    if let Some(name) = chosen
+        && let Some(t) = crate::theme::theme_by_name(&name)
+    {
+        crate::theme::set_theme(t);
+        replay_event_log_global();
+        reprint_cached_anim_lines();
+        redraw_input_frame();
+        let public_name = crate::theme::theme_public_name(crate::theme::theme());
+        if let Err(e) = crate::config::save_style_to_global_cli_toml(public_name) {
+            eprintln!("warning: could not persist style to ~/.aura/cli.toml: {e}");
         }
-        _ => ImmediateResult::NotHandled,
     }
 }
 
@@ -304,7 +275,10 @@ fn mid_stream_cycle_matches(buf: &str, forward: bool) -> bool {
 pub fn drain_stdin(buf: &mut String) -> bool {
     let mut esc_pressed = false;
     if SIGINT_RECEIVED.swap(false, Ordering::Relaxed) && handle_ctrlc() {
-        set_pending_command(PendingCommand::Quit);
+        set_pending_command(PendingCommand {
+            command: &QUIT_COMMAND,
+            args: String::new(),
+        });
         esc_pressed = true;
     }
     #[cfg(unix)]
@@ -328,7 +302,10 @@ pub fn drain_stdin(buf: &mut String) -> bool {
                 let b = bytes[i];
                 if b == 0x03 {
                     if handle_ctrlc() {
-                        set_pending_command(PendingCommand::Quit);
+                        set_pending_command(PendingCommand {
+                            command: &QUIT_COMMAND,
+                            args: String::new(),
+                        });
                         esc_pressed = true;
                     }
                     i += 1;

--- a/crates/aura-cli/src/ui/prompt.rs
+++ b/crates/aura-cli/src/ui/prompt.rs
@@ -7,19 +7,18 @@
 // ---------------------------------------------------------------------------
 
 // Re-export from state.rs
-pub(crate) use super::state::lock_term;
 pub use super::state::{
-    ACTIVE_ORCH_TOOLS, ORCH_SCROLLBACK_COUNTER, PendingCommand, cache_anim_lines,
-    capture_style_preview_original, check_resize, clear_display_events, clear_queued_input,
-    clear_style_preview_original, extend_display_events, frame_lines, get_model_matches,
-    get_selected_model, install_sigint_handler, is_expanded_output, is_pretty,
-    last_mid_stream_history_entry, print_welcome_state, print_welcome_state_animated,
-    push_display_event, push_mid_stream_history, random_bullet_color, reset_input_geometry,
-    reset_task_colors, restore_style_preview_original, set_expanded_output, set_mid_stream_history,
-    set_pending_command, set_pretty, set_processing, set_queued_input, set_selected_model,
-    set_welcome_state, take_pending_command, take_queued_input, task_color_for, term_size,
+    ACTIVE_ORCH_TOOLS, ORCH_SCROLLBACK_COUNTER, cache_anim_lines, capture_style_preview_original,
+    check_resize, clear_display_events, clear_queued_input, clear_style_preview_original,
+    extend_display_events, frame_lines, get_model_matches, get_selected_model,
+    install_sigint_handler, is_expanded_output, is_pretty, last_mid_stream_history_entry,
+    print_welcome_state, print_welcome_state_animated, push_display_event, push_mid_stream_history,
+    random_bullet_color, reset_input_geometry, reset_task_colors, restore_style_preview_original,
+    set_expanded_output, set_mid_stream_history, set_pretty, set_processing, set_queued_input,
+    set_selected_model, set_welcome_state, take_queued_input, task_color_for, term_size,
     text_lines, with_event_log, with_event_log_mut,
 };
+pub(crate) use super::state::{lock_term, take_pending_command};
 
 // Re-export from status_bar.rs
 pub(crate) use super::status_bar::update_status_bar_unlocked;

--- a/crates/aura-cli/src/ui/state.rs
+++ b/crates/aura-cli/src/ui/state.rs
@@ -15,6 +15,7 @@ use std::time::Instant;
 use crossterm::style::Color;
 
 use crate::api::types::DisplayEvent;
+use crate::repl::registry::PendingCommand;
 use crate::ui::welcome::WelcomeState;
 
 use super::orchestrator::{ActiveOrchTool, OrchLastToolInfo};
@@ -91,7 +92,8 @@ pub(crate) static WELCOME_STATE: Mutex<Option<WelcomeState>> = Mutex::new(None);
 pub(crate) static LAST_ANIM_LINES: Mutex<(String, String)> =
     Mutex::new((String::new(), String::new()));
 
-/// Pending command from mid-stream input that needs main-loop execution.
+/// A registry command typed mid-stream that must run in the main loop after
+/// the stream tears down, already resolved so no re-parsing is needed.
 pub(crate) static PENDING_COMMAND: Mutex<Option<PendingCommand>> = Mutex::new(None);
 
 /// Flag set by a SIGINT handler so drain_stdin detects Ctrl-C even when ISIG
@@ -214,24 +216,6 @@ pub(crate) static TASK_COLOR_INDEXES: LazyLock<Mutex<HashMap<String, usize>>> =
 pub(crate) static STYLE_PREVIEW_ORIGINAL: Mutex<Option<&'static crate::theme::Theme>> =
     Mutex::new(None);
 
-// ---------------------------------------------------------------------------
-// Command list & input hint state
-// ---------------------------------------------------------------------------
-
-pub(crate) const COMMANDS: &[(&str, &str)] = &[
-    ("/quit", "exit the REPL"),
-    ("/exit", "exit the REPL"),
-    ("/clear", "start a new conversation"),
-    ("/help", "show available commands"),
-    ("/expand", "toggle expanded/compact tool call view"),
-    ("/stream", "toggle SSE event stream panel"),
-    ("/conversations", "list saved conversations"),
-    ("/resume", "resume a saved conversation"),
-    ("/rename", "rename the current conversation"),
-    ("/model", "select a model"),
-    ("/style", "switch the visual style"),
-];
-
 // Cached matches from the last /resume autocomplete lookup.
 pub(crate) static RESUME_MATCHES: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
 
@@ -263,16 +247,6 @@ pub(crate) static TAB_SELECT_INDEX: Mutex<Option<usize>> = Mutex::new(None);
 pub(crate) static MODEL_FETCH_CONFIG: Mutex<
     Option<(String, Option<String>, Vec<(String, String)>)>,
 > = Mutex::new(None);
-
-// ---------------------------------------------------------------------------
-// PendingCommand enum
-// ---------------------------------------------------------------------------
-
-pub enum PendingCommand {
-    Quit,
-    Clear,
-    Resume(String),
-}
 
 // ---------------------------------------------------------------------------
 // Basic accessor functions
@@ -334,11 +308,11 @@ pub fn cache_anim_lines(top: &str, bottom: &str) {
     }
 }
 
-pub fn set_pending_command(cmd: PendingCommand) {
+pub(crate) fn set_pending_command(cmd: PendingCommand) {
     *PENDING_COMMAND.lock().unwrap() = Some(cmd);
 }
 
-pub fn take_pending_command() -> Option<PendingCommand> {
+pub(crate) fn take_pending_command() -> Option<PendingCommand> {
     PENDING_COMMAND.lock().unwrap().take()
 }
 


### PR DESCRIPTION
Slash commands were defined across five hand-synced sites: the
dispatch chain, midstream execution, a command table, the
Enter-submission validator, and the /help text. These drifted
(e.g. /stream and /style were absent from /help) and the validator
and dispatcher matched command names by different rules.

Introduce repl::registry as the single source of truth. Each Command
holds its name, description, usage hint, handler, and an optional
submission gate; dispatch, validation, /help, and autocomplete all read
from one COMMANDS table, so adding a command is one entry plus a
handler.

- replace the if/else dispatch chain with a registry lookup returning a
  CommandOutcome (handled, reinject input, or exit)
- match commands by exact name in the dispatcher, validator, and
  mid-stream handler, dropping the duplicated prefix-resolution helper;
  abbreviations are still completed via Tab
- generate /help and the autocomplete hint from the registry
- add unit tests for lookup, submission gates, validation, and argument
  splitting
- drive midstream execution from the registry

User-visible changes: /help now lists every command (including /stream
and /style); unknown or partial commands now submit and report "unknown
command" instead of being silently ignored.

Fixes: https://github.com/mezmo/aura/issues/177