### PR TITLE
Fix docker exec command to docker compose exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ With AURA you can:
 ## Quick Start
 
 ```bash
-cp .env.example .env                                              # set your LLM provider, model, and API key
-docker compose up -d                                              # starts Aura (orchestrator mode) + LibreChat + Phoenix
-docker exec -it aura ./aura --api-url http://localhost:8080       # chat with the orchestrator from your terminal
+cp .env.example .env                                                  # set your LLM provider, model, and API key
+docker compose up -d                                                  # starts Aura (orchestrator mode) + LibreChat + Phoenix
+docker compose exec -it aura ./aura --api-url http://localhost:8080   # chat with the orchestrator from your terminal
 ```
 
 Aura boots in **orchestrator mode**: a coordinator routes each request — answering simple ones directly and decomposing complex ones across specialized workers. The bundled `aura` connects to the in-container server automatically and renders the coordinator's plan and worker activity as it streams.


### PR DESCRIPTION
This ensure the `exec` call is scoped to the current compose containers, instead of potentially hitting another container named 'aura', unlikely as that is.