### PR TITLE
feat(cli): default to standalone mode when --api-url is absent

### DIFF
--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -54,6 +54,11 @@ nextest: $(DOCKER_ENV) $(NEXTEST_BIN) $(REPORT_DIR)
 lint-rust: | $(DOCKER_ENV) $(REPORT_DIR)  ## lint rust code via clippy
 	$(RUN) cargo clippy $(if $(IS_CI),-q,) --all-targets --all-features $(if $(IS_CI),--message-format=json,) -- -D warnings $(if $(IS_CI),> $(REPORT_DIR)/clippy.json,)
 
+.PHONY: check-cli-http-only
+check-cli-http-only: $(DOCKER_ENV) ## Verify the HTTP-only (no-default-features) aura-cli still builds
+	$(RUN) cargo clippy -p aura-cli --no-default-features --all-targets -- -D warnings
+	$(RUN) cargo test -p aura-cli --no-default-features
+
 .PHONY: update-lockfile
 update-lockfile: $(DOCKER_ENV) ## Regenerate Cargo.lock after version changes
 	$(RUN) cargo update --quiet --workspace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,8 @@ CONFIG_PATH=configs/example-math-orchestration.toml AURA_CUSTOM_EVENTS=true carg
 # Build and run CLI (HTTP mode — connects to aura-web-server)
 cargo run -p aura-cli -- --api-url http://localhost:8080
 
-# Build and run CLI (standalone mode — no server needed)
-cargo run -p aura-cli --features standalone-cli -- --standalone --config configs/my-agent.toml
+# Build and run CLI (standalone mode — no server needed, default when --api-url absent)
+cargo run -p aura-cli -- --config configs/my-agent.toml
 
 # Run integration tests (local, requires Docker)
 make test-integration-local                        # base integration
@@ -115,8 +115,8 @@ aura/
 ### CLI (`aura-cli`)
 - Interactive terminal client with REPL, one-shot mode, and conversation persistence
 - **One-shot output contract** (`--query`): stdout is the **raw assistant response only** — no `●` markers, no markdown rendering, no tool-execution summaries, no response-summary header, no `backend.summarize` round-trip. Errors, permission prompts, and warnings go to stderr (with `error:` / `warning:` prefixes, no markers). Exit code 0 ⇒ stdout is the full response; non-zero ⇒ stderr explains and stdout is empty. The REPL retains rich formatting; the strict-output rules apply only to `--query` mode. See `crates/aura-cli/src/oneshot.rs`.
-- **Two backends:** HTTP mode (default) and standalone mode (`--standalone --config`, builds agents in-process)
-- Standalone mode requires `--features standalone-cli` at build time and explicit `--standalone` flag at runtime
+- **Two backends:** standalone mode (default when `--api-url` absent) and HTTP mode (`--api-url`)
+- Standalone mode is enabled by the `standalone-cli` default feature; `--standalone` flag overrides `AURA_API_URL` env var but is mutually exclusive with the `--api-url` flag. HTTP-only builds: `--no-default-features`
 - `--model` works in both modes: HTTP passes it as starting model; standalone matches against agent.name/agent.alias in configs
 - `--system-prompt` works in both modes: standalone prompts for append/replace; HTTP prompts for AURA vs OpenAI-compatible service
 - `--force` bypasses non-critical warnings (e.g. HTTP system-prompt in query mode)
@@ -128,7 +128,7 @@ aura/
 - `/model` command works in both modes — lists server models (HTTP) or loaded TOML configs (standalone)
 - Env vars: `AURA_API_URL`, `AURA_API_KEY`, `AURA_MODEL`, `AURA_EXTRA_HEADERS`, `AURA_LOG_FILE`
 - **Diagnostic logs**: opt-in via `--log-file <path>` / `AURA_LOG_FILE` / `cli.toml` `log_file` (precedence: CLI > env > project > global > none). Events are appended to the file (no rotation — user-managed) in **both REPL and one-shot mode**, so stdout stays a clean pipe. Default filter is `warn,aura=info,aura_cli=info,aura_config=info,rig::agent::prompt_request=info`; override with `RUST_LOG`.
-- **OpenTelemetry (standalone only)**: when built with `--features standalone-cli` and run with `--standalone`, the CLI installs an OTel layer when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Trace shape mirrors the web server — `agent.stream` root span via `direct.rs`, with `agent.turn` / `mcp.tool_call` / `orchestration.*` nesting under it. CLI omits the HTTP-infrastructure spans (`chat_completions`, `streaming_completion`) since it has no HTTP layer.
+- **OpenTelemetry (standalone only)**: when running in standalone mode, the CLI installs an OTel layer when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Trace shape mirrors the web server — `agent.stream` root span via `direct.rs`, with `agent.turn` / `mcp.tool_call` / `orchestration.*` nesting under it. CLI omits the HTTP-infrastructure spans (`chat_completions`, `streaming_completion`) since it has no HTTP layer.
 - **Single shared tokio runtime**: `main` owns one `tokio::runtime::Runtime` and threads it into `Backend::from_config`, `run_oneshot`, and `run_repl`. `logging::init` runs inside `rt.enter()` so the OTLP gRPC exporter can call `Handle::current()` during `with_tonic()` construction; the `BatchSpanProcessor` worker lives on the same runtime that handles every subsequent request. `main` calls `aura::logging::shutdown_tracer()` via `rt.block_on(...)` before returning to flush buffered spans.
 - SSE event parsing uses shared types from `aura-events` crate (not in `default-members`, build explicitly with `cargo build -p aura-cli`)
 - See `crates/aura-cli/README.md` for full documentation

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ To validate your own config file, start the web server or CLI — both validate 
 cargo run -p aura-web-server -- --config your-config.toml
 
 # Validate via standalone CLI (exits on parse error before REPL)
-cargo run -p aura-cli --features standalone-cli -- --standalone --config your-config.toml
+cargo run -p aura-cli -- --config your-config.toml
 ```
 
 ### Orchestration

--- a/crates/aura-cli/Cargo.toml
+++ b/crates/aura-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "aura-cli"
 path = "src/main.rs"
 
 [features]
-default = []
+default = ["standalone-cli"]
 standalone-cli = ["dep:aura", "dep:aura-config", "dep:aura-web-server", "dep:bytes", "dep:tokio-stream", "dep:tokio-util", "dep:thiserror"]
 
 [dependencies]

--- a/crates/aura-cli/README.md
+++ b/crates/aura-cli/README.md
@@ -9,11 +9,11 @@ A fast, interactive terminal client for chat completions with tool execution. Bu
 ### Build from the mono-repo
 
 ```bash
-# HTTP-only mode (lightweight, connects to an aura-web-server)
+# Default build (standalone + HTTP — builds agents in-process from TOML config)
 cargo build -p aura-cli --release
 
-# Standalone mode (builds agents in-process from TOML config, no server needed)
-cargo build -p aura-cli --release --features standalone-cli
+# HTTP-only mode (lightweight, no agent/MCP dependencies)
+cargo build -p aura-cli --release --no-default-features
 ```
 
 The binary will be at `target/release/aura-cli`.
@@ -35,20 +35,23 @@ aura-cli --api-url "https://api.example.com" \
 
 #### Standalone mode (no server needed)
 
-When built with `--features standalone-cli`, the CLI can load agent configs directly and run without an HTTP server. Use the `--standalone` flag along with `--config`:
+Standalone mode is enabled by default. The CLI loads agent configs directly and runs without an HTTP server. When `--api-url` is not set, standalone mode activates automatically:
 
 ```bash
+# Uses config.toml in the current directory by default
+aura-cli
+
 # Single TOML config file
-aura-cli --standalone --config path/to/agent.toml
+aura-cli --config path/to/agent.toml
 
 # Directory of TOML configs (enables /model switching between agents)
-aura-cli --standalone --config configs/
+aura-cli --config configs/
 
 # One-shot query in standalone mode
-aura-cli --standalone --config agent.toml --query "hello"
+aura-cli --config agent.toml --query "hello"
 
 # Select a specific agent from a config directory
-aura-cli --standalone --config configs/ --model "Math Agent"
+aura-cli --config configs/ --model "Math Agent"
 ```
 
 In standalone mode, the CLI builds agents in-process using the same code paths as `aura-web-server`. MCP tools from the TOML config are available. CLI local tools (Shell, Read, Update, ...) become available when **both** sides opt in — pass `--enable-client-tools` and set `[agent].enable_client_tools = true` in the loaded TOML config (single-agent configs only; orchestrated configs drop client tools). See [Client-Side Tools](#client-side-tools) for details. The `/model` command works identically — it lists all loaded configs and lets you switch between them.
@@ -99,25 +102,25 @@ aura-cli init --provider openai --model gpt-4o --non-interactive
 
 ## Backends
 
-AURA CLI supports two backends, selected explicitly via the `--standalone` flag:
+AURA CLI supports two backends, selected by the presence of `--api-url`:
 
 | Backend                 | When                         | Dependencies                             | Tools                                                                            |
 | ----------------------- | ---------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------- |
-| **HTTP** (default)      | No `--standalone` flag       | Lightweight — just HTTP client           | Server-side MCP tools always; CLI local tools when both sides opt in (see below) |
-| **Direct** (standalone) | `--standalone --config path` | Full AURA stack (agents, MCP, providers) | MCP tools from TOML config; CLI local tools when `--enable-client-tools` is set  |
+| **Direct** (standalone, default) | No `--api-url` flag    | Full AURA stack (agents, MCP, providers) | MCP tools from TOML config; CLI local tools when `--enable-client-tools` is set  |
+| **HTTP**                         | `--api-url <URL>`      | Lightweight — just HTTP client           | Server-side MCP tools always; CLI local tools when both sides opt in (see below) |
 
 Both backends produce identical SSE event streams and share the same stream parser (`process_sse_events`), so all CLI features (stream panel, tool display, orchestration events, etc.) work identically regardless of backend.
 
 ### Feature flag: `standalone-cli`
 
-The `--standalone` and `--config` flags require the `standalone-cli` Cargo feature. Without it, the binary is a lightweight HTTP-only client with no agent or MCP dependencies.
+The `standalone-cli` Cargo feature is **enabled by default**. It includes the full agent framework, MCP integration, and provider support. To build a lightweight HTTP-only client with no agent or MCP dependencies, disable default features:
 
 ```bash
-# HTTP-only (default) — small binary, fast compile
+# Default build — standalone + HTTP
 cargo build -p aura-cli
 
-# Standalone — includes full agent framework
-cargo build -p aura-cli --features standalone-cli
+# HTTP-only — small binary, fast compile, no agent dependencies
+cargo build -p aura-cli --no-default-features
 ```
 
 ---
@@ -127,7 +130,7 @@ cargo build -p aura-cli --features standalone-cli
 - **Interactive REPL** with conversation history, streaming responses, and markdown rendering
 - **One-shot mode** for scripting and pipelines (`--query`) — stdout is the raw assistant response, no markers or markdown rendering
 - **Local tool execution** — the model can read files, search code, list directories, run shell commands, and edit files on your behalf
-- **Standalone mode** — run agents directly from TOML config without a web server (`--standalone --config`)
+- **Standalone mode** (default) — run agents directly from TOML config without a web server
 - **Conversation persistence** — pick up where you left off with `--resume` or `/resume`
 - **Tab completion** — cycle through matching models and conversations with `Tab` / `Shift+Tab`
 - **Model selection** — browse and select models from the server (or loaded configs in standalone mode)
@@ -170,8 +173,8 @@ aura-cli [OPTIONS]
 | `--force`                                  | —                                    | Bypass warnings and non-critical errors (useful in one-shot/query mode)                                  |
 | `--enable-client-tools[=<bool>]`           | `AURA_ENABLE_CLIENT_TOOLS`           | Advertise CLI local tools to the model (default: disabled — see [Client-Side Tools](#client-side-tools)) |
 | `--enable-final-response-summary[=<bool>]` | `AURA_ENABLE_FINAL_RESPONSE_SUMMARY` | Generate a one-line LLM title for each final response (adds an extra round-trip per turn; default: disabled) |
-| `--standalone`                             | —                                    | Run in standalone mode (requires `--config`, requires `standalone-cli` feature)                          |
-| `--config <PATH>`                          | —                                    | Path to TOML agent config file or directory (requires `--standalone`)                                    |
+| `--standalone`                             | —                                    | Force standalone mode (default when `--api-url` is absent; mutually exclusive with `--api-url` flag, but overrides `AURA_API_URL` env var) |
+| `--config <PATH>`                          | —                                    | Path to TOML agent config file or directory (standalone mode; defaults to `config.toml`)                 |
 | `--log-file <PATH>`                        | `AURA_LOG_FILE`                      | Append diagnostic tracing logs to this file. Omit for no logging (see [Logging](#logging))               |
 
 **Precedence:** CLI flags > environment variables > project `cli.toml` > global `cli.toml` > defaults.
@@ -449,7 +452,7 @@ levels.
 
 ### Standalone-mode OpenTelemetry
 
-When built with `--features standalone-cli` and run with `--standalone`, the
+When running in standalone mode (the default when `--api-url` is absent), the
 CLI runs the agent in-process. Set `OTEL_EXPORTER_OTLP_ENDPOINT` and the CLI
 will install an OpenTelemetry layer alongside (or instead of) the file fmt
 layer — the same trace structure (`agent.stream` → `agent.turn` →
@@ -520,21 +523,21 @@ When `--enable-client-tools` is off, the CLI only sees server-side tool executio
 ## Building & Testing
 
 ```bash
-# Build (HTTP-only)
+# Build (default — standalone + HTTP)
 cargo build -p aura-cli
 
-# Build (standalone)
-cargo build -p aura-cli --features standalone-cli
+# Build (HTTP-only — lightweight, no agent dependencies)
+cargo build -p aura-cli --no-default-features
 
 # Run tests
-cargo test -p aura-cli                           # HTTP-only mode
-cargo test -p aura-cli --features standalone-cli  # + standalone tests
+cargo test -p aura-cli                       # default (standalone + HTTP)
+cargo test -p aura-cli --no-default-features  # HTTP-only path
 
 # Clippy
 cargo clippy -p aura-cli --all-targets
-cargo clippy -p aura-cli --features standalone-cli --all-targets
+cargo clippy -p aura-cli --no-default-features --all-targets
 
 # Run directly
-cargo run -p aura-cli -- --api-url "http://localhost:8080"
-cargo run -p aura-cli --features standalone-cli -- --standalone --config agent.toml
+cargo run -p aura-cli -- --config agent.toml                    # standalone (default)
+cargo run -p aura-cli -- --api-url "http://localhost:8080"      # HTTP mode
 ```

--- a/crates/aura-cli/src/backend/mod.rs
+++ b/crates/aura-cli/src/backend/mod.rs
@@ -27,17 +27,19 @@ pub enum Backend {
 impl Backend {
     /// Create the appropriate backend based on config.
     ///
-    /// If `--standalone` is set, uses `DirectBackend` with the config from `--config`.
+    /// When `is_standalone` is true, uses `DirectBackend` with the config from
+    /// `--config` (or `config.toml` in the current directory if omitted).
     /// Otherwise, uses `HttpBackend` (HTTP/SSE to aura-web-server).
     pub fn from_config(
         _rt: &tokio::runtime::Runtime,
         config: &AppConfig,
         _args: &Args,
+        _is_standalone: bool,
     ) -> Result<Self> {
         #[cfg(feature = "standalone-cli")]
-        if _args.standalone {
-            // validate_standalone_args guarantees --config is present when --standalone is set
-            let config_path = _args.agent_config.as_ref().unwrap();
+        if _is_standalone {
+            let default_config = String::from("config.toml");
+            let config_path = _args.agent_config.as_ref().unwrap_or(&default_config);
             let direct = _rt.block_on(direct::DirectBackend::from_toml(
                 config_path,
                 config.extra_headers.clone(),

--- a/crates/aura-cli/src/cli.rs
+++ b/crates/aura-cli/src/cli.rs
@@ -85,12 +85,19 @@ pub struct Args {
           num_args = 0..=1, default_missing_value = "true")]
     pub enable_final_response_summary: Option<bool>,
 
-    /// Run in standalone mode (requires --config). Builds agents in-process from TOML config.
+    /// Run in standalone mode — builds agents in-process from TOML config
+    /// instead of connecting to an aura-web-server over HTTP. This is the
+    /// default when --api-url is not provided; pass --standalone explicitly
+    /// when you want standalone mode *and* --api-url is set (e.g. for
+    /// debugging).
     #[cfg(feature = "standalone-cli")]
     #[arg(long)]
     pub standalone: bool,
 
-    /// Path to TOML agent config file or directory (requires --standalone)
+    /// Path to TOML agent config file or directory for standalone mode.
+    /// When --api-url is not set, standalone mode is the default and this
+    /// flag selects which config to load. When omitted, defaults to
+    /// `config.toml` in the current directory.
     #[cfg(feature = "standalone-cli")]
     #[arg(long = "config")]
     pub agent_config: Option<String>,
@@ -110,8 +117,11 @@ pub struct Args {
     pub log_file: Option<String>,
 }
 
-/// Pre-parse check for `--config` and `--standalone` when the standalone-cli feature is not enabled.
-/// Gives a helpful error instead of clap's generic "unexpected argument" message.
+/// Pre-parse check when the standalone-cli feature is not enabled.
+///
+/// Catches `--config`/`--standalone` before clap parses (clap would give a
+/// cryptic "unexpected argument" message). Also errors when no `--api-url` is
+/// set, since standalone mode (the default) is unavailable without the feature.
 #[cfg(not(feature = "standalone-cli"))]
 pub fn check_standalone_flag() {
     let has_standalone = std::env::args().any(|a| a == "--standalone");
@@ -125,38 +135,65 @@ pub fn check_standalone_flag() {
         };
         eprintln!(
             "error: {flag} requires the standalone-cli feature\n\n\
-             This build of aura-cli is an HTTP client only and cannot load \
-             agent configs directly.\n\n\
-             To run standalone (without an aura-web-server), you'll need a \
-             \"standalone-cli\" build of aura-cli.\n\n\
-             Without --standalone, aura-cli connects to a server via HTTP.\n\
-             Use --api-url to specify the server address."
+             This build of aura-cli is HTTP-only and cannot load agent configs \
+             directly. Standalone mode (the default) is not available.\n\n\
+             Pass --api-url to connect to an aura-web-server over HTTP, or \
+             rebuild with the standalone-cli feature (enabled by default)."
+        );
+        std::process::exit(2);
+    }
+
+    let has_api_url = std::env::args().any(|a| a == "--api-url" || a.starts_with("--api-url="))
+        || std::env::var("AURA_API_URL").ok().filter(|v| !v.is_empty()).is_some();
+
+    if !has_api_url {
+        eprintln!(
+            "error: --api-url is required (standalone mode unavailable)\n\n\
+             This build of aura-cli was compiled without the standalone-cli \
+             feature, so it cannot run agents in-process. Provide --api-url \
+             to connect to an aura-web-server, or rebuild with the default \
+             features to enable standalone mode."
         );
         std::process::exit(2);
     }
 }
 
-/// Post-parse validation for standalone mode flag pairing.
-/// Ensures --standalone and --config are used together.
+/// Resolve whether the CLI should run in standalone mode and which config
+/// to use. Standalone is the default when `--api-url` is absent.
+///
+/// Returns `true` if standalone mode should be used.
 #[cfg(feature = "standalone-cli")]
-pub fn validate_standalone_args(args: &Args) {
-    if args.agent_config.is_some() && !args.standalone {
+pub fn resolve_standalone(args: &Args) -> bool {
+    let api_url_set = args.api_url.is_some()
+        || std::env::var("AURA_API_URL").ok().filter(|v| !v.is_empty()).is_some();
+
+    if args.standalone && api_url_set && args.agent_config.is_none() {
         eprintln!(
-            "error: --config requires --standalone\n\n\
-             The --config flag is only valid in standalone mode. Add --standalone \
-             to run agents in-process from TOML config:\n\n\
-             aura-cli --standalone --config <path>"
+            "error: --standalone with --api-url requires --config\n\n\
+             When both --standalone and --api-url are set, standalone mode is \
+             explicit and needs a TOML config. Provide --config <path>, or drop \
+             --standalone to use HTTP mode."
         );
         std::process::exit(2);
     }
 
-    if args.standalone && args.agent_config.is_none() {
-        eprintln!(
-            "error: --standalone requires --config\n\n\
-             Standalone mode needs a TOML agent config to load. Provide the path \
-             to a config file or directory:\n\n\
-             aura-cli --standalone --config <path>"
-        );
-        std::process::exit(2);
+    if args.standalone {
+        return true;
     }
+
+    // No --api-url and no explicit --standalone → standalone by default
+    if !api_url_set {
+        return true;
+    }
+
+    // --api-url is set and --standalone is not → HTTP mode.
+    // --config is ignored in HTTP mode; warn if it was passed.
+    if args.agent_config.is_some() {
+        eprintln!(
+            "warning: --config is ignored in HTTP mode (--api-url is set)\n\
+             To run standalone with a config, omit --api-url or add --standalone."
+        );
+    }
+
+    false
 }

--- a/crates/aura-cli/src/cli.rs
+++ b/crates/aura-cli/src/cli.rs
@@ -123,6 +123,13 @@ pub struct Args {
 /// set, since standalone mode (the default) is unavailable without the feature.
 #[cfg(not(feature = "standalone-cli"))]
 pub fn check_standalone_flag() {
+    // Let clap handle --help / --version and subcommands before we error
+    let pass_through = std::env::args()
+        .any(|a| matches!(a.as_str(), "--help" | "-h" | "--version" | "-V" | "init"));
+    if pass_through {
+        return;
+    }
+
     let has_standalone = std::env::args().any(|a| a == "--standalone");
     let has_config = std::env::args().any(|a| a == "--config" || a.starts_with("--config="));
 

--- a/crates/aura-cli/src/cli.rs
+++ b/crates/aura-cli/src/cli.rs
@@ -144,7 +144,10 @@ pub fn check_standalone_flag() {
     }
 
     let has_api_url = std::env::args().any(|a| a == "--api-url" || a.starts_with("--api-url="))
-        || std::env::var("AURA_API_URL").ok().filter(|v| !v.is_empty()).is_some();
+        || std::env::var("AURA_API_URL")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .is_some();
 
     if !has_api_url {
         eprintln!(
@@ -165,7 +168,10 @@ pub fn check_standalone_flag() {
 #[cfg(feature = "standalone-cli")]
 pub fn resolve_standalone(args: &Args) -> bool {
     let api_url_set = args.api_url.is_some()
-        || std::env::var("AURA_API_URL").ok().filter(|v| !v.is_empty()).is_some();
+        || std::env::var("AURA_API_URL")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .is_some();
 
     if args.standalone && api_url_set && args.agent_config.is_none() {
         eprintln!(

--- a/crates/aura-cli/src/cli.rs
+++ b/crates/aura-cli/src/cli.rs
@@ -87,9 +87,8 @@ pub struct Args {
 
     /// Run in standalone mode — builds agents in-process from TOML config
     /// instead of connecting to an aura-web-server over HTTP. This is the
-    /// default when --api-url is not provided; pass --standalone explicitly
-    /// when you want standalone mode *and* --api-url is set (e.g. for
-    /// debugging).
+    /// default when --api-url is not provided. Mutually exclusive with the
+    /// --api-url flag, but overrides the AURA_API_URL env var.
     #[cfg(feature = "standalone-cli")]
     #[arg(long)]
     pub standalone: bool,
@@ -167,28 +166,34 @@ pub fn check_standalone_flag() {
 /// Returns `true` if standalone mode should be used.
 #[cfg(feature = "standalone-cli")]
 pub fn resolve_standalone(args: &Args) -> bool {
-    let api_url_set = args.api_url.is_some()
-        || std::env::var("AURA_API_URL")
-            .ok()
-            .filter(|v| !v.is_empty())
-            .is_some();
+    // clap merges --api-url and AURA_API_URL into args.api_url, so we
+    // check raw argv to distinguish the CLI flag from the env var.
+    let api_url_from_flag =
+        std::env::args().any(|a| a == "--api-url" || a.starts_with("--api-url="));
+    let api_url_from_env = std::env::var("AURA_API_URL")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .is_some();
 
-    if args.standalone && api_url_set && args.agent_config.is_none() {
+    if args.standalone && api_url_from_flag {
         eprintln!(
-            "error: --standalone with --api-url requires --config\n\n\
-             When both --standalone and --api-url are set, standalone mode is \
-             explicit and needs a TOML config. Provide --config <path>, or drop \
-             --standalone to use HTTP mode."
+            "error: --standalone and --api-url are mutually exclusive\n\n\
+             Standalone mode builds agents in-process and never contacts a \
+             remote server. Drop one of the two flags.\n\n\
+             If AURA_API_URL is set in your environment and you want \
+             standalone mode, pass --standalone (without --api-url) to \
+             override the env var."
         );
         std::process::exit(2);
     }
 
+    // --standalone overrides AURA_API_URL env var
     if args.standalone {
         return true;
     }
 
-    // No --api-url and no explicit --standalone → standalone by default
-    if !api_url_set {
+    // No API URL from either source → standalone by default
+    if args.api_url.is_none() && !api_url_from_env {
         return true;
     }
 

--- a/crates/aura-cli/src/main.rs
+++ b/crates/aura-cli/src/main.rs
@@ -34,16 +34,12 @@ fn main() -> Result<()> {
         dotenvy::from_path(dir.join(".env")).ok();
     }
 
-    // Validate --standalone + --config pairing when feature is enabled.
     #[cfg(feature = "standalone-cli")]
-    aura_cli::cli::validate_standalone_args(&args);
-
-    let mut config = AppConfig::load(&args)?;
-
-    #[cfg(feature = "standalone-cli")]
-    let is_standalone = args.standalone;
+    let is_standalone = aura_cli::cli::resolve_standalone(&args);
     #[cfg(not(feature = "standalone-cli"))]
     let is_standalone = false;
+
+    let mut config = AppConfig::load(&args)?;
 
     // One process-wide tokio runtime, owned by `main` and threaded into
     // `Backend::from_config`, `run_oneshot`, and `run_repl`.
@@ -82,7 +78,7 @@ fn main() -> Result<()> {
     // `render_queued_wave` in `ui::animation`.
     aura_cli::ui::prompt::set_pretty(config.pretty);
     let permissions = PermissionChecker::load(&std::env::current_dir()?)?;
-    let mut backend = Backend::from_config(&rt, &config, &args)?;
+    let mut backend = Backend::from_config(&rt, &config, &args, is_standalone)?;
 
     let is_query = config.query.is_some();
 

--- a/crates/aura-cli/tests/cli_args.rs
+++ b/crates/aura-cli/tests/cli_args.rs
@@ -261,35 +261,50 @@ fn help_includes_standalone_and_config_flags() {
 
 #[cfg(feature = "standalone-cli")]
 #[test]
-fn standalone_without_config_exits_with_error() {
+fn standalone_without_config_defaults_to_config_toml() {
+    // --standalone without --config should try to load config.toml (will fail
+    // because the file doesn't exist, but it should NOT error about missing flags)
     let output = aura_cli().arg("--standalone").output().unwrap();
-    assert!(
-        !output.status.success(),
-        "--standalone without --config should fail"
-    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("--standalone requires --config"),
-        "should explain that --config is required"
+        !stderr.contains("requires --config"),
+        "should not require --config; defaults to config.toml"
     );
 }
 
 #[cfg(feature = "standalone-cli")]
 #[test]
-fn config_without_standalone_exits_with_error() {
+fn config_without_standalone_implies_standalone() {
+    // --config without --standalone and without --api-url should enter
+    // standalone mode (will fail to load the file, but shouldn't error
+    // about missing --standalone)
     let output = aura_cli()
         .arg("--config")
         .arg("some/path.toml")
         .output()
         .unwrap();
-    assert!(
-        !output.status.success(),
-        "--config without --standalone should fail"
-    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("--config requires --standalone"),
-        "should explain that --standalone is required"
+        !stderr.contains("requires --standalone"),
+        "should not require --standalone; standalone is default without --api-url"
+    );
+}
+
+#[cfg(feature = "standalone-cli")]
+#[test]
+fn config_with_api_url_warns_ignored() {
+    // --config + --api-url (without --standalone) → HTTP mode, warns about --config
+    let output = aura_cli()
+        .arg("--api-url")
+        .arg("http://localhost:9999")
+        .arg("--config")
+        .arg("some/path.toml")
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--config is ignored in HTTP mode"),
+        "should warn that --config is ignored when --api-url is set"
     );
 }
 

--- a/crates/aura-cli/tests/cli_args.rs
+++ b/crates/aura-cli/tests/cli_args.rs
@@ -308,6 +308,28 @@ fn config_with_api_url_warns_ignored() {
     );
 }
 
+#[cfg(feature = "standalone-cli")]
+#[test]
+fn standalone_and_api_url_flags_are_mutually_exclusive() {
+    let output = aura_cli()
+        .arg("--standalone")
+        .arg("--api-url")
+        .arg("http://localhost:9999")
+        .arg("--config")
+        .arg("some/path.toml")
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "--standalone and --api-url together should fail"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("mutually exclusive"),
+        "should explain that --standalone and --api-url are mutually exclusive"
+    );
+}
+
 #[cfg(not(feature = "standalone-cli"))]
 #[test]
 fn standalone_flag_without_feature_exits_with_error() {

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,11 +57,11 @@ cargo build -p aura-cli --release
 ./target/release/aura-cli
 ```
 
-The CLI also supports a **standalone mode** that runs agents in-process from a TOML config — no server needed:
+The CLI defaults to **standalone mode** — it runs agents in-process from a TOML config, no server needed:
 
 ```bash
-cargo build -p aura-cli --release --features standalone-cli
-./target/release/aura-cli --standalone --config quickstart.toml
+cargo build -p aura-cli --release
+./target/release/aura-cli --config quickstart.toml
 ```
 
 See the [CLI README](../crates/aura-cli/README.md) for the full feature set.


### PR DESCRIPTION
## Summary

- Make `standalone-cli` a default cargo feature so release binaries and the Docker image include standalone support without extra build flags
- Default to standalone mode when `--api-url` / `AURA_API_URL` is not set — simplifies the common invocation from `aura-cli --standalone --config config.toml` to just `aura-cli`
- `--config` defaults to `config.toml` in the current directory when omitted
- `--standalone` is only required when the user wants standalone mode *and* `--api-url` is set (e.g. for debugging)

## Changes

- **`Cargo.toml`**: `default = ["standalone-cli"]`
- **`cli.rs`**: New `resolve_standalone()` replaces `validate_standalone_args()` — decides mode based on whether `--api-url` is present. Non-feature builds error early when `--api-url` is absent
- **`backend/mod.rs`**: `from_config` takes `is_standalone: bool` instead of reading `args.standalone`; defaults config path to `config.toml`
- **`main.rs`**: Wired up to new `resolve_standalone()`
- **`tests/cli_args.rs`**: Updated tests for new behavior + new test for `--config` + `--api-url` warning

## Test plan

- [x] `cargo build -p aura-cli` (default features, includes standalone)
- [x] `cargo build -p aura-cli --no-default-features` (HTTP-only build)
- [x] `cargo test -p aura-cli` — 380 tests pass (366 unit + 14 integration)
- [x] `cargo clippy -p aura-cli` — clean
- [x] Verify `aura-cli` with no args enters standalone mode and tries `config.toml`
- [x] Verify `aura-cli --api-url http://... ` enters HTTP mode
- [ ] Verify Docker image build still works

Fixes #268