### PR TITLE
feat(build): add macos release binaries

### DIFF
--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -94,31 +94,90 @@ fmt-rust:: $(REPORT_DIR)                 ## Format code with rustfmt
 $(DIST_DIR):
 	@mkdir -p $(@)
 
-.PHONY: build-release-binary-amd64
-build-release-binary-amd64: $(DIST_DIR) $(DOCKER_ENV) ## Build release binaries for linux/amd64
-	$(RUN) cargo build --release --bin aura-web-server
-	$(RUN) cargo build --release -p aura-cli --bin aura
-	cp target/release/aura-web-server $(DIST_DIR)/aura-web-server-linux-amd64
-	cp target/release/aura $(DIST_DIR)/aura-linux-amd64
+# Cargo build profile for the packaged binaries: "release" or "debug". Selects
+# both the cargo flag and the target/ output subdirectory cargo writes to.
+PROFILE ?= release
+ifeq ($(filter $(PROFILE),release debug),)
+$(error PROFILE must be 'release' or 'debug' (got '$(PROFILE)'))
+endif
+CARGO_PROFILE_FLAG := $(if $(filter release,$(PROFILE)),--release,)
 
-.PHONY: build-release-binary-arm64
-build-release-binary-arm64: $(DIST_DIR) $(DOCKER_ENV) ## Cross-compile release binaries for linux/arm64
+# Shell snippet that aborts unless the build host matches $(1)=uname -s and
+# $(2)=uname -m ($(2) empty = any arch). Inlined into a build's bash -c so the
+# check runs against the same context that compiles.
+require_host = os=\$$(uname -s); arch=\$$(uname -m); if [ \$$os != $(1) ]$(if $(2), || [ \$$arch != $(2) ],); then echo error: $@ must be built on $(1)$(if $(2), $(2),), build host is \$$os \$$arch >&2; exit 1; fi;
+
+.PHONY: build-binary-linux-amd64
+build-binary-linux-amd64: $(DIST_DIR) $(DOCKER_ENV) ## Build binaries for linux/amd64 (PROFILE=release|debug)
 	$(RUN) bash -c "\
+		$(call require_host,Linux,x86_64) \
+		cargo build $(CARGO_PROFILE_FLAG) --bin aura-web-server && \
+		cargo build $(CARGO_PROFILE_FLAG) -p aura-cli --bin aura"
+	cp target/$(PROFILE)/aura-web-server $(DIST_DIR)/aura-web-server-linux-amd64
+	cp target/$(PROFILE)/aura $(DIST_DIR)/aura-linux-amd64
+
+.PHONY: build-binary-linux-arm64
+build-binary-linux-arm64: $(DIST_DIR) $(DOCKER_ENV) ## Build binaries for linux/arm64 (PROFILE=release|debug)
+	$(RUN) bash -c "\
+		$(call require_host,Linux,x86_64) \
 		rustup target add aarch64-unknown-linux-gnu 2>/dev/null; \
 		export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc; \
 		export CC_aarch64_unknown_linux_gnu=/usr/bin/aarch64-linux-gnu-gcc; \
 		export CXX_aarch64_unknown_linux_gnu=/usr/bin/aarch64-linux-gnu-g++; \
 		export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig; \
 		export PKG_CONFIG_ALLOW_CROSS=1; \
-		cargo build --release --target aarch64-unknown-linux-gnu --bin aura-web-server && \
-		cargo build --release --target aarch64-unknown-linux-gnu -p aura-cli --bin aura"
-	cp target/aarch64-unknown-linux-gnu/release/aura-web-server $(DIST_DIR)/aura-web-server-linux-arm64
-	cp target/aarch64-unknown-linux-gnu/release/aura $(DIST_DIR)/aura-linux-arm64
+		cargo build $(CARGO_PROFILE_FLAG) --target aarch64-unknown-linux-gnu --bin aura-web-server && \
+		cargo build $(CARGO_PROFILE_FLAG) --target aarch64-unknown-linux-gnu -p aura-cli --bin aura"
+	cp target/aarch64-unknown-linux-gnu/$(PROFILE)/aura-web-server $(DIST_DIR)/aura-web-server-linux-arm64
+	cp target/aarch64-unknown-linux-gnu/$(PROFILE)/aura $(DIST_DIR)/aura-linux-arm64
 
-.PHONY: build-release-binaries
-build-release-binaries: ## Build release binaries for all platforms
-	$(MAKE) -j2 build-release-binary-amd64 build-release-binary-arm64
+.PHONY: build-binary-darwin-amd64
+build-binary-darwin-amd64: $(DIST_DIR) $(DOCKER_ENV) ## Build binaries for darwin/amd64 (PROFILE=release|debug)
+	$(RUN) bash -c "\
+		$(call require_host,Darwin,) \
+		rustup target add x86_64-apple-darwin 2>/dev/null; \
+		cargo build $(CARGO_PROFILE_FLAG) --target x86_64-apple-darwin --bin aura-web-server && \
+		cargo build $(CARGO_PROFILE_FLAG) --target x86_64-apple-darwin -p aura-cli --bin aura"
+	cp target/x86_64-apple-darwin/$(PROFILE)/aura-web-server $(DIST_DIR)/aura-web-server-darwin-amd64
+	cp target/x86_64-apple-darwin/$(PROFILE)/aura $(DIST_DIR)/aura-darwin-amd64
+
+.PHONY: build-binary-darwin-arm64
+build-binary-darwin-arm64: $(DIST_DIR) $(DOCKER_ENV) ## Build binaries for darwin/arm64 (PROFILE=release|debug)
+	$(RUN) bash -c "\
+		$(call require_host,Darwin,) \
+		rustup target add aarch64-apple-darwin 2>/dev/null; \
+		cargo build $(CARGO_PROFILE_FLAG) --target aarch64-apple-darwin --bin aura-web-server && \
+		cargo build $(CARGO_PROFILE_FLAG) --target aarch64-apple-darwin -p aura-cli --bin aura"
+	cp target/aarch64-apple-darwin/$(PROFILE)/aura-web-server $(DIST_DIR)/aura-web-server-darwin-arm64
+	cp target/aarch64-apple-darwin/$(PROFILE)/aura $(DIST_DIR)/aura-darwin-arm64
+
+.PHONY: build-binaries-linux
+build-binaries-linux: ## Build binaries for linux (amd64 + arm64, PROFILE=release|debug)
+	$(MAKE) build-binary-linux-amd64 build-binary-linux-arm64
+
+.PHONY: build-binaries-darwin
+build-binaries-darwin: ## Build binaries for darwin (amd64 + arm64, PROFILE=release|debug)
+	$(MAKE) build-binary-darwin-amd64 build-binary-darwin-arm64
+
+.PHONY: build-checksums
+build-checksums: ## Write sha256 checksums for the binaries in dist
 	cd $(DIST_DIR) && sha256sum aura-* > checksums.txt
+
+# Every binary a complete release must contain, across all platforms.
+EXPECTED_BINARIES := \
+	aura-linux-amd64 aura-web-server-linux-amd64 \
+	aura-linux-arm64 aura-web-server-linux-arm64 \
+	aura-darwin-amd64 aura-web-server-darwin-amd64 \
+	aura-darwin-arm64 aura-web-server-darwin-arm64
+
+.PHONY: verify-binaries
+verify-binaries: build-checksums ## Verify every expected binary is present and checksummed correctly
+	@cd $(DIST_DIR) && \
+	for f in $(EXPECTED_BINARIES); do \
+		[ -f "$$f" ] || { echo "error: missing binary: $$f" >&2; exit 1; }; \
+		grep -q " $$f\$$" checksums.txt || { echo "error: $$f absent from checksums.txt" >&2; exit 1; }; \
+	done
+	cd $(DIST_DIR) && sha256sum -c checksums.txt
 
 clean:: clean-dist
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2854,9 +2854,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2885,9 +2885,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
         jiraSendBuildInfo site: 'logdna.atlassian.net'
         sh 'ls -alh -R report'
         archiveArtifacts allowEmptyArchive: true, artifacts: 'report/ci/**', caseSensitive: false, followSymlinks: false
-        sh: 'make clean'
+        sh 'make clean'
         if (env.SANITY_BUILD == 'true') {
           notifySlack(
             currentBuild.currentResult,
@@ -231,26 +231,81 @@ pipeline {
                 }
               }
 
-              environment {
-                 GIT_BRANCH = "${CURRENT_BRANCH}"
-                 BRANCH_NAME = "${CURRENT_BRANCH}"
-                 CHANGE_ID = ''
-              }
+              stages {
+                stage('Build Release Artifacts') {
+                  stages {
+                    stage('Build Linux Artifacts') {
+                      steps {
+                        sh 'make build-binaries-linux PROFILE=debug'
 
-              steps {
-                script {
-                  def releaseCmd = 'npm run release:dry'
-                  if (env.CHANGE_FORK) {
-                    sh "git checkout -B ${CURRENT_BRANCH}"
-                    releaseCmd = "npm run release:dry -- --repository-url=file://${env.WORKSPACE} --plugins @semantic-release/commit-analyzer @semantic-release/release-notes-generator"
+                        stash(
+                          name: 'linux-release-artifacts',
+                          includes: 'dist/**',
+                          allowEmpty: false
+                        )
+                      }
+                    }
+
+                    stage('Build Darwin Artifacts') {
+                      agent {
+                        node {
+                          label 'ec2-fleet-oss-macos'
+                          customWorkspace("/tmp/workspace/${BUILD_SLUG}-darwin")
+                        }
+                      }
+
+                      environment {
+                        ENABLE_DOCKER = 'false'
+                      }
+
+                      steps {
+                        sh 'make build-binaries-darwin PROFILE=debug'
+
+                        stash(
+                          name: 'darwin-release-artifacts',
+                          includes: 'dist/**',
+                          allowEmpty: false
+                        )
+                      }
+                    }
                   }
-                  docker.withRegistry(
-                      'https://index.docker.io/v1/',
-                      'dockerhub-token-mezmo'
-                  ) {
-                    withCredentials(RELEASE_CREDENTIALS) {
-                      buildx {
-                        withReport('Release Test', releaseCmd)
+                }
+
+                stage('Verify Release Artifacts') {
+                  steps {
+                    sh 'rm -rf dist'
+                    sh 'mkdir -p dist'
+
+                    unstash 'linux-release-artifacts'
+                    unstash 'darwin-release-artifacts'
+
+                    sh 'make verify-binaries'
+                  }
+                }
+
+                stage('Semantic Release Dry Run') {
+                  environment {
+                    GIT_BRANCH = "${CURRENT_BRANCH}"
+                    BRANCH_NAME = "${CURRENT_BRANCH}"
+                    CHANGE_ID = ''
+                  }
+
+                  steps {
+                    script {
+                      def releaseCmd = 'npm run release:dry'
+                      if (env.CHANGE_FORK) {
+                        sh "git checkout -B ${CURRENT_BRANCH}"
+                        releaseCmd = "npm run release:dry -- --repository-url=file://${env.WORKSPACE} --plugins @semantic-release/commit-analyzer @semantic-release/release-notes-generator"
+                      }
+                      docker.withRegistry(
+                          'https://index.docker.io/v1/',
+                          'dockerhub-token-mezmo'
+                      ) {
+                        withCredentials(RELEASE_CREDENTIALS) {
+                          buildx {
+                            withReport('Release Test', releaseCmd)
+                          }
+                        }
                       }
                     }
                   }
@@ -313,19 +368,70 @@ pipeline {
         }
       }
 
-      steps {
-        script {
-          docker.withRegistry(
-              'https://index.docker.io/v1/',
-              'dockerhub-token-mezmo'
-          ) {
-            withCredentials(RELEASE_CREDENTIALS) {
-              buildx(
-                tooling: true,
-                project: PROJECT_NAME,
-                versionFn: { -> npm.semver().version }
+      stages {
+        stage('Build Release Artifacts') {
+          parallel {
+            stage('Build Linux Artifacts') {
+              steps {
+                sh 'make build-binaries-linux'
+
+                stash(
+                  name: 'linux-release-artifacts',
+                  includes: 'dist/**',
+                  allowEmpty: false
+                )
+              }
+            }
+
+            stage('Build Darwin Artifacts') {
+              agent {
+                node {
+                  label 'ec2-fleet-oss-macos'
+                  customWorkspace("/tmp/workspace/${BUILD_SLUG}-darwin")
+                }
+              }
+
+              environment {
+                ENABLE_DOCKER = 'false'
+              }
+
+              steps {
+                sh 'make build-binaries-darwin'
+
+                stash(
+                  name: 'darwin-release-artifacts',
+                  includes: 'dist/**',
+                  allowEmpty: false
+                )
+              }
+            }
+          }
+        }
+
+        stage('Semantic Release') {
+          steps {
+            sh 'rm -rf dist'
+            sh 'mkdir -p dist'
+
+            unstash 'linux-release-artifacts'
+            unstash 'darwin-release-artifacts'
+
+            sh 'make verify-binaries'
+
+            script {
+              docker.withRegistry(
+                'https://index.docker.io/v1/',
+                'dockerhub-token-mezmo'
               ) {
-                withReport('Release', 'npm run release')
+                withCredentials(RELEASE_CREDENTIALS) {
+                  buildx(
+                    tooling: true,
+                    project: PROJECT_NAME,
+                    versionFn: { -> npm.semver().version }
+                  ) {
+                    withReport('Release', 'npm run release')
+                  }
+                }
               }
             }
           }

--- a/release.config.js
+++ b/release.config.js
@@ -2,9 +2,6 @@
 
 const config = require('@mezmoinc/release-config-docker')
 
-const buildReleaseBinariesCmd = 'make build-release-binaries'
-
-
 const plugins = config.plugins.map((plugin) => {
   const [name, config = {}] = plugin
   // there is a config name clash with github + git
@@ -29,10 +26,7 @@ module.exports = {
   branches: ['main'],
 
   // https://github.com/semantic-release/exec
-  prepareCmd: `./scripts/set-version.sh \${nextRelease.version}; sleep 2; ${buildReleaseBinariesCmd}`,
-  // On a dry run (no prepare step), build the release binaries during verify so
-  // a broken cross-compile is caught before the change reaches the release branch.
-  verifyReleaseCmd: `if [ "\${options.dryRun}" = "true" ]; then ${buildReleaseBinariesCmd}; fi`,
+  prepareCmd: `./scripts/set-version.sh \${nextRelease.version}`,
   // https://github.com/esatterwhite/semantic-release-docker
   dockerProject: 'mezmo',
   dockerImage: 'aura',


### PR DESCRIPTION
Add darwin amd64/arm64 to the release set, cross-compiled per target with the runner image's linux toolchains and the macOS SDK.

Guard each target against the wrong build host so an unsupported combination fails fast instead of emitting a mislabeled binary: linux builds require an amd64 linux host, darwin builds require macOS.

Closes: #297