### PR TITLE
ci: add release-mode compilation check to PR validation

### DIFF
--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -54,6 +54,10 @@ nextest: $(DOCKER_ENV) $(NEXTEST_BIN) $(REPORT_DIR)
 lint-rust: | $(DOCKER_ENV) $(REPORT_DIR)  ## lint rust code via clippy
 	$(RUN) cargo clippy $(if $(IS_CI),-q,) --all-targets --all-features $(if $(IS_CI),--message-format=json,) -- -D warnings $(if $(IS_CI),> $(REPORT_DIR)/clippy.json,)
 
+.PHONY: check-release
+check-release: $(DOCKER_ENV) ## Verify release-mode compilation (catches cmake / native build issues)
+	$(RUN) cargo check --release --workspace
+
 .PHONY: check-cli-http-only
 check-cli-http-only: $(DOCKER_ENV) ## Verify the HTTP-only (no-default-features) aura-cli still builds
 	$(RUN) cargo clippy -p aura-cli --no-default-features --all-targets -- -D warnings

--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -59,6 +59,8 @@ check-release: $(DOCKER_ENV) ## Verify release-mode compilation for amd64 and ar
 	$(RUN) cargo check --release --workspace
 	$(RUN) bash -c "rustup target add aarch64-unknown-linux-gnu 2>/dev/null; \
 		export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc; \
+		export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig; \
+		export PKG_CONFIG_ALLOW_CROSS=1; \
 		cargo check --release --target aarch64-unknown-linux-gnu --workspace"
 
 .PHONY: check-cli-http-only

--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -55,8 +55,11 @@ lint-rust: | $(DOCKER_ENV) $(REPORT_DIR)  ## lint rust code via clippy
 	$(RUN) cargo clippy $(if $(IS_CI),-q,) --all-targets --all-features $(if $(IS_CI),--message-format=json,) -- -D warnings $(if $(IS_CI),> $(REPORT_DIR)/clippy.json,)
 
 .PHONY: check-release
-check-release: $(DOCKER_ENV) ## Verify release-mode compilation (catches cmake / native build issues)
+check-release: $(DOCKER_ENV) ## Verify release-mode compilation for amd64 and arm64
 	$(RUN) cargo check --release --workspace
+	$(RUN) bash -c "rustup target add aarch64-unknown-linux-gnu 2>/dev/null; \
+		export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc; \
+		cargo check --release --target aarch64-unknown-linux-gnu --workspace"
 
 .PHONY: check-cli-http-only
 check-cli-http-only: $(DOCKER_ENV) ## Verify the HTTP-only (no-default-features) aura-cli still builds

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN <<EOR
   dpkg --add-architecture arm64
   apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates libssl3 curl nodejs npm \
-    gcc-aarch64-linux-gnu libc6-dev-arm64-cross libssl-dev:arm64
+    gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross libssl-dev:arm64
   rm -rf /var/lib/apt/lists/*
 EOR
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,6 +171,12 @@ pipeline {
             }
           }
         }
+
+        stage("Release Check") {
+          steps {
+            withReport('Release Check', 'make check-release')
+          }
+        }
       } // End Parallel
     } // End Validate
 


### PR DESCRIPTION
## Summary

- Adds `cargo check --release --workspace` as a parallel stage in ChangeSet Validation
- Debug-mode builds (clippy) don't exercise cmake-dependent native build scripts like `sentencepiece-sys`, so cmake failures only surface during the release Docker build on main
- New `make check-release` target runs inside the Docker runner (same as clippy/fmt), so it has the same toolchain context
- Runs in parallel with existing lint stages — no added wall-clock time beyond the slowest existing check

## Test plan

- [ ] Observe the new "Release Check" stage appears in Jenkins PR build
- [ ] Verify it runs in parallel with clippy/fmt/hadolint/commitlint
- [ ] Confirm it catches cmake/native build failures that debug clippy misses