### PR TITLE
doc(examples): update quickstarts to current config layout and image

### DIFF
--- a/examples/quickstart-k8s-sre/README.md
+++ b/examples/quickstart-k8s-sre/README.md
@@ -141,8 +141,9 @@ helm install aura ./deployment/helm/aura \
   --set secrets.openaiApiKey="$OPENAI_API_KEY"
 ```
 
-> **Using a different LLM provider?** Edit `aura-values.yaml` and update the `[llm]`
-> section. See [`examples/reference.toml`](../reference.toml) for all provider options.
+> **Using a different LLM provider?** Edit `aura-values.yaml` and update the
+> `[agent.llm]` section. See [`examples/reference.toml`](../reference.toml) for all
+> provider options.
 
 Wait for AURA:
 
@@ -152,15 +153,12 @@ kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=aura --timeout=
 
 ### 5. Try it out
 
-Launch [AURA CLI](https://hub.docker.com/r/mezmo/aura) inside the cluster,
-pointed at the AURA service:
+The [AURA CLI](../../crates/aura-cli/README.md) ships **inside the same image**
+as the server, so there's no separate CLI container to deploy. Exec into the
+running AURA pod and launch the bundled CLI against the in-pod server:
 
 ```bash
-kubectl run -it --rm aura \
-  --image=mezmo/aura \
-  --restart=Never \
-  --command -- ./aura --api-url http://aura:80 \
-  --model "kubernetes-sre"
+kubectl exec -it deploy/aura -- ./aura --api-url http://localhost:8080 --model kubernetes-sre
 ```
 
 This drops you into an interactive REPL. Try these queries:
@@ -187,6 +185,10 @@ You can toggle the SSE event panel with `/stream` to watch the orchestration in
 real time.
 
 Type `/quit` to exit.
+
+> **Prefer a browser or a local CLI?** Port-forward the service with
+> `kubectl port-forward svc/aura 8080:80`, then point any OpenAI-compatible
+> client — or a locally built `aura --api-url http://localhost:8080` — at it.
 
 ## How the orchestration config works
 

--- a/examples/quickstart-k8s-sre/aura-values.yaml
+++ b/examples/quickstart-k8s-sre/aura-values.yaml
@@ -8,14 +8,16 @@ replicaCount: 1
 
 image:
   repository: mezmo/aura
-  tag: "orchestration"
+  tag: "latest"
   pullPolicy: IfNotPresent
 
+# The mezmo/aura image ships both binaries: the server (default CMD,
+# ./aura-web-server) and the CLI (./aura). The chart already runs the server by
+# default, so no command/args override is needed here — step 5 execs the bundled
+# CLI into this same pod.
 server:
   httpPort: 8080
   loglevel: info
-  command: ["./aura-web-server"]
-  args: ["--verbose"]
 
 streaming:
   toolResultMode: "aura"
@@ -36,10 +38,10 @@ resources:
 
 config:
   content: |
-    [llm]
-    provider = "openai"
-    api_key = "{{ env.OPENAI_API_KEY }}"
-    model = "gpt-5.4-mini"
+    # Root the orchestration run artifacts on disk. `memory_dir` is a top-level
+    # key; the older `[orchestration.artifacts].memory_dir` form still works as a
+    # fallback.
+    memory_dir = "/tmp/aura-orchestration"
 
     [mcp]
     sanitize_schemas = true
@@ -72,6 +74,13 @@ config:
     Prefer read-only operations unless the user explicitly requests changes.
     """
     turn_depth = 20
+
+    # LLM config lives under [agent.llm]. Workers inherit it unless they set
+    # their own [orchestration.worker.<name>.llm].
+    [agent.llm]
+    provider = "openai"
+    api_key = "{{ env.OPENAI_API_KEY }}"
+    model = "gpt-5.4-mini"
     max_tokens = 4096
 
     # ── Orchestration ────────────────────────────────────────────────
@@ -86,9 +95,6 @@ config:
 
     [orchestration.timeouts]
     per_call_timeout_secs = 120
-
-    [orchestration.artifacts]
-    memory_dir = "/tmp/aura-orchestration"
 
     # ── Workers ──────────────────────────────────────────────────────
     #

--- a/examples/quickstart-orchestration-math/README.md
+++ b/examples/quickstart-orchestration-math/README.md
@@ -2,7 +2,7 @@
 
 One command to spin up AURA in **orchestration mode** with a math tool server:
 
-- **AURA** — the AI agent server running in orchestration mode (`mezmo/aura:orchestration`)
+- **AURA** — the AI agent server running in orchestration mode (`mezmo/aura:latest`)
 - **Math MCP** — an MCP server providing arithmetic, statistics, and trigonometry tools
 - **LibreChat** — a ChatGPT-style web UI connected to AURA
 - **Phoenix** — an LLM trace viewer for inspecting every tool call, prompt, and token

--- a/examples/quickstart-orchestration-math/config.toml
+++ b/examples/quickstart-orchestration-math/config.toml
@@ -7,17 +7,10 @@
 # This config connects to the math-mcp service defined in docker-compose.yml.
 # For all available options, see: examples/reference.toml
 
-# ── LLM Provider ────────────────────────────────────────────────────
-
-[llm]
-provider = "openai"
-api_key = "{{ env.OPENAI_API_KEY }}"
-model = "gpt-5.4-mini"
-
-# Anthropic:
-# provider = "anthropic"
-# api_key = "{{ env.ANTHROPIC_API_KEY }}"
-# model = "claude-sonnet-4-20250514"
+# Root the orchestration run artifacts on disk. `memory_dir` is a top-level
+# key; the older `[orchestration.artifacts].memory_dir` form still works as a
+# fallback.
+memory_dir = "/tmp/aura-orchestration"
 
 # ── Agent (Coordinator) ─────────────────────────────────────────────
 # In orchestration mode the [agent] system_prompt is given to the
@@ -37,6 +30,20 @@ ROUTING GUIDANCE:
 IMPORTANT: Always delegate calculations to workers — do not compute results yourself.
 """
 turn_depth = 5
+
+# ── LLM Provider ────────────────────────────────────────────────────
+# LLM config lives under [agent.llm]. Workers inherit it unless they set
+# their own [orchestration.worker.<name>.llm].
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.4-mini"
+
+# Anthropic:
+# provider = "anthropic"
+# api_key = "{{ env.ANTHROPIC_API_KEY }}"
+# model = "claude-sonnet-4-20250514"
 
 # ── MCP Tool Server ──────────────────────────────────────────────────
 # Points at the math-mcp container defined in docker-compose.yml.
@@ -62,9 +69,6 @@ tools_in_planning = "summary"
 
 [orchestration.timeouts]
 per_call_timeout_secs = 60
-
-[orchestration.artifacts]
-memory_dir = "/tmp/aura-orchestration"
 
 # Worker: arithmetic
 # Handles basic arithmetic operations using the math MCP tools.

--- a/examples/quickstart-orchestration-math/docker-compose.yml
+++ b/examples/quickstart-orchestration-math/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   # ── Aura Agent Server (Orchestration Mode) ──────────────────────────
   aura:
-    image: mezmo/aura:orchestration
+    image: mezmo/aura:latest
     container_name: aura
     command:
       - ./aura-web-server


### PR DESCRIPTION
Modernize the k8s-sre and orchestration-math quickstart examples to match the current configuration surface:

- move LLM settings from the legacy top-level [llm] table to [agent.llm], which workers inherit unless overridden
- replace [orchestration.artifacts].memory_dir with the top-level memory_dir key (the old form still works as a fallback)
- switch the image tag from mezmo/aura:orchestration to mezmo/aura:latest now that one image ships both binaries
- exec the bundled CLI inside the running AURA pod in the k8s quickstart instead of launching a separate CLI pod, and document the port-forward alternative for local clients