### PR TITLE
feat(agent): ability to hide agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,15 @@ system_prompt = "You are a DevOps expert."
 model_owner = "mezmo"        # override owned_by in /v1/models (defaults to LLM provider)
 ```
 
+**Hidden agents** are excluded from `GET /v1/models` and the CLI's `/model` list but remain fully accessible when a caller targets them by exact name or alias. Set `hidden = true` to hide agents that are in development, restricted to known callers, or should not appear in model pickers (LibreChat, OpenWebUI, etc.):
+
+```toml
+[agent]
+name = "Internal Triage Agent"
+hidden = true         # excluded from /v1/models and CLI model list; still callable by name
+system_prompt = "..."
+```
+
 Aliases must be unique across all loaded configs. If two configs share the same `name` and neither has an alias, loading fails with a validation error.
 
 ### Configuration Sections

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -106,6 +106,7 @@ impl DirectBackend {
         self.app_state
             .configs
             .iter()
+            .filter(|c| !c.agent.hidden)
             .map(|c| {
                 c.agent
                     .alias
@@ -514,6 +515,25 @@ mod tests {
             make_config("Code Agent", None, ""),
         ]);
         assert_eq!(backend.model_ids(), vec!["math", "Code Agent"]);
+    }
+
+    #[test]
+    fn model_ids_excludes_hidden_agents() {
+        let mut hidden = make_config("Secret Agent", None, "");
+        hidden.agent.hidden = true;
+        let backend = make_backend(vec![make_config("Visible Agent", None, ""), hidden]);
+        assert_eq!(backend.model_ids(), vec!["Visible Agent"]);
+    }
+
+    #[test]
+    fn find_matching_model_finds_hidden_agents() {
+        let mut hidden = make_config("Secret Agent", None, "");
+        hidden.agent.hidden = true;
+        let backend = make_backend(vec![hidden]);
+        assert_eq!(
+            backend.find_matching_model("Secret Agent"),
+            Some("Secret Agent".to_string())
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -1,3 +1,4 @@
+use crate::lenient_bool;
 use crate::lenient_int;
 use crate::orchestration::OrchestrationConfig;
 use crate::scratchpad::{ScratchpadConfig, ScratchpadToolEntry};
@@ -669,6 +670,11 @@ pub struct AgentConfig {
     /// provide `[orchestration.worker.<name>.scratchpad]`.
     #[serde(default)]
     pub scratchpad: Option<ScratchpadConfig>,
+    /// Indicates an agent should be hidden from a models list endpoint.
+    /// Useful when a model is not ready to be  or should only be invoked
+    /// by known callers (default: false)
+    #[serde(default, deserialize_with = "lenient_bool::deserialize_bool")]
+    pub hidden: bool,
 }
 
 fn default_turn_depth() -> Option<usize> {
@@ -697,6 +703,7 @@ impl Default for AgentConfig {
             client_tool_filter: None,
             llm: LlmConfig::default(),
             scratchpad: None,
+            hidden: bool::default(),
         }
     }
 }

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -921,6 +921,40 @@ seed = 42
     }
 
     #[test]
+    fn test_hidden_property() {
+        let test_cases: Vec<(&str, bool)> = vec![
+            //missing
+            ("", false),
+            // boolean
+            ("hidden = false", false),
+            ("hidden = true", true),
+            // string representation
+            ("hidden = \"false\"", false),
+            ("hidden = \"true\"", true),
+        ];
+
+        for (input, expected) in &test_cases {
+            let config_str = format!(
+                r#"
+[agent]
+name = "Test"
+system_prompt = "meh"
+{}
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
+"#,
+                input
+            );
+            let config_str = config_str.as_str();
+            let config = load_config_from_str(config_str).expect("config should have parsed");
+            assert_eq!(config.agent.hidden, *expected);
+        }
+    }
+
+    #[test]
     fn test_bedrock_embedding_config_parsing() {
         let config_str = r#"
 [agent.llm]

--- a/crates/aura-config/src/lenient_bool.rs
+++ b/crates/aura-config/src/lenient_bool.rs
@@ -1,0 +1,99 @@
+/// Serde helper for accepting booleans as either native bool or string ("true"/"false").
+///
+/// Helm/Go tooling can render booleans as quoted strings in generated configs.
+use serde::{Deserialize, Deserializer};
+
+pub fn deserialize_bool<'de, D: Deserializer<'de>>(deserializer: D) -> Result<bool, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum BoolOrString {
+        Bool(bool),
+        Str(String),
+    }
+
+    match BoolOrString::deserialize(deserializer)? {
+        BoolOrString::Bool(b) => Ok(b),
+        BoolOrString::Str(s) => match s.trim() {
+            "true" => Ok(true),
+            "false" => Ok(false),
+            other => Err(serde::de::Error::custom(format!(
+                "expected \"true\" or \"false\", got \"{other}\""
+            ))),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TestBool {
+        #[serde(deserialize_with = "deserialize_bool")]
+        val: bool,
+    }
+
+    fn from_json(json: &str) -> Result<TestBool, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    #[test]
+    fn accepts_native_true() {
+        assert!(from_json(r#"{"val": true}"#).unwrap().val);
+    }
+
+    #[test]
+    fn accepts_native_false() {
+        assert!(!from_json(r#"{"val": false}"#).unwrap().val);
+    }
+
+    #[test]
+    fn accepts_string_true() {
+        assert!(from_json(r#"{"val": "true"}"#).unwrap().val);
+    }
+
+    #[test]
+    fn accepts_string_false() {
+        assert!(!from_json(r#"{"val": "false"}"#).unwrap().val);
+    }
+
+    #[test]
+    fn accepts_padded_whitespace() {
+        assert!(from_json(r#"{"val": "  true  "}"#).unwrap().val);
+    }
+
+    #[test]
+    fn rejects_mixed_case() {
+        assert!(from_json(r#"{"val": "True"}"#).is_err());
+    }
+
+    #[test]
+    fn rejects_yes() {
+        assert!(from_json(r#"{"val": "yes"}"#).is_err());
+    }
+
+    #[test]
+    fn rejects_numeric_string() {
+        assert!(from_json(r#"{"val": "1"}"#).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_string() {
+        assert!(from_json(r#"{"val": ""}"#).is_err());
+    }
+
+    #[test]
+    fn rejects_whitespace_only() {
+        assert!(from_json(r#"{"val": "   "}"#).is_err());
+    }
+
+    #[test]
+    fn error_message_shows_the_bad_value() {
+        let err = from_json(r#"{"val": "yes"}"#).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("expected \"true\" or \"false\", got \"yes\"")
+        );
+    }
+}

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod env;
 pub mod error;
+pub mod lenient_bool;
 pub mod lenient_int;
 pub mod loader;
 pub mod orchestration;

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -861,10 +861,12 @@ pub async fn health() -> Response {
 
 /// OpenAI-compatible model listing endpoint.
 /// Each model `id` maps to an agent's `alias` (if set) or `name` from the TOML config.
+/// Filters out `hidden` agents
 pub async fn list_models(State(state): State<Arc<AppState>>) -> Response {
     let models: Vec<serde_json::Value> = state
         .configs
         .iter()
+        .filter(|config| !config.agent.hidden)
         .map(|config| {
             let id = config.agent.alias.as_deref().unwrap_or(&config.agent.name);
             let created = config.agent.created_at / 1000;
@@ -1140,6 +1142,73 @@ mod tests {
         ];
         let (_, history) = convert_chat_messages(&messages, true).unwrap();
         assert_eq!(history.len(), 1);
+    }
+
+    // --- list_models tests ---
+
+    fn make_state(configs: Vec<aura_config::Config>) -> Arc<AppState> {
+        Arc::new(AppState {
+            configs: Arc::new(configs),
+            tool_result_mode: crate::streaming::ToolResultMode::None,
+            tool_result_max_length: 0,
+            streaming_buffer_size: 32,
+            aura_custom_events: false,
+            aura_emit_reasoning: false,
+            streaming_timeout_secs: 0,
+            first_chunk_timeout_secs: 0,
+            shutdown_token: tokio_util::sync::CancellationToken::new(),
+            stream_shutdown_token: tokio_util::sync::CancellationToken::new(),
+            active_requests: Arc::new(crate::types::ActiveRequestTracker::new()),
+            default_agent: None,
+            additional_tools: Arc::new(Vec::new),
+        })
+    }
+
+    fn parse_config(toml: &str) -> aura_config::Config {
+        aura_config::Config::parse_toml(toml).expect("invalid test config")
+    }
+
+    #[tokio::test]
+    async fn test_list_models_returns_non_hidden_agents() {
+        let hidden = parse_config(
+            r#"
+[agent]
+name = "hidden-agent"
+system_prompt = "You are hidden."
+hidden = true
+
+[agent.llm]
+provider = "openai"
+api_key = "test"
+model = "gpt-4o"
+"#,
+        );
+
+        let visible = parse_config(
+            r#"
+[agent]
+name = "visible-agent"
+system_prompt = "You are visible."
+
+[agent.llm]
+provider = "openai"
+api_key = "test"
+model = "gpt-4o"
+"#,
+        );
+
+        let state = make_state(vec![hidden, visible]);
+        let resp = list_models(State(state)).await;
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        let data = json["data"].as_array().unwrap();
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0]["id"], "visible-agent");
+        assert_eq!(data[0]["object"], "model");
+        assert_eq!(data[0]["owned_by"], "openai");
     }
 
     // --- streaming / response builder tests ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -171,6 +171,21 @@ Restart with `docker compose up -d`. Clients that support model selection (Libre
 > appropriate keys to your `.env` — they're automatically loaded into the container
 > via `env_file`. See `.env.example` for the full list.
 
+#### Hide an agent from discovery
+
+Set `hidden = true` in an agent's `[agent]` block to keep it out of discovery listings. AURA omits a hidden agent from the `GET /v1/models` response and from the CLI's `/model` list, so it won't appear in client model pickers. The agent stays fully usable. Any caller that already knows its name or alias can still select it by sending that value as the `model` field. This helps when an agent isn't ready yet, or when you want only known callers to invoke it during development/testing/production.
+
+```toml
+[agent]
+name = "hidden agent"
+hidden = true
+system_prompt = "You are a hidden agent that does not show up in listings, but still invokable by known callers."
+```
+
+The `hidden` field defaults to `false`. It accepts either a TOML boolean (`true` or `false`) or the quoted strings `"true"` and `"false"`. The quoted form is convenient when a templating tool such as Helm renders the value as a string.
+
+> **Note:** If you load only a single hidden agent, both `GET /v1/models` and the CLI `/model` list come back empty even though the agent is still the active, invocable default.
+
 ### Customize orchestration
 
 `quickstart.toml` ships with orchestration enabled: a coordinator and two tool-free workers (`researcher` and `writer`) that reason with the LLM alone. The coordinator's routing is controlled by the `[orchestration]` block:

--- a/examples/complete/hidden-agent.toml
+++ b/examples/complete/hidden-agent.toml
@@ -1,0 +1,14 @@
+[agent]
+name = "non-visible agent"
+hidden = true
+system_prompt = """
+You are an agent setup as stub receiver.
+You cannot actually do any work. Tell the user
+theres no actions available upon prompting.
+"""
+turn_depth = 2
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"


### PR DESCRIPTION
summary: add hidden attribute to agents to allow them to be hidden from the models endpoint of the webserver and the model command of the cli. Still allows the model to be used by the caller if known, but to be hidden during development and/or testing phases

fixes: #280