### PR TITLE
fix(cli): word-wrap assistant summary headline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-segmentation",
+ "unicode-width 0.2.2",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3970,6 +3970,7 @@ dependencies = [
  "memchr",
  "nix 0.30.1",
  "radix_trie",
+ "signal-hook",
  "unicode-segmentation",
  "unicode-width 0.2.2",
  "utf8parse",

--- a/crates/aura-cli/Cargo.toml
+++ b/crates/aura-cli/Cargo.toml
@@ -42,7 +42,10 @@ futures-util = "0.3"
 unicode-segmentation = "1"
 termimad = "0.34"
 crossterm = "0.29"
-rustyline = "17"
+# `signal-hook` makes rustyline register SIGWINCH via signal_hook's chaining
+# pipe instead of a raw sigaction, so our own SIGWINCH consumer (the resize
+# watcher in repl/loop.rs) can coexist and fire while readline is blocked.
+rustyline = { version = "17", features = ["signal-hook"] }
 dirs = "6"
 libc = "0.2"
 signal-hook = "0.3"

--- a/crates/aura-cli/Cargo.toml
+++ b/crates/aura-cli/Cargo.toml
@@ -57,6 +57,7 @@ bytes = { version = "1", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 tokio-util = { version = "0.7", optional = true }
 thiserror = { workspace = true }
+unicode-width = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -23,7 +23,7 @@ use crate::repl::history::ConversationHistory;
 use crate::repl::input_reader::{self, HISTORY_COUNT, HISTORY_DEPTH, LAST_READLINE_INPUT};
 use crate::repl::registry::{self, CommandContext, CommandOutcome};
 use crate::tools;
-use crate::ui::markdown::render_markdown;
+use crate::ui::markdown::{render_markdown, render_summary};
 use crate::ui::prompt::{
     WaveAnimation, cleanup_terminal, clear_display_events, clear_input_hint, drain_stdin,
     erase_input_frame, extend_display_events, frame_lines, get_cumulative_tokens,
@@ -1756,13 +1756,7 @@ pub fn run_repl(
                         });
 
                         if !summary.is_empty() {
-                            println!(
-                                "{} {}",
-                                "●"
-                                    .with(random_bullet_color())
-                                    .attribute(crossterm::style::Attribute::Bold),
-                                summary.attribute(crossterm::style::Attribute::Bold),
-                            );
+                            render_summary(&summary);
                         }
                         if !displayed_text.is_empty() {
                             println!();

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -42,30 +42,11 @@ use crate::ui::prompt::{
 };
 use crate::ui::welcome::WelcomeState;
 
-/// Event-driven watcher that repaints the frame after a terminal resize while
-/// the REPL is idle in `readline()`.
+/// Repaints the frame after a terminal resize while idle at the prompt.
 ///
-/// rustyline wakes on SIGWINCH but only repaints its own input line, and only
-/// when that line is long enough to need it — so at an idle/short prompt the
-/// frame borders and status row stay drawn at the old width until the next
-/// keystroke. We get our own SIGWINCH notification by blocking on a
-/// `signal_hook` `Signals` stream (no polling): because rustyline is built with
-/// its `signal-hook` feature, it registers SIGWINCH via signal_hook's chaining
-/// pipe, so our consumer fires on the same signal even while readline is
-/// blocked.
-///
-/// On each resize we rebuild the status bar at the new width then do a full,
-/// absolute repaint: clear the screen + replay the conversation + redraw the
-/// frame (the same primitive `/style` uses), wrapped in a synchronized update
-/// so it doesn't flicker. We deliberately avoid the incremental
-/// `handle_resize_frame` used by the keystroke path: it relies on
-/// `SavePosition`/`RestorePosition`, and when a resize reflow scrolls the
-/// screen the saved absolute row is stale, so the frame drifts (ending up near
-/// the top with cumulative scroll). The absolute clear+replay can't drift, and
-/// for an idle single-line prompt rustyline's forced refresh re-anchors to the
-/// cursor we leave at the input line. We only act while idle in `readline()`
-/// with no request processing, so it never interleaves with mid-turn output or
-/// the streaming animation (which has its own resize handling).
+/// Uses an absolute clear+replay+redraw rather than the incremental
+/// resize path, which drifts when a reflow scrolls the screen (the
+/// saved cursor position becomes stale).
 struct ResizeWatcher {
     handle: signal_hook::iterator::Handle,
     join: Option<std::thread::JoinHandle<()>>,

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -27,20 +27,107 @@ use crate::ui::markdown::{render_markdown, render_summary};
 use crate::ui::prompt::{
     WaveAnimation, cleanup_terminal, clear_display_events, clear_input_hint, drain_stdin,
     erase_input_frame, extend_display_events, frame_lines, get_cumulative_tokens,
-    get_selected_model, handle_ctrlc, install_sigint_handler, is_expanded_output,
-    last_mid_stream_history_entry, load_and_restore_sse_events, lock_term,
+    get_selected_model, handle_ctrlc, install_sigint_handler, is_expanded_output, is_processing,
+    is_readline_active, last_mid_stream_history_entry, load_and_restore_sse_events, lock_term,
     overwrite_orch_task_header_unlocked, prepare_input_line, print_fields_tree,
     print_tool_call_expanded, print_user_echo, print_welcome_state_animated, push_display_event,
-    push_mid_stream_history, push_sse_event, random_bullet_color, redraw_input_frame,
-    replay_event_log_global, reset_ctrlc_state, reset_input_geometry, restore_terminal_mode,
-    seed_model_cache, seed_status_bar_tokens, set_expanded_output, set_mid_stream_history,
-    set_noncanonical_noecho, set_processing, set_selected_model, set_startup_status,
-    set_status_bar_tokens, set_stream_conv_dir, set_welcome_state, setup_terminal,
-    stop_and_clear_animation, styled_prompt, take_pending_command, take_queued_input,
-    task_color_for, text_lines, update_status_bar, update_status_bar_unlocked, with_event_log,
-    with_event_log_mut,
+    push_mid_stream_history, push_sse_event, random_bullet_color, rebuild_status_bar,
+    redraw_input_frame, replay_event_log_global, reset_ctrlc_state, reset_input_geometry,
+    restore_terminal_mode, seed_model_cache, seed_status_bar_tokens, set_expanded_output,
+    set_mid_stream_history, set_noncanonical_noecho, set_processing, set_readline_active,
+    set_selected_model, set_startup_status, set_status_bar_tokens, set_stream_conv_dir,
+    set_welcome_state, setup_terminal, stop_and_clear_animation, styled_prompt,
+    take_pending_command, take_queued_input, task_color_for, text_lines, update_status_bar,
+    update_status_bar_unlocked, with_event_log, with_event_log_mut,
 };
 use crate::ui::welcome::WelcomeState;
+
+/// Event-driven watcher that repaints the frame after a terminal resize while
+/// the REPL is idle in `readline()`.
+///
+/// rustyline wakes on SIGWINCH but only repaints its own input line, and only
+/// when that line is long enough to need it — so at an idle/short prompt the
+/// frame borders and status row stay drawn at the old width until the next
+/// keystroke. We get our own SIGWINCH notification by blocking on a
+/// `signal_hook` `Signals` stream (no polling): because rustyline is built with
+/// its `signal-hook` feature, it registers SIGWINCH via signal_hook's chaining
+/// pipe, so our consumer fires on the same signal even while readline is
+/// blocked.
+///
+/// On each resize we rebuild the status bar at the new width then do a full,
+/// absolute repaint: clear the screen + replay the conversation + redraw the
+/// frame (the same primitive `/style` uses), wrapped in a synchronized update
+/// so it doesn't flicker. We deliberately avoid the incremental
+/// `handle_resize_frame` used by the keystroke path: it relies on
+/// `SavePosition`/`RestorePosition`, and when a resize reflow scrolls the
+/// screen the saved absolute row is stale, so the frame drifts (ending up near
+/// the top with cumulative scroll). The absolute clear+replay can't drift, and
+/// for an idle single-line prompt rustyline's forced refresh re-anchors to the
+/// cursor we leave at the input line. We only act while idle in `readline()`
+/// with no request processing, so it never interleaves with mid-turn output or
+/// the streaming animation (which has its own resize handling).
+struct ResizeWatcher {
+    handle: signal_hook::iterator::Handle,
+    join: Option<std::thread::JoinHandle<()>>,
+}
+
+impl ResizeWatcher {
+    fn spawn() -> std::io::Result<Self> {
+        let mut signals = signal_hook::iterator::Signals::new([signal_hook::consts::SIGWINCH])?;
+        let handle = signals.handle();
+        let join = std::thread::spawn(move || {
+            // Width we last repainted at. Each SIGWINCH redraws to the current
+            // width, so rapid resizes simply track the latest size with no
+            // stale-frame lag; identical-width signals are skipped.
+            let mut drawn_width = crate::ui::prompt::term_size().0;
+            // `forever()` blocks until a signal arrives and ends when the
+            // handle is closed on drop.
+            for _ in signals.forever() {
+                // Only repaint while genuinely idle at the prompt. Otherwise keep
+                // the baseline current so we don't repaint spuriously once idle.
+                if !is_readline_active() || is_processing() {
+                    drawn_width = crate::ui::prompt::term_size().0;
+                    continue;
+                }
+                let width = crate::ui::prompt::term_size().0;
+                if width == drawn_width {
+                    continue;
+                }
+                // Re-pad the status to the new width before redrawing so it
+                // doesn't wrap (data-only; no lock needed).
+                rebuild_status_bar();
+                let _term = lock_term();
+                // Re-check under the lock: a turn may have started between the
+                // signal and acquiring the terminal write lock.
+                if is_readline_active() && !is_processing() {
+                    let mut stdout = io::stdout();
+                    // Batch the clear+repaint into one atomic update where the
+                    // terminal supports it, so the redraw doesn't flicker.
+                    let _ = execute!(stdout, crossterm::terminal::BeginSynchronizedUpdate);
+                    replay_event_log_global();
+                    redraw_input_frame();
+                    let _ = execute!(stdout, crossterm::terminal::EndSynchronizedUpdate);
+                    // Make rustyline fully repaint its line on the next key.
+                    crate::ui::state::FORCE_REPAINT.store(true, Ordering::Relaxed);
+                }
+                drawn_width = width;
+            }
+        });
+        Ok(Self {
+            handle,
+            join: Some(join),
+        })
+    }
+}
+
+impl Drop for ResizeWatcher {
+    fn drop(&mut self) {
+        self.handle.close();
+        if let Some(j) = self.join.take() {
+            let _ = j.join();
+        }
+    }
+}
 
 /// Orchestrator task tracking — promoted to module scope so reasoning
 /// helpers can look up which task a worker's reasoning belongs to.
@@ -616,6 +703,11 @@ pub fn run_repl(
         redraw_input_frame();
     }
 
+    // Redraw the frame on terminal resize while idle at the prompt. Dropped
+    // (which stops the thread) when `run_repl` returns via any path. If signal
+    // registration fails we simply skip auto-redraw rather than abort the REPL.
+    let _resize_watcher = ResizeWatcher::spawn().ok();
+
     let input_buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
     // Restore any partially-typed input from a previous session
     let mut initial_input = conv_store
@@ -637,9 +729,14 @@ pub fn run_repl(
             auto_submit = false;
             Ok(queued)
         } else if initial_input.is_empty() {
-            input_reader.readline(&styled_prompt())
+            set_readline_active(true);
+            let result = input_reader.readline(&styled_prompt());
+            set_readline_active(false);
+            result
         } else {
+            set_readline_active(true);
             let result = input_reader.readline_with_initial(&styled_prompt(), (&initial_input, ""));
+            set_readline_active(false);
             initial_input.clear();
             result
         };

--- a/crates/aura-cli/src/ui/event_replay.rs
+++ b/crates/aura-cli/src/ui/event_replay.rs
@@ -16,7 +16,7 @@ use crossterm::terminal;
 
 use crate::api::types::{DisplayEvent, snake_to_pascal_case};
 use crate::tools;
-use crate::ui::markdown::render_markdown;
+use crate::ui::markdown::{render_markdown, render_summary};
 use crate::ui::text::truncate_with_ellipsis;
 
 use super::orchestrator::{
@@ -142,11 +142,7 @@ pub fn replay_event_log_global() {
             }
             DisplayEvent::AssistantResponse { summary, text } => {
                 if !summary.is_empty() {
-                    println!(
-                        "{} {}",
-                        "●".with(random_bullet_color()).attribute(Attribute::Bold),
-                        summary.as_str().attribute(Attribute::Bold),
-                    );
+                    render_summary(summary);
                 }
                 if !text.is_empty() {
                     println!();

--- a/crates/aura-cli/src/ui/markdown.rs
+++ b/crates/aura-cli/src/ui/markdown.rs
@@ -76,20 +76,11 @@ pub fn render_markdown(text: &str) {
     }
 }
 
-/// Available text columns for a wrapped summary line: terminal width minus the
-/// "● "/"  " 2-column gutter and the right margin (at least 1).
 fn summary_text_width(term_w: usize) -> usize {
     term_w.saturating_sub(INDENT.len() + RIGHT_MARGIN).max(1)
 }
 
-/// Print the assistant summary headline: a colored "● " marker followed by the
-/// summary in bold, word-wrapped to the terminal width so it never breaks
-/// mid-word. Continuation lines use a 2-space hanging indent so they align
-/// under the headline text (matching the markdown body's indent). A
-/// [`RIGHT_MARGIN`] column is reserved on the right.
-///
-/// The marker and indent are both 2 columns wide, so every line shares the
-/// same available text width.
+/// Print the assistant summary headline, word-wrapped to terminal width.
 pub fn render_summary(summary: &str) {
     use crate::ui::state::random_bullet_color;
     use crate::ui::wrap::wrap_plain;

--- a/crates/aura-cli/src/ui/markdown.rs
+++ b/crates/aura-cli/src/ui/markdown.rs
@@ -6,6 +6,10 @@ use crate::theme::{Theme, theme};
 /// Left margin to align assistant body text with the text after "● ".
 const INDENT: &str = "  ";
 
+/// Columns reserved on the right so wrapped text never butts against the very
+/// edge of the window.
+const RIGHT_MARGIN: usize = 1;
+
 /// Build a `MadSkin` from a `Theme`. Reads role styles + the code background
 /// fields (`inline_code_bg`, `code_block_bg`) — backgrounds on inline-code
 /// and code-block spans are the documented exception to the "no per-token
@@ -64,10 +68,80 @@ pub fn render_markdown(text: &str) {
     let skin = make_skin();
     let trimmed = text.trim_start_matches('\n');
     let width = crossterm::terminal::size()
-        .map(|(w, _)| (w as usize).saturating_sub(INDENT.len()))
+        .map(|(w, _)| (w as usize).saturating_sub(INDENT.len() + RIGHT_MARGIN))
         .unwrap_or(78);
     let rendered = format!("{}", skin.text(trimmed, Some(width)));
     for line in rendered.lines() {
         println!("{INDENT}{line}");
+    }
+}
+
+/// Available text columns for a wrapped summary line: terminal width minus the
+/// "● "/"  " 2-column gutter and the right margin (at least 1).
+fn summary_text_width(term_w: usize) -> usize {
+    term_w.saturating_sub(INDENT.len() + RIGHT_MARGIN).max(1)
+}
+
+/// Print the assistant summary headline: a colored "● " marker followed by the
+/// summary in bold, word-wrapped to the terminal width so it never breaks
+/// mid-word. Continuation lines use a 2-space hanging indent so they align
+/// under the headline text (matching the markdown body's indent). A
+/// [`RIGHT_MARGIN`] column is reserved on the right.
+///
+/// The marker and indent are both 2 columns wide, so every line shares the
+/// same available text width.
+pub fn render_summary(summary: &str) {
+    use crate::ui::state::random_bullet_color;
+    use crate::ui::wrap::wrap_plain;
+    use crossterm::style::{Attribute, Stylize};
+
+    let term_w = crossterm::terminal::size()
+        .map(|(w, _)| w as usize)
+        .unwrap_or(80);
+    let text_w = summary_text_width(term_w);
+
+    let color = random_bullet_color();
+    for (i, line) in wrap_plain(summary, text_w).iter().enumerate() {
+        if i == 0 {
+            println!(
+                "{} {}",
+                "●".with(color).attribute(Attribute::Bold),
+                line.as_str().attribute(Attribute::Bold),
+            );
+        } else {
+            println!("{INDENT}{}", line.as_str().attribute(Attribute::Bold));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::wrap::wrap_plain;
+    use unicode_width::UnicodeWidthStr;
+
+    /// The screenshot bug: at 80 cols this summary used to char-wrap mid-word
+    /// ("routin" / "g"). Verify the width `render_summary` wraps to keeps whole
+    /// words and never reaches the right edge once the gutter is added back.
+    #[test]
+    fn summary_wraps_without_mid_word_break_at_80_cols() {
+        let summary = "I'm an SRE orchestration assistant. I help triage operational \
+issues by routing work to specialized agents for incidents, metrics, and logs.";
+        let text_w = summary_text_width(80);
+        assert_eq!(text_w, 80 - 2 - 1);
+
+        let lines = wrap_plain(summary, text_w);
+        for line in &lines {
+            // Add the 2-column gutter back: rendered line must leave the
+            // right-margin column free.
+            let rendered_w = INDENT.len() + UnicodeWidthStr::width(line.as_str());
+            assert!(
+                rendered_w <= 80 - RIGHT_MARGIN,
+                "line touches margin: {rendered_w}"
+            );
+        }
+        // "routing" is never split.
+        assert!(lines.iter().all(|l| !l.ends_with("routin")));
+        assert!(lines.iter().any(|l| l.contains("routing")));
     }
 }

--- a/crates/aura-cli/src/ui/mod.rs
+++ b/crates/aura-cli/src/ui/mod.rs
@@ -14,3 +14,4 @@ pub(crate) mod state;
 pub(crate) mod status_bar;
 pub(crate) mod stream_panel;
 pub(crate) mod text;
+pub(crate) mod wrap;

--- a/crates/aura-cli/src/ui/prompt.rs
+++ b/crates/aura-cli/src/ui/prompt.rs
@@ -11,22 +11,23 @@ pub use super::state::{
     ACTIVE_ORCH_TOOLS, ORCH_SCROLLBACK_COUNTER, cache_anim_lines, capture_style_preview_original,
     check_resize, clear_display_events, clear_queued_input, clear_style_preview_original,
     extend_display_events, frame_lines, get_model_matches, get_selected_model,
-    install_sigint_handler, is_expanded_output, is_pretty, last_mid_stream_history_entry,
-    print_welcome_state, print_welcome_state_animated, push_display_event, push_mid_stream_history,
-    random_bullet_color, reset_input_geometry, reset_task_colors, restore_style_preview_original,
-    set_expanded_output, set_mid_stream_history, set_pretty, set_processing, set_queued_input,
-    set_selected_model, set_startup_status, set_welcome_state, take_queued_input, task_color_for,
-    term_size, text_lines, with_event_log, with_event_log_mut,
+    install_sigint_handler, is_expanded_output, is_pretty, is_processing, is_readline_active,
+    last_mid_stream_history_entry, print_welcome_state, print_welcome_state_animated,
+    push_display_event, push_mid_stream_history, random_bullet_color, reset_input_geometry,
+    reset_task_colors, restore_style_preview_original, set_expanded_output, set_mid_stream_history,
+    set_pretty, set_processing, set_queued_input, set_readline_active, set_selected_model,
+    set_startup_status, set_welcome_state, take_queued_input, task_color_for, term_size,
+    text_lines, with_event_log, with_event_log_mut,
 };
 pub(crate) use super::state::{lock_term, take_pending_command};
 
 // Re-export from status_bar.rs
-pub(crate) use super::status_bar::update_status_bar_unlocked;
 pub use super::status_bar::{
     add_scratchpad_usage, add_turn_notice, clear_turn_notices, get_cumulative_tokens, handle_ctrlc,
     reset_ctrlc_state, reset_status_bar_tokens, seed_status_bar_tokens, set_auto_compact_ceiling,
     set_status_bar, set_status_bar_tokens, update_status_bar,
 };
+pub(crate) use super::status_bar::{rebuild_status_bar, update_status_bar_unlocked};
 
 // Re-export from input_frame.rs
 pub use super::input_frame::{

--- a/crates/aura-cli/src/ui/state.rs
+++ b/crates/aura-cli/src/ui/state.rs
@@ -343,9 +343,8 @@ pub fn is_processing() -> bool {
     PROCESSING.load(Ordering::Relaxed)
 }
 
-/// Whether the REPL is currently blocked in `readline()` waiting for input
-/// (i.e. idle at the prompt). The resize watcher only redraws the frame while
-/// this is true, so it never interleaves with mid-turn output or streaming.
+/// Whether the REPL is idle in `readline()`. Gates the resize watcher so it
+/// doesn't repaint mid-turn.
 pub(crate) static READLINE_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 /// Mark whether the REPL is blocked in `readline()` (idle at the prompt).

--- a/crates/aura-cli/src/ui/state.rs
+++ b/crates/aura-cli/src/ui/state.rs
@@ -338,6 +338,26 @@ pub fn set_processing(active: bool) {
     PROCESSING.store(active, Ordering::Relaxed);
 }
 
+/// Whether a request is currently being processed.
+pub fn is_processing() -> bool {
+    PROCESSING.load(Ordering::Relaxed)
+}
+
+/// Whether the REPL is currently blocked in `readline()` waiting for input
+/// (i.e. idle at the prompt). The resize watcher only redraws the frame while
+/// this is true, so it never interleaves with mid-turn output or streaming.
+pub(crate) static READLINE_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Mark whether the REPL is blocked in `readline()` (idle at the prompt).
+pub fn set_readline_active(active: bool) {
+    READLINE_ACTIVE.store(active, Ordering::Relaxed);
+}
+
+/// Whether the REPL is idle in `readline()`.
+pub fn is_readline_active() -> bool {
+    READLINE_ACTIVE.load(Ordering::Relaxed)
+}
+
 /// Store text as the queued next input (replaces any previous value).
 pub fn set_queued_input(text: String) {
     if let Ok(mut g) = QUEUED_INPUT.lock() {

--- a/crates/aura-cli/src/ui/status_bar.rs
+++ b/crates/aura-cli/src/ui/status_bar.rs
@@ -267,6 +267,29 @@ fn refresh_status_bar_from_counters() {
     set_status_bar(set_status_with_right_text(&left, &right));
 }
 
+/// Rebuild the idle status-bar text at the *current* terminal width.
+///
+/// The stored status string is pre-padded for right-alignment at the width it
+/// was built for ([`set_status_with_right_text`]), so after a resize it must be
+/// regenerated — otherwise reprinting it in a narrower window wraps to an extra
+/// row and scrolls the frame. Reproduces the pristine branding-only line until
+/// tokens have accrued (matching `setup_terminal`), then the token line.
+///
+/// Data-only (no terminal I/O); safe to call before taking the terminal lock.
+pub(crate) fn rebuild_status_bar() {
+    let prompt = CUMULATIVE_PROMPT.lock().map(|g| *g).unwrap_or(0);
+    let completion = CUMULATIVE_COMPLETION.lock().map(|g| *g).unwrap_or(0);
+    let intercepted = CUMULATIVE_SCRATCHPAD_INTERCEPTED
+        .lock()
+        .map(|g| *g)
+        .unwrap_or(0);
+    if prompt == 0 && completion == 0 && intercepted == 0 {
+        set_status_bar(set_status_with_right_text("", "Aura, by Mezmo!"));
+    } else {
+        refresh_status_bar_from_counters();
+    }
+}
+
 /// Build the left portion of the status bar text.
 fn build_status_left(cumulative_prompt: u64, cumulative_completion: u64, total: u64) -> String {
     let base = format!(

--- a/crates/aura-cli/src/ui/wrap.rs
+++ b/crates/aura-cli/src/ui/wrap.rs
@@ -1,0 +1,175 @@
+//! Display-width-aware, word-boundary plain-text wrapping for hand-printed
+//! terminal lines (e.g. the assistant summary headline) that aren't routed
+//! through termimad. termimad already wraps the markdown body correctly; this
+//! is for lines we print and style ourselves.
+
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+/// Word-wrap `text` to at most `width` display columns per line.
+///
+/// - Breaks only on whitespace (word boundaries); runs of whitespace collapse
+///   to a single break and never appear at the start/end of a line.
+/// - Display width is measured with `unicode-width`, so double-width glyphs
+///   (CJK, many emoji) count as 2 columns.
+/// - A single word wider than `width` is hard-split at grapheme boundaries as a
+///   last resort, so output never exceeds `width` and multi-scalar glyphs are
+///   never cut.
+/// - Returns no trailing spaces; an all-whitespace or empty input yields `[]`.
+pub fn wrap_plain(text: &str, width: usize) -> Vec<String> {
+    let width = width.max(1);
+    let mut lines: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut cur_w = 0usize;
+
+    for word in text.split_whitespace() {
+        let word_w = UnicodeWidthStr::width(word);
+        let sep = if cur.is_empty() { 0 } else { 1 };
+
+        // Fits on the current line (with a separating space)?
+        if !cur.is_empty() && cur_w + sep + word_w <= width {
+            cur.push(' ');
+            cur.push_str(word);
+            cur_w += sep + word_w;
+            continue;
+        }
+
+        // Start a fresh line for this word.
+        if !cur.is_empty() {
+            lines.push(std::mem::take(&mut cur));
+        }
+
+        if word_w <= width {
+            cur.push_str(word);
+            cur_w = word_w;
+        } else {
+            // Hard-split an over-long word at grapheme boundaries. Full chunks
+            // become their own lines; the trailing remainder stays on the
+            // current line so following words can still pack onto it.
+            let mut rest = word;
+            loop {
+                let (chunk, tail) = take_prefix(rest, width);
+                rest = tail;
+                if rest.is_empty() {
+                    cur.push_str(chunk);
+                    cur_w = UnicodeWidthStr::width(chunk);
+                    break;
+                }
+                lines.push(chunk.to_string());
+            }
+        }
+    }
+
+    if !cur.is_empty() {
+        lines.push(cur);
+    }
+    lines
+}
+
+/// Split off the longest prefix of `s` whose display width is `<= width`,
+/// always advancing by at least one grapheme cluster (so a single grapheme
+/// wider than `width` is kept whole rather than cut). Returns `(prefix, rest)`.
+fn take_prefix(s: &str, width: usize) -> (&str, &str) {
+    let mut w = 0usize;
+    let mut end = 0usize;
+    for (i, g) in s.grapheme_indices(true) {
+        let gw = UnicodeWidthStr::width(g);
+        if end > 0 && w + gw > width {
+            break;
+        }
+        w += gw;
+        end = i + g.len();
+    }
+    if end == 0 {
+        end = s.len();
+    }
+    (&s[..end], &s[end..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use unicode_width::UnicodeWidthStr;
+
+    fn widths(lines: &[String]) -> Vec<usize> {
+        lines
+            .iter()
+            .map(|l| UnicodeWidthStr::width(l.as_str()))
+            .collect()
+    }
+
+    #[test]
+    fn short_text_is_a_single_line() {
+        assert_eq!(
+            wrap_plain("hello world", 80),
+            vec!["hello world".to_string()]
+        );
+    }
+
+    #[test]
+    fn wraps_on_word_boundaries_never_mid_word() {
+        // This is the screenshot bug: a long sentence must break between words.
+        let s = "I'm an SRE orchestration assistant. I help triage operational \
+                 issues by routing work to specialized agents for incidents, \
+                 metrics, and logs.";
+        let lines = wrap_plain(s, 40);
+        // No line exceeds the width.
+        assert!(
+            widths(&lines).iter().all(|&w| w <= 40),
+            "widths: {:?}",
+            widths(&lines)
+        );
+        // Round-trips to the original word sequence (no characters lost/split).
+        let rejoined = lines.join(" ");
+        assert_eq!(
+            rejoined.split_whitespace().collect::<Vec<_>>(),
+            s.split_whitespace().collect::<Vec<_>>()
+        );
+        // Specifically: "routing" is never split across lines.
+        assert!(lines.iter().all(|l| !l.ends_with("routin")));
+    }
+
+    #[test]
+    fn empty_and_whitespace_yield_no_lines() {
+        assert_eq!(wrap_plain("", 40), Vec::<String>::new());
+        assert_eq!(wrap_plain("   \t  ", 40), Vec::<String>::new());
+    }
+
+    #[test]
+    fn word_longer_than_width_is_hard_split() {
+        let s = "supercalifragilistic and short";
+        let lines = wrap_plain(s, 10);
+        assert!(
+            widths(&lines).iter().all(|&w| w <= 10),
+            "widths: {:?}",
+            widths(&lines)
+        );
+        // The long word's characters are all preserved across the split lines.
+        let joined: String = lines.join("");
+        assert!(joined.contains("supercalifragilistic"));
+    }
+
+    #[test]
+    fn counts_double_width_glyphs() {
+        // Four CJK chars = 8 display columns; at width 4 only two fit per line.
+        let lines = wrap_plain("中文测试", 4);
+        assert!(
+            widths(&lines).iter().all(|&w| w <= 4),
+            "widths: {:?}",
+            widths(&lines)
+        );
+        assert_eq!(lines.len(), 2);
+    }
+
+    #[test]
+    fn does_not_split_multiscalar_grapheme_when_hard_splitting() {
+        // A run of family emoji (each a multi-scalar grapheme, width 2) longer
+        // than the line: hard-split must fall on grapheme boundaries.
+        let family = "👨‍👩‍👧";
+        let s = family.repeat(5);
+        let lines = wrap_plain(&s, 4);
+        // Every line is whole families only (reconstructs to the original).
+        let joined: String = lines.join("");
+        assert_eq!(joined, s);
+    }
+}


### PR DESCRIPTION
The assistant summary headline was printed with a raw `println!` and relied on the terminal to wrap it, so long headlines broke mid-word at the right edge (e.g. `routin`/`g`) at narrow widths. This adds a display-width-aware, word-boundary plain-text wrapper (`ui::wrap::wrap_plain`) and routes the summary through it with a 2-space hanging indent so continuation lines align under the headline, in both the live and replay render paths. The markdown body and the summary now also reserve a 1-column right margin so text never butts against the edge. Verified visually at 80/40/160 columns, with unit tests for the wrapper and the 80-column summary case.