### PR TITLE
fix(ci): fix release dry-run for fork PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -239,13 +239,18 @@ pipeline {
 
               steps {
                 script {
+                  def releaseCmd = 'npm run release:dry'
+                  if (env.CHANGE_FORK) {
+                    sh "git checkout -B ${CURRENT_BRANCH}"
+                    releaseCmd = "npm run release:dry -- --repository-url=file://${env.WORKSPACE} --plugins @semantic-release/commit-analyzer @semantic-release/release-notes-generator"
+                  }
                   docker.withRegistry(
                       'https://index.docker.io/v1/',
                       'dockerhub-token-mezmo'
                   ) {
                     withCredentials(RELEASE_CREDENTIALS) {
                       buildx {
-                        withReport('Release Test', 'npm run release:dry')
+                        withReport('Release Test', releaseCmd)
                       }
                     }
                   }


### PR DESCRIPTION
## Summary

The Release Test stage fails on all fork PRs (#250, #223, #200) because
`semantic-release --dry-run --branches=${BRANCH_NAME}` requires the
branch to exist on the upstream remote, which it never does for forks.

This was always broken — fork PRs never actually ran the release
dry-run. Before `95bbb10` (which added `set -o pipefail` to
`withReport`), the semantic-release failure was masked: `tee` exited 0
at the end of the pipe, hiding the non-zero exit from semantic-release.

## Fix

For fork PRs (`env.CHANGE_FORK` is set):
1. Create a local branch ref from the already-checked-out HEAD
2. Run semantic-release with `--repository-url=file://${WORKSPACE}` and
   only the `commit-analyzer` and `release-notes-generator` plugins —
   validates that commits parse correctly without needing GitHub API
   access or the branch on the upstream remote

Non-fork PR builds are unchanged.

## Test plan
- [x] This PR is itself from a fork — all checks passing validates the fix
- [ ] Verify non-fork PRs are unaffected (no `CHANGE_FORK`, original command runs)