### PR TITLE
fix(orchestration): propagate max_tokens to coordinator agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1696,7 +1696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2284,7 +2284,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2791,7 +2791,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3229,7 +3229,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -3420,7 +3420,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3457,9 +3457,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.28.0"
-source = "git+https://github.com/mezmo/rig.git?rev=890853065c8d46cd886b6f93bca5895a492d750c#890853065c8d46cd886b6f93bca5895a492d750c"
+source = "git+https://github.com/mezmo/rig.git?rev=e6f008eaf555733d93368c9dd174d1d61d7d096d#e6f008eaf555733d93368c9dd174d1d61d7d096d"
 dependencies = [
  "as-any",
  "async-stream",
@@ -3863,7 +3863,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4456,7 +4456,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mezmo/aura"
 
 [workspace.dependencies]
-rig-core = { git = "https://github.com/mezmo/rig.git", rev = "890853065c8d46cd886b6f93bca5895a492d750c", features = ["rmcp"] }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "e6f008eaf555733d93368c9dd174d1d61d7d096d", features = ["rmcp"] }
 # Pinned to exact versions compatible with our rig-core 0.28.x fork.
 # Newer versions pull in rig-core 0.31+ which is semver-incompatible with the fork.
 rig-bedrock = "=0.3.10"
@@ -89,5 +89,5 @@ http = "1.0"
 
 # Patch rig-core to use the fork with streaming hook + span propagation fix
 [patch.crates-io]
-rig-core = { git = "https://github.com/mezmo/rig.git", rev = "890853065c8d46cd886b6f93bca5895a492d750c" }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "e6f008eaf555733d93368c9dd174d1d61d7d096d" }
 

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -2026,6 +2026,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         preamble: &str,
         temperature: Option<f64>,
         additional_params: Option<serde_json::Value>,
+        max_tokens: Option<u64>,
         tools: CoordinatorTools,
     ) -> rig::agent::Agent<M> {
         let mut builder = rig::agent::AgentBuilder::new(completion_model);
@@ -2035,6 +2036,9 @@ Assign tasks to the worker whose tools best match the required operations."#,
         }
         if let Some(params) = additional_params {
             builder = builder.additional_params(params);
+        }
+        if let Some(max) = max_tokens {
+            builder = builder.max_tokens(max);
         }
         let mut state = BuilderState::Initial(builder);
         if let Some(list_tools) = tools.list_tools {
@@ -2208,6 +2212,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 &preamble,
                 temperature,
                 self.agent_config.llm.additional_params(),
+                self.agent_config.llm.max_tokens(),
                 coordinator_tools,
             )
             .await?;
@@ -2247,6 +2252,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         preamble: &str,
         temperature: Option<f64>,
         additional_params: Option<serde_json::Value>,
+        max_tokens: Option<u64>,
         tools: CoordinatorTools,
     ) -> Result<ProviderAgent, Box<dyn std::error::Error + Send + Sync>> {
         match &self.agent_config.llm {
@@ -2271,6 +2277,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     preamble,
                     temperature,
                     additional_params,
+                    max_tokens,
                     tools,
                 )))
             }
@@ -2294,6 +2301,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     preamble,
                     temperature,
                     additional_params,
+                    max_tokens,
                     tools,
                 )))
             }
@@ -2325,6 +2333,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     preamble,
                     temperature,
                     additional_params,
+                    max_tokens,
                     tools,
                 )))
             }
@@ -2348,6 +2357,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     preamble,
                     temperature,
                     additional_params,
+                    max_tokens,
                     tools,
                 )))
             }
@@ -2366,6 +2376,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     preamble,
                     temperature,
                     additional_params,
+                    max_tokens,
                     tools,
                 )))
             }
@@ -2389,6 +2400,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     preamble,
                     temperature,
                     additional_params,
+                    max_tokens,
                     tools,
                 )))
             }


### PR DESCRIPTION
## Summary

Wire `max_tokens` from `[agent.llm]` config through the coordinator build path (`create_coordinator` → `build_provider_agent_with_tools` → `build_agent_with_tools`). Also bumps the rig-core fork pin to include `claude-sonnet-5` / `claude-fable-5` model registry entries (merged in mezmo/rig#8).

## Problem

In orchestration mode, the coordinator agent was built without propagating `max_tokens` from `[agent.llm]` to the rig `AgentBuilder`. Anthropic (including Sonnet 5) hard-requires this field — orchestrated requests against Claude models failed immediately with:

```
`max_tokens` must be set for Anthropic
```

Workers and single-agent mode already propagated `max_tokens`; only the coordinator path was missing it.

## Fix

- **`crates/aura/src/orchestration/orchestrator.rs`** (12 insertions): add `max_tokens: Option<u64>` param to `build_agent_with_tools` and `build_provider_agent_with_tools`, forward to all 6 provider arms, pass `self.agent_config.llm.max_tokens()` from `create_coordinator`. Uses the same 3-line idiom already present at 4 worker sites.
- **`Cargo.toml`** (2 lines): bump rig-core fork rev from `8908530` to `e6f008ea` (includes mezmo/rig#8 — `claude-sonnet-5` / `claude-fable-5` in `calculate_max_tokens`).
- **`Cargo.lock`**: refreshed.

## Verification

- `cargo build -p aura` — clean
- `cargo clippy -p aura -- -D warnings` — clean
- `cargo test -p aura` — 765 passed, 0 failed
- Adversarial review (rust-review subagent): APPROVE, no findings
- All 6 provider arms verified, no missed callers (grep confirmed)

## Depends on

mezmo/rig#8 (merged) — adds `claude-sonnet-5` / `claude-fable-5` to rig's `calculate_max_tokens` safety-net default.

Fixes: #312
