### PR TITLE
fix(cli): friendly error when standalone config is missing

### DIFF
--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -57,6 +57,30 @@ impl DirectBackend {
         config_path: &str,
         extra_headers: Vec<(String, String)>,
     ) -> Result<Self> {
+        // Surface a friendly, actionable message when the config is simply
+        // missing, instead of leaking a raw "No such file or directory" IO
+        // error. This is the common first-run case: `aura-cli` defaults to
+        // `config.toml` in the current directory when neither `--config` nor
+        // `--api-url` is given.
+        if !std::path::Path::new(config_path).exists() {
+            // Derive the program name from the running executable rather than
+            // hardcoding it, so the suggested command stays correct if the
+            // binary is renamed (e.g. `aura-cli` -> `aura`).
+            let prog = std::env::current_exe()
+                .ok()
+                .as_deref()
+                .and_then(std::path::Path::file_name)
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "aura".to_string());
+            anyhow::bail!(
+                "No agent config found at `{config_path}`.\n\n\
+                 Standalone mode needs a TOML agent config. To get started:\n  \
+                 • run `{prog} init` to generate one in the current directory\n  \
+                 • pass `--config <path>` to point at an existing config file or directory\n  \
+                 • set `--api-url <url>` (or AURA_API_URL) to connect to a running aura-web-server instead"
+            );
+        }
+
         let configs =
             aura_config::load_config(config_path).context("Failed to load agent config")?;
         if configs.is_empty() {

--- a/crates/aura-cli/tests/cli_args.rs
+++ b/crates/aura-cli/tests/cli_args.rs
@@ -238,9 +238,8 @@ fn standalone_otel_init_does_not_panic_without_collector() {
     // The actual failure should be the missing config — confirms we
     // got *past* OTel setup before hitting the expected error.
     assert!(
-        stderr.contains("Failed to load agent config")
-            || stderr.contains("No such file or directory"),
-        "expected config-load failure on stderr; got:\n{stderr}"
+        stderr.contains("No agent config found at"),
+        "expected friendly missing-config message on stderr; got:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
Running `aura-cli` standalone with no config present dumped a raw `No such file or directory` errno chain. This happens on first run: standalone mode falls back to `config.toml` in the current directory when neither `--config` nor `--api-url` is given. Now the CLI detects the missing path before `load_config` and exits with an actionable message that names the path it looked at and suggests running `init`, passing `--config`, or setting `--api-url`. The program name in the message is derived from the running executable so it stays correct if the binary is renamed. The OTel config-load test was updated to assert the new wording.