### PR TITLE
feat(orchestration): add per-iteration phase timing metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,50 @@ make docker-build   # Build Docker image
 make lint           # Run clippy + fmt check
 ```
 
+## Code Comment Conventions
+
+- **Document behavior where it lives, not on data.** A comment describing *what
+  happens* (how a value is produced, consumed, derived, or interpreted) belongs
+  on the function/branch that implements it — not on a struct, field, enum
+  variant, or other type definition. Type-level comments state only *what the
+  value is* (its meaning/unit), never cross-referenced runtime behavior.
+  - **The drift test — apply it to every type-level comment:** if the comment
+    would have to change when code in *a different function* changes, it is in
+    the wrong place. Move it to that function.
+  - **Red-flag words on a type definition.** These almost always signal behavior
+    narration that belongs elsewhere: "when", "if", "unless", "for … that",
+    "absent/`None`/empty when", "set/populated when", "becomes", "used by",
+    "consumed by", "so that", "which lets", "approximates", "exceeds",
+    "falls back". Seeing one on a struct/field/enum is a prompt to move it.
+  - **`Option`, enums, and defaults describe their own shape — don't narrate it.**
+    The `Option` already says the value can be absent; the enum already lists its
+    variants. Do *not* document *when* each state occurs (`None when …`,
+    `Empty for …`) on the type — that condition lives at the code that sets it.
+  - Bad (on a struct field): `execution_ms - tool_ms approximates LLM-thinking
+    time`; `None for direct answers and runs that failed before any iteration`;
+    `becomes the next iteration's planning_ms`. Each describes behavior owned by
+    a consumer or a write site.
+  - Good (on the field): `Plan ready → continuation-prompt entrypoint.` The
+    derivation/interpretation lives at the code that computes or displays it.
+- **Don't describe the same behavior in more than one place.** Pick the single
+  site that implements it; from elsewhere, reference — don't restate. Duplicated
+  prose drifts out of sync. If you find yourself writing something already
+  documented at the implementing site, delete it rather than restating it.
+- **Comment on current behavior, not change history.** Describe what the code
+  does now, as if it were always this way — git records the diff, the comment
+  should not. Do not phrase a comment relative to the past: avoid "prior we did
+  XYZ, now we ABC", "(unchanged)", "legacy behavior", "now does X",
+  "previously…", "still works as before", "moved from…", "keep current
+  behavior". History-relative phrasing drifts out of sync as the code evolves
+  and is noise to anyone who didn't witness the change — rewrite it as a
+  present-tense statement of what the code does.
+- **Before finishing any code change, run the drift test on every comment you
+  added or touched that sits on a struct, field, enum, or variant.** For each,
+  ask "would this change if a different function changed?" — if yes, move (don't
+  copy) it onto the implementing code. Check the whole comment, not just its
+  first clause: the anti-pattern often hides as a trailing "; …when…" or "; …
+  becomes…" appended to an otherwise-correct definition.
+
 ## Commit and Contribution Rules
 
 - **No AI co-authorship**: Never add `Co-Authored-By` lines for Claude or any AI assistant. Claude cannot accept the CLA.

--- a/crates/aura-cli/src/api/types.rs
+++ b/crates/aura-cli/src/api/types.rs
@@ -291,7 +291,8 @@ pub enum DisplayEvent {
     OrchestratorSynthesizing,
     OrchestratorIterationComplete {
         iteration: u64,
-        quality_score: String,
+        /// Pre-rendered phase-timing summary line (planning/execution/tool/compute).
+        timing_line: String,
         fields: BTreeMap<String, serde_json::Value>,
     },
     OrchestratorScratchpadSavings {

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -2832,9 +2832,28 @@ impl StreamHandler for ReplStreamHandler {
                 // disturb in-flight reasoning blocks.
                 event_names::ITERATION_COMPLETE => {
                     let iteration = get_u64(val, "iteration");
-                    let quality_score = get_str(val, "quality_score");
+                    // Phase timings. LLM-thinking time ≈ execution - tools.
+                    // Durations are humanized (1.5s, 34.0s) to match the rest
+                    // of the orchestrator timing display.
+                    use crate::ui::orchestrator::format_orch_duration_ms;
+                    let planning = format_orch_duration_ms(get_u64(val, "planning_ms"));
+                    let execution = format_orch_duration_ms(get_u64(val, "execution_ms"));
+                    let task_compute = format_orch_duration_ms(get_u64(val, "task_compute_ms"));
+                    let tool = format_orch_duration_ms(get_u64(val, "tool_ms"));
+                    let timing_line = format!(
+                        "planning {planning} · execution {execution} \
+                         (tools {tool}, compute {task_compute})"
+                    );
                     let expanded = is_expanded_output();
                     let has_fields = expanded && !fields.is_empty();
+                    // `will_replan == false` marks the terminal iteration — the one
+                    // immediately followed by the final-answer bullet, which is the
+                    // only transition where the frame-collapse clobber below bites.
+                    let will_replan = val
+                        .get("will_replan")
+                        .or_else(|| val.get("data").and_then(|d| d.get("will_replan")))
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
                     crate::ui::prompt::clear_agent_reasoning();
                     println!(
                         "{} {}",
@@ -2844,17 +2863,25 @@ impl StreamHandler for ReplStreamHandler {
                         "Iteration complete".attribute(crossterm::style::Attribute::Bold),
                     );
                     crate::ui::prompt::increment_orch_scrollback();
+                    // Timing is printed before iteration so that, if the clobber
+                    // below over-reaches, the more valuable timing data is the last
+                    // thing to be lost.
+                    println!(
+                        "{} timing: {}",
+                        "├─".themed(AuraStyle::Connector),
+                        timing_line.as_str().themed(AuraStyle::Muted),
+                    );
+                    // The timing line can be long; count its wrapped rows so later
+                    // frame cursor math stays aligned (unstyled text drives the
+                    // width calc, no ANSI escapes).
+                    crate::ui::prompt::increment_orch_scrollback_wrapped(&format!(
+                        "├─ timing: {timing_line}"
+                    ));
+                    let iteration_connector = if has_fields { "├─" } else { "└─" };
                     println!(
                         "{} iteration: {}",
-                        "├─".themed(AuraStyle::Connector),
+                        iteration_connector.themed(AuraStyle::Connector),
                         iteration.to_string().as_str().themed(AuraStyle::Muted),
-                    );
-                    crate::ui::prompt::increment_orch_scrollback();
-                    let quality_connector = if has_fields { "├─" } else { "└─" };
-                    println!(
-                        "{} quality: {}",
-                        quality_connector.themed(AuraStyle::Connector),
-                        quality_score.as_str().themed(AuraStyle::Muted),
                     );
                     crate::ui::prompt::increment_orch_scrollback();
                     if has_fields {
@@ -2875,9 +2902,20 @@ impl StreamHandler for ReplStreamHandler {
                     }
                     println!();
                     crate::ui::prompt::increment_orch_scrollback();
+                    // On the terminal iteration the final-answer bullet is drawn by
+                    // the input-frame collapse, whose cursor math rebuilds the frame
+                    // ~2 rows too high in some terminals and paints over the last
+                    // scrollback rows (eating the iteration line + the blank above).
+                    // Emit a second sacrificial blank so the over-eat consumes only
+                    // blanks and both summary lines survive. Live-only; `/expand`
+                    // repaints from the display event with a single blank.
+                    if !will_replan {
+                        println!();
+                        crate::ui::prompt::increment_orch_scrollback();
+                    }
                     push_display_event(DisplayEvent::OrchestratorIterationComplete {
                         iteration,
-                        quality_score,
+                        timing_line,
                         fields,
                     });
                 }

--- a/crates/aura-cli/src/ui/event_replay.rs
+++ b/crates/aura-cli/src/ui/event_replay.rs
@@ -613,7 +613,7 @@ pub fn replay_event_log_global() {
             }
             DisplayEvent::OrchestratorIterationComplete {
                 iteration,
-                quality_score,
+                timing_line,
                 fields,
             } => {
                 let bc = task_color_for("__orchestrator__");
@@ -623,16 +623,18 @@ pub fn replay_event_log_global() {
                     "Iteration complete".attribute(Attribute::Bold),
                 );
                 let has_fields = expanded && !fields.is_empty();
+                // Order mirrors the live render in `repl/loop.rs`: timing first,
+                // iteration last, so both paths look identical.
+                println!(
+                    "{} timing: {}",
+                    "├─".themed(AuraStyle::Connector),
+                    timing_line.as_str().themed(AuraStyle::Muted),
+                );
+                let iteration_connector = if has_fields { "├─" } else { "└─" };
                 println!(
                     "{} iteration: {}",
-                    "├─".themed(AuraStyle::Connector),
+                    iteration_connector.themed(AuraStyle::Connector),
                     iteration.to_string().as_str().themed(AuraStyle::Muted),
-                );
-                let quality_connector = if has_fields { "├─" } else { "└─" };
-                println!(
-                    "{} quality: {}",
-                    quality_connector.themed(AuraStyle::Connector),
-                    quality_score.as_str().themed(AuraStyle::Muted),
                 );
                 if has_fields {
                     print_fields_tree(fields);

--- a/crates/aura-cli/src/ui/orchestrator.rs
+++ b/crates/aura-cli/src/ui/orchestrator.rs
@@ -465,6 +465,15 @@ pub fn increment_orch_scrollback() {
     ORCH_SCROLLBACK_COUNTER.fetch_add(1, Ordering::Relaxed);
 }
 
+/// Increment the orchestrator scrollback counter by the number of *visual*
+/// rows a line consumes, accounting for wrap. Pass the unstyled line text
+/// (no ANSI escapes) so the width math is correct — a long line that wraps
+/// must advance the counter by every physical row it occupies, or later
+/// cursor math clobbers the wrapped tail.
+pub fn increment_orch_scrollback_wrapped(line_text: &str) {
+    ORCH_SCROLLBACK_COUNTER.fetch_add(visual_row_count(line_text), Ordering::Relaxed);
+}
+
 /// Reset orchestrator tool tracking.
 pub fn reset_orch_tools() {
     if let Ok(mut guard) = ACTIVE_ORCH_TOOLS.lock() {

--- a/crates/aura-cli/src/ui/prompt.rs
+++ b/crates/aura-cli/src/ui/prompt.rs
@@ -61,8 +61,8 @@ pub(crate) use super::orchestrator::overwrite_orch_task_header_unlocked;
 pub use super::orchestrator::{
     ActiveOrchTool, OrchLastToolInfo, clear_agent_reasoning, clear_orch_task_tools,
     current_orch_scrollback, finalize_orch_tool, increment_orch_scrollback,
-    overwrite_orch_task_header, record_tool_progress_token, register_orch_tool, reset_orch_tools,
-    set_agent_reasoning, set_orch_tool_progress_by_token,
+    increment_orch_scrollback_wrapped, overwrite_orch_task_header, record_tool_progress_token,
+    register_orch_tool, reset_orch_tools, set_agent_reasoning, set_orch_tool_progress_by_token,
 };
 
 // Re-export from mid_stream.rs

--- a/crates/aura-events/src/orchestration.rs
+++ b/crates/aura-events/src/orchestration.rs
@@ -148,6 +148,18 @@ pub enum OrchestrationStreamEvent {
         reasoning: Option<String>,
         #[serde(skip_serializing_if = "Vec::is_empty")]
         gaps: Vec<String>,
+        /// Prompt → plan created (ms).
+        #[serde(default)]
+        planning_ms: u64,
+        /// Plan ready → continuation-prompt entrypoint (ms), wall-clock.
+        #[serde(default)]
+        execution_ms: u64,
+        /// Sum of per-task wall durations (ms) across the iteration.
+        #[serde(default)]
+        task_compute_ms: u64,
+        /// Sum of tool-call durations (ms) within the iteration.
+        #[serde(default)]
+        tool_ms: u64,
         #[serde(flatten)]
         context: EventContext,
     },
@@ -329,6 +341,10 @@ impl OrchestrationStreamEvent {
         evaluation_skipped: bool,
         reasoning: Option<String>,
         gaps: Vec<String>,
+        planning_ms: u64,
+        execution_ms: u64,
+        task_compute_ms: u64,
+        tool_ms: u64,
         context: EventContext,
     ) -> Self {
         Self::IterationComplete {
@@ -339,6 +355,10 @@ impl OrchestrationStreamEvent {
             evaluation_skipped,
             reasoning,
             gaps,
+            planning_ms,
+            execution_ms,
+            task_compute_ms,
+            tool_ms,
             context,
         }
     }

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -1161,11 +1161,15 @@ fn handle_orchestrator_event(
             will_replan,
             reasoning,
             gaps,
+            timings,
         } => {
             tracing::debug!(
-                "Orchestrator: iteration {} complete (will_replan={})",
+                "Orchestrator: iteration {} complete (will_replan={}, planning={}ms, execution={}ms, tool={}ms)",
                 iteration,
-                will_replan
+                will_replan,
+                timings.planning_ms,
+                timings.execution_ms,
+                timings.tool_ms,
             );
             OrchestrationStreamEvent::iteration_complete(
                 *iteration,
@@ -1176,6 +1180,7 @@ fn handle_orchestrator_event(
                     Some(reasoning.to_string())
                 },
                 gaps.clone(),
+                *timings,
                 event_context,
             )
         }

--- a/crates/aura/src/orchestration/events.rs
+++ b/crates/aura/src/orchestration/events.rs
@@ -113,6 +113,8 @@ pub enum OrchestratorEvent {
         reasoning: String,
         /// Identified gaps or issues (empty if not replanning)
         gaps: Vec<String>,
+        /// Phase-level wall-clock timings for this iteration.
+        timings: super::types::IterationTimings,
     },
     /// The orchestrator is starting a replan cycle.
     ///

--- a/crates/aura/src/orchestration/frame_validation_tests.rs
+++ b/crates/aura/src/orchestration/frame_validation_tests.rs
@@ -158,6 +158,7 @@ fn sample_manifest(
         response_summary: None,
         task_summaries: tasks,
         artifact_paths: vec![],
+        phase_timings: None,
     }
 }
 
@@ -551,6 +552,7 @@ fn test_session_history_direct_response_run() {
         response_summary: Some("The answer is 4".into()),
         task_summaries: vec![],
         artifact_paths: vec![],
+        phase_timings: None,
     };
 
     let history = build_session_context(&[manifest]);
@@ -582,6 +584,7 @@ fn test_session_history_multi_run_chronological() {
             vec![],
         )],
         artifact_paths: vec![],
+        phase_timings: None,
     };
     let m2 = RunManifest {
         run_id: "run_002".into(),
@@ -595,6 +598,7 @@ fn test_session_history_multi_run_chronological() {
         response_summary: None,
         task_summaries: vec![],
         artifact_paths: vec![],
+        phase_timings: None,
     };
     let m3 = RunManifest {
         run_id: "run_003".into(),
@@ -608,6 +612,7 @@ fn test_session_history_multi_run_chronological() {
         response_summary: Some("The result is X".into()),
         task_summaries: vec![],
         artifact_paths: vec![],
+        phase_timings: None,
     };
 
     // build_session_context expects most-recent-first (as returned by load_session_manifests)
@@ -971,6 +976,7 @@ fn test_session_history_routed_single_worker() {
             vec![],
         )],
         artifact_paths: vec![],
+        phase_timings: None,
     };
 
     let history = build_session_context(&[manifest]);

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -63,8 +63,8 @@ use super::events::OrchestratorEvent;
 use super::persistence::ExecutionPersistence;
 use super::prompt_journal::{JournalPhase, PromptJournal};
 use super::types::{
-    FailedTaskRecord, FailureCategory, FailureSummary, IterationContext, IterationOutcome, Plan,
-    PlanningResponse, TaskState, TaskStatus,
+    FailedTaskRecord, FailureCategory, FailureSummary, IterationContext, IterationOutcome,
+    IterationTimings, Plan, PlanningResponse, TaskState, TaskStatus,
 };
 
 // ============================================================================
@@ -2621,14 +2621,18 @@ Assign tasks to the worker whose tools best match the required operations."#,
     /// dependencies complete in subsequent iterations.
     ///
     /// Each worker receives the plan goal (not the raw query) to understand context.
+    ///
+    /// Returns the aggregate task-compute time (sum of per-task wall durations
+    /// across all waves), used for the iteration's phase-timing breakdown.
     async fn execute(
         &self,
         plan: &mut Plan,
         event_tx: &tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>,
-    ) -> Result<(), StreamError> {
+    ) -> Result<u64, StreamError> {
         use futures::StreamExt;
         use futures::stream::FuturesUnordered;
 
+        let mut task_compute_ms: u64 = 0;
         while !plan.is_finished() {
             // Collect ready tasks with their context and worker assignment
             // Tuple: (task_id, description, context, worker_name)
@@ -2701,6 +2705,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             while let Some((task_id, result, duration_ms, worker_name, task_desc)) =
                 futures.next().await
             {
+                task_compute_ms += duration_ms;
                 match result {
                     Ok(exec_result) => {
                         let final_result = self
@@ -2780,7 +2785,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             }
         }
 
-        Ok(())
+        Ok(task_compute_ms)
     }
 
     /// Collect failed tasks from this iteration into failure records.
@@ -3470,6 +3475,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
 
         // Set iteration for initial planning (journal reads this via AtomicUsize)
         self.current_iteration.store(1, Ordering::Relaxed);
+        // Planning latency: prompt → plan created (includes correction retries).
+        // Spans the whole planning call, so any planning-correction retries
+        // inside plan_with_routing are counted in planning_ms.
+        let planning_start = Instant::now();
         let (response, _prompt, _coordinator_text) = self
             .plan_with_routing(
                 query,
@@ -3479,6 +3488,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 Some(&event_tx),
             )
             .await?;
+        let initial_planning_ms = planning_start.elapsed().as_millis() as u64;
 
         let result = match response {
             PlanningResponse::Direct {
@@ -3541,6 +3551,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     &mut coordinator_state,
                     event_tx,
                     orchestration_start,
+                    initial_planning_ms,
                 )
                 .await
             }
@@ -3562,6 +3573,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
     /// Budget enforcement: at each iteration boundary, checks whether remaining
     /// wall-clock time is less than `per_call_timeout_secs`. If so, returns the
     /// best available result instead of starting a new iteration.
+    #[allow(clippy::too_many_arguments)]
     async fn run_orchestration_loop(
         &self,
         query: &str,
@@ -3570,11 +3582,17 @@ Assign tasks to the worker whose tools best match the required operations."#,
         coordinator_state: &mut CoordinatorState,
         event_tx: tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>,
         orchestration_start: Instant,
+        initial_planning_ms: u64,
     ) -> Result<String, StreamError> {
         let mut iteration = 0;
         let mut previous_context: Option<IterationContext> = None;
         let mut plan = initial_plan;
         let mut failure_history: Vec<FailedTaskRecord> = Vec::new();
+        // Planning latency for the next iteration. The first iteration uses the
+        // initial planning call; replanned iterations inherit the prior
+        // iteration's continuation-decision latency (that call produced the
+        // plan being executed).
+        let mut planning_ms = initial_planning_ms;
 
         let final_result = loop {
             iteration += 1;
@@ -3589,6 +3607,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     previous_context.as_ref(),
                     &event_tx,
                     orchestration_start,
+                    planning_ms,
                     &mut failure_history,
                 )
                 .await?
@@ -3597,9 +3616,11 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 IterationOutcome::Continue {
                     new_plan,
                     previous_context: pc,
+                    planning_ms: next_planning_ms,
                 } => {
                     plan = new_plan;
                     previous_context = pc;
+                    planning_ms = next_planning_ms;
                 }
             }
         };
@@ -3616,6 +3637,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
             orchestration.task_count = tracing::field::Empty,
             orchestration.post_execute_decision = tracing::field::Empty,
             orchestration.decision_latency_seconds = tracing::field::Empty,
+            orchestration.planning_ms = planning_ms,
+            orchestration.execution_ms = tracing::field::Empty,
+            orchestration.task_compute_ms = tracing::field::Empty,
+            orchestration.tool_ms = tracing::field::Empty,
         )
     )]
     async fn run_iteration(
@@ -3628,9 +3653,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
         previous_context: Option<&IterationContext>,
         event_tx: &tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>,
         orchestration_start: Instant,
+        planning_ms: u64,
         failure_history: &mut Vec<FailedTaskRecord>,
     ) -> Result<IterationOutcome, StreamError> {
         let elapsed = orchestration_start.elapsed().as_secs_f64();
+        // Execution span: plan ready → continuation-prompt entrypoint. Covers
+        // worker waves, persistence drain, and result consolidation.
+        let execution_start = Instant::now();
 
         tracing::info!(
             "Starting iteration {}/{} (elapsed={:.1}s, per_call_timeout={}s)",
@@ -3660,10 +3689,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
         // ----------------------------------------------------------------
         // EXECUTE: Run workers on tasks (parallel when possible)
         // ----------------------------------------------------------------
-        if let Err(e) = self.execute(&mut plan, event_tx).await {
-            self.write_run_manifest(&plan, iteration).await;
-            return Err(e);
-        }
+        let task_compute_ms = match self.execute(&mut plan, event_tx).await {
+            Ok(ms) => ms,
+            Err(e) => {
+                self.write_run_manifest(&plan, iteration, None).await;
+                return Err(e);
+            }
+        };
         let new_failure_start = failure_history.len();
         failure_history.extend(Self::collect_iteration_failures(&plan, iteration));
         let this_iteration_failures = &failure_history[new_failure_start..];
@@ -3743,7 +3775,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     this_iteration_failures.len(),
                     summary
                 );
-                self.write_run_manifest(&plan, iteration).await;
+                self.write_run_manifest(&plan, iteration, None).await;
                 return Err(format!(
                     "Provider error: all tasks failed due to provider issues (not retryable via replan):\n{}",
                     summary
@@ -3779,6 +3811,27 @@ Assign tasks to the worker whose tools best match the required operations."#,
         // paid for instead of an empty response.
         // ----------------------------------------------------------------
         let tool_traces = self.load_tool_traces_for_plan(&plan).await;
+
+        // Phase timings for this iteration. `execution_ms` is the wall-clock
+        // from plan-ready to here (the continuation-prompt entrypoint);
+        // `tool_ms` is the aggregate tool-execution time within it, so
+        // `execution_ms - tool_ms` approximates LLM-thinking time.
+        let tool_ms: u64 = tool_traces
+            .values()
+            .flat_map(|entries| entries.iter())
+            .map(|e| e.duration_ms)
+            .sum();
+        let timings = IterationTimings {
+            planning_ms,
+            execution_ms: execution_start.elapsed().as_millis() as u64,
+            task_compute_ms,
+            tool_ms,
+        };
+        let current_span = tracing::Span::current();
+        current_span.record("orchestration.execution_ms", timings.execution_ms);
+        current_span.record("orchestration.task_compute_ms", timings.task_compute_ms);
+        current_span.record("orchestration.tool_ms", timings.tool_ms);
+
         let post_execute_ctx = IterationContext::new(
             iteration,
             plan.clone(),
@@ -3798,7 +3851,12 @@ Assign tasks to the worker whose tools best match the required operations."#,
             )
             .await;
 
-        let decision_latency = decision_start.elapsed().as_secs_f64();
+        let decision_elapsed = decision_start.elapsed();
+        let decision_latency = decision_elapsed.as_secs_f64();
+        // The continuation decision call doubles as the planning step for the
+        // next iteration when it returns a new plan, so carry its latency
+        // forward as that iteration's `planning_ms`.
+        let decision_latency_ms = decision_elapsed.as_millis() as u64;
         tracing::Span::current().record("orchestration.decision_latency_seconds", decision_latency);
 
         match routing {
@@ -3828,6 +3886,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         will_replan: false,
                         reasoning: String::new(),
                         gaps: vec![],
+                        timings,
                     },
                 )
                 .await;
@@ -3837,8 +3896,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     orchestration_start.elapsed().as_secs_f64(),
                     decision_latency,
                 );
-                self.write_run_manifest_with_summary(&plan, iteration, response_summary)
-                    .await;
+                self.write_run_manifest_with_summary(
+                    &plan,
+                    iteration,
+                    response_summary,
+                    Some(timings),
+                )
+                .await;
                 Ok(IterationOutcome::FinalResult(response))
             }
             Ok((
@@ -3870,6 +3934,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         will_replan: false,
                         reasoning: String::new(),
                         gaps: vec![],
+                        timings,
                     },
                 )
                 .await;
@@ -3879,7 +3944,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     orchestration_start.elapsed().as_secs_f64(),
                     decision_latency,
                 );
-                self.write_run_manifest(&plan, iteration).await;
+                self.write_run_manifest(&plan, iteration, Some(timings))
+                    .await;
                 Ok(IterationOutcome::FinalResult(question))
             }
             Ok((resp @ PlanningResponse::StepsPlan { .. }, _, _)) => {
@@ -3904,10 +3970,12 @@ Assign tasks to the worker whose tools best match the required operations."#,
                             will_replan: false,
                             reasoning: "Replan budget exhausted".to_string(),
                             gaps: vec![],
+                            timings,
                         },
                     )
                     .await;
-                    self.write_run_manifest(&plan, iteration).await;
+                    self.write_run_manifest(&plan, iteration, Some(timings))
+                        .await;
                     return Ok(IterationOutcome::FinalResult(raw));
                 }
 
@@ -3937,6 +4005,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         will_replan: true,
                         reasoning: String::new(),
                         gaps: vec![],
+                        timings,
                     },
                 )
                 .await;
@@ -3971,6 +4040,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 Ok(IterationOutcome::Continue {
                     new_plan,
                     previous_context: new_previous_context,
+                    planning_ms: decision_latency_ms,
                 })
             }
             // Post-execute coordinator call errored before routing (timeout,
@@ -4003,10 +4073,12 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         will_replan: false,
                         reasoning: note,
                         gaps: vec![],
+                        timings,
                     },
                 )
                 .await;
-                self.write_run_manifest(&plan, iteration).await;
+                self.write_run_manifest(&plan, iteration, Some(timings))
+                    .await;
                 Ok(IterationOutcome::FinalResult(raw))
             }
         }
@@ -4072,8 +4144,16 @@ Assign tasks to the worker whose tools best match the required operations."#,
 
     /// Called at the end of `run_orchestration_loop()` on all exit paths.
     /// Errors are logged but not propagated — manifest is observability, not control flow.
-    async fn write_run_manifest(&self, plan: &Plan, iterations: usize) {
-        self.write_run_manifest_with_summary(plan, iterations, None)
+    ///
+    /// `timings` carries the final iteration's phase timings when available
+    /// (`None` for paths that failed before the timed consolidation step).
+    async fn write_run_manifest(
+        &self,
+        plan: &Plan,
+        iterations: usize,
+        timings: Option<IterationTimings>,
+    ) {
+        self.write_run_manifest_with_summary(plan, iterations, None, timings)
             .await;
     }
 
@@ -4082,6 +4162,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         plan: &Plan,
         iterations: usize,
         response_summary: Option<String>,
+        timings: Option<IterationTimings>,
     ) {
         use super::persistence::{
             ArtifactEntry, ErrorContext, RunManifest, RunStatus, TaskSummary, ToolTraceEntry,
@@ -4195,6 +4276,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             response_summary,
             task_summaries,
             artifact_paths,
+            phase_timings: timings,
         };
 
         if let Err(e) = persistence.write_manifest(&manifest).await {
@@ -4231,6 +4313,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             response_summary,
             task_summaries: vec![],
             artifact_paths: vec![],
+            phase_timings: None,
         };
 
         if let Err(e) = persistence.write_manifest(&manifest).await {

--- a/crates/aura/src/orchestration/persistence.rs
+++ b/crates/aura/src/orchestration/persistence.rs
@@ -112,6 +112,9 @@ pub struct RunManifest {
     pub task_summaries: Vec<TaskSummary>,
     /// Relative paths to large artifact files.
     pub artifact_paths: Vec<String>,
+    /// Phase-level wall-clock timings for the final iteration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase_timings: Option<super::types::IterationTimings>,
 }
 
 /// Summary of a single task for the run manifest.
@@ -1441,6 +1444,7 @@ mod tests {
                 },
             ],
             artifact_paths: vec!["task-0-research-iter-1-result.txt".to_string()],
+            phase_timings: None,
         };
 
         let json = serde_json::to_string_pretty(&manifest).unwrap();
@@ -1478,6 +1482,7 @@ mod tests {
             response_summary: None,
             task_summaries: vec![],
             artifact_paths: vec![],
+            phase_timings: None,
         };
 
         let path = persistence.write_manifest(&manifest).await.unwrap();
@@ -1505,6 +1510,7 @@ mod tests {
             response_summary: None,
             task_summaries: vec![],
             artifact_paths: vec![],
+            phase_timings: None,
         };
         let path = persistence.write_manifest(&manifest).await.unwrap();
         assert_eq!(path, PathBuf::new());
@@ -1552,6 +1558,7 @@ mod tests {
                 artifacts: vec![],
             }],
             artifact_paths: vec![],
+            phase_timings: None,
         }
     }
 
@@ -1761,6 +1768,7 @@ mod tests {
                 artifacts: vec![],
             }],
             artifact_paths: vec![],
+            phase_timings: None,
         };
 
         let result = build_session_context(&[manifest]);
@@ -1811,6 +1819,7 @@ mod tests {
                 artifacts: vec![],
             }],
             artifact_paths: vec![],
+            phase_timings: None,
         };
 
         let result = build_session_context(&[manifest]);
@@ -1860,6 +1869,7 @@ mod tests {
                 ],
             }],
             artifact_paths: vec![],
+            phase_timings: None,
         };
 
         let result = build_session_context(&[manifest]);
@@ -1918,6 +1928,7 @@ mod tests {
                 artifacts: vec![],
             }],
             artifact_paths: vec![],
+            phase_timings: None,
         };
 
         let result = build_session_context(&[manifest]);
@@ -1943,6 +1954,7 @@ mod tests {
             response_summary: Some("The answer is 4.".to_string()),
             task_summaries: vec![],
             artifact_paths: vec![],
+            phase_timings: None,
         };
 
         let result = build_session_context(&[manifest]);
@@ -2249,6 +2261,7 @@ mod tests {
                 },
             ],
             artifact_paths: vec!["task-0-sre-iter-1-result.txt".to_string()],
+            phase_timings: None,
         };
 
         let json = serde_json::to_string_pretty(&manifest).unwrap();

--- a/crates/aura/src/orchestration/stream_events.rs
+++ b/crates/aura/src/orchestration/stream_events.rs
@@ -137,6 +137,8 @@ pub enum OrchestrationStreamEvent {
         #[serde(skip_serializing_if = "Vec::is_empty")]
         gaps: Vec<String>,
         #[serde(flatten)]
+        timings: crate::orchestration::types::IterationTimings,
+        #[serde(flatten)]
         context: EventContext,
     },
     /// Emitted when orchestrator starts a replan cycle.
@@ -308,6 +310,7 @@ impl OrchestrationStreamEvent {
         will_replan: bool,
         reasoning: Option<String>,
         gaps: Vec<String>,
+        timings: crate::orchestration::types::IterationTimings,
         context: EventContext,
     ) -> Self {
         Self::IterationComplete {
@@ -315,6 +318,7 @@ impl OrchestrationStreamEvent {
             will_replan,
             reasoning,
             gaps,
+            timings,
             context,
         }
     }
@@ -515,12 +519,21 @@ mod tests {
             false,
             Some("Single-task plan completed successfully".to_string()),
             vec![],
+            crate::orchestration::types::IterationTimings {
+                planning_ms: 1200,
+                execution_ms: 4500,
+                task_compute_ms: 4500,
+                tool_ms: 800,
+            },
             test_ctx(),
         );
         let sse = event.format_sse();
 
         assert!(sse.contains("\"will_replan\":false"));
         assert!(sse.contains("\"iteration\":1"));
+        assert!(sse.contains("\"planning_ms\":1200"));
+        assert!(sse.contains("\"execution_ms\":4500"));
+        assert!(sse.contains("\"tool_ms\":800"));
     }
 
     #[test]

--- a/crates/aura/src/orchestration/tools/list_prior_runs.rs
+++ b/crates/aura/src/orchestration/tools/list_prior_runs.rs
@@ -175,6 +175,7 @@ mod tests {
                 })
                 .collect(),
             artifact_paths: vec!["artifacts/result.txt".to_string()],
+            phase_timings: None,
         }
     }
 

--- a/crates/aura/src/orchestration/types.rs
+++ b/crates/aura/src/orchestration/types.rs
@@ -1082,6 +1082,20 @@ fn truncate_reasoning(s: &str, max_chars: usize) -> String {
     }
 }
 
+/// Phase-level wall-clock timings for one orchestration iteration, in
+/// milliseconds.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct IterationTimings {
+    /// Prompt → plan created.
+    pub planning_ms: u64,
+    /// Plan ready → continuation-prompt entrypoint.
+    pub execution_ms: u64,
+    /// Sum of per-task wall durations across the iteration.
+    pub task_compute_ms: u64,
+    /// Sum of tool-call durations recorded for the iteration's tasks.
+    pub tool_ms: u64,
+}
+
 /// Outcome returned by `run_iteration` to drive the orchestration loop.
 ///
 /// Errors bubble via `Result` — this enum carries only the success variants.
@@ -1093,6 +1107,8 @@ pub(crate) enum IterationOutcome {
     Continue {
         new_plan: Plan,
         previous_context: Option<IterationContext>,
+        /// Wall-clock of the continuation-decision call that produced `new_plan`.
+        planning_ms: u64,
     },
 }
 

--- a/docs/streaming-api-guide.md
+++ b/docs/streaming-api-guide.md
@@ -452,7 +452,7 @@ When `orchestration.enabled = true` and `AURA_CUSTOM_EVENTS=true`, the server em
 | `aura.orchestrator.task_started` | Worker began executing a task |
 | `aura.orchestrator.task_completed` | Worker finished task (success/failure with duration) |
 | `aura.orchestrator.worker_reasoning` | Worker reasoning content with task/worker attribution |
-| `aura.orchestrator.iteration_complete` | Iteration finished with replan decision and reasoning |
+| `aura.orchestrator.iteration_complete` | Iteration finished with replan decision, reasoning, and phase timing (planning/execution/tool ms) |
 | `aura.orchestrator.replan_started` | Replan cycle triggered (coordinator-routed or task failures) |
 | `aura.orchestrator.synthesizing` | Coordinator merging worker results (includes iteration number) |
 | `aura.orchestrator.tool_call_started` | A tool call began (coordinator or worker); see the tool-coverage note below |
@@ -649,12 +649,27 @@ data:
   "iteration": 1,
   "will_replan": false,
   "reasoning": "All tasks completed successfully",
+  "planning_ms": 1180,
+  "execution_ms": 4620,
+  "task_compute_ms": 4500,
+  "tool_ms": 820,
   "agent_id": "coordinator",
   "session_id": "sess_xyz"
 }
 ```
 
 The `reasoning` and `gaps` fields are included only when non-empty (i.e., when replanning is triggered).
+
+**Phase timing fields** (all milliseconds, present on every `iteration_complete`):
+
+| Field | Meaning |
+|-------|---------|
+| `planning_ms` | Prompt → plan created. Includes planning-correction retries. For replanned iterations this is the prior iteration's continuation-decision latency (that call produced this iteration's plan). |
+| `execution_ms` | Plan ready → continuation-prompt entrypoint — one iteration's execution span (worker waves + persistence drain + result consolidation), measured as wall-clock. |
+| `task_compute_ms` | Sum of per-task wall durations across the iteration (aggregate compute; exceeds `execution_ms` when tasks run in parallel). |
+| `tool_ms` | Sum of tool-call durations recorded for the iteration's tasks. |
+
+To separate time the LLM spent *deciding what to call* from time spent *executing tools*, compute `execution_ms - tool_ms` ≈ LLM-thinking time. This is exact for single-task routes; for parallel waves it is approximate, since `tool_ms` and `task_compute_ms` are summed compute rather than wall-clock — compare them against `execution_ms` to gauge overlap. The same four fields are written to the run manifest (`phase_timings`) and recorded as `orchestration.{planning,execution,task_compute,tool}_ms` attributes on the `orchestration.iteration` OTel span.
 
 **Replan started** (new planning cycle triggered):
 ```


### PR DESCRIPTION
Record planning, execution, task-compute, and tool durations for each orchestration iteration. Surface them on the
aura.orchestrator.iteration_complete SSE event, the run manifest (phase_timings), and OTel spans.

The CLI shows a humanized timing line (e.g. 1.5s, 34.0s) and pads the terminal iteration with a sacrificial blank so the final-answer frame collapse cannot clobber the summary lines.

## Normal (not expanded) output

<img width="4032" height="1744" alt="image" src="https://github.com/user-attachments/assets/a1a5a4c4-5e0c-49dd-91ed-3e59c1e45fec" />

## Iteration Complete Expanded 

<img width="758" height="248" alt="image" src="https://github.com/user-attachments/assets/4ffd4ef8-198f-4c67-8f56-607b4ac96664" />


Also codify code-comment conventions in CLAUDE.md: document behavior at the implementing code, not on type definitions.

Ref: GH-217