### PR TITLE
doc: add xquik mcp example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,7 @@ Full agent compositions that combine an LLM provider with real MCP tool servers 
 | [`incident-response-mezmo.toml`](complete/incident-response-mezmo.toml) | PagerDuty + Mezmo |
 | [`incident-response-datadog.toml`](complete/incident-response-datadog.toml) | PagerDuty + Datadog |
 | [`kubernetes-sre.toml`](complete/kubernetes-sre.toml) | K8s MCP + Prometheus |
+| [`x-intelligence.toml`](complete/x-intelligence.toml) | Xquik MCP |
 
 ### Serving Multiple Agents
 

--- a/examples/complete/x-intelligence.toml
+++ b/examples/complete/x-intelligence.toml
@@ -1,0 +1,43 @@
+# X intelligence agent - Xquik MCP.
+# Searches public X data and helps analyze accounts, posts, and trends.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY="sk-..."
+#   export XQUIK_API_KEY="..."
+#
+# Usage:
+#   CONFIG_PATH=examples/complete/x-intelligence.toml cargo run --bin aura-web-server
+
+[mcp]
+sanitize_schemas = true
+
+# Xquik - X data search and analysis
+# Uses Xquik's hosted Streamable HTTP MCP endpoint.
+[mcp.servers.xquik]
+transport = "http_streamable"
+url = "https://xquik.com/mcp"
+description = "X data search, account lookup, and public post analysis"
+
+[mcp.servers.xquik.headers]
+Authorization = "Bearer {{ env.XQUIK_API_KEY | default: '' }}"
+
+[agent]
+name = "X Intelligence Agent"
+alias = "x-intelligence"
+model_owner = "mezmo"
+system_prompt = """
+You are an X intelligence assistant with access to Xquik.
+Help users research public X accounts, posts, topics, and audience signals.
+
+Workflow:
+1. Use Xquik tools for current X data instead of guessing.
+2. Summarize findings with source handles, post links, and timestamps.
+3. Separate observed data from interpretation.
+4. Ask for a narrower account, topic, or date range when needed.
+"""
+turn_depth = 10
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"


### PR DESCRIPTION
## What

Adds `examples/complete/x-intelligence.toml`, a complete Aura agent config that connects to the Xquik Streamable HTTP MCP endpoint with `XQUIK_API_KEY`.

Updates the examples index so users can discover the new config next to the existing complete agent examples.

## Why

Aura already supports remote MCP servers with environment-based auth. This gives teams a ready-made public X research example without changing runtime defaults or requiring local sidecars.

## Validation

- `taplo check examples/complete/x-intelligence.toml examples/README.md`
- `aura-config` package tests passed: 120 tests
- Changed-file whitespace check passed
- Xquik live MCP manifest checked at `https://xquik.com/.well-known/mcp.json`
