### PR TITLE
feat(streaming): consistent aura.usage and add aura.context_usage event

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,8 @@ aura/
 ### Streaming
 - OpenAI-compatible SSE streaming (`/v1/chat/completions`)
 - Custom `aura.*` events (opt-in via `AURA_CUSTOM_EVENTS=true`):
-  - `aura.session_info`, `aura.mcp_status`, `aura.tool_requested`, `aura.tool_start`, `aura.tool_complete`, `aura.reasoning`, `aura.progress`, `aura.worker_phase`, `aura.tool_usage`, `aura.usage`, `aura.scratchpad_usage`
+  - `aura.session_info`, `aura.mcp_status`, `aura.tool_requested`, `aura.tool_start`, `aura.tool_complete`, `aura.reasoning`, `aura.progress`, `aura.worker_phase`, `aura.tool_usage`, `aura.usage`, `aura.context_usage`, `aura.scratchpad_usage`
+  - `aura.usage` reports **cumulative provider-billed** tokens (Σ input + Σ output across every LLM turn), identical in single-agent and orchestration mode. `aura.context_usage` reports **context-window occupancy** — the provider's final-turn input/output (`context_tokens`/`response_tokens`) plus optional `context_window` — per-agent (single-agent emits one; orchestration emits one per worker + coordinator). Both derive from provider usage, not a local tokenizer. See `crates/aura/src/streaming_request_hook.rs` (`UsageState`) for the billed-vs-occupancy split
 - Request cancellation on timeout or client disconnect
 - Two-phase graceful shutdown: new requests rejected immediately (503), in-flight streams get configurable grace period (`SHUTDOWN_TIMEOUT_SECS`, default 30s)
 

--- a/crates/aura-cli/src/api/stream.rs
+++ b/crates/aura-cli/src/api/stream.rs
@@ -71,7 +71,22 @@ pub trait StreamHandler {
     }
 
     /// Called with (prompt_tokens, completion_tokens) from `aura.usage` events.
+    /// These are cumulative provider-billed totals for the request, not context
+    /// size — use [`on_context_usage`](Self::on_context_usage) for the context
+    /// window indicator.
     fn on_usage(&mut self, _prompt_tokens: u64, _completion_tokens: u64) {}
+
+    /// Called with (context_tokens, response_tokens, context_window) from
+    /// `aura.context_usage` events. `context_tokens` is the absolute size of the
+    /// context carried into the agent's final turn — the value to display as
+    /// context-window occupancy.
+    fn on_context_usage(
+        &mut self,
+        _context_tokens: u64,
+        _response_tokens: u64,
+        _context_window: Option<u64>,
+    ) {
+    }
 
     /// Called for `aura.reasoning` events, with (content, agent_id, fields).
     fn on_reasoning(
@@ -247,6 +262,17 @@ where
                     }) = serde_json::from_str::<AuraStreamEvent>(&event.data)
                     {
                         handler.on_usage(prompt_tokens, completion_tokens);
+                    }
+                }
+                event_names::CONTEXT_USAGE => {
+                    if let Ok(AuraStreamEvent::ContextUsage {
+                        context_tokens,
+                        response_tokens,
+                        context_window,
+                        ..
+                    }) = serde_json::from_str::<AuraStreamEvent>(&event.data)
+                    {
+                        handler.on_context_usage(context_tokens, response_tokens, context_window);
                     }
                 }
                 event_names::TOOL_USAGE => {

--- a/crates/aura-cli/src/api/stream.rs
+++ b/crates/aura-cli/src/api/stream.rs
@@ -71,7 +71,23 @@ pub trait StreamHandler {
     }
 
     /// Called with (prompt_tokens, completion_tokens) from `aura.usage` events.
+    /// These are cumulative provider-billed totals for the request, not context
+    /// size — use [`on_context_usage`](Self::on_context_usage) for the context
+    /// window indicator.
     fn on_usage(&mut self, _prompt_tokens: u64, _completion_tokens: u64) {}
+
+    /// Called with (context_tokens, response_tokens, context_window) from
+    /// `aura.context_usage` events. `context_tokens` is the absolute size of the
+    /// context carried into the agent's final turn — the value to display as
+    /// context-window occupancy.
+    fn on_context_usage(
+        &mut self,
+        _context_tokens: u64,
+        _response_tokens: u64,
+        _context_window: Option<u64>,
+        _agent_id: &str,
+    ) {
+    }
 
     /// Called for `aura.reasoning` events, with (content, agent_id, fields).
     fn on_reasoning(
@@ -247,6 +263,23 @@ where
                     }) = serde_json::from_str::<AuraStreamEvent>(&event.data)
                     {
                         handler.on_usage(prompt_tokens, completion_tokens);
+                    }
+                }
+                event_names::CONTEXT_USAGE => {
+                    if let Ok(AuraStreamEvent::ContextUsage {
+                        context_tokens,
+                        response_tokens,
+                        context_window,
+                        agent,
+                        ..
+                    }) = serde_json::from_str::<AuraStreamEvent>(&event.data)
+                    {
+                        handler.on_context_usage(
+                            context_tokens,
+                            response_tokens,
+                            context_window,
+                            &agent.agent_id,
+                        );
                     }
                 }
                 event_names::TOOL_USAGE => {

--- a/crates/aura-cli/src/api/types.rs
+++ b/crates/aura-cli/src/api/types.rs
@@ -243,6 +243,11 @@ pub enum DisplayEvent {
         prompt_tokens: u64,
         completion_tokens: u64,
     },
+    ContextUsage {
+        context_tokens: u64,
+        response_tokens: u64,
+        context_window: Option<u64>,
+    },
     Compacted {
         messages_removed: usize,
     },

--- a/crates/aura-cli/src/api/types.rs
+++ b/crates/aura-cli/src/api/types.rs
@@ -247,6 +247,11 @@ pub enum DisplayEvent {
         prompt_tokens: u64,
         completion_tokens: u64,
     },
+    ContextUsage {
+        context_tokens: u64,
+        response_tokens: u64,
+        context_window: Option<u64>,
+    },
     Compacted {
         messages_removed: usize,
     },

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -27,21 +27,58 @@ use crate::tools;
 use crate::ui::markdown::{render_markdown, render_summary};
 use crate::ui::prompt::{
     WaveAnimation, cleanup_terminal, clear_display_events, clear_input_hint, drain_stdin,
-    erase_input_frame, extend_display_events, frame_lines, get_cumulative_tokens,
-    get_selected_model, handle_ctrlc, install_sigint_handler, is_expanded_output, is_processing,
-    is_readline_active, last_mid_stream_history_entry, load_and_restore_sse_events, lock_term,
+    erase_input_frame, extend_display_events, frame_lines, fresh_context_fill_ratio,
+    get_context_tokens, get_cumulative_tokens, get_selected_model, handle_ctrlc,
+    install_sigint_handler, is_expanded_output, is_processing, is_readline_active,
+    last_mid_stream_history_entry, load_and_restore_sse_events, lock_term,
     overwrite_orch_task_header_unlocked, prepare_input_line, print_fields_tree,
     print_tool_call_expanded, print_user_echo, print_welcome_state_animated, push_display_event,
     push_mid_stream_history, push_sse_event, random_bullet_color, rebuild_status_bar,
     redraw_input_frame, replay_event_log_global, reset_ctrlc_state, reset_input_geometry,
-    restore_terminal_mode, seed_model_cache, seed_status_bar_tokens, set_expanded_output,
-    set_mid_stream_history, set_noncanonical_noecho, set_processing, set_readline_active,
-    set_selected_model, set_startup_status, set_status_bar_tokens, set_stream_conv_dir,
-    set_welcome_state, setup_terminal, stop_and_clear_animation, styled_prompt,
-    take_pending_command, take_queued_input, task_color_for, text_lines, update_status_bar,
-    update_status_bar_unlocked, with_event_log, with_event_log_mut,
+    restore_terminal_mode, seed_model_cache, seed_status_bar_tokens, set_context_window_usage,
+    set_expanded_output, set_mid_stream_history, set_noncanonical_noecho, set_processing,
+    set_readline_active, set_selected_model, set_startup_status, set_status_bar_tokens,
+    set_stream_conv_dir, set_welcome_state, setup_terminal, stop_and_clear_animation,
+    styled_prompt, take_pending_command, take_queued_input, task_color_for, text_lines,
+    update_status_bar, update_status_bar_unlocked, with_event_log, with_event_log_mut,
 };
 use crate::ui::welcome::WelcomeState;
+
+/// Agent id carrying the conversation's own context — `"main"` in single-agent
+/// mode and for an orchestration coordinator; workers report other ids.
+const CONVERSATION_AGENT_ID: &str = "main";
+
+/// Context fill at which an over-long tool result is retried against a
+/// compacted conversation.
+const AUTO_COMPACT_FILL: f64 = 0.85;
+/// Context fill at which the user is nudged to compact.
+const COMPACT_NUDGE_FILL: f64 = 0.75;
+/// Fill the conversation must drop back below before a further nudge is armed,
+/// so one long conversation does not nudge on every turn.
+const COMPACT_NUDGE_REARM_FILL: f64 = 0.6;
+
+// Re-arming has to sit below the nudge, and the nudge below the retry, or a
+// conversation is compacted with no warning first.
+const _: () = assert!(COMPACT_NUDGE_REARM_FILL < COMPACT_NUDGE_FILL);
+const _: () = assert!(COMPACT_NUDGE_FILL < AUTO_COMPACT_FILL);
+const _: () = assert!(AUTO_COMPACT_FILL < 1.0);
+
+/// Whether to nudge at this fill, updating the armed flag.
+///
+/// Hysteresis between [`COMPACT_NUDGE_FILL`] and [`COMPACT_NUDGE_REARM_FILL`]
+/// replaces the token-count bands used when the window size is unknown: a
+/// conversation hovering near the threshold nudges once, and compacting it
+/// re-arms the next one.
+fn should_nudge_at_fill(fill: f64, armed: &mut bool) -> bool {
+    if *armed && fill >= COMPACT_NUDGE_FILL {
+        *armed = false;
+        return true;
+    }
+    if fill < COMPACT_NUDGE_REARM_FILL {
+        *armed = true;
+    }
+    false
+}
 
 /// Repaints the frame after a terminal resize while idle at the prompt.
 ///
@@ -598,6 +635,7 @@ pub fn run_repl(
 
     // Context compaction state
     let mut last_compact_prompt_threshold: u64 = 2_000_000;
+    let mut compact_nudge_armed = true;
     let mut compact_hint_pending = false;
 
     // Handle --resume flag: load conversation from disk
@@ -933,6 +971,7 @@ pub fn run_repl(
                 // Per-turn status notices (e.g. MCP connection errors/warnings)
                 // are scoped to the current request; clear last turn's set.
                 crate::ui::prompt::clear_turn_notices();
+                crate::ui::prompt::begin_turn_context_tracking();
 
                 // Per-turn event recording state
                 let pending_args: Arc<
@@ -1143,9 +1182,15 @@ pub fn run_repl(
 
                     match result {
                         Ok(StreamResult::TextResponse(text)) => {
-                            // Check for auto-compaction trigger
-                            let tokens = get_cumulative_tokens();
-                            if tokens >= 8_000_000
+                            // Check for auto-compaction trigger (context pressure).
+                            // Occupancy is bounded by the window, so it is
+                            // judged as a fill fraction; the token count only
+                            // applies when no window-relative reading exists.
+                            let under_pressure = match fresh_context_fill_ratio() {
+                                Some(fill) => fill >= AUTO_COMPACT_FILL,
+                                None => get_cumulative_tokens() >= 8_000_000,
+                            };
+                            if under_pressure
                                 && text.contains(
                                     "My tools returned more data than I can work with at once",
                                 )
@@ -1179,10 +1224,10 @@ pub fn run_repl(
                                             .attribute(crossterm::style::Attribute::Bold),
                                     );
                                     println!(
-                                        "{} Context limit reached — removed {} messages ({} total tokens)",
+                                        "{} Context limit reached — removed {} messages ({} tokens in context)",
                                         "└─".themed(AuraStyle::Connector),
                                         removed,
-                                        tokens,
+                                        get_context_tokens(),
                                     );
                                     println!();
 
@@ -1901,15 +1946,24 @@ pub fn run_repl(
 
                     conversation.add_assistant(&final_text);
 
-                    // Check if we've crossed a 2M token boundary — nudge on next turn
-                    let current_tokens = get_cumulative_tokens();
-                    if current_tokens >= last_compact_prompt_threshold {
-                        while last_compact_prompt_threshold <= current_tokens {
-                            last_compact_prompt_threshold += 2_000_000;
+                    // Nudge on the next turn once the context is filling up.
+                    match fresh_context_fill_ratio() {
+                        Some(fill) => {
+                            if should_nudge_at_fill(fill, &mut compact_nudge_armed) {
+                                compact_hint_pending = true;
+                            }
                         }
-                        compact_hint_pending = true;
-                        // Show "Context left: N%" in the status bar from now on
-                        crate::ui::prompt::set_auto_compact_ceiling(8_000_000);
+                        None => {
+                            let current_tokens = get_cumulative_tokens();
+                            if current_tokens >= last_compact_prompt_threshold {
+                                while last_compact_prompt_threshold <= current_tokens {
+                                    last_compact_prompt_threshold += 2_000_000;
+                                }
+                                compact_hint_pending = true;
+                                // Show "Context left: N%" in the status bar from now on
+                                crate::ui::prompt::set_auto_compact_ceiling(8_000_000);
+                            }
+                        }
                     }
                 }
 
@@ -2402,6 +2456,29 @@ impl StreamHandler for ReplStreamHandler {
             events.push(DisplayEvent::Usage {
                 prompt_tokens,
                 completion_tokens,
+            });
+        }
+    }
+
+    fn on_context_usage(
+        &mut self,
+        context_tokens: u64,
+        response_tokens: u64,
+        context_window: Option<u64>,
+        agent_id: &str,
+    ) {
+        // Orchestration workers report their own sub-context; only the
+        // conversation-level agent's occupancy belongs on the status bar, and
+        // worker completion order is nondeterministic.
+        if agent_id == CONVERSATION_AGENT_ID {
+            set_context_window_usage(context_tokens, response_tokens, context_window);
+            update_status_bar();
+        }
+        if let Ok(mut events) = self.turn_events.lock() {
+            events.push(DisplayEvent::ContextUsage {
+                context_tokens,
+                response_tokens,
+                context_window,
             });
         }
     }
@@ -3566,8 +3643,35 @@ impl StreamHandler for ReplStreamHandler {
 
 #[cfg(test)]
 mod tests {
-    use super::{COMMAND_ALIASES, ReplTelemetryLifecycle, command_hint};
+    use super::{
+        COMMAND_ALIASES, COMPACT_NUDGE_FILL, ReplTelemetryLifecycle, command_hint,
+        should_nudge_at_fill,
+    };
     use crate::repl::registry;
+
+    #[test]
+    fn nudges_once_while_the_context_stays_full() {
+        let mut armed = true;
+
+        assert!(!should_nudge_at_fill(0.50, &mut armed));
+        assert!(should_nudge_at_fill(COMPACT_NUDGE_FILL, &mut armed));
+        // Still full on later turns — one nudge per fill-up, not one per turn.
+        assert!(!should_nudge_at_fill(0.80, &mut armed));
+        assert!(!should_nudge_at_fill(0.95, &mut armed));
+    }
+
+    #[test]
+    fn compacting_below_the_rearm_fill_arms_the_next_nudge() {
+        let mut armed = true;
+        assert!(should_nudge_at_fill(0.90, &mut armed));
+
+        // Hovering between re-arm and nudge does not re-arm.
+        assert!(!should_nudge_at_fill(0.70, &mut armed));
+        // A compaction drops the fill; the next fill-up nudges again.
+        assert!(!should_nudge_at_fill(0.30, &mut armed));
+        assert!(should_nudge_at_fill(0.78, &mut armed));
+    }
+
     use aura_telemetry::events::{CliSessionStarted, ExitReason};
     use aura_telemetry::properties::{DeploymentMethod, OsFamily, Source};
     use aura_telemetry::{DisableReason, TelemetryConfig, TelemetryState};

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -27,19 +27,20 @@ use crate::tools;
 use crate::ui::markdown::{render_markdown, render_summary};
 use crate::ui::prompt::{
     WaveAnimation, cleanup_terminal, clear_display_events, clear_input_hint, drain_stdin,
-    erase_input_frame, extend_display_events, frame_lines, get_cumulative_tokens,
-    get_selected_model, handle_ctrlc, install_sigint_handler, is_expanded_output, is_processing,
-    is_readline_active, last_mid_stream_history_entry, load_and_restore_sse_events, lock_term,
-    overwrite_orch_task_header_unlocked, prepare_input_line, print_fields_tree,
-    print_tool_call_expanded, print_user_echo, print_welcome_state_animated, push_display_event,
-    push_mid_stream_history, push_sse_event, random_bullet_color, rebuild_status_bar,
-    redraw_input_frame, replay_event_log_global, reset_ctrlc_state, reset_input_geometry,
-    restore_terminal_mode, seed_model_cache, seed_status_bar_tokens, set_expanded_output,
-    set_mid_stream_history, set_noncanonical_noecho, set_processing, set_readline_active,
-    set_selected_model, set_startup_status, set_status_bar_tokens, set_stream_conv_dir,
-    set_welcome_state, setup_terminal, stop_and_clear_animation, styled_prompt,
-    take_pending_command, take_queued_input, task_color_for, text_lines, update_status_bar,
-    update_status_bar_unlocked, with_event_log, with_event_log_mut,
+    erase_input_frame, extend_display_events, frame_lines, get_context_tokens,
+    get_cumulative_tokens, get_selected_model, handle_ctrlc, install_sigint_handler,
+    is_expanded_output, is_processing, is_readline_active, last_mid_stream_history_entry,
+    load_and_restore_sse_events, lock_term, overwrite_orch_task_header_unlocked, prepare_input_line,
+    print_fields_tree, print_tool_call_expanded, print_user_echo, print_welcome_state_animated,
+    push_display_event, push_mid_stream_history, push_sse_event, random_bullet_color,
+    rebuild_status_bar, redraw_input_frame, replay_event_log_global, reset_ctrlc_state,
+    reset_input_geometry, restore_terminal_mode, seed_model_cache, seed_status_bar_tokens,
+    set_context_window_usage, set_expanded_output, set_mid_stream_history, set_noncanonical_noecho,
+    set_processing, set_readline_active, set_selected_model, set_startup_status,
+    set_status_bar_tokens, set_stream_conv_dir, set_welcome_state, setup_terminal,
+    stop_and_clear_animation, styled_prompt, take_pending_command, take_queued_input,
+    task_color_for, text_lines, update_status_bar, update_status_bar_unlocked, with_event_log,
+    with_event_log_mut,
 };
 use crate::ui::welcome::WelcomeState;
 
@@ -1088,8 +1089,8 @@ pub fn run_repl(
 
                     match result {
                         Ok(StreamResult::TextResponse(text)) => {
-                            // Check for auto-compaction trigger
-                            let tokens = get_cumulative_tokens();
+                            // Check for auto-compaction trigger (context pressure)
+                            let tokens = get_context_tokens();
                             if tokens >= 8_000_000
                                 && text.contains(
                                     "My tools returned more data than I can work with at once",
@@ -1847,7 +1848,7 @@ pub fn run_repl(
                     conversation.add_assistant(&final_text);
 
                     // Check if we've crossed a 2M token boundary — nudge on next turn
-                    let current_tokens = get_cumulative_tokens();
+                    let current_tokens = get_context_tokens();
                     if current_tokens >= last_compact_prompt_threshold {
                         while last_compact_prompt_threshold <= current_tokens {
                             last_compact_prompt_threshold += 2_000_000;
@@ -2208,6 +2209,23 @@ impl StreamHandler for ReplStreamHandler {
             events.push(DisplayEvent::Usage {
                 prompt_tokens,
                 completion_tokens,
+            });
+        }
+    }
+
+    fn on_context_usage(
+        &mut self,
+        context_tokens: u64,
+        response_tokens: u64,
+        context_window: Option<u64>,
+    ) {
+        set_context_window_usage(context_tokens, response_tokens, context_window);
+        update_status_bar();
+        if let Ok(mut events) = self.turn_events.lock() {
+            events.push(DisplayEvent::ContextUsage {
+                context_tokens,
+                response_tokens,
+                context_window,
             });
         }
     }

--- a/crates/aura-cli/src/ui/event_replay.rs
+++ b/crates/aura-cli/src/ui/event_replay.rs
@@ -25,7 +25,7 @@ use super::orchestrator::{
 use super::state::{
     EVENT_LOG, EXPANDED_OUTPUT, WELCOME_STATE, random_bullet_color, task_color_for,
 };
-use super::status_bar::{reset_status_bar_tokens, set_status_bar_tokens};
+use super::status_bar::{reset_status_bar_tokens, set_context_window_usage, set_status_bar_tokens};
 
 /// Clear the terminal and replay all recorded events.
 pub fn replay_event_log_global() {
@@ -184,6 +184,14 @@ pub fn replay_event_log_global() {
                 completion_tokens,
             } => {
                 set_status_bar_tokens(*prompt_tokens, *completion_tokens);
+                i += 1;
+            }
+            DisplayEvent::ContextUsage {
+                context_tokens,
+                response_tokens,
+                context_window,
+            } => {
+                set_context_window_usage(*context_tokens, *response_tokens, *context_window);
                 i += 1;
             }
             DisplayEvent::OrchestratorScratchpadSavings {

--- a/crates/aura-cli/src/ui/prompt.rs
+++ b/crates/aura-cli/src/ui/prompt.rs
@@ -23,9 +23,11 @@ pub(crate) use super::state::{lock_term, take_pending_command};
 
 // Re-export from status_bar.rs
 pub use super::status_bar::{
-    add_scratchpad_usage, add_turn_notice, clear_turn_notices, get_cumulative_tokens, handle_ctrlc,
-    reset_ctrlc_state, reset_status_bar_tokens, seed_status_bar_tokens, set_auto_compact_ceiling,
-    set_status_bar, set_status_bar_tokens, update_status_bar,
+    add_scratchpad_usage, add_turn_notice, begin_turn_context_tracking, clear_turn_notices,
+    context_fill_ratio, fresh_context_fill_ratio, get_context_tokens, get_cumulative_tokens,
+    handle_ctrlc, reset_ctrlc_state, reset_status_bar_tokens, seed_status_bar_tokens,
+    set_auto_compact_ceiling, set_context_window_usage, set_status_bar, set_status_bar_tokens,
+    update_status_bar,
 };
 pub(crate) use super::status_bar::{rebuild_status_bar, update_status_bar_unlocked};
 

--- a/crates/aura-cli/src/ui/prompt.rs
+++ b/crates/aura-cli/src/ui/prompt.rs
@@ -23,9 +23,10 @@ pub(crate) use super::state::{lock_term, take_pending_command};
 
 // Re-export from status_bar.rs
 pub use super::status_bar::{
-    add_scratchpad_usage, add_turn_notice, clear_turn_notices, get_cumulative_tokens, handle_ctrlc,
-    reset_ctrlc_state, reset_status_bar_tokens, seed_status_bar_tokens, set_auto_compact_ceiling,
-    set_status_bar, set_status_bar_tokens, update_status_bar,
+    add_scratchpad_usage, add_turn_notice, clear_turn_notices, get_context_tokens,
+    get_cumulative_tokens, handle_ctrlc, reset_ctrlc_state, reset_status_bar_tokens,
+    seed_status_bar_tokens, set_auto_compact_ceiling, set_context_window_usage, set_status_bar,
+    set_status_bar_tokens, update_status_bar,
 };
 pub(crate) use super::status_bar::{rebuild_status_bar, update_status_bar_unlocked};
 

--- a/crates/aura-cli/src/ui/state.rs
+++ b/crates/aura-cli/src/ui/state.rs
@@ -60,6 +60,11 @@ pub(crate) static STATUS_HINT: Mutex<Vec<String>> = Mutex::new(Vec::new());
 pub(crate) static TURN_NOTICES: Mutex<Vec<String>> = Mutex::new(Vec::new());
 pub(crate) static CUMULATIVE_PROMPT: Mutex<u64> = Mutex::new(0);
 pub(crate) static CUMULATIVE_COMPLETION: Mutex<u64> = Mutex::new(0);
+/// Absolute context-window occupancy from the latest `aura.context_usage`
+/// event (input + output of the agent's final turn). Drives the "Context left"
+/// indicator and auto-compaction pressure, independent of cumulative *billed*
+/// tokens (`CUMULATIVE_PROMPT`/`CUMULATIVE_COMPLETION`). 0 until first reported.
+pub(crate) static CONTEXT_OCCUPANCY: AtomicU64 = AtomicU64::new(0);
 pub(crate) static CUMULATIVE_SCRATCHPAD_INTERCEPTED: Mutex<u64> = Mutex::new(0);
 pub(crate) static CUMULATIVE_SCRATCHPAD_EXTRACTED: Mutex<u64> = Mutex::new(0);
 pub(crate) static PROCESSING: AtomicBool = AtomicBool::new(false);

--- a/crates/aura-cli/src/ui/state.rs
+++ b/crates/aura-cli/src/ui/state.rs
@@ -60,6 +60,10 @@ pub(crate) static STATUS_HINT: Mutex<Vec<String>> = Mutex::new(Vec::new());
 pub(crate) static TURN_NOTICES: Mutex<Vec<String>> = Mutex::new(Vec::new());
 pub(crate) static CUMULATIVE_PROMPT: Mutex<u64> = Mutex::new(0);
 pub(crate) static CUMULATIVE_COMPLETION: Mutex<u64> = Mutex::new(0);
+/// Context-window occupancy in tokens: input plus output of an agent's final turn.
+pub(crate) static CONTEXT_OCCUPANCY: AtomicU64 = AtomicU64::new(0);
+/// Whether [`CONTEXT_OCCUPANCY`] was reported during the current turn.
+pub(crate) static CONTEXT_OCCUPANCY_FRESH: AtomicBool = AtomicBool::new(false);
 pub(crate) static CUMULATIVE_SCRATCHPAD_INTERCEPTED: Mutex<u64> = Mutex::new(0);
 pub(crate) static CUMULATIVE_SCRATCHPAD_EXTRACTED: Mutex<u64> = Mutex::new(0);
 pub(crate) static PROCESSING: AtomicBool = AtomicBool::new(false);

--- a/crates/aura-cli/src/ui/status_bar.rs
+++ b/crates/aura-cli/src/ui/status_bar.rs
@@ -15,10 +15,11 @@ use crate::theme::{AuraStyle, Themed};
 
 use super::animation::render_queued_wave;
 use super::state::{
-    AUTO_COMPACT_CEILING, CTRLC_HINT_VISIBLE, CTRLC_RESET_SKIP, CUMULATIVE_COMPLETION,
-    CUMULATIVE_PROMPT, CUMULATIVE_SCRATCHPAD_EXTRACTED, CUMULATIVE_SCRATCHPAD_INTERCEPTED,
-    CURSOR_ROW, FRAME_LINES, LAST_CTRLC, PROCESSING, QUEUED_INPUT, QUEUED_WAVE_POS, STATUS_BAR,
-    STATUS_HINT, STATUS_ROWS, TURN_NOTICES, lock_term, status_rows, term_size,
+    AUTO_COMPACT_CEILING, CONTEXT_OCCUPANCY, CTRLC_HINT_VISIBLE, CTRLC_RESET_SKIP,
+    CUMULATIVE_COMPLETION, CUMULATIVE_PROMPT, CUMULATIVE_SCRATCHPAD_EXTRACTED,
+    CUMULATIVE_SCRATCHPAD_INTERCEPTED, CURSOR_ROW, FRAME_LINES, LAST_CTRLC, PROCESSING,
+    QUEUED_INPUT, QUEUED_WAVE_POS, STATUS_BAR, STATUS_HINT, STATUS_ROWS, TURN_NOTICES, lock_term,
+    status_rows, term_size,
 };
 
 /// Format a number with comma separators (e.g. 1234 -> "1,234").
@@ -228,9 +229,10 @@ pub fn set_status_bar_tokens(prompt_tokens: u64, completion_tokens: u64) {
 
     let left = build_status_left(cumulative_prompt, cumulative_completion, total);
 
+    let pressure = context_pressure_tokens(total);
     let ceiling = AUTO_COMPACT_CEILING.load(Ordering::Relaxed);
-    let right = if ceiling > 0 && total < ceiling {
-        let remaining_pct = ((ceiling - total) as f64 / ceiling as f64 * 100.0).round() as u64;
+    let right = if ceiling > 0 && pressure < ceiling {
+        let remaining_pct = ((ceiling - pressure) as f64 / ceiling as f64 * 100.0).round() as u64;
         format!("Context left: {remaining_pct}%")
     } else {
         "AURA, by Mezmo!".to_string()
@@ -257,9 +259,10 @@ fn refresh_status_bar_from_counters() {
 
     let left = build_status_left(cumulative_prompt, cumulative_completion, total);
 
+    let pressure = context_pressure_tokens(total);
     let ceiling = AUTO_COMPACT_CEILING.load(Ordering::Relaxed);
-    let right = if ceiling > 0 && total < ceiling {
-        let remaining_pct = ((ceiling - total) as f64 / ceiling as f64 * 100.0).round() as u64;
+    let right = if ceiling > 0 && pressure < ceiling {
+        let remaining_pct = ((ceiling - pressure) as f64 / ceiling as f64 * 100.0).round() as u64;
         format!("Context left: {remaining_pct}%")
     } else {
         "AURA, by Mezmo!".to_string()
@@ -335,11 +338,46 @@ pub fn set_auto_compact_ceiling(ceiling: u64) {
     AUTO_COMPACT_CEILING.store(ceiling, Ordering::Relaxed);
 }
 
-/// Return the current cumulative total tokens.
+/// Return the current cumulative total *billed* tokens (left-side display).
 pub fn get_cumulative_tokens() -> u64 {
     let prompt = CUMULATIVE_PROMPT.lock().map(|g| *g).unwrap_or(0);
     let completion = CUMULATIVE_COMPLETION.lock().map(|g| *g).unwrap_or(0);
     prompt + completion
+}
+
+/// Tokens used to gauge context-window pressure: the reported context
+/// occupancy when available, otherwise the cumulative billed total as a
+/// pre-`aura.context_usage` fallback.
+fn context_pressure_tokens(cumulative_total: u64) -> u64 {
+    let occupancy = CONTEXT_OCCUPANCY.load(Ordering::Relaxed);
+    if occupancy > 0 {
+        occupancy
+    } else {
+        cumulative_total
+    }
+}
+
+/// Context-window pressure in tokens — used for auto-compaction decisions.
+/// Reflects actual context occupancy (not cumulative billed usage).
+pub fn get_context_tokens() -> u64 {
+    context_pressure_tokens(get_cumulative_tokens())
+}
+
+/// Record context-window occupancy from an `aura.context_usage` event.
+///
+/// Sets the absolute occupancy that drives the "Context left" indicator and
+/// auto-compaction, and, when the model's context window is known, points the
+/// ceiling at it so the percentage reflects the real window.
+pub fn set_context_window_usage(
+    context_tokens: u64,
+    response_tokens: u64,
+    context_window: Option<u64>,
+) {
+    CONTEXT_OCCUPANCY.store(context_tokens + response_tokens, Ordering::Relaxed);
+    if let Some(window) = context_window {
+        AUTO_COMPACT_CEILING.store(window, Ordering::Relaxed);
+    }
+    refresh_status_bar_from_counters();
 }
 
 /// Seed cumulative token counters (used when resuming).
@@ -369,6 +407,7 @@ pub fn reset_status_bar_tokens() {
     if let Ok(mut g) = CUMULATIVE_SCRATCHPAD_EXTRACTED.lock() {
         *g = 0;
     }
+    CONTEXT_OCCUPANCY.store(0, Ordering::Relaxed);
     set_status_bar(set_status_with_right_text("", "AURA, by Mezmo!"));
 }
 

--- a/crates/aura-cli/src/ui/status_bar.rs
+++ b/crates/aura-cli/src/ui/status_bar.rs
@@ -15,10 +15,11 @@ use crate::theme::{AuraStyle, Themed};
 
 use super::animation::render_queued_wave;
 use super::state::{
-    AUTO_COMPACT_CEILING, CTRLC_HINT_VISIBLE, CTRLC_RESET_SKIP, CUMULATIVE_COMPLETION,
-    CUMULATIVE_PROMPT, CUMULATIVE_SCRATCHPAD_EXTRACTED, CUMULATIVE_SCRATCHPAD_INTERCEPTED,
-    CURSOR_ROW, FRAME_LINES, LAST_CTRLC, PROCESSING, QUEUED_INPUT, QUEUED_WAVE_POS, STATUS_BAR,
-    STATUS_HINT, STATUS_ROWS, TURN_NOTICES, lock_term, status_rows, term_size,
+    AUTO_COMPACT_CEILING, CONTEXT_OCCUPANCY, CONTEXT_OCCUPANCY_FRESH, CTRLC_HINT_VISIBLE,
+    CTRLC_RESET_SKIP, CUMULATIVE_COMPLETION, CUMULATIVE_PROMPT, CUMULATIVE_SCRATCHPAD_EXTRACTED,
+    CUMULATIVE_SCRATCHPAD_INTERCEPTED, CURSOR_ROW, FRAME_LINES, LAST_CTRLC, PROCESSING,
+    QUEUED_INPUT, QUEUED_WAVE_POS, STATUS_BAR, STATUS_HINT, STATUS_ROWS, TURN_NOTICES, lock_term,
+    status_rows, term_size,
 };
 
 /// Format a number with comma separators (e.g. 1234 -> "1,234").
@@ -228,9 +229,10 @@ pub fn set_status_bar_tokens(prompt_tokens: u64, completion_tokens: u64) {
 
     let left = build_status_left(cumulative_prompt, cumulative_completion, total);
 
+    let pressure = context_pressure_tokens(total);
     let ceiling = AUTO_COMPACT_CEILING.load(Ordering::Relaxed);
-    let right = if ceiling > 0 && total < ceiling {
-        let remaining_pct = ((ceiling - total) as f64 / ceiling as f64 * 100.0).round() as u64;
+    let right = if ceiling > 0 && pressure < ceiling {
+        let remaining_pct = ((ceiling - pressure) as f64 / ceiling as f64 * 100.0).round() as u64;
         format!("Context left: {remaining_pct}%")
     } else {
         "AURA, by Mezmo!".to_string()
@@ -257,9 +259,10 @@ fn refresh_status_bar_from_counters() {
 
     let left = build_status_left(cumulative_prompt, cumulative_completion, total);
 
+    let pressure = context_pressure_tokens(total);
     let ceiling = AUTO_COMPACT_CEILING.load(Ordering::Relaxed);
-    let right = if ceiling > 0 && total < ceiling {
-        let remaining_pct = ((ceiling - total) as f64 / ceiling as f64 * 100.0).round() as u64;
+    let right = if ceiling > 0 && pressure < ceiling {
+        let remaining_pct = ((ceiling - pressure) as f64 / ceiling as f64 * 100.0).round() as u64;
         format!("Context left: {remaining_pct}%")
     } else {
         "AURA, by Mezmo!".to_string()
@@ -335,11 +338,81 @@ pub fn set_auto_compact_ceiling(ceiling: u64) {
     AUTO_COMPACT_CEILING.store(ceiling, Ordering::Relaxed);
 }
 
-/// Return the current cumulative total tokens.
+/// Return the current cumulative total *billed* tokens (left-side display).
 pub fn get_cumulative_tokens() -> u64 {
     let prompt = CUMULATIVE_PROMPT.lock().map(|g| *g).unwrap_or(0);
     let completion = CUMULATIVE_COMPLETION.lock().map(|g| *g).unwrap_or(0);
     prompt + completion
+}
+
+/// Tokens used to gauge context-window pressure: the reported context
+/// occupancy when available, otherwise the cumulative billed total as a
+/// pre-`aura.context_usage` fallback.
+fn context_pressure_tokens(cumulative_total: u64) -> u64 {
+    let occupancy = CONTEXT_OCCUPANCY.load(Ordering::Relaxed);
+    if occupancy > 0 {
+        occupancy
+    } else {
+        cumulative_total
+    }
+}
+
+/// Mark the occupancy reading as belonging to a previous turn.
+///
+/// The reading itself is kept: it is the closest estimate available while the
+/// current turn streams, and dropping it would fall back to cumulative billed
+/// tokens, which exceed the window and blank the indicator. Decisions that must
+/// not act on a previous turn's context use
+/// [`fresh_context_fill_ratio`] instead.
+pub fn begin_turn_context_tracking() {
+    CONTEXT_OCCUPANCY_FRESH.store(false, Ordering::Relaxed);
+}
+
+/// Occupied fraction of the model's context window.
+///
+/// `None` when either the occupancy or the window is unknown — no
+/// `aura.context_usage` has arrived, or the model's window was never
+/// configured — which callers treat as "fall back to token-count thresholds".
+pub fn context_fill_ratio() -> Option<f64> {
+    let occupancy = CONTEXT_OCCUPANCY.load(Ordering::Relaxed);
+    let window = AUTO_COMPACT_CEILING.load(Ordering::Relaxed);
+    (occupancy > 0 && window > 0).then(|| occupancy as f64 / window as f64)
+}
+
+/// [`context_fill_ratio`] restricted to a reading the current turn reported.
+///
+/// `None` once a turn passes without an `aura.context_usage` event, so callers
+/// fall back to token-count thresholds rather than acting on a fill fraction
+/// that describes an earlier turn's context.
+pub fn fresh_context_fill_ratio() -> Option<f64> {
+    if !CONTEXT_OCCUPANCY_FRESH.load(Ordering::Relaxed) {
+        return None;
+    }
+    context_fill_ratio()
+}
+
+/// Context-window pressure in tokens — used for auto-compaction decisions.
+/// Reflects actual context occupancy (not cumulative billed usage).
+pub fn get_context_tokens() -> u64 {
+    context_pressure_tokens(get_cumulative_tokens())
+}
+
+/// Record context-window occupancy from an `aura.context_usage` event.
+///
+/// Sets the absolute occupancy that drives the "Context left" indicator and
+/// auto-compaction, and, when the model's context window is known, points the
+/// ceiling at it so the percentage reflects the real window.
+pub fn set_context_window_usage(
+    context_tokens: u64,
+    response_tokens: u64,
+    context_window: Option<u64>,
+) {
+    CONTEXT_OCCUPANCY.store(context_tokens + response_tokens, Ordering::Relaxed);
+    CONTEXT_OCCUPANCY_FRESH.store(true, Ordering::Relaxed);
+    if let Some(window) = context_window {
+        AUTO_COMPACT_CEILING.store(window, Ordering::Relaxed);
+    }
+    refresh_status_bar_from_counters();
 }
 
 /// Seed cumulative token counters (used when resuming).
@@ -369,6 +442,8 @@ pub fn reset_status_bar_tokens() {
     if let Ok(mut g) = CUMULATIVE_SCRATCHPAD_EXTRACTED.lock() {
         *g = 0;
     }
+    CONTEXT_OCCUPANCY.store(0, Ordering::Relaxed);
+    CONTEXT_OCCUPANCY_FRESH.store(false, Ordering::Relaxed);
     set_status_bar(set_status_with_right_text("", "AURA, by Mezmo!"));
 }
 
@@ -434,4 +509,28 @@ pub fn reset_ctrlc_state() {
         h.clear();
     }
     update_status_bar();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_previous_turns_reading_still_displays_but_stops_driving_decisions() {
+        set_context_window_usage(100_000, 5_000, Some(200_000));
+        assert_eq!(fresh_context_fill_ratio(), Some(0.525));
+
+        // A later turn starts without reporting: the gauge keeps showing the
+        // last known occupancy rather than blanking...
+        begin_turn_context_tracking();
+        assert_eq!(CONTEXT_OCCUPANCY.load(Ordering::Relaxed), 105_000);
+        assert_eq!(context_fill_ratio(), Some(0.525));
+
+        // ...while compaction decisions see no usable reading and fall back.
+        assert_eq!(fresh_context_fill_ratio(), None);
+
+        // A reading from the current turn drives decisions again.
+        set_context_window_usage(150_000, 5_000, Some(200_000));
+        assert_eq!(fresh_context_fill_ratio(), Some(0.775));
+    }
 }

--- a/crates/aura-events/src/event_names.rs
+++ b/crates/aura-events/src/event_names.rs
@@ -15,6 +15,7 @@ pub const WORKER_PHASE: &str = "aura.worker_phase";
 pub const TOOL_USAGE: &str = "aura.tool_usage";
 pub const USAGE: &str = "aura.usage";
 pub const SCRATCHPAD_USAGE: &str = "aura.scratchpad_usage";
+pub const CONTEXT_USAGE: &str = "aura.context_usage";
 pub const APPROVAL_REQUESTED: &str = "aura.approval_requested";
 pub const APPROVAL_PENDING: &str = "aura.approval_pending";
 pub const APPROVAL_COMPLETED: &str = "aura.approval_completed";

--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -377,6 +377,23 @@ pub enum AuraStreamEvent {
         #[serde(flatten)]
         correlation: CorrelationContext,
     },
+    /// Per-agent context-window occupancy from the provider-reported input/output
+    /// of that agent's final LLM turn. Unlike [`Self::Usage`] (cumulative billed
+    /// tokens), this reflects the context carried into the last call. Derived
+    /// from provider usage, never a local tokenizer.
+    ContextUsage {
+        /// Provider-reported input tokens of the agent's final turn (context size).
+        context_tokens: u64,
+        /// Provider-reported output tokens of the agent's final turn.
+        response_tokens: u64,
+        /// Model context-window limit, when known, for a direct fill percentage.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context_window: Option<u64>,
+        #[serde(flatten)]
+        agent: AgentContext,
+        #[serde(flatten)]
+        correlation: CorrelationContext,
+    },
     /// Emitted when a HITL approval request is raised.
     ApprovalRequested(ApprovalRequested),
     /// Emitted when a HITL approval is awaiting an attended decision.
@@ -410,6 +427,7 @@ impl AuraStreamEvent {
             Self::ToolUsage { .. } => event_names::TOOL_USAGE,
             Self::Usage { .. } => event_names::USAGE,
             Self::ScratchpadUsage { .. } => event_names::SCRATCHPAD_USAGE,
+            Self::ContextUsage { .. } => event_names::CONTEXT_USAGE,
             Self::ApprovalRequested(_) => event_names::APPROVAL_REQUESTED,
             Self::ApprovalPending(_) => event_names::APPROVAL_PENDING,
             Self::ApprovalCompleted(_) => event_names::APPROVAL_COMPLETED,
@@ -597,6 +615,23 @@ impl AuraStreamEvent {
             correlation,
         }
     }
+
+    /// Create a ContextUsage event (per-agent context-window occupancy).
+    pub fn context_usage(
+        context_tokens: u64,
+        response_tokens: u64,
+        context_window: Option<u64>,
+        agent: AgentContext,
+        correlation: CorrelationContext,
+    ) -> Self {
+        Self::ContextUsage {
+            context_tokens,
+            response_tokens,
+            context_window,
+            agent,
+            correlation,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -711,6 +746,35 @@ mod tests {
                 assert_eq!(completion_tokens, 50);
             }
             other => panic!("expected Usage, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn context_usage_roundtrip_and_event_name() {
+        let event = AuraStreamEvent::context_usage(
+            12_000,
+            340,
+            Some(200_000),
+            AgentContext::worker("log-analyst", None, "orchestrator"),
+            CorrelationContext::new("s1", None),
+        );
+        assert_eq!(event.event_name(), "aura.context_usage");
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: AuraStreamEvent = serde_json::from_str(&json).unwrap();
+        match parsed {
+            AuraStreamEvent::ContextUsage {
+                context_tokens,
+                response_tokens,
+                context_window,
+                agent,
+                ..
+            } => {
+                assert_eq!(context_tokens, 12_000);
+                assert_eq!(response_tokens, 340);
+                assert_eq!(context_window, Some(200_000));
+                assert_eq!(agent.agent_id, "log-analyst");
+            }
+            other => panic!("expected ContextUsage, got {:?}", other),
         }
     }
 

--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -437,6 +437,21 @@ pub enum AuraStreamEvent {
         #[serde(flatten)]
         correlation: CorrelationContext,
     },
+    /// Per-agent context-window occupancy: the provider-reported input and
+    /// output of that agent's final LLM turn.
+    ContextUsage {
+        /// Provider-reported input tokens of the agent's final turn.
+        context_tokens: u64,
+        /// Provider-reported output tokens of the agent's final turn.
+        response_tokens: u64,
+        /// Model context-window limit in tokens.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context_window: Option<u64>,
+        #[serde(flatten)]
+        agent: AgentContext,
+        #[serde(flatten)]
+        correlation: CorrelationContext,
+    },
     /// Emitted when a HITL approval request is raised.
     ApprovalRequested(ApprovalRequested),
     /// Emitted when a HITL approval is awaiting an attended decision.
@@ -470,6 +485,7 @@ impl AuraStreamEvent {
             Self::ToolUsage { .. } => event_names::TOOL_USAGE,
             Self::Usage { .. } => event_names::USAGE,
             Self::ScratchpadUsage { .. } => event_names::SCRATCHPAD_USAGE,
+            Self::ContextUsage { .. } => event_names::CONTEXT_USAGE,
             Self::ApprovalRequested(_) => event_names::APPROVAL_REQUESTED,
             Self::ApprovalPending(_) => event_names::APPROVAL_PENDING,
             Self::ApprovalCompleted(_) => event_names::APPROVAL_COMPLETED,
@@ -653,6 +669,23 @@ impl AuraStreamEvent {
         Self::ScratchpadUsage {
             tokens_intercepted,
             tokens_extracted,
+            agent,
+            correlation,
+        }
+    }
+
+    /// Create a ContextUsage event (per-agent context-window occupancy).
+    pub fn context_usage(
+        context_tokens: u64,
+        response_tokens: u64,
+        context_window: Option<u64>,
+        agent: AgentContext,
+        correlation: CorrelationContext,
+    ) -> Self {
+        Self::ContextUsage {
+            context_tokens,
+            response_tokens,
+            context_window,
             agent,
             correlation,
         }
@@ -890,6 +923,35 @@ mod tests {
                 assert_eq!(completion_tokens, 50);
             }
             other => panic!("expected Usage, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn context_usage_roundtrip_and_event_name() {
+        let event = AuraStreamEvent::context_usage(
+            12_000,
+            340,
+            Some(200_000),
+            AgentContext::worker("log-analyst", None, "orchestrator"),
+            CorrelationContext::new("s1", None),
+        );
+        assert_eq!(event.event_name(), "aura.context_usage");
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: AuraStreamEvent = serde_json::from_str(&json).unwrap();
+        match parsed {
+            AuraStreamEvent::ContextUsage {
+                context_tokens,
+                response_tokens,
+                context_window,
+                agent,
+                ..
+            } => {
+                assert_eq!(context_tokens, 12_000);
+                assert_eq!(response_tokens, 340);
+                assert_eq!(context_window, Some(200_000));
+                assert_eq!(agent.agent_id, "log-analyst");
+            }
+            other => panic!("expected ContextUsage, got {:?}", other),
         }
     }
 

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -360,6 +360,9 @@ impl AgentExecutor for AuraAgentExecutor {
                     Ok(StreamItem::TurnUsage(_)) => {
                         event!(Level::DEBUG, request_id, "turn usage");
                     }
+                    Ok(StreamItem::ContextUsage { .. }) => {
+                        event!(Level::DEBUG, request_id, "context usage");
+                    }
                     Ok(StreamItem::OrchestratorEvent(_)) => {
                         event!(Level::DEBUG, request_id, "orchestration event");
                     }

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -401,6 +401,9 @@ impl AgentExecutor for AuraAgentExecutor {
                     Ok(StreamItem::TurnUsage(_)) => {
                         event!(Level::DEBUG, request_id, "turn usage");
                     }
+                    Ok(StreamItem::ContextUsage { .. }) => {
+                        event!(Level::DEBUG, request_id, "context usage");
+                    }
                     Ok(StreamItem::OrchestratorEvent(_)) => {
                         event!(Level::DEBUG, request_id, "orchestration event");
                     }

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -410,6 +410,34 @@ where
     termination
 }
 
+/// Resolve the cumulative billed usage `(prompt, completion, total)` for the
+/// final `aura.usage` event.
+///
+/// The single-agent path carries rig's turn-aggregated usage on
+/// `StreamItem::Final` (`usage_stats`), which sums every LLM turn — including
+/// tool-call-only turns. The hook's per-turn `store_usage` misses those turns:
+/// rig invokes `on_stream_completion_response_finish` only for turns that
+/// produced assistant text, so the hook total (`UsageState::get_final_usage`)
+/// under-reports whenever a tool turn had no text preamble (common on
+/// Bedrock-Claude). Prefer the aggregated `Final` usage when present.
+///
+/// Orchestration leaves `Final.usage` zero and accumulates billed tokens through
+/// `UsageState::accumulate_usage`, so fall back to the hook total when no
+/// aggregated `Final` usage is available.
+fn resolve_billed_usage(
+    usage_stats: &Option<UsageInfo>,
+    usage_state: &UsageState,
+) -> (u64, u64, u64) {
+    match usage_stats {
+        Some(u) if u.prompt_tokens > 0 => (
+            u.prompt_tokens,
+            u.completion_tokens,
+            u.prompt_tokens + u.completion_tokens,
+        ),
+        _ => usage_state.get_final_usage(),
+    }
+}
+
 /// Send final usage events, finish chunk, and [DONE] marker to the client.
 async fn send_final_events(
     emit_custom_events: bool,
@@ -438,9 +466,10 @@ async fn send_final_events(
         }
     }
 
-    // Emit aura.usage at stream end
+    // Emit aura.usage (cumulative billed) and aura.context_usage at stream end.
     if emit_custom_events {
-        let (prompt, completion, total) = callbacks.usage_state.get_final_usage();
+        let (prompt, completion, total) =
+            resolve_billed_usage(&state.usage_stats, &callbacks.usage_state);
         if prompt > 0 {
             tracing::debug!(
                 "Emitting aura.usage event: prompt={}, completion={}, total={}",
@@ -451,6 +480,22 @@ async fn send_final_events(
             let usage_event =
                 AuraStreamEvent::usage(prompt, completion, total, ctx.correlation.clone());
             let _ = tx.send(Ok(Bytes::from(usage_event.format_sse()))).await;
+        }
+
+        // Single-agent context-window occupancy from the final turn. The
+        // orchestration path emits per-agent context_usage during execution and
+        // leaves the shared usage_state's context counters at zero, so this
+        // emission fires only for single-agent requests.
+        let (context_tokens, response_tokens) = callbacks.usage_state.get_context_usage();
+        if context_tokens > 0 {
+            let context_event = AuraStreamEvent::context_usage(
+                context_tokens,
+                response_tokens,
+                callbacks.agent.context_window(),
+                aura::stream_events::AgentContext::single_agent(),
+                ctx.correlation.clone(),
+            );
+            let _ = tx.send(Ok(Bytes::from(context_event.format_sse()))).await;
         }
     }
 
@@ -665,6 +710,32 @@ fn handle_stream_item(
             let event = AuraStreamEvent::scratchpad_usage(
                 *tokens_intercepted,
                 *tokens_extracted,
+                agent_ctx,
+                ctx.correlation.clone(),
+            );
+            vec![Bytes::from(event.format_sse())]
+        }
+        StreamItem::ContextUsage {
+            agent_id,
+            context_tokens,
+            response_tokens,
+            context_window,
+        } => {
+            tracing::debug!(
+                "Context usage for agent {}: context={} tokens, response={} tokens",
+                agent_id,
+                context_tokens,
+                response_tokens,
+            );
+            let agent_ctx = aura::stream_events::AgentContext {
+                agent_id: agent_id.clone(),
+                agent_name: None,
+                parent_agent_id: None,
+            };
+            let event = AuraStreamEvent::context_usage(
+                *context_tokens,
+                *response_tokens,
+                *context_window,
                 agent_ctx,
                 ctx.correlation.clone(),
             );
@@ -1490,6 +1561,69 @@ mod tests {
         assert!(!is_context_overflow_error("authentication failed"));
         assert!(!is_context_overflow_error("rate limit exceeded")); // rate limit != context
         assert!(!is_context_overflow_error("internal server error"));
+    }
+
+    #[test]
+    fn test_resolve_billed_usage_prefers_aggregated_final_over_hook_undercount() {
+        // Single-agent regression: a tool-call-only turn (no assistant text) is
+        // never seen by the hook — rig invokes
+        // on_stream_completion_response_finish only on text turns — so
+        // store_usage records only the final text turn and the hook total
+        // undercounts billed tokens.
+        let usage_state = UsageState::new();
+        // Real turns: tool turn (5000/50) then final text turn (7000/200).
+        // Only the text turn reaches store_usage.
+        usage_state.store_usage(7000, 200, 7200, false);
+        assert_eq!(
+            usage_state.get_final_usage(),
+            (7000, 200, 7200),
+            "hook total omits the tool-only turn"
+        );
+
+        // rig's aggregated Final usage sums both turns.
+        let usage_stats = Some(UsageInfo {
+            prompt_tokens: 12_000,
+            completion_tokens: 250,
+            total_tokens: 12_250,
+        });
+
+        // The fix: aura.usage reflects the aggregated total, not the undercount.
+        assert_eq!(
+            resolve_billed_usage(&usage_stats, &usage_state),
+            (12_000, 250, 12_250),
+            "aura.usage must include every turn, including tool-only turns"
+        );
+    }
+
+    #[test]
+    fn test_resolve_billed_usage_falls_back_to_hook_for_orchestration() {
+        // Orchestration emits StreamItem::Final with zero usage and accumulates
+        // billed tokens through UsageState::accumulate_usage, so resolve must
+        // fall back to the hook total when Final carries no aggregated usage.
+        let usage_state = UsageState::new();
+        usage_state.accumulate_usage(5000, 200); // planning
+        usage_state.accumulate_usage(8000, 400); // worker + synthesis
+
+        let usage_stats = Some(UsageInfo {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+        });
+
+        assert_eq!(
+            resolve_billed_usage(&usage_stats, &usage_state),
+            (13_000, 600, 13_600),
+            "orchestration billed usage comes from accumulate_usage"
+        );
+    }
+
+    #[test]
+    fn test_resolve_billed_usage_falls_back_when_no_final() {
+        // Incomplete stream (timeout/shutdown before Final): no aggregated
+        // usage, so fall back to whatever the hook recorded.
+        let usage_state = UsageState::new();
+        usage_state.store_usage(1500, 100, 1600, false);
+        assert_eq!(resolve_billed_usage(&None, &usage_state), (1500, 100, 1600));
     }
 
     #[tokio::test]

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -442,6 +442,34 @@ where
     termination
 }
 
+/// Resolve the cumulative billed usage `(prompt, completion, total)` for the
+/// final `aura.usage` event.
+///
+/// The single-agent path carries rig's turn-aggregated usage on
+/// `StreamItem::Final` (`usage_stats`), which sums every LLM turn — including
+/// tool-call-only turns. The hook's per-turn `store_usage` misses those turns:
+/// rig invokes `on_stream_completion_response_finish` only for turns that
+/// produced assistant text, so the hook total (`UsageState::get_final_usage`)
+/// under-reports whenever a tool turn had no text preamble (common on
+/// Bedrock-Claude). Prefer the aggregated `Final` usage when present.
+///
+/// Orchestration leaves `Final.usage` zero and accumulates billed tokens through
+/// `UsageState::accumulate_usage`, so fall back to the hook total when no
+/// aggregated `Final` usage is available.
+fn resolve_billed_usage(
+    usage_stats: &Option<UsageInfo>,
+    usage_state: &UsageState,
+) -> (u64, u64, u64) {
+    match usage_stats {
+        Some(u) if u.prompt_tokens > 0 => (
+            u.prompt_tokens,
+            u.completion_tokens,
+            u.prompt_tokens + u.completion_tokens,
+        ),
+        _ => usage_state.get_final_usage(),
+    }
+}
+
 /// Send final usage events, finish chunk, and [DONE] marker to the client.
 async fn send_final_events(
     emit_custom_events: bool,
@@ -470,9 +498,10 @@ async fn send_final_events(
         }
     }
 
-    // Emit aura.usage at stream end
+    // Emit aura.usage (cumulative billed) and aura.context_usage at stream end.
     if emit_custom_events {
-        let (prompt, completion, total) = callbacks.usage_state.get_final_usage();
+        let (prompt, completion, total) =
+            resolve_billed_usage(&state.usage_stats, &callbacks.usage_state);
         if prompt > 0 {
             tracing::debug!(
                 "Emitting aura.usage event: prompt={}, completion={}, total={}",
@@ -483,6 +512,22 @@ async fn send_final_events(
             let usage_event =
                 AuraStreamEvent::usage(prompt, completion, total, ctx.correlation.clone());
             let _ = tx.send(Ok(Bytes::from(usage_event.format_sse()))).await;
+        }
+
+        // Single-agent context-window occupancy from the final turn. The
+        // orchestration path emits per-agent context_usage during execution and
+        // leaves the shared usage_state's context counters at zero, so this
+        // emission fires only for single-agent requests.
+        let (context_tokens, response_tokens) = callbacks.usage_state.get_context_usage();
+        if context_tokens > 0 {
+            let context_event = AuraStreamEvent::context_usage(
+                context_tokens,
+                response_tokens,
+                callbacks.agent.context_window(),
+                aura::stream_events::AgentContext::single_agent(),
+                ctx.correlation.clone(),
+            );
+            let _ = tx.send(Ok(Bytes::from(context_event.format_sse()))).await;
         }
     }
 
@@ -697,6 +742,32 @@ fn handle_stream_item(
             let event = AuraStreamEvent::scratchpad_usage(
                 *tokens_intercepted,
                 *tokens_extracted,
+                agent_ctx,
+                ctx.correlation.clone(),
+            );
+            vec![Bytes::from(event.format_sse())]
+        }
+        StreamItem::ContextUsage {
+            agent_id,
+            context_tokens,
+            response_tokens,
+            context_window,
+        } => {
+            tracing::debug!(
+                "Context usage for agent {}: context={} tokens, response={} tokens",
+                agent_id,
+                context_tokens,
+                response_tokens,
+            );
+            let agent_ctx = aura::stream_events::AgentContext {
+                agent_id: agent_id.clone(),
+                agent_name: None,
+                parent_agent_id: None,
+            };
+            let event = AuraStreamEvent::context_usage(
+                *context_tokens,
+                *response_tokens,
+                *context_window,
                 agent_ctx,
                 ctx.correlation.clone(),
             );
@@ -1522,6 +1593,69 @@ mod tests {
         assert!(!is_context_overflow_error("authentication failed"));
         assert!(!is_context_overflow_error("rate limit exceeded")); // rate limit != context
         assert!(!is_context_overflow_error("internal server error"));
+    }
+
+    #[test]
+    fn test_resolve_billed_usage_prefers_aggregated_final_over_hook_undercount() {
+        // Single-agent regression: a tool-call-only turn (no assistant text) is
+        // never seen by the hook — rig invokes
+        // on_stream_completion_response_finish only on text turns — so
+        // store_usage records only the final text turn and the hook total
+        // undercounts billed tokens.
+        let usage_state = UsageState::new();
+        // Real turns: tool turn (5000/50) then final text turn (7000/200).
+        // Only the text turn reaches store_usage.
+        usage_state.store_usage(7000, 200, 7200, false);
+        assert_eq!(
+            usage_state.get_final_usage(),
+            (7000, 200, 7200),
+            "hook total omits the tool-only turn"
+        );
+
+        // rig's aggregated Final usage sums both turns.
+        let usage_stats = Some(UsageInfo {
+            prompt_tokens: 12_000,
+            completion_tokens: 250,
+            total_tokens: 12_250,
+        });
+
+        // The fix: aura.usage reflects the aggregated total, not the undercount.
+        assert_eq!(
+            resolve_billed_usage(&usage_stats, &usage_state),
+            (12_000, 250, 12_250),
+            "aura.usage must include every turn, including tool-only turns"
+        );
+    }
+
+    #[test]
+    fn test_resolve_billed_usage_falls_back_to_hook_for_orchestration() {
+        // Orchestration emits StreamItem::Final with zero usage and accumulates
+        // billed tokens through UsageState::accumulate_usage, so resolve must
+        // fall back to the hook total when Final carries no aggregated usage.
+        let usage_state = UsageState::new();
+        usage_state.accumulate_usage(5000, 200); // planning
+        usage_state.accumulate_usage(8000, 400); // worker + synthesis
+
+        let usage_stats = Some(UsageInfo {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+        });
+
+        assert_eq!(
+            resolve_billed_usage(&usage_stats, &usage_state),
+            (13_000, 600, 13_600),
+            "orchestration billed usage comes from accumulate_usage"
+        );
+    }
+
+    #[test]
+    fn test_resolve_billed_usage_falls_back_when_no_final() {
+        // Incomplete stream (timeout/shutdown before Final): no aggregated
+        // usage, so fall back to whatever the hook recorded.
+        let usage_state = UsageState::new();
+        usage_state.store_usage(1500, 100, 1600, false);
+        assert_eq!(resolve_billed_usage(&None, &usage_state), (1500, 100, 1600));
     }
 
     #[tokio::test]

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -428,6 +428,61 @@ struct StreamCallParams<'a> {
     event_tx: Option<&'a tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>>,
 }
 
+/// Agent id for the conversation-level context an orchestration run carries,
+/// matching the single-agent id so clients key context pressure the same way
+/// in both modes.
+const COORDINATOR_AGENT_ID: &str = "main";
+
+/// Every exit path of a stream loop must route its turns through
+/// [`TurnTally::record`]: a turn counted locally but not into the shared
+/// `UsageState` is billed usage the client never sees.
+#[derive(Default)]
+struct TurnTally {
+    total: rig::completion::Usage,
+    last: rig::completion::Usage,
+}
+
+impl TurnTally {
+    fn record(&mut self, turn: &rig::completion::Usage, usage_state: &crate::UsageState) {
+        self.total.input_tokens += turn.input_tokens;
+        self.total.output_tokens += turn.output_tokens;
+        self.total.total_tokens += turn.total_tokens;
+        self.last = rig::completion::Usage {
+            input_tokens: turn.input_tokens,
+            output_tokens: turn.output_tokens,
+            total_tokens: turn.total_tokens,
+        };
+        usage_state.accumulate_usage(turn.input_tokens, turn.output_tokens);
+    }
+
+    /// Reconcile against a loop total the provider reported separately.
+    ///
+    /// Returns what the total carries beyond the recorded turns, saturating at
+    /// zero. Non-zero means turns reached the provider without reaching
+    /// [`record`](Self::record) — the caller accumulates the difference so
+    /// billing stays whole, and warns because occupancy cannot be recovered.
+    fn reconcile(&self, reported_total: &rig::completion::Usage) -> rig::completion::Usage {
+        let input_tokens = reported_total
+            .input_tokens
+            .saturating_sub(self.total.input_tokens);
+        let output_tokens = reported_total
+            .output_tokens
+            .saturating_sub(self.total.output_tokens);
+        rig::completion::Usage {
+            input_tokens,
+            output_tokens,
+            total_tokens: input_tokens + output_tokens,
+        }
+    }
+}
+
+struct ForwardedRun {
+    response: crate::provider_agent::CompletionResponse,
+    /// Provider-reported usage of the loop's last turn — context-window
+    /// occupancy, as opposed to `response.usage`'s loop total.
+    last_turn: rig::completion::Usage,
+}
+
 /// One guarded step of a deadline-wrapped stream loop.
 enum LoopStep {
     End,
@@ -942,6 +997,219 @@ impl Orchestrator {
         })
     }
 
+    /// Drive one agent loop's stream, forwarding events and tallying usage.
+    ///
+    /// Split from [`Self::stream_and_forward`] so tests can drive the arms with
+    /// a scripted stream; every exit path here must record turns through
+    /// [`TurnTally::record`].
+    #[allow(clippy::too_many_arguments)]
+    async fn drive_forward_loop(
+        mut stream: std::pin::Pin<
+            Box<dyn futures::Stream<Item = Result<StreamItem, StreamError>> + Send>,
+        >,
+        usage_state: &crate::UsageState,
+        inactivity_secs: u64,
+        scratchpad_budget: Option<&scratchpad::ContextBudget>,
+        phase: &str,
+        event_tx: Option<&tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>>,
+        stream_context: Option<StreamContext<'_>>,
+        decision_ready: impl Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>>,
+    ) -> Result<ForwardedRun, Box<dyn std::error::Error + Send + Sync>> {
+        use crate::provider_agent::{
+            CompletionResponse, StreamedAssistantContent, StreamedUserContent,
+        };
+        use futures::StreamExt;
+        use rig::completion::Usage;
+        use std::collections::HashMap;
+
+        let emit_scratchpad_events = scratchpad::emit_scratchpad_tool_events_enabled();
+        let mut content = String::new();
+        let mut tally = TurnTally::default();
+        // Set only by the Final arm, whose reported loop total supersedes
+        // the per-turn sum as the response's authoritative usage.
+        let mut final_total: Option<Usage> = None;
+        // Start times for tools forwarded manually here (skills, orchestration
+        // operations, and scratchpad tools when enabled) so the matching
+        // ToolResult can report a duration. Membership also gates completion:
+        // only IDs we started get completed, so MCP tools (covered by
+        // ObserverWrapper) are never double-emitted.
+        let mut internal_tool_starts: HashMap<String, std::time::Instant> = HashMap::new();
+
+        // Two guarded phases per iteration, so the body (its sends and the
+        // decision-ready branch's inner `next()`) runs under the deadline
+        // state the received item implies, not the previous item's state.
+        // A ToolCall's suspension lands after its body, covering exactly
+        // the next receive, where rig executes the tool.
+        //
+        // new_disarmed(): the per-call budget already bounds the wait for
+        // the first token, so this window governs only silence between
+        // stream items; the first touch arms it.
+        let mut deadline = crate::inactivity::InactivityDeadline::new_disarmed(
+            Duration::from_secs(inactivity_secs),
+        );
+        loop {
+            let item = tokio::select! {
+                biased;
+                _ = deadline.expired() => {
+                    return Err(deadline.stall_error(phase));
+                }
+                item = stream.next() => item,
+            };
+            let Some(item) = item else {
+                break;
+            };
+            let liveness = liveness_of(&item);
+            match liveness {
+                // `touch` is ignored while suspended, so a finished tool
+                // must resume explicitly.
+                Liveness::ToolFinished => deadline.resume(),
+                _ => deadline.touch(),
+            }
+            let body = async {
+                match item {
+                    Ok(StreamItem::StreamAssistantItem(StreamedAssistantContent::Text(t))) => {
+                        content.push_str(&t);
+                    }
+                    Ok(StreamItem::StreamAssistantItem(
+                        StreamedAssistantContent::ReasoningDelta { delta, .. },
+                    )) => {
+                        if let Some(tx) = event_tx {
+                            if let Some(ref ctx) = stream_context {
+                                let _ = tx
+                                    .send(Ok(StreamItem::OrchestratorEvent(
+                                        OrchestratorEvent::WorkerReasoning {
+                                            task_id: ctx.task_id,
+                                            worker_id: ctx.worker_id.to_string(),
+                                            content: delta,
+                                        },
+                                    )))
+                                    .await;
+                            } else {
+                                let _ = tx
+                                    .send(Ok(StreamItem::StreamAssistantItem(
+                                        StreamedAssistantContent::ReasoningDelta {
+                                            delta,
+                                            id: None,
+                                        },
+                                    )))
+                                    .await;
+                            }
+                        }
+                    }
+                    Ok(StreamItem::StreamAssistantItem(StreamedAssistantContent::Reasoning(_))) => {
+                        // Final reasoning block — already forwarded as deltas above.
+                        // Skip to avoid double-emission.
+                    }
+                    // Forward calls to the non-MCP tools ObserverWrapper does not
+                    // cover: skills and orchestration operations always, scratchpad
+                    // tools only when the debug flag is on. The matching completion
+                    // is emitted from the ToolResult arm below.
+                    Ok(StreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCall(
+                        ref tc,
+                    ))) if scratchpad::should_forward_tool_event(
+                        &tc.name,
+                        emit_scratchpad_events,
+                    ) =>
+                    {
+                        let (task_id, worker_id) = match stream_context.as_ref() {
+                            Some(w) => (Some(w.task_id), w.worker_id),
+                            None => (None, "main"),
+                        };
+                        forward_internal_tool_started(
+                            event_tx,
+                            task_id,
+                            worker_id,
+                            &tc.id,
+                            &tc.name,
+                            &tc.arguments,
+                            &mut internal_tool_starts,
+                        )
+                        .await;
+                    }
+                    Ok(StreamItem::Final(info)) => {
+                        let unrecorded = tally.reconcile(&info.usage);
+                        if unrecorded.input_tokens > 0 || unrecorded.output_tokens > 0 {
+                            tracing::warn!(
+                                "{}: {} input / {} output tokens reached the provider \
+                                 without a TurnUsage item; billing reconciled, occupancy \
+                                 may understate the final turn",
+                                phase,
+                                unrecorded.input_tokens,
+                                unrecorded.output_tokens
+                            );
+                            usage_state.accumulate_usage(
+                                unrecorded.input_tokens,
+                                unrecorded.output_tokens,
+                            );
+                        }
+                        content = info.content;
+                        final_total = Some(info.usage);
+                        return Ok(LoopStep::End);
+                    }
+                    Ok(StreamItem::FinalMarker) => {
+                        // Per-turn marker — not end-of-stream. Continue collecting.
+                    }
+                    Ok(StreamItem::TurnUsage(turn)) => {
+                        tally.record(&turn, usage_state);
+                        if let Some(budget) = scratchpad_budget {
+                            budget.set_estimated_used(turn.input_tokens, turn.output_tokens);
+                        }
+                    }
+                    Err(e) => return Err(e),
+                    Ok(StreamItem::StreamUserItem(StreamedUserContent::ToolResult(ref tr))) => {
+                        // No-op unless a start was tracked above; emitting here (not
+                        // in a dedicated arm) keeps the decision short-circuit intact
+                        // for tools like submit_result.
+                        forward_internal_tool_completed(
+                            event_tx,
+                            stream_context.as_ref().map(|w| w.task_id),
+                            &tr.id,
+                            &tr.result,
+                            &mut internal_tool_starts,
+                        )
+                        .await;
+                        tracing::debug!(
+                            "{}: tool result received (id={}, call_id={})",
+                            phase,
+                            tr.id,
+                            tr.call_id.as_deref().unwrap_or("-")
+                        );
+                        if decision_ready().await {
+                            tracing::debug!("{}: decision captured, reading turn usage", phase);
+                            if let Some(Ok(StreamItem::TurnUsage(turn))) = stream.next().await {
+                                tally.record(&turn, usage_state);
+                            }
+                            return Ok(LoopStep::End);
+                        }
+                    }
+                    _ => {} // ToolCall, ToolCallDelta — rig handles execution
+                }
+                Ok(LoopStep::Continue)
+            };
+            let step = tokio::select! {
+                biased;
+                _ = deadline.expired() => {
+                    return Err(deadline.stall_error(phase));
+                }
+                step = body => step?,
+            };
+            if matches!(step, LoopStep::End) {
+                break;
+            }
+            if matches!(liveness, Liveness::ToolStarted) {
+                deadline.suspend();
+            }
+        }
+
+        Ok(ForwardedRun {
+            response: CompletionResponse {
+                content,
+                usage: final_total.unwrap_or(tally.total),
+            },
+            last_turn: tally.last,
+        })
+    }
+
     /// Stream a full ReAct chat, forwarding reasoning events and collecting the final response.
     ///
     /// Runs the full multi-turn tool loop at the agent's configured
@@ -958,15 +1226,7 @@ impl Orchestrator {
         params: StreamCallParams<'_>,
         stream_context: Option<StreamContext<'_>>,
         decision_ready: impl Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>>,
-    ) -> Result<crate::provider_agent::CompletionResponse, Box<dyn std::error::Error + Send + Sync>>
-    {
-        use crate::provider_agent::{
-            CompletionResponse, StreamedAssistantContent, StreamedUserContent,
-        };
-        use futures::StreamExt;
-        use rig::completion::Usage;
-        use std::collections::HashMap;
-
+    ) -> Result<ForwardedRun, Box<dyn std::error::Error + Send + Sync>> {
         let StreamCallParams {
             prompt,
             history,
@@ -974,183 +1234,19 @@ impl Orchestrator {
             event_tx,
         } = params;
         let timeout_secs = self.config.per_call_timeout_secs();
-        let inactivity_secs = self.config.stream_inactivity_timeout_secs();
-        let emit_scratchpad_events = scratchpad::emit_scratchpad_tool_events_enabled();
         let stream_future = async {
-            let mut stream = agent.stream_chat(prompt, history).await;
-            let mut content = String::new();
-            let mut usage = Usage {
-                input_tokens: 0,
-                output_tokens: 0,
-                total_tokens: 0,
-            };
-            // Start times for tools forwarded manually here (skills, orchestration
-            // operations, and scratchpad tools when enabled) so the matching
-            // ToolResult can report a duration. Membership also gates completion:
-            // only IDs we started get completed, so MCP tools (covered by
-            // ObserverWrapper) are never double-emitted.
-            let mut internal_tool_starts: HashMap<String, std::time::Instant> = HashMap::new();
-
-            // Two guarded phases per iteration, so the body (its sends and the
-            // decision-ready branch's inner `next()`) runs under the deadline
-            // state the received item implies, not the previous item's state.
-            // A ToolCall's suspension lands after its body, covering exactly
-            // the next receive, where rig executes the tool.
-            //
-            // new_disarmed(): the per-call budget already bounds the wait for
-            // the first token, so this window governs only silence between
-            // stream items; the first touch arms it.
-            let mut deadline = crate::inactivity::InactivityDeadline::new_disarmed(
-                Duration::from_secs(inactivity_secs),
-            );
-            loop {
-                let item = tokio::select! {
-                    biased;
-                    _ = deadline.expired() => {
-                        return Err(deadline.stall_error(phase));
-                    }
-                    item = stream.next() => item,
-                };
-                let Some(item) = item else {
-                    break;
-                };
-                let liveness = liveness_of(&item);
-                match liveness {
-                    // `touch` is ignored while suspended, so a finished tool
-                    // must resume explicitly.
-                    Liveness::ToolFinished => deadline.resume(),
-                    _ => deadline.touch(),
-                }
-                let body = async {
-                    match item {
-                        Ok(StreamItem::StreamAssistantItem(StreamedAssistantContent::Text(t))) => {
-                            content.push_str(&t);
-                        }
-                        Ok(StreamItem::StreamAssistantItem(
-                            StreamedAssistantContent::ReasoningDelta { delta, .. },
-                        )) => {
-                            if let Some(tx) = event_tx {
-                                if let Some(ref ctx) = stream_context {
-                                    let _ = tx
-                                        .send(Ok(StreamItem::OrchestratorEvent(
-                                            OrchestratorEvent::WorkerReasoning {
-                                                task_id: ctx.task_id,
-                                                worker_id: ctx.worker_id.to_string(),
-                                                content: delta,
-                                            },
-                                        )))
-                                        .await;
-                                } else {
-                                    let _ = tx
-                                        .send(Ok(StreamItem::StreamAssistantItem(
-                                            StreamedAssistantContent::ReasoningDelta {
-                                                delta,
-                                                id: None,
-                                            },
-                                        )))
-                                        .await;
-                                }
-                            }
-                        }
-                        Ok(StreamItem::StreamAssistantItem(
-                            StreamedAssistantContent::Reasoning(_),
-                        )) => {
-                            // Final reasoning block — already forwarded as deltas above.
-                            // Skip to avoid double-emission.
-                        }
-                        // Forward calls to the non-MCP tools ObserverWrapper does not
-                        // cover: skills and orchestration operations always, scratchpad
-                        // tools only when the debug flag is on. The matching completion
-                        // is emitted from the ToolResult arm below.
-                        Ok(StreamItem::StreamAssistantItem(
-                            StreamedAssistantContent::ToolCall(ref tc),
-                        )) if scratchpad::should_forward_tool_event(
-                            &tc.name,
-                            emit_scratchpad_events,
-                        ) =>
-                        {
-                            let (task_id, worker_id) = match stream_context.as_ref() {
-                                Some(w) => (Some(w.task_id), w.worker_id),
-                                None => (None, "main"),
-                            };
-                            forward_internal_tool_started(
-                                event_tx,
-                                task_id,
-                                worker_id,
-                                &tc.id,
-                                &tc.name,
-                                &tc.arguments,
-                                &mut internal_tool_starts,
-                            )
-                            .await;
-                        }
-                        Ok(StreamItem::Final(info)) => {
-                            content = info.content;
-                            usage = info.usage;
-                            return Ok(LoopStep::End);
-                        }
-                        Ok(StreamItem::FinalMarker) => {
-                            // Per-turn marker — not end-of-stream. Continue collecting.
-                        }
-                        Ok(StreamItem::TurnUsage(turn)) => {
-                            usage.input_tokens += turn.input_tokens;
-                            usage.output_tokens += turn.output_tokens;
-                            usage.total_tokens += turn.total_tokens;
-                            self.usage_state
-                                .accumulate_usage(turn.input_tokens, turn.output_tokens);
-                            if let Some(ref budget) = agent.scratchpad_budget {
-                                budget.set_estimated_used(turn.input_tokens, turn.output_tokens);
-                            }
-                        }
-                        Err(e) => return Err(e),
-                        Ok(StreamItem::StreamUserItem(StreamedUserContent::ToolResult(ref tr))) => {
-                            // No-op unless a start was tracked above; emitting here (not
-                            // in a dedicated arm) keeps the decision short-circuit intact
-                            // for tools like submit_result.
-                            forward_internal_tool_completed(
-                                event_tx,
-                                stream_context.as_ref().map(|w| w.task_id),
-                                &tr.id,
-                                &tr.result,
-                                &mut internal_tool_starts,
-                            )
-                            .await;
-                            tracing::debug!(
-                                "{}: tool result received (id={}, call_id={})",
-                                phase,
-                                tr.id,
-                                tr.call_id.as_deref().unwrap_or("-")
-                            );
-                            if decision_ready().await {
-                                tracing::debug!("{}: decision captured, reading turn usage", phase);
-                                if let Some(Ok(StreamItem::TurnUsage(turn))) = stream.next().await {
-                                    usage.input_tokens += turn.input_tokens;
-                                    usage.output_tokens += turn.output_tokens;
-                                    usage.total_tokens += turn.total_tokens;
-                                }
-                                return Ok(LoopStep::End);
-                            }
-                        }
-                        _ => {} // ToolCall, ToolCallDelta — rig handles execution
-                    }
-                    Ok(LoopStep::Continue)
-                };
-                let step = tokio::select! {
-                    biased;
-                    _ = deadline.expired() => {
-                        return Err(deadline.stall_error(phase));
-                    }
-                    step = body => step?,
-                };
-                if matches!(step, LoopStep::End) {
-                    break;
-                }
-                if matches!(liveness, Liveness::ToolStarted) {
-                    deadline.suspend();
-                }
-            }
-
-            Ok(CompletionResponse { content, usage })
+            let stream = agent.stream_chat(prompt, history).await;
+            Self::drive_forward_loop(
+                stream,
+                &self.usage_state,
+                self.config.stream_inactivity_timeout_secs(),
+                agent.scratchpad_budget.as_ref(),
+                phase,
+                event_tx,
+                stream_context,
+                decision_ready,
+            )
+            .await
         };
 
         if timeout_secs == 0 {
@@ -1217,11 +1313,10 @@ impl Orchestrator {
                 .stream_chat_with_depth(prompt, history, agent.max_depth)
                 .await;
             let mut content = String::new();
-            let mut usage = Usage {
-                input_tokens: 0,
-                output_tokens: 0,
-                total_tokens: 0,
-            };
+            let mut tally = TurnTally::default();
+            // Set only by the Final arm, whose reported loop total supersedes
+            // the per-turn sum as the response's authoritative usage.
+            let mut final_total: Option<Usage> = None;
             // The coordinator is not ObserverWrapped, so forward the same non-MCP
             // tool calls a worker does (skills, orchestration operations), attributed
             // to the main agent.
@@ -1312,27 +1407,33 @@ impl Orchestrator {
                             if decision_ready().await {
                                 tracing::debug!("{}: decision captured, reading turn usage", phase);
                                 if let Some(Ok(StreamItem::TurnUsage(turn))) = stream.next().await {
-                                    usage.input_tokens += turn.input_tokens;
-                                    usage.output_tokens += turn.output_tokens;
-                                    usage.total_tokens += turn.total_tokens;
-                                    self.usage_state
-                                        .accumulate_usage(turn.input_tokens, turn.output_tokens);
+                                    tally.record(&turn, &self.usage_state);
                                 }
                                 return Ok(LoopStep::End);
                             }
                         }
                         // Final response — authoritative content + usage
                         Ok(StreamItem::Final(info)) => {
+                            let unrecorded = tally.reconcile(&info.usage);
+                            if unrecorded.input_tokens > 0 || unrecorded.output_tokens > 0 {
+                                tracing::warn!(
+                                    "{}: {} input / {} output tokens reached the provider \
+                                     without a TurnUsage item; billing reconciled",
+                                    phase,
+                                    unrecorded.input_tokens,
+                                    unrecorded.output_tokens
+                                );
+                                self.usage_state.accumulate_usage(
+                                    unrecorded.input_tokens,
+                                    unrecorded.output_tokens,
+                                );
+                            }
                             content = info.content;
-                            usage = info.usage;
+                            final_total = Some(info.usage);
                             return Ok(LoopStep::End);
                         }
                         Ok(StreamItem::TurnUsage(turn)) => {
-                            usage.input_tokens += turn.input_tokens;
-                            usage.output_tokens += turn.output_tokens;
-                            usage.total_tokens += turn.total_tokens;
-                            self.usage_state
-                                .accumulate_usage(turn.input_tokens, turn.output_tokens);
+                            tally.record(&turn, &self.usage_state);
                         }
                         Ok(StreamItem::FinalMarker) => return Ok(LoopStep::End),
                         // MaxDepthError: success if decision was captured, error otherwise
@@ -1366,7 +1467,25 @@ impl Orchestrator {
                     deadline.suspend();
                 }
             }
-            Ok(CompletionResponse { content, usage })
+            // Coordinator occupancy under the same agent id single-agent uses,
+            // so clients track one conversation context across both modes. The
+            // last planning cycle runs after the workers, so its event is the
+            // one that lands last.
+            if let Some(tx) = event_tx.filter(|_| tally.last.input_tokens > 0) {
+                let _ = tx
+                    .send(Ok(StreamItem::ContextUsage {
+                        agent_id: COORDINATOR_AGENT_ID.to_string(),
+                        context_tokens: tally.last.input_tokens,
+                        response_tokens: tally.last.output_tokens,
+                        context_window: agent.context_window,
+                    }))
+                    .await;
+            }
+
+            Ok(CompletionResponse {
+                content,
+                usage: final_total.unwrap_or(tally.total),
+            })
         };
 
         if timeout_secs == 0 {
@@ -2330,7 +2449,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 mcp_manager: None, // Coordinator doesn't have MCP tools
                 fallback_tool_parsing: false,
                 fallback_tool_names: vec![],
-                context_window: None,
+                context_window: self.agent_config.llm.context_window(),
                 scratchpad_budget: None,
                 client_tool_names: Default::default(),
                 turn_nudge: None,
@@ -3240,9 +3359,25 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 }
             }
 
+            // Emit this agent's context-window occupancy from its final
+            // response turn — provider-reported, no local tokenizer.
+            if let (Ok(run), Some(tx)) = (&stream_result, event_tx) {
+                let agent_id = worker_name
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| self.orchestrator_id.clone());
+                let _ = tx
+                    .send(Ok(StreamItem::ContextUsage {
+                        agent_id,
+                        context_tokens: run.last_turn.input_tokens,
+                        response_tokens: run.last_turn.output_tokens,
+                        context_window: worker.context_window,
+                    }))
+                    .await;
+            }
+
             // Detect context overflow and other errors — don't retry hard errors
             let result = match stream_result {
-                Ok(r) => Ok(r.content),
+                Ok(r) => Ok(r.response.content),
                 Err(e) if is_context_overflow_error(e.as_ref()) => {
                     let suggestion = context_overflow_suggestion("worker");
                     Err(format!(
@@ -4619,6 +4754,252 @@ fn context_overflow_suggestion(phase: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn usage(input_tokens: u64, output_tokens: u64) -> rig::completion::Usage {
+        rig::completion::Usage {
+            input_tokens,
+            output_tokens,
+            total_tokens: input_tokens + output_tokens,
+        }
+    }
+
+    /// Turn figures are AWS Bedrock invocation-log records for one `arithmetic`
+    /// worker loop: 2012/115 then 2152/124.
+    #[test]
+    fn test_tally_records_every_turn_into_shared_usage_state() {
+        let usage_state = crate::UsageState::new();
+        let mut tally = TurnTally::default();
+
+        tally.record(&usage(2012, 115), &usage_state);
+        tally.record(&usage(2152, 124), &usage_state);
+
+        // Billed usage is the whole loop.
+        assert_eq!(usage_state.get_final_usage(), (4164, 239, 4403));
+        assert_eq!(tally.total.input_tokens, 4164);
+        // Occupancy is the last turn alone, not the loop total.
+        assert_eq!(tally.last.input_tokens, 2152);
+        assert_eq!(tally.last.output_tokens, 124);
+    }
+
+    #[test]
+    fn test_tally_reconciles_to_zero_when_every_turn_was_recorded() {
+        let usage_state = crate::UsageState::new();
+        let mut tally = TurnTally::default();
+        tally.record(&usage(2012, 115), &usage_state);
+        tally.record(&usage(2152, 124), &usage_state);
+
+        // The provider's loop total for these turns — nothing bypassed record().
+        let unrecorded = tally.reconcile(&usage(4164, 239));
+
+        assert_eq!(unrecorded.input_tokens, 0);
+        assert_eq!(unrecorded.output_tokens, 0);
+    }
+
+    #[test]
+    fn test_tally_reconcile_surfaces_turns_that_bypassed_record() {
+        let usage_state = crate::UsageState::new();
+        let mut tally = TurnTally::default();
+        tally.record(&usage(2012, 115), &usage_state);
+
+        let unrecorded = tally.reconcile(&usage(4164, 239));
+
+        assert_eq!(unrecorded.input_tokens, 2152);
+        assert_eq!(unrecorded.output_tokens, 124);
+    }
+
+    #[test]
+    fn test_tally_reconcile_saturates_when_total_trails_recorded() {
+        let usage_state = crate::UsageState::new();
+        let mut tally = TurnTally::default();
+        tally.record(&usage(4164, 239), &usage_state);
+
+        let unrecorded = tally.reconcile(&usage(100, 10));
+
+        assert_eq!(unrecorded.input_tokens, 0);
+        assert_eq!(unrecorded.output_tokens, 0);
+    }
+
+    /// A two-worker orchestration run replayed from its Bedrock
+    /// invocation-log records: coordinator 3258/270 planning and 4133/308
+    /// synthesis, arithmetic 2012/115 + 2152/124, reporter 2085/313 + 2584/278.
+    /// Billed usage must equal the provider's own sum, 16224/1408.
+    #[test]
+    fn test_orchestration_run_accumulates_to_the_provider_total() {
+        let usage_state = crate::UsageState::new();
+
+        for turns in [
+            vec![usage(3258, 270)],
+            vec![usage(2012, 115), usage(2152, 124)],
+            vec![usage(2085, 313), usage(2584, 278)],
+            vec![usage(4133, 308)],
+        ] {
+            let mut tally = TurnTally::default();
+            for turn in &turns {
+                tally.record(turn, &usage_state);
+            }
+        }
+
+        let (prompt, completion, total) = usage_state.get_final_usage();
+        assert_eq!(prompt, 16224, "billed input must match the provider sum");
+        assert_eq!(
+            completion, 1408,
+            "billed output must match the provider sum"
+        );
+        assert_eq!(total, 17632);
+    }
+
+    // ========================================================================
+    // Scripted-stream harness
+    //
+    // Drives the real `drive_forward_loop` arms so a future exit path that
+    // forgets `TurnTally::record` fails here rather than in production.
+    // ========================================================================
+
+    fn scripted(
+        items: Vec<Result<StreamItem, StreamError>>,
+    ) -> std::pin::Pin<Box<dyn futures::Stream<Item = Result<StreamItem, StreamError>> + Send>>
+    {
+        Box::pin(futures::stream::iter(items))
+    }
+
+    fn turn(input_tokens: u64, output_tokens: u64) -> Result<StreamItem, StreamError> {
+        Ok(StreamItem::TurnUsage(usage(input_tokens, output_tokens)))
+    }
+
+    fn tool_result(id: &str) -> Result<StreamItem, StreamError> {
+        Ok(StreamItem::StreamUserItem(
+            crate::provider_agent::StreamedUserContent::ToolResult(
+                crate::provider_agent::ToolResult {
+                    id: id.to_string(),
+                    call_id: Some(id.to_string()),
+                    result: "ok".to_string(),
+                },
+            ),
+        ))
+    }
+
+    fn never_ready()
+    -> impl Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>> {
+        || Box::pin(async { false })
+    }
+
+    fn always_ready()
+    -> impl Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>> {
+        || Box::pin(async { true })
+    }
+
+    async fn drive(
+        items: Vec<Result<StreamItem, StreamError>>,
+        usage_state: &crate::UsageState,
+        decision_ready: impl Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>>,
+    ) -> ForwardedRun {
+        Orchestrator::drive_forward_loop(
+            scripted(items),
+            usage_state,
+            0,
+            None,
+            "test",
+            None,
+            None,
+            decision_ready,
+        )
+        .await
+        .expect("scripted stream should drive to completion")
+    }
+
+    /// Turn figures are Bedrock invocation-log records for one `arithmetic`
+    /// worker loop: 2012/115 then 2152/124.
+    #[tokio::test]
+    async fn test_loop_bills_every_turn_and_reports_the_last_as_occupancy() {
+        let usage_state = crate::UsageState::new();
+
+        let run = drive(
+            vec![
+                turn(2012, 115),
+                turn(2152, 124),
+                Ok(StreamItem::Final(
+                    crate::provider_agent::FinalResponseInfo {
+                        content: "done".to_string(),
+                        usage: usage(4164, 239),
+                    },
+                )),
+            ],
+            &usage_state,
+            never_ready(),
+        )
+        .await;
+
+        assert_eq!(usage_state.get_final_usage(), (4164, 239, 4403));
+        assert_eq!(run.last_turn.input_tokens, 2152);
+        assert_eq!(run.last_turn.output_tokens, 124);
+        assert_eq!(run.response.content, "done");
+    }
+
+    /// The `submit_result` exit consumes a turn off the stream itself; before
+    /// this path recorded through the tally it was billed to nobody.
+    #[tokio::test]
+    async fn test_submit_result_exit_bills_the_turn_it_consumes() {
+        let usage_state = crate::UsageState::new();
+
+        let run = drive(
+            vec![
+                turn(2012, 115),
+                tool_result("submit_result"),
+                turn(2152, 124),
+            ],
+            &usage_state,
+            always_ready(),
+        )
+        .await;
+
+        assert_eq!(
+            usage_state.get_final_usage(),
+            (4164, 239, 4403),
+            "the turn consumed by the early exit must reach UsageState"
+        );
+        assert_eq!(run.last_turn.input_tokens, 2152);
+        assert_eq!(run.response.usage.input_tokens, 4164);
+    }
+
+    /// A loop total larger than the recorded turns means a turn bypassed the
+    /// tally; billing is reconciled from the remainder.
+    #[tokio::test]
+    async fn test_loop_reconciles_a_total_that_exceeds_recorded_turns() {
+        let usage_state = crate::UsageState::new();
+
+        drive(
+            vec![
+                turn(2012, 115),
+                Ok(StreamItem::Final(
+                    crate::provider_agent::FinalResponseInfo {
+                        content: "done".to_string(),
+                        usage: usage(4164, 239),
+                    },
+                )),
+            ],
+            &usage_state,
+            never_ready(),
+        )
+        .await;
+
+        assert_eq!(usage_state.get_final_usage(), (4164, 239, 4403));
+    }
+
+    #[tokio::test]
+    async fn test_loop_without_a_final_reports_the_summed_turns() {
+        let usage_state = crate::UsageState::new();
+
+        let run = drive(
+            vec![turn(2012, 115), turn(2152, 124)],
+            &usage_state,
+            never_ready(),
+        )
+        .await;
+
+        assert_eq!(run.response.usage.input_tokens, 4164);
+        assert_eq!(run.response.usage.output_tokens, 239);
+        assert_eq!(usage_state.get_final_usage(), (4164, 239, 4403));
+    }
 
     #[test]
     fn test_truncate_query_short() {

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -3078,6 +3078,22 @@ Assign tasks to the worker whose tools best match the required operations."#,
             // stream_and_forward, so failed attempts also contribute.
             if let Ok(ref response) = stream_result {
                 last_usage = response.usage;
+
+                // Emit this agent's context-window occupancy from its final
+                // response turn — provider-reported, no local tokenizer.
+                if let Some(tx) = event_tx {
+                    let agent_id = worker_name
+                        .map(|n| n.to_string())
+                        .unwrap_or_else(|| self.orchestrator_id.clone());
+                    let _ = tx
+                        .send(Ok(StreamItem::ContextUsage {
+                            agent_id,
+                            context_tokens: response.usage.input_tokens,
+                            response_tokens: response.usage.output_tokens,
+                            context_window: worker.context_window,
+                        }))
+                        .await;
+                }
             }
 
             // Detect context overflow and other errors — don't retry hard errors

--- a/crates/aura/src/provider_agent.rs
+++ b/crates/aura/src/provider_agent.rs
@@ -400,6 +400,22 @@ pub enum StreamItem {
         /// Tokens extracted from scratchpad back into context.
         tokens_extracted: usize,
     },
+    /// Per-agent context-window occupancy report.
+    ///
+    /// Emitted after an orchestration agent finishes, carrying the provider's
+    /// final-turn input/output. The web server handler converts this to an
+    /// `aura.context_usage` SSE event, filling in correlation context from the
+    /// request.
+    ContextUsage {
+        /// The agent that produced this usage (worker name, coordinator id, etc.).
+        agent_id: String,
+        /// Provider-reported input tokens of the final turn (context size).
+        context_tokens: u64,
+        /// Provider-reported output tokens of the final turn.
+        response_tokens: u64,
+        /// Model context-window limit, when known.
+        context_window: Option<u64>,
+    },
     /// MCP server connection status snapshot.
     ///
     /// Emitted once near the start of an orchestration run (after the shared

--- a/crates/aura/src/streaming_request_hook.rs
+++ b/crates/aura/src/streaming_request_hook.rs
@@ -50,26 +50,24 @@ const MAX_PENDING_TOOL_IDS: usize = 256;
 
 /// Shared usage state that survives hook cloning.
 ///
-/// Tracks context window position across multi-turn tool call loops.
-/// The UI needs to know context size for warning thresholds.
-///
-/// Context window = what will be sent in the NEXT request:
-/// - `initial_prompt_tokens`: First LLM turn's input (system + history + user message)
-/// - `accumulated_completion_tokens`: SUM of all LLM turn outputs (all streamed to frontend)
-/// - `tool_completion_tokens`: Subset of accumulated_completion spent generating tool call JSON
-///
-/// All completion tokens are accumulated because everything streams to the frontend
-/// and gets stored in the thread history for the next request.
+/// Tracks two quantities clients read independently: **billed usage** (input and
+/// output summed across every turn, surfaced as `aura.usage`) and **context
+/// occupancy** (the most recent turn's input/output, surfaced as
+/// `aura.context_usage`).
 #[derive(Clone, Default)]
 pub struct UsageState {
-    /// Whether initial_prompt_tokens has been set (first turn captured)
+    /// Whether any usage has been recorded.
     initialized: Arc<AtomicBool>,
-    /// Prompt tokens from the FIRST LLM turn (system + history + user message)
-    initial_prompt_tokens: Arc<AtomicU64>,
-    /// Accumulated completion tokens across ALL LLM turns (all stream to frontend)
+    /// Cumulative provider-billed input tokens across all LLM turns.
+    billed_prompt_tokens: Arc<AtomicU64>,
+    /// Cumulative provider-billed output tokens across all LLM turns.
     accumulated_completion_tokens: Arc<AtomicU64>,
-    /// Completion tokens spent on tool-call turns (subset of accumulated_completion_tokens)
+    /// Completion tokens spent on tool-call turns.
     tool_completion_tokens: Arc<AtomicU64>,
+    /// Input tokens of the most recent turn.
+    last_input_tokens: Arc<AtomicU64>,
+    /// Output tokens of the most recent turn.
+    last_output_tokens: Arc<AtomicU64>,
     /// Tool IDs completed since the last usage event (for aura.tool_usage correlation)
     pending_tool_ids: Arc<Mutex<Vec<String>>>,
 }
@@ -80,19 +78,25 @@ impl UsageState {
         Self::default()
     }
 
-    /// Get the final usage values for context window calculation.
-    ///
-    /// Returns (prompt_tokens, completion_tokens, total_tokens) where:
-    /// - prompt_tokens: Initial input from first LLM turn (system + history + user msg)
-    /// - completion_tokens: Accumulated output across ALL LLM turns (all stream to frontend)
-    /// - total_tokens: prompt + completion = context window position for next request
-    ///
-    /// This gives accurate context tracking since all completions stream to frontend
-    /// and get stored in thread history.
+    /// Cumulative provider-billed usage for the whole request as
+    /// `(prompt, completion, total)`, summed across every LLM turn. Powers
+    /// `aura.usage`. See [`get_context_usage`](Self::get_context_usage) for
+    /// context-window occupancy.
     pub fn get_final_usage(&self) -> (u64, u64, u64) {
-        let prompt = self.initial_prompt_tokens.load(Ordering::Acquire);
+        let prompt = self.billed_prompt_tokens.load(Ordering::Acquire);
         let completion = self.accumulated_completion_tokens.load(Ordering::Acquire);
         (prompt, completion, prompt + completion)
+    }
+
+    /// The most recent turn's context-window occupancy as
+    /// `(context_tokens, response_tokens)` — the provider-reported input/output
+    /// of the last LLM call. `(0, 0)` until a turn is recorded via `store_usage`,
+    /// so the orchestration path (`accumulate_usage`) reports zero here.
+    pub fn get_context_usage(&self) -> (u64, u64) {
+        (
+            self.last_input_tokens.load(Ordering::Acquire),
+            self.last_output_tokens.load(Ordering::Acquire),
+        )
     }
 
     /// Get the completion tokens spent on tool-call turns.
@@ -103,22 +107,21 @@ impl UsageState {
         self.tool_completion_tokens.load(Ordering::Acquire)
     }
 
-    /// Store usage values from a completion response.
-    ///
-    /// On first call: captures initial_prompt_tokens (the actual frontend input).
-    /// On each call: accumulates completion tokens (all LLM output streams to frontend).
-    /// When `is_tool_turn` is true, also accumulates into the tool completion counter.
-    ///
-    /// The `_total` parameter is ignored - we calculate total as prompt + accumulated_completion.
+    /// Record one completion turn (single-agent path): accumulate billed
+    /// prompt/completion across turns and overwrite the latest context-window
+    /// occupancy with this turn's input/output. `is_tool_turn` also accumulates
+    /// the tool-completion counter. `_total` is ignored — derived as
+    /// prompt + completion.
     pub fn store_usage(&self, prompt: u64, completion: u64, _total: u64, is_tool_turn: bool) {
-        // Only set initial_prompt_tokens on first call
-        if !self.initialized.swap(true, Ordering::AcqRel) {
-            self.initial_prompt_tokens.store(prompt, Ordering::Release);
-            tracing::debug!(
-                "Captured initial prompt tokens: {} (first LLM turn)",
-                prompt
-            );
-        }
+        self.initialized.store(true, Ordering::Release);
+
+        // Cumulative billed input across every turn.
+        self.billed_prompt_tokens
+            .fetch_add(prompt, Ordering::AcqRel);
+
+        // Latest turn defines current context-window occupancy.
+        self.last_input_tokens.store(prompt, Ordering::Release);
+        self.last_output_tokens.store(completion, Ordering::Release);
 
         // Accumulate all completion tokens (everything streams to frontend)
         let prev = self
@@ -139,20 +142,16 @@ impl UsageState {
         }
     }
 
-    /// Accumulate usage additively across multiple LLM calls.
+    /// Accumulate billed usage across independent LLM calls (orchestration path).
     ///
-    /// Unlike [`store_usage`](Self::store_usage), which captures only the *first*
-    /// turn's prompt, this adds to both prompt and completion counters. Use when
-    /// the caller already aggregates usage across independent LLM calls (e.g. the
-    /// orchestrator summing planning, workers, synthesis, and evaluation turns)
-    /// and needs the final `aura.usage` event to reflect *total billed* tokens
-    /// rather than a single-turn snapshot.
-    ///
-    /// Marks the state as initialized so the stream handler emits `aura.usage`
-    /// even when prompt was only ever accumulated through this method.
+    /// Adds to the billed counters like [`store_usage`](Self::store_usage) but
+    /// does not touch context-window occupancy: the orchestrator sums usage
+    /// across planning, workers, and synthesis — separate context windows — so a
+    /// single "latest turn" is meaningless. Per-agent `aura.context_usage` is
+    /// emitted from each agent's final response instead.
     pub fn accumulate_usage(&self, prompt: u64, completion: u64) {
         self.initialized.store(true, Ordering::Release);
-        self.initial_prompt_tokens
+        self.billed_prompt_tokens
             .fetch_add(prompt, Ordering::AcqRel);
         self.accumulated_completion_tokens
             .fetch_add(completion, Ordering::AcqRel);
@@ -712,6 +711,44 @@ mod tests {
     }
 
     #[test]
+    fn test_store_usage_accumulates_billed_and_tracks_last_turn() {
+        let usage_state = UsageState::new();
+
+        // Multi-turn single-agent loop: prompt grows each turn, final turn is
+        // the response after a tool turn.
+        usage_state.store_usage(1000, 80, 0, true); // tool turn
+        usage_state.store_usage(1300, 250, 0, false); // final response turn
+
+        // Billed usage sums every turn's input and output.
+        let (prompt, completion, total) = usage_state.get_final_usage();
+        assert_eq!(prompt, 2300, "billed prompt = sum of all turn inputs");
+        assert_eq!(
+            completion, 330,
+            "billed completion = sum of all turn outputs"
+        );
+        assert_eq!(total, 2630);
+
+        // Context occupancy reflects only the latest turn.
+        assert_eq!(
+            usage_state.get_context_usage(),
+            (1300, 250),
+            "context usage = most recent turn's input/output"
+        );
+    }
+
+    #[test]
+    fn test_accumulate_usage_leaves_context_usage_zero() {
+        // Orchestration path: billed usage accrues, but context occupancy stays
+        // zero so the single-agent context_usage emission is correctly skipped.
+        let usage_state = UsageState::new();
+        usage_state.accumulate_usage(5000, 200);
+        usage_state.accumulate_usage(8000, 400);
+
+        assert_eq!(usage_state.get_final_usage(), (13_000, 600, 13_600));
+        assert_eq!(usage_state.get_context_usage(), (0, 0));
+    }
+
+    #[test]
     fn test_usage_state_accumulate_marks_initialized() {
         let usage_state = UsageState::new();
         // Before any usage, get_final_usage returns 0 — handler would skip aura.usage.
@@ -913,59 +950,48 @@ mod tests {
     }
 
     #[test]
-    fn test_multi_turn_context_window_tracking() {
-        // Simulates a multi-turn tool call scenario within a SINGLE request:
-        // Turn 1: LLM decides to call a tool (streams to frontend)
-        // Turn 2: LLM calls another tool (streams to frontend)
-        // Turn 3: Final text response (streams to frontend)
-        //
-        // All completions stream to frontend and go into thread history,
-        // so we accumulate ALL completion tokens.
+    fn test_multi_turn_billed_and_context_tracking() {
+        // Multi-turn tool-call scenario within a SINGLE request:
+        // Turn 1: LLM calls a tool, Turn 2: another tool, Turn 3: final text.
+        // Billed usage sums every turn; context occupancy follows the latest turn.
         let usage_state = UsageState::new();
 
-        // Turn 1: LLM receives initial request, decides to call a tool
-        // prompt=5000 (history + system + user), completion=50 (tool call JSON)
+        // Turn 1: tool call. prompt=5000 (history + system + user), completion=50.
         usage_state.store_usage(5000, 50, 5050, true);
+        assert_eq!(usage_state.get_final_usage(), (5000, 50, 5050));
+        assert_eq!(usage_state.get_context_usage(), (5000, 50));
+        assert_eq!(usage_state.get_tool_completion_tokens(), 50);
 
-        let (prompt, completion, total) = usage_state.get_final_usage();
-        assert_eq!(prompt, 5000, "First turn captures initial prompt");
-        assert_eq!(completion, 50, "Completion accumulated: 50");
-        assert_eq!(total, 5050, "Total = initial_prompt + accumulated");
-        assert_eq!(
-            usage_state.get_tool_completion_tokens(),
-            50,
-            "Tool completion: 50"
-        );
-
-        // Turn 2: LLM receives tool result, calls another tool
-        // prompt=7000 (inflated internally), completion=60 (another tool call)
+        // Turn 2: another tool call. prompt grows to 7000 as the context fills.
         usage_state.store_usage(7000, 60, 7060, true);
-
-        let (prompt, completion, total) = usage_state.get_final_usage();
-        assert_eq!(prompt, 5000, "Initial prompt unchanged");
-        assert_eq!(completion, 110, "Completion accumulated: 50 + 60");
-        assert_eq!(total, 5110, "Total = 5000 + 110");
         assert_eq!(
-            usage_state.get_tool_completion_tokens(),
-            110,
-            "Tool completion: 50 + 60"
+            usage_state.get_final_usage(),
+            (12_000, 110, 12_110),
+            "billed = (5000+7000, 50+60)"
         );
+        assert_eq!(
+            usage_state.get_context_usage(),
+            (7000, 60),
+            "context follows the most recent turn"
+        );
+        assert_eq!(usage_state.get_tool_completion_tokens(), 110);
 
-        // Turn 3: Final response (no more tool calls)
-        // prompt=9000 (inflated internally), completion=200 (final text)
+        // Turn 3: final response (no tool call). prompt=9000.
         usage_state.store_usage(9000, 200, 9200, false);
-
-        let (prompt, completion, total) = usage_state.get_final_usage();
-        assert_eq!(prompt, 5000, "Initial prompt still unchanged");
-        assert_eq!(completion, 310, "Completion accumulated: 50 + 60 + 200");
         assert_eq!(
-            total, 5310,
-            "Context window = initial_prompt(5000) + all_completions(310)"
+            usage_state.get_final_usage(),
+            (21_000, 310, 21_310),
+            "billed = (5000+7000+9000, 50+60+200)"
+        );
+        assert_eq!(
+            usage_state.get_context_usage(),
+            (9000, 200),
+            "final turn defines context-window occupancy"
         );
         assert_eq!(
             usage_state.get_tool_completion_tokens(),
             110,
-            "Tool completion unchanged after final response turn"
+            "tool completion unchanged after the final response turn"
         );
     }
 }

--- a/docs/streaming-api-guide.md
+++ b/docs/streaming-api-guide.md
@@ -132,7 +132,8 @@ AURA_CUSTOM_EVENTS=true cargo run --bin aura-web-server
 | `aura.mcp_status` | Per-server MCP connection status emitted at stream start (connected/failed/not_attempted, with failure reason) | ✅ Implemented |
 | `aura.worker_phase` | Worker phase transitions in multi-agent mode (planning/executing/analyzing) | ✅ Implemented |
 | `aura.tool_usage` | Usage snapshot after tool execution (associates tool IDs with token counts) | ✅ Implemented |
-| `aura.usage` | Final token usage emitted at stream end (prompt/completion/total) | ✅ Implemented |
+| `aura.usage` | Cumulative provider-billed tokens at stream end (Σ prompt/completion/total across all turns), identical in single-agent and orchestration | ✅ Implemented |
+| `aura.context_usage` | Per-agent context-window occupancy (final-turn `context_tokens`/`response_tokens` + optional `context_window`), derived from provider usage | ✅ Implemented |
 | `aura.scratchpad_usage` | Per-agent scratchpad usage summary (single-agent or worker), emitted when an agent finishes with scratchpad activity | ✅ Implemented |
 | `aura.approval_requested` | HITL approval request raised for a gated tool or `request_approval` call | ✅ Implemented for webhook and conversational routes |
 | `aura.approval_pending` | HITL approval is waiting for an attended decision | ✅ Implemented for conversational route |
@@ -345,7 +346,7 @@ data:
 
 Emitted from the `on_stream_completion_response_finish` hook when usage data is available. Associates the completed tool IDs with a token usage snapshot. No `agent_id` field (only `CorrelationContext`).
 
-**Usage** (final token usage at stream end):
+**Usage** (cumulative provider-billed tokens at stream end):
 ```
 event: aura.usage
 data:
@@ -359,7 +360,34 @@ data:
 }
 ```
 
-Use `prompt_tokens` with `model_context_limit` from `aura.session_info` to calculate context window fill percentage: `(prompt_tokens / model_context_limit) * 100`. No `agent_id` field (only `CorrelationContext`).
+`aura.usage` reports the **billed cost** of the request: `prompt_tokens` and
+`completion_tokens` are summed across *every* LLM turn (including tool turns),
+with identical semantics in single-agent and orchestration mode. It is **not**
+the context-window size — use `aura.context_usage` below for that. No `agent_id`
+field (only `CorrelationContext`).
+
+**Context usage** (per-agent context-window occupancy):
+```
+event: aura.context_usage
+data:
+```
+```json
+{
+  "context_tokens": 18777,
+  "response_tokens": 342,
+  "context_window": 200000,
+  "agent_id": "main",
+  "session_id": "sess_xyz"
+}
+```
+
+`context_tokens` is the provider-reported input of the agent's final turn — the
+size of the context carried into the last call — and `response_tokens` its
+output. Compute context-window fill as `context_tokens / context_window`
+(falling back to `model_context_limit` from `aura.session_info` if
+`context_window` is absent). Emitted per agent: single-agent requests emit one
+(`agent_id: "main"`); orchestration emits one per worker and the coordinator.
+Derived from provider usage, never a local tokenizer.
 
 **Scratchpad usage** (per-agent report when an agent finishes with scratchpad activity):
 ```


### PR DESCRIPTION
aura.usage reported different things per mode: single-agent sent the first turn's input plus all output, orchestration sent summed billed tokens. Clients could not read it uniformly.

aura.usage now reports cumulative provider-billed tokens (input and output summed across every turn) identically in both modes. A new aura.context_usage event reports context-window occupancy from the provider's final-turn input/output, per agent — single-agent emits one, orchestration one per worker and the coordinator. Both derive from provider usage, not a local tokenizer.

The CLI status bar now tracks context occupancy from aura.context_usage for the "Context left" indicator and auto-compaction, leaving aura.usage to feed the billed-token display.

Closes: #113