### PR TITLE
fix(scratchpad): stop large MCP outputs from producing spurious tool-call errors

### DIFF
--- a/crates/aura/src/orchestration/mod.rs
+++ b/crates/aura/src/orchestration/mod.rs
@@ -50,7 +50,7 @@ mod observer_wrapper;
 mod orchestrator;
 mod overview;
 mod persistence;
-mod persistence_wrapper;
+pub(crate) mod persistence_wrapper;
 mod prompt_constants;
 mod prompt_journal;
 mod stream_events;

--- a/crates/aura/src/orchestration/persistence_wrapper.rs
+++ b/crates/aura/src/orchestration/persistence_wrapper.rs
@@ -36,6 +36,18 @@ const REASONING_FIELD: &str = "_aura_reasoning";
 /// `on_complete` can rendezvous on the same entry in `raw_outputs`.
 const CALL_ID_FIELD: &str = "_persistence_call_id";
 
+/// Start of the inline footer `transform_output` appends to promoted tool
+/// outputs (`"{marker}{filename}]"`).
+pub(crate) const ARTIFACT_FOOTER_MARKER: &str = "\n\n[Tool output saved to artifact: ";
+
+/// Strip a trailing artifact footer from `output`, if present.
+pub(crate) fn strip_artifact_footer(output: &str) -> &str {
+    match output.rfind(ARTIFACT_FOOTER_MARKER) {
+        Some(pos) => &output[..pos],
+        None => output,
+    }
+}
+
 /// RAII guard that decrements the in-flight counter and notifies drain waiters
 /// on drop. Guarantees the counter is decremented even on early returns or
 /// panics inside `on_complete`.
@@ -218,7 +230,7 @@ impl ToolWrapper for PersistenceWrapper {
             task_id, worker, self.iteration, tool, call_idx
         );
 
-        let footer = format!("\n\n[Tool output saved to artifact: {}]", filename);
+        let footer = format!("{ARTIFACT_FOOTER_MARKER}{filename}]");
         TransformOutputResult::new(format!("{}{}", output, footer))
     }
 
@@ -263,10 +275,7 @@ impl ToolWrapper for PersistenceWrapper {
         let output_text = output.as_deref().unwrap_or("");
         // Strip any artifact footer appended by transform_output so we write
         // clean output and compute thresholds on the original size.
-        let output_clean = output_text
-            .rfind("\n\n[Tool output saved to artifact: ")
-            .map(|pos| &output_text[..pos])
-            .unwrap_or(output_text);
+        let output_clean = strip_artifact_footer(output_text);
         let should_promote = match (
             output_clean.len(),
             self.size_threshold,
@@ -317,11 +326,7 @@ impl ToolWrapper for PersistenceWrapper {
                 .clone()
                 .unwrap_or_else(|| serde_json::json!({})),
             reasoning,
-            output: output.map(|o| {
-                o.rfind("\n\n[Tool output saved to artifact: ")
-                    .map(|pos| o[..pos].to_string())
-                    .unwrap_or(o)
-            }),
+            output: output.map(|o| strip_artifact_footer(&o).to_string()),
             error,
             duration_ms,
             artifact_filename,

--- a/crates/aura/src/scratchpad/tools.rs
+++ b/crates/aura/src/scratchpad/tools.rs
@@ -27,7 +27,9 @@ pub enum ScratchpadToolError {
     Path(String),
     #[error("Invalid argument: {0}")]
     InvalidArg(String),
-    #[error("Not JSON: file is not valid JSON")]
+    #[error(
+        "File is not valid JSON. Use `read`, `head`, `grep`, or `slice` to explore it as text."
+    )]
     NotJson,
     #[error("Key path not found: {0}")]
     KeyNotFound(String),
@@ -485,8 +487,16 @@ impl Tool for GrepTool {
             )));
         }
         let content = read_scratchpad_file(&self.storage, &args.file).await?;
-        let regex = regex::Regex::new(&args.pattern)
-            .map_err(|e| ScratchpadToolError::InvalidArg(format!("Invalid regex: {e}")))?;
+        // The LLM frequently passes a literal snippet (e.g. a JSON fragment
+        // like `"metric": {`) as the pattern; the unescaped `{` then fails to
+        // compile ("unclosed counted repetition"). Fall back to a literal
+        // (escaped) search so grep behaves like the substring match the model
+        // expected instead of erroring.
+        let regex = match regex::Regex::new(&args.pattern) {
+            Ok(re) => re,
+            Err(_) => regex::Regex::new(&regex::escape(&args.pattern))
+                .map_err(|e| ScratchpadToolError::InvalidArg(format!("Invalid regex: {e}")))?,
+        };
 
         let lines: Vec<&str> = content.lines().collect();
         let total_lines = lines.len();
@@ -1941,6 +1951,35 @@ mod tests {
             .await
             .unwrap();
         assert!(result.contains("No matches"));
+    }
+
+    /// The LLM frequently passes a literal JSON fragment as the grep pattern.
+    /// An unescaped `{` is an invalid regex quantifier ("unclosed counted
+    /// repetition"); grep must fall back to a literal search instead of
+    /// erroring. Regression test for the noisy `Invalid regex` tool-call error.
+    #[tokio::test]
+    async fn test_grep_falls_back_to_literal_on_invalid_regex() {
+        let (_tmp, storage, budget) = setup().await;
+        // Pretty-printed on write, so the file contains the line `  "metric": {`.
+        storage
+            .write_output("metrics", "{\"metric\":{\"id\":1},\"value\":2}")
+            .await
+            .unwrap();
+
+        let tool = GrepTool::new(storage, budget);
+        let result = tool
+            .call(GrepArgs {
+                file: "metrics.json".to_string(),
+                pattern: "\"metric\": {".to_string(),
+                context: 0,
+            })
+            .await
+            .expect("invalid regex should fall back to literal search, not error");
+        assert!(
+            result.contains("\"metric\": {"),
+            "literal fallback should match the JSON fragment, got: {}",
+            &result[..result.len().min(200)]
+        );
     }
 
     #[tokio::test]

--- a/crates/aura/src/scratchpad/wrapper.rs
+++ b/crates/aura/src/scratchpad/wrapper.rs
@@ -11,6 +11,24 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
+/// Inline footer the persistence wrapper appends to promoted tool outputs
+/// (see `orchestration::persistence_wrapper`). Kept in sync with that marker.
+const ARTIFACT_FOOTER_MARKER: &str = "\n\n[Tool output saved to artifact: ";
+
+/// Strip a trailing persistence artifact footer from `output`, if present.
+///
+/// `ComposedWrapper` runs `transform_output` in reverse order, so the
+/// persistence wrapper appends its footer before this wrapper sees the output.
+/// Mirrors the strip in `persistence_wrapper` so the scratchpad never writes
+/// the footer into a file, where it would corrupt otherwise-valid JSON and
+/// break `get_in`/`schema`/`iterate_over`.
+fn strip_artifact_footer(output: &str) -> &str {
+    match output.rfind(ARTIFACT_FOOTER_MARKER) {
+        Some(pos) => &output[..pos],
+        None => output,
+    }
+}
+
 /// Build the primary "this lives in a file, explore it with these tools"
 /// pointer. Shared by [`ScratchpadWrapper`] (for intercepted MCP output) and
 /// the orchestration `read_artifact` tool (for large artifacts read in place),
@@ -91,7 +109,18 @@ impl ToolWrapper for ScratchpadWrapper {
             None => return TransformOutputResult::new(output),
         };
 
-        let output_tokens = self.budget.count_tokens(&output);
+        // Persistence runs before this wrapper (ComposedWrapper applies
+        // transform_output in reverse order) and may have appended an artifact
+        // footer. Diverting to the scratchpad replaces the output with our own
+        // pointer, so that footer is redundant here — and writing it into the
+        // scratchpad file would append a non-JSON line that breaks get_in,
+        // schema, and iterate_over on otherwise-valid JSON. Strip it before
+        // counting, hashing, and writing. The passthrough returns below keep
+        // the original output so the footer still serves as the persistence
+        // read_artifact pointer when the scratchpad does not intercept.
+        let content = strip_artifact_footer(&output);
+
+        let output_tokens = self.budget.count_tokens(content);
         if output_tokens < min_tokens {
             tracing::debug!(
                 "Scratchpad: {} output (~{} tokens) below threshold ({}), passing through",
@@ -107,7 +136,7 @@ impl ToolWrapper for ScratchpadWrapper {
         // runs after this wrapper and compares pointer strings; a fresh UUID
         // every call would defeat duplicate detection on intercepted tools.
         let mut hasher = DefaultHasher::new();
-        output.hash(&mut hasher);
+        content.hash(&mut hasher);
         let content_hash = format!("{:016x}", hasher.finish());
 
         let file_id = format!(
@@ -137,7 +166,7 @@ impl ToolWrapper for ScratchpadWrapper {
         // the LLM round-trip that follows — so briefly blocking the actix
         // worker is acceptable (for now). Revisit if scratchpad payloads grow into the
         // multi-MB range or if profiling shows the sync write on the hot path.
-        let write = self.storage.write_output_sync(&file_id, &output);
+        let write = self.storage.write_output_sync(&file_id, content);
         match write {
             Ok(result) => {
                 let filename = result
@@ -360,6 +389,74 @@ mod tests {
         // Verify file was written
         let files = storage.list_files().await.unwrap();
         assert!(!files.is_empty());
+    }
+
+    #[test]
+    fn test_strip_artifact_footer() {
+        let body = "{\"a\":1}";
+        let with_footer =
+            format!("{body}\n\n[Tool output saved to artifact: task-0-w-iter-1-t-0-output.txt]");
+        assert_eq!(strip_artifact_footer(&with_footer), body);
+        // No footer → returned unchanged.
+        assert_eq!(strip_artifact_footer(body), body);
+    }
+
+    /// A large JSON output that arrives carrying the persistence wrapper's
+    /// artifact footer (persistence runs first under `ComposedWrapper`) must be
+    /// written to the scratchpad file WITHOUT the footer, so the exploration
+    /// tools can still parse it as JSON. Regression test for the footer leaking
+    /// into the file and breaking get_in/schema/iterate_over with "not valid
+    /// JSON".
+    #[tokio::test]
+    async fn test_wrapper_strips_persistence_footer_before_write() {
+        let tmp = TempDir::new().unwrap();
+        let storage = Arc::new(
+            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-footer")
+                .await
+                .unwrap(),
+        );
+
+        let tools = HashMap::from([("execute_range_query".to_string(), 10)]);
+        let counter = TiktokenCounter::default_counter();
+        let budget = ContextBudget::new(128_000, 0.20, 0, std::sync::Arc::new(counter));
+        let wrapper = ScratchpadWrapper::new(tools, storage.clone(), budget);
+
+        // Valid JSON payload, large enough to be intercepted...
+        let items: String = (0..200)
+            .map(|i| format!("{{\"metric\":{{\"id\":{i}}},\"value\":{i}}},"))
+            .collect();
+        let json = format!("{{\"result\":[{}]}}", items.trim_end_matches(','));
+        // ...with the persistence footer appended, exactly as persistence does.
+        let with_footer = format!(
+            "{json}\n\n[Tool output saved to artifact: \
+             task-0-metrics-iter-1-execute_range_query-0-output.txt]"
+        );
+
+        let mut ctx = ToolCallContext::new("execute_range_query");
+        ctx.task_id = Some(0);
+        ctx.tool_initiator_id = "metrics".to_string();
+        ctx.attempt = Some(0);
+
+        let result = wrapper.transform_output(with_footer, &ok(), &ctx, None);
+        assert!(result.output.contains("[scratchpad:"), "must intercept");
+
+        let files = storage.list_files().await.unwrap();
+        let name = files.first().expect("a scratchpad file must be written");
+        let written = tokio::fs::read_to_string(storage.dir().join(name))
+            .await
+            .unwrap();
+
+        assert!(
+            !written.contains("[Tool output saved to artifact:"),
+            "persistence footer must be stripped from the scratchpad file; tail: {}",
+            &written[written.len().saturating_sub(120)..]
+        );
+        // The file (pretty-printed on write) must parse as JSON and match the
+        // original payload semantically — the whole point of the strip.
+        let written_value: serde_json::Value = serde_json::from_str(&written)
+            .expect("written scratchpad file must be valid JSON after footer strip");
+        let expected: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(written_value, expected);
     }
 
     #[tokio::test]

--- a/crates/aura/src/scratchpad/wrapper.rs
+++ b/crates/aura/src/scratchpad/wrapper.rs
@@ -4,30 +4,13 @@
 use super::context_budget::ContextBudget;
 use super::storage::ScratchpadStorage;
 use crate::mcp_response::CallOutcome;
+use crate::orchestration::persistence_wrapper::strip_artifact_footer;
 use crate::tool_wrapper::{ToolCallContext, ToolWrapper, TransformOutputResult};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
-
-/// Inline footer the persistence wrapper appends to promoted tool outputs
-/// (see `orchestration::persistence_wrapper`). Kept in sync with that marker.
-const ARTIFACT_FOOTER_MARKER: &str = "\n\n[Tool output saved to artifact: ";
-
-/// Strip a trailing persistence artifact footer from `output`, if present.
-///
-/// `ComposedWrapper` runs `transform_output` in reverse order, so the
-/// persistence wrapper appends its footer before this wrapper sees the output.
-/// Mirrors the strip in `persistence_wrapper` so the scratchpad never writes
-/// the footer into a file, where it would corrupt otherwise-valid JSON and
-/// break `get_in`/`schema`/`iterate_over`.
-fn strip_artifact_footer(output: &str) -> &str {
-    match output.rfind(ARTIFACT_FOOTER_MARKER) {
-        Some(pos) => &output[..pos],
-        None => output,
-    }
-}
 
 /// Build the primary "this lives in a file, explore it with these tools"
 /// pointer. Shared by [`ScratchpadWrapper`] (for intercepted MCP output) and
@@ -109,15 +92,13 @@ impl ToolWrapper for ScratchpadWrapper {
             None => return TransformOutputResult::new(output),
         };
 
-        // Persistence runs before this wrapper (ComposedWrapper applies
-        // transform_output in reverse order) and may have appended an artifact
-        // footer. Diverting to the scratchpad replaces the output with our own
-        // pointer, so that footer is redundant here — and writing it into the
-        // scratchpad file would append a non-JSON line that breaks get_in,
-        // schema, and iterate_over on otherwise-valid JSON. Strip it before
-        // counting, hashing, and writing. The passthrough returns below keep
-        // the original output so the footer still serves as the persistence
-        // read_artifact pointer when the scratchpad does not intercept.
+        // The output may arrive with a trailing artifact footer already
+        // appended. The pointer built below replaces the whole output, and
+        // the scratchpad file must hold only the raw tool output — a
+        // trailing non-JSON footer breaks get_in, schema, and iterate_over
+        // on otherwise-valid JSON. Strip it before counting, hashing, and
+        // writing. Passthrough returns hand back `output` untouched, footer
+        // and all.
         let content = strip_artifact_footer(&output);
 
         let output_tokens = self.budget.count_tokens(content);
@@ -401,12 +382,11 @@ mod tests {
         assert_eq!(strip_artifact_footer(body), body);
     }
 
-    /// A large JSON output that arrives carrying the persistence wrapper's
-    /// artifact footer (persistence runs first under `ComposedWrapper`) must be
-    /// written to the scratchpad file WITHOUT the footer, so the exploration
-    /// tools can still parse it as JSON. Regression test for the footer leaking
-    /// into the file and breaking get_in/schema/iterate_over with "not valid
-    /// JSON".
+    /// A large JSON output that arrives carrying a trailing artifact footer
+    /// must be written to the scratchpad file WITHOUT the footer, so the
+    /// exploration tools can still parse it as JSON. Regression test for the
+    /// footer leaking into the file and breaking get_in/schema/iterate_over
+    /// with "not valid JSON".
     #[tokio::test]
     async fn test_wrapper_strips_persistence_footer_before_write() {
         let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Two recoverable-but-noisy `ToolCallError` warnings were appearing in production when the agent used MCP tools that return large outputs (e.g. Prometheus range queries):

- `Not JSON: file is not valid JSON`
- `Invalid argument: Invalid regex: regex parse error … unclosed counted repetition`

Both originate in the **scratchpad** layer, not the MCP servers. This PR fixes the root causes.

## Root cause & fixes

**1. Persistence footer corrupted the scratchpad file (`wrapper.rs`)**

`ComposedWrapper` runs `transform_output` in reverse order, so the persistence wrapper runs *before* the scratchpad wrapper and appends an inline `[Tool output saved to artifact: …]` footer. The scratchpad then wrote that footer-bearing output verbatim to disk. For JSON tool results this left a non-JSON line after the closing brace, so the file was invalid JSON and `get_in`/`schema`/`iterate_over` failed with `Not JSON`.

Fix: strip the footer before counting, hashing, and writing. Passthrough returns keep the original output, so the footer still serves as the `read_artifact` pointer when the scratchpad doesn't intercept. Stripping before hashing also closes a dedup gap (identical raw outputs previously hashed differently due to call-specific footer text).

**2. `grep` rejected literal patterns (`tools.rs`)**

The model often passes a literal JSON fragment (e.g. `"metric": {`) as the grep pattern; the unescaped `{` fails to compile as a regex. `grep` now falls back to a literal (escaped) search instead of erroring.

**3. Clearer non-JSON error (`tools.rs`)**

The `NotJson` message now points the model at `read`/`head`/`grep`/`slice` so it self-corrects instead of retrying a JSON-only tool.

## Tests

New regression tests (all passing; `cargo clippy -p aura` clean):
- `test_strip_artifact_footer`
- `test_wrapper_strips_persistence_footer_before_write`
- `test_grep_falls_back_to_literal_on_invalid_regex`

## Related

- #111 — sibling cause of the same `Not JSON` symptom (double-encoded JSON from MCP). Not fixed here, but the clearer error message helps that case too.