### PR TITLE
ci: always rebuild runner image and verify release build on dry run

### DIFF
--- a/.makefiles/docker.mk
+++ b/.makefiles/docker.mk
@@ -14,9 +14,7 @@ endif
 
 .PHONY:setup-docker
 setup-docker:
-	@if [ -z "$$(docker images -q $(AURA_RUNNER_IMAGE))" ]; then \
-		$(DOCKER) build -t $(AURA_RUNNER_IMAGE) --target runner -f $(DOCKER_FILE) $(PROJECT_ROOT); \
-	fi
+	$(DOCKER) build -t $(AURA_RUNNER_IMAGE) --target runner -f $(DOCKER_FILE) $(PROJECT_ROOT)
 
 .PHONY:docker-shell
 shell: $(DOCKER_ENV)

--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -106,6 +106,8 @@ build-release-binary-arm64: $(DIST_DIR) $(DOCKER_ENV) ## Cross-compile release b
 	$(RUN) bash -c "\
 		rustup target add aarch64-unknown-linux-gnu 2>/dev/null; \
 		export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc; \
+		export CC_aarch64_unknown_linux_gnu=/usr/bin/aarch64-linux-gnu-gcc; \
+		export CXX_aarch64_unknown_linux_gnu=/usr/bin/aarch64-linux-gnu-g++; \
 		export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig; \
 		export PKG_CONFIG_ALLOW_CROSS=1; \
 		cargo build --release --target aarch64-unknown-linux-gnu --bin aura-web-server && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM rust:1.95 AS core
 # (pulled in via gemini-tokenizer) builds its C++ library with cmake, so cmake
 # and a C++ compiler are required on top of the base C toolchain.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake g++ \
+    cmake g++ g++-aarch64-linux-gnu \
   && rm -rf /var/lib/apt/lists/*
 
 ### 001 Runner
@@ -22,7 +22,7 @@ RUN <<EOR
   dpkg --add-architecture arm64
   apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates libssl3 curl nodejs npm \
-    gcc-aarch64-linux-gnu libc6-dev-arm64-cross libssl-dev:arm64
+    libc6-dev-arm64-cross libssl-dev:arm64
   rm -rf /var/lib/apt/lists/*
 EOR
 

--- a/release.config.js
+++ b/release.config.js
@@ -2,6 +2,8 @@
 
 const config = require('@mezmoinc/release-config-docker')
 
+const buildReleaseBinariesCmd = 'make build-release-binaries'
+
 
 const plugins = config.plugins.map((plugin) => {
   const [name, config = {}] = plugin
@@ -27,7 +29,10 @@ module.exports = {
   branches: ['main'],
 
   // https://github.com/semantic-release/exec
-  prepareCmd: './scripts/set-version.sh ${nextRelease.version}; sleep 2; make build-release-binaries',
+  prepareCmd: `./scripts/set-version.sh \${nextRelease.version}; sleep 2; ${buildReleaseBinariesCmd}`,
+  // On a dry run (no prepare step), build the release binaries during verify so
+  // a broken cross-compile is caught before the change reaches the release branch.
+  verifyReleaseCmd: `if [ "\${options.dryRun}" = "true" ]; then ${buildReleaseBinariesCmd}; fi`,
   // https://github.com/esatterwhite/semantic-release-docker
   dockerProject: 'mezmo',
   dockerImage: 'aura',


### PR DESCRIPTION
Build the runner image unconditionally in setup-docker (Docker layer caching keeps it fast) so a stale local runner can't keep shipping an image with missing dependencies.
    
Also run make build-release-binaries during verifyRelease on a dry run, so a broken cross-compile is caught before reaching main.

Closes: #301