### PR TITLE
feat(cli): show orchestration workers at boot via aura info endpoint

### DIFF
--- a/crates/aura-cli/src/api/client.rs
+++ b/crates/aura-cli/src/api/client.rs
@@ -229,6 +229,22 @@ impl ChatClient {
         let body: serde_json::Value = response.json().await.ok()?;
         body.get("aura_version")?.as_str().map(str::to_string)
     }
+
+    /// Fetch `GET /aura/info` for the agent overview. Best-effort with a short
+    /// timeout so startup and `/model` never stall.
+    #[must_use]
+    pub async fn server_info(&self) -> Option<aura_events::ServerInfo> {
+        let response = self
+            .build_request(reqwest::Method::GET, &self.config.info_url(), None)
+            .timeout(std::time::Duration::from_millis(1500))
+            .send()
+            .await
+            .ok()?;
+        if !response.status().is_success() {
+            return None;
+        }
+        response.json().await.ok()
+    }
 }
 
 #[cfg(test)]

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -139,13 +139,7 @@ impl DirectBackend {
             .configs
             .iter()
             .filter(|c| !c.agent.hidden)
-            .map(|c| {
-                c.agent
-                    .alias
-                    .as_deref()
-                    .unwrap_or(&c.agent.name)
-                    .to_string()
-            })
+            .map(|c| c.agent_id().to_string())
             .collect()
     }
 
@@ -160,12 +154,7 @@ impl DirectBackend {
     pub fn find_matching_model(&self, model_name: &str) -> Option<String> {
         let lower = model_name.to_lowercase();
         for config in self.app_state.configs.iter() {
-            let effective_id = config
-                .agent
-                .alias
-                .as_deref()
-                .unwrap_or(&config.agent.name)
-                .to_string();
+            let effective_id = config.agent_id().to_string();
 
             // Match against effective ID, name, or alias independently
             if effective_id.to_lowercase() == lower
@@ -186,15 +175,10 @@ impl DirectBackend {
     pub fn get_config_system_prompt(&self, model: Option<&str>) -> Option<String> {
         let config = if let Some(model_name) = model {
             let lower = model_name.to_lowercase();
-            self.app_state.configs.iter().find(|c| {
-                let effective = c
-                    .agent
-                    .alias
-                    .as_deref()
-                    .unwrap_or(&c.agent.name)
-                    .to_lowercase();
-                effective == lower
-            })
+            self.app_state
+                .configs
+                .iter()
+                .find(|c| c.agent_id().to_lowercase() == lower)
         } else {
             self.app_state.configs.first()
         };
@@ -207,15 +191,9 @@ impl DirectBackend {
         let mut configs: Vec<_> = (*self.app_state.configs).clone();
         let target = if let Some(model_name) = model {
             let lower = model_name.to_lowercase();
-            configs.iter_mut().find(|c| {
-                let effective = c
-                    .agent
-                    .alias
-                    .as_deref()
-                    .unwrap_or(&c.agent.name)
-                    .to_lowercase();
-                effective == lower
-            })
+            configs
+                .iter_mut()
+                .find(|c| c.agent_id().to_lowercase() == lower)
         } else {
             configs.first_mut()
         };
@@ -372,6 +350,32 @@ impl DirectBackend {
     pub async fn list_models(&self) -> Result<Vec<String>> {
         Ok(self.model_ids())
     }
+
+    pub(crate) fn startup_agent_overview(&self) -> Option<aura_events::AgentInfo> {
+        let selected = get_selected_model();
+        self.agent_overview_for_model(selected.as_deref())
+    }
+
+    /// Project non-hidden configs into a `ServerInfo` and resolve the overview
+    /// agent with the shared selection policy (`backend::select_agent`).
+    /// Standalone has no default agent, so multi-config needs an explicit
+    /// selection.
+    fn agent_overview_for_model(&self, selected: Option<&str>) -> Option<aura_events::AgentInfo> {
+        let agents = self
+            .app_state
+            .configs
+            .iter()
+            .filter(|config| !config.agent.hidden)
+            .map(aura::agent_info)
+            .collect();
+        super::select_agent(
+            aura_events::ServerInfo {
+                default_agent: None,
+                agents,
+            },
+            selected,
+        )
+    }
 }
 
 /// Map the CLI-side `Message` (OpenAI-shaped, with role as a string) to the
@@ -458,6 +462,44 @@ mod tests {
         config.agent.alias = alias.map(|a| a.to_string());
         config.agent.system_prompt = system_prompt.to_string();
         config
+    }
+
+    fn make_orch_config(name: &str, alias: Option<&str>, worker: &str) -> aura_config::Config {
+        let alias = alias
+            .map(|alias| format!(r#"alias = "{alias}""#))
+            .unwrap_or_default();
+        aura_config::load_config_from_str(&format!(
+            r#"
+[agent]
+name = "{name}"
+{alias}
+system_prompt = "p"
+[agent.llm]
+provider = "openai"
+model = "gpt-4o"
+api_key = "k"
+
+[orchestration]
+enabled = true
+
+[orchestration.worker.{worker}]
+description = "{worker} work"
+preamble = "p"
+"#
+        ))
+        .unwrap()
+    }
+
+    fn agent_worker_names(agent: Option<aura_events::AgentInfo>) -> Vec<String> {
+        agent
+            .map(|agent| {
+                agent
+                    .workers
+                    .into_iter()
+                    .map(|worker| worker.name)
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     // -----------------------------------------------------------------------
@@ -568,6 +610,36 @@ mod tests {
             backend.find_matching_model("Secret Agent"),
             Some("Secret Agent".to_string())
         );
+    }
+
+    #[test]
+    fn startup_agent_overview_uses_single_config_for_any_selected_model() {
+        let backend = make_backend(vec![make_orch_config("orch", None, "planner")]);
+
+        let agent = backend.agent_overview_for_model(Some("provider-model"));
+
+        assert_eq!(agent.as_ref().map(|agent| agent.id.as_str()), Some("orch"));
+        assert_eq!(
+            agent.as_ref().map(|agent| agent.model.as_str()),
+            Some("gpt-4o")
+        );
+        assert_eq!(agent_worker_names(agent), vec!["planner"]);
+    }
+
+    #[test]
+    fn startup_agent_overview_requires_selected_model_with_multiple_configs() {
+        let orch = make_orch_config("orch", None, "planner");
+        let solo = make_config("solo", None, "p");
+        let mut ghost = make_config("ghost", None, "p");
+        ghost.agent.hidden = true;
+        let backend = make_backend(vec![solo, orch, ghost]);
+
+        let agent = backend.agent_overview_for_model(Some("orch"));
+
+        assert_eq!(agent.as_ref().map(|agent| agent.id.as_str()), Some("orch"));
+        assert_eq!(agent_worker_names(agent), vec!["planner"]);
+        assert!(backend.agent_overview_for_model(None).is_none());
+        assert!(backend.agent_overview_for_model(Some("ghost")).is_none());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/aura-cli/src/backend/http.rs
+++ b/crates/aura-cli/src/backend/http.rs
@@ -55,4 +55,12 @@ impl HttpBackend {
     pub async fn connection_summary(&self) -> String {
         self.client.connection_summary().await
     }
+
+    /// Fetch the selected agent overview from `GET /aura/info`.
+    /// Returns `None` if the server is unreachable, doesn't support the
+    /// endpoint, or the selected model cannot be resolved.
+    pub async fn startup_agent_overview(&self) -> Option<aura_events::AgentInfo> {
+        let info = self.client.server_info().await?;
+        super::select_agent(info, crate::ui::prompt::get_selected_model().as_deref())
+    }
 }

--- a/crates/aura-cli/src/backend/mod.rs
+++ b/crates/aura-cli/src/backend/mod.rs
@@ -113,6 +113,14 @@ impl Backend {
         }
     }
 
+    pub async fn startup_agent_overview(&self) -> Option<aura_events::AgentInfo> {
+        match self {
+            Self::Http(http) => http.startup_agent_overview().await,
+            #[cfg(feature = "standalone-cli")]
+            Self::Direct(direct) => direct.startup_agent_overview(),
+        }
+    }
+
     /// Access the direct backend (standalone mode only). Panics if not Direct.
     #[cfg(feature = "standalone-cli")]
     pub fn as_direct(&self) -> &direct::DirectBackend {
@@ -149,5 +157,94 @@ impl Backend {
                 crate::ui::prompt::seed_model_cache(direct.model_ids());
             }
         }
+    }
+}
+
+/// Priority: single-agent passthrough > selected model > default_agent.
+/// Id matching is case-insensitive.
+pub(crate) fn select_agent(
+    info: aura_events::ServerInfo,
+    selected: Option<&str>,
+) -> Option<aura_events::AgentInfo> {
+    if info.agents.len() == 1 {
+        return info.agents.into_iter().next();
+    }
+    let target = selected.or(info.default_agent.as_deref())?;
+    info.agents
+        .into_iter()
+        .find(|agent| agent.id.eq_ignore_ascii_case(target))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_fixtures::{agent, worker};
+    use aura_events::{AgentInfo, ServerInfo};
+
+    fn server_info(agents: Vec<AgentInfo>, default_agent: Option<&str>) -> ServerInfo {
+        ServerInfo {
+            default_agent: default_agent.map(str::to_owned),
+            agents,
+        }
+    }
+
+    #[test]
+    fn select_agent_resolves_expected_agent() {
+        let cases = [
+            (
+                "single-agent passthrough",
+                server_info(vec![agent("solo", vec![])], None),
+                None,
+                Some("solo"),
+            ),
+            (
+                "multi-agent selected match is case-insensitive",
+                server_info(vec![agent("solo", vec![]), agent("orch", vec![])], None),
+                Some("ORCH"),
+                Some("orch"),
+            ),
+            (
+                "multi-agent default agent fallback is case-insensitive",
+                server_info(
+                    vec![agent("solo", vec![]), agent("orch", vec![])],
+                    Some("Orch"),
+                ),
+                None,
+                Some("orch"),
+            ),
+            (
+                "selected miss does not fall back to default agent",
+                server_info(
+                    vec![agent("solo", vec![]), agent("orch", vec![])],
+                    Some("orch"),
+                ),
+                Some("nonexistent"),
+                None,
+            ),
+        ];
+
+        for (name, info, selected, expected_id) in cases {
+            let agent = select_agent(info, selected);
+            assert_eq!(
+                agent.as_ref().map(|agent| agent.id.as_str()),
+                expected_id,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn select_agent_passes_agent_info_through_whole() {
+        let info = server_info(
+            vec![
+                agent("solo", vec![]),
+                agent("orch", vec![worker("planner"), worker("writer")]),
+            ],
+            None,
+        );
+        let agent = select_agent(info, Some("orch")).expect("orch should be selected");
+        let names: Vec<_> = agent.workers.iter().map(|w| w.name.as_str()).collect();
+        assert_eq!(names, ["planner", "writer"]);
+        assert_eq!(agent.model, "gpt-4o");
     }
 }

--- a/crates/aura-cli/src/config.rs
+++ b/crates/aura-cli/src/config.rs
@@ -263,6 +263,11 @@ impl AppConfig {
     pub fn health_url(&self) -> String {
         format!("{}/health", self.api_url.trim_end_matches('/'))
     }
+
+    /// Build the aura-native info endpoint URL from the base URL.
+    pub fn info_url(&self) -> String {
+        format!("{}/aura/info", self.api_url.trim_end_matches('/'))
+    }
 }
 
 /// Persist the user's selected style to `~/.aura/cli.toml`. Updates the

--- a/crates/aura-cli/src/lib.rs
+++ b/crates/aura-cli/src/lib.rs
@@ -12,3 +12,6 @@ pub mod repl;
 pub mod theme;
 pub mod tools;
 pub mod ui;
+
+#[cfg(test)]
+pub(crate) mod test_fixtures;

--- a/crates/aura-cli/src/repl/commands.rs
+++ b/crates/aura-cli/src/repl/commands.rs
@@ -5,19 +5,52 @@ use std::io::{self, Write};
 use std::sync::atomic::Ordering;
 
 use crate::api::types::DisplayEvent;
+use crate::backend::Backend;
 use crate::repl::conversations::ConversationStore;
 use crate::repl::history::ConversationHistory;
 use crate::repl::input_reader::{AuraHelper, HISTORY_COUNT, HISTORY_DEPTH};
 use crate::ui::prompt::{
     clear_display_events, clear_stream_events, clear_stream_panel_in_place, extend_display_events,
-    get_model_matches, is_expanded_output, list_conversations, load_and_restore_sse_events,
-    print_help, print_welcome_state, redraw_input_frame, replay_event_log_global,
-    reset_status_bar_tokens, seed_model_cache, seed_status_bar_tokens, set_expanded_output,
-    set_mid_stream_history, set_selected_model, set_stream_conv_dir, set_stream_show_all,
-    set_welcome_state, toggle_stream_panel, with_event_log,
+    get_model_cache, get_model_matches, is_expanded_output, list_conversations,
+    load_and_restore_sse_events, print_help, print_welcome_state, redraw_input_frame,
+    replay_event_log_global, reset_status_bar_tokens, seed_model_cache, seed_status_bar_tokens,
+    set_expanded_output, set_mid_stream_history, set_selected_model, set_stream_conv_dir,
+    set_stream_show_all, set_welcome_state, toggle_stream_panel, with_event_log,
 };
 use crate::ui::state::{RESUME_MATCHES, get_tab_select_index, set_tab_select_index};
 use crate::ui::welcome::WelcomeState;
+
+fn set_model_and_print_overview(
+    model_id: String,
+    conv_store: &Option<ConversationStore>,
+    rt: &tokio::runtime::Runtime,
+    backend: &Backend,
+) {
+    set_selected_model(Some(model_id.clone()));
+    if let Some(store) = conv_store {
+        store.save_model(&model_id);
+    }
+    println!("Model set to: {model_id}");
+    if let Some(agent) = rt.block_on(backend.startup_agent_overview()) {
+        crate::ui::agent_overview::print_agent_overview(&agent);
+    }
+}
+
+fn model_matches_for_command(filter: &str) -> Vec<String> {
+    let cached = get_model_cache();
+    if cached.is_empty() {
+        return get_model_matches();
+    }
+    if filter.is_empty() {
+        return cached;
+    }
+
+    let lower = filter.to_lowercase();
+    cached
+        .into_iter()
+        .filter(|model| model.to_lowercase().contains(&lower))
+        .collect()
+}
 
 /// Handle the `/clear` command: save/delete the current conversation, reset state,
 /// and redisplay the welcome screen.
@@ -358,42 +391,35 @@ pub(crate) fn handle_resume(
 }
 
 /// Handle the `/model` or `/model <filter>` command.
-pub(crate) fn handle_model(filter: &str, conv_store: &Option<ConversationStore>) {
+pub(crate) fn handle_model(
+    filter: &str,
+    conv_store: &Option<ConversationStore>,
+    rt: &tokio::runtime::Runtime,
+    backend: &Backend,
+) {
     // Check if a model was selected via Tab
     if let Some(tab_idx) = get_tab_select_index() {
-        let matches = get_model_matches();
+        let matches = model_matches_for_command(filter);
         if let Some(model_id) = matches.get(tab_idx) {
             let model_id = model_id.clone();
-            set_selected_model(Some(model_id.clone()));
-            if let Some(store) = conv_store {
-                store.save_model(&model_id);
-            }
-            println!("Model set to: {}", model_id);
+            set_model_and_print_overview(model_id, conv_store, rt, backend);
             set_tab_select_index(None);
             redraw_input_frame();
             return;
         }
         set_tab_select_index(None);
     }
-    let matches = get_model_matches();
+    let matches = model_matches_for_command(filter);
     if matches.len() == 1 {
         // Exact or unique match — use it directly
         let model_id = matches[0].clone();
-        set_selected_model(Some(model_id.clone()));
-        if let Some(store) = conv_store {
-            store.save_model(&model_id);
-        }
-        println!("Model set to: {}", model_id);
+        set_model_and_print_overview(model_id, conv_store, rt, backend);
     } else if !filter.is_empty() {
         // Check if filter exactly matches a listed model (case-insensitive)
         let exact = matches.iter().find(|m| m.eq_ignore_ascii_case(filter));
         if let Some(model_id) = exact {
             let model_id = model_id.clone();
-            set_selected_model(Some(model_id.clone()));
-            if let Some(store) = conv_store {
-                store.save_model(&model_id);
-            }
-            println!("Model set to: {}", model_id);
+            set_model_and_print_overview(model_id, conv_store, rt, backend);
         } else {
             // Unlisted model — ask for confirmation with immediate keypress
             use crossterm::event::{self, Event, KeyCode as CKC, KeyEventKind};
@@ -418,11 +444,7 @@ pub(crate) fn handle_model(filter: &str, conv_store: &Option<ConversationStore>)
             println!();
             if accepted {
                 let model_id = filter.to_string();
-                set_selected_model(Some(model_id.clone()));
-                if let Some(store) = conv_store {
-                    store.save_model(&model_id);
-                }
-                println!("Model set to: {}", model_id);
+                set_model_and_print_overview(model_id, conv_store, rt, backend);
             } else {
                 println!("Model selection cancelled.");
             }

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -641,6 +641,10 @@ pub fn run_repl(
     } else {
         crate::ui::prompt::print_welcome_state();
     }
+    let startup_agent = rt.block_on(backend.startup_agent_overview());
+    if let Some(agent) = startup_agent {
+        crate::ui::agent_overview::print_agent_overview(&agent);
+    }
     setup_terminal();
 
     // If telemetry is already Enabled at launch (a recorded preference),
@@ -784,6 +788,8 @@ pub fn run_repl(
                         conv_store: &mut conv_store,
                         input_reader: &mut input_reader,
                         telemetry,
+                        rt,
+                        backend,
                     };
                     match registry::dispatch(&input, &mut ctx) {
                         Some(CommandOutcome::Exit) => break,
@@ -1917,6 +1923,8 @@ pub fn run_repl(
                         conv_store: &mut conv_store,
                         input_reader: &mut input_reader,
                         telemetry,
+                        rt,
+                        backend,
                     };
                     match (pending.command.handler)(&mut ctx, &pending.args) {
                         CommandOutcome::Exit => break,
@@ -2497,7 +2505,7 @@ impl StreamHandler for ReplStreamHandler {
         // tool_start for).
         //
         // These transient events (progress, worker_phase,
-        // session_info, non-orchestrator-prefixed) update
+        // non-orchestrator-prefixed) update
         // the spinner sub-line or task header in-place —
         // they don't add to scrollback, so they must NOT
         // flush the live reasoning block. Flushing here

--- a/crates/aura-cli/src/repl/registry.rs
+++ b/crates/aura-cli/src/repl/registry.rs
@@ -13,6 +13,7 @@ use super::commands;
 use super::conversations::ConversationStore;
 use super::history::ConversationHistory;
 use super::input_reader::AuraHelper;
+use crate::backend::Backend;
 use crate::ui::prompt::{is_expanded_output, with_event_log};
 use crate::ui::state::{MODEL_MATCHES, RESUME_MATCHES, STYLE_MATCHES, get_tab_select_index};
 
@@ -25,6 +26,8 @@ pub(crate) struct CommandContext<'a> {
     /// state and persist an opt-out. Inspection/disable only — dispatch
     /// happens before the consent gate, so a slash command never enables.
     pub telemetry: &'a aura_telemetry::TelemetryHandle,
+    pub rt: &'a tokio::runtime::Runtime,
+    pub backend: &'a Backend,
 }
 
 /// What the REPL loop should do after a command handler returns.
@@ -262,7 +265,7 @@ fn cmd_rename(ctx: &mut CommandContext, args: &str) -> CommandOutcome {
 }
 
 fn cmd_model(ctx: &mut CommandContext, args: &str) -> CommandOutcome {
-    commands::handle_model(args, ctx.conv_store);
+    commands::handle_model(args, ctx.conv_store, ctx.rt, ctx.backend);
     CommandOutcome::Handled
 }
 

--- a/crates/aura-cli/src/test_fixtures.rs
+++ b/crates/aura-cli/src/test_fixtures.rs
@@ -1,0 +1,19 @@
+//! Shared test fixtures for `aura_events` overview types.
+
+use aura_events::{AgentInfo, WorkerOverview};
+
+pub(crate) fn worker(name: &str) -> WorkerOverview {
+    WorkerOverview {
+        name: name.to_string(),
+        description: format!("{name} does work"),
+        model: None,
+    }
+}
+
+pub(crate) fn agent(id: &str, workers: Vec<WorkerOverview>) -> AgentInfo {
+    AgentInfo {
+        id: id.to_string(),
+        model: "gpt-4o".to_string(),
+        workers,
+    }
+}

--- a/crates/aura-cli/src/ui/agent_overview.rs
+++ b/crates/aura-cli/src/ui/agent_overview.rs
@@ -1,0 +1,114 @@
+use std::borrow::Cow;
+
+use aura_events::{AgentInfo, WorkerOverview};
+
+use crate::theme::{AuraStyle, Themed};
+use crate::ui::state::term_size;
+use crate::ui::text::wrap_words;
+
+const INDENT: &str = "  ";
+
+/// Print the agent overview block followed by a blank line.
+pub fn print_agent_overview(agent: &AgentInfo) {
+    for line in agent_overview_block_lines(agent) {
+        println!("{line}");
+    }
+    println!();
+}
+
+fn agent_overview_block_lines(agent: &AgentInfo) -> Vec<String> {
+    let mut lines = Vec::with_capacity(agent.workers.len() + 3);
+    let role = if agent.workers.is_empty() {
+        "model"
+    } else {
+        "coordinator"
+    };
+
+    lines.push(format!("{}", "Agent".themed(AuraStyle::Heading)));
+    lines.push(format!(
+        "{INDENT}{} {} {} {}: {}",
+        "•".themed(AuraStyle::Muted),
+        agent.id.as_str().themed(AuraStyle::Heading),
+        "—".themed(AuraStyle::Muted),
+        role.themed(AuraStyle::Muted),
+        agent.model.as_str().themed(AuraStyle::Muted),
+    ));
+
+    lines.extend(worker_block_lines(&agent.workers));
+
+    lines
+}
+
+fn worker_block_lines(workers: &[WorkerOverview]) -> Vec<String> {
+    if workers.is_empty() {
+        return Vec::new();
+    }
+
+    let (w, _) = term_size();
+    let width = w as usize;
+    let mut lines = Vec::with_capacity(workers.len() + 1);
+    lines.push(format!("{}", "Workers".themed(AuraStyle::Heading)));
+
+    for worker in workers {
+        let text = match &worker.model {
+            Some(model) => Cow::Owned(format!("{} ({model})", worker.description)),
+            None => Cow::Borrowed(worker.description.as_str()),
+        };
+        let prefix_len = INDENT.len() + 2 + worker.name.chars().count() + 3;
+        let wrapped = wrap_words(&text, width.saturating_sub(prefix_len));
+
+        lines.push(format!(
+            "{INDENT}{} {} {} {}",
+            "•".themed(AuraStyle::Muted),
+            worker.name.as_str().themed(AuraStyle::Heading),
+            "—".themed(AuraStyle::Muted),
+            wrapped[0].as_str().themed(AuraStyle::Muted),
+        ));
+        let hang = " ".repeat(prefix_len);
+        for line in &wrapped[1..] {
+            lines.push(format!("{hang}{}", line.as_str().themed(AuraStyle::Muted)));
+        }
+    }
+
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_fixtures::{agent, worker};
+
+    #[test]
+    fn agent_overview_renders_single_agent_model_without_workers() {
+        let agent = agent("ui-orch", Vec::new());
+        let all = agent_overview_block_lines(&agent).join("\n");
+
+        assert!(all.contains("Agent"));
+        assert!(all.contains("ui-orch"));
+        assert!(all.contains("model"));
+        assert!(all.contains("gpt-4o"));
+        assert!(!all.contains("Workers"));
+    }
+
+    #[test]
+    fn agent_overview_renders_coordinator_and_workers() {
+        let agent = agent("ui-orch", vec![worker("planner"), worker("writer")]);
+        let all = agent_overview_block_lines(&agent).join("\n");
+
+        assert!(all.contains("Agent"));
+        assert!(all.contains("coordinator"));
+        assert!(all.contains("gpt-4o"));
+        assert!(all.contains("Workers"));
+        assert!(all.contains("planner"));
+        assert!(all.contains("writer"));
+    }
+
+    #[test]
+    fn worker_block_annotates_model_overrides() {
+        let mut planner = worker("planner");
+        planner.model = Some("gpt-4o-mini".to_string());
+        let all = worker_block_lines(&[planner, worker("writer")]).join("\n");
+        assert!(all.contains("(gpt-4o-mini)"));
+        assert_eq!(all.matches('(').count(), 1);
+    }
+}

--- a/crates/aura-cli/src/ui/mod.rs
+++ b/crates/aura-cli/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_overview;
 pub mod markdown;
 pub mod pre_launch;
 pub mod prompt;

--- a/crates/aura-cli/src/ui/prompt.rs
+++ b/crates/aura-cli/src/ui/prompt.rs
@@ -10,7 +10,7 @@
 pub use super::state::{
     ACTIVE_ORCH_TOOLS, ORCH_SCROLLBACK_COUNTER, cache_anim_lines, capture_style_preview_original,
     check_resize, clear_display_events, clear_queued_input, clear_style_preview_original,
-    extend_display_events, frame_lines, get_model_matches, get_selected_model,
+    extend_display_events, frame_lines, get_model_cache, get_model_matches, get_selected_model,
     install_sigint_handler, is_expanded_output, is_pretty, is_processing, is_readline_active,
     last_mid_stream_history_entry, print_welcome_state, print_welcome_state_animated,
     push_display_event, push_mid_stream_history, random_bullet_color, reset_input_geometry,

--- a/crates/aura-cli/src/ui/state.rs
+++ b/crates/aura-cli/src/ui/state.rs
@@ -437,6 +437,10 @@ pub fn get_model_matches() -> Vec<String> {
     MODEL_MATCHES.lock().map(|g| g.clone()).unwrap_or_default()
 }
 
+pub fn get_model_cache() -> Vec<String> {
+    MODEL_CACHE.lock().map(|g| g.clone()).unwrap_or_default()
+}
+
 /// Get the cached style matches (populated while typing `/style`).
 pub fn get_style_matches() -> Vec<String> {
     STYLE_MATCHES.lock().map(|g| g.clone()).unwrap_or_default()

--- a/crates/aura-cli/src/ui/text.rs
+++ b/crates/aura-cli/src/ui/text.rs
@@ -18,6 +18,36 @@ pub fn truncate_with_ellipsis(text: &str, max: usize) -> String {
     format!("{prefix}...")
 }
 
+/// Greedy word-wrap of `text` into lines of at most `width` columns.
+///
+/// Counts `char`s, not grapheme clusters, so multi-scalar glyphs may be
+/// over-counted when measuring line width.
+pub fn wrap_words(text: &str, width: usize) -> Vec<String> {
+    let width = width.max(1);
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    let mut current_len = 0;
+
+    for word in text.split_whitespace() {
+        let word_len = word.chars().count();
+        if current.is_empty() {
+            current.push_str(word);
+            current_len = word_len;
+        } else if current_len + 1 + word_len <= width {
+            current.push(' ');
+            current.push_str(word);
+            current_len += 1 + word_len;
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current.push_str(word);
+            current_len = word_len;
+        }
+    }
+
+    lines.push(current);
+    lines
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -57,5 +87,13 @@ mod tests {
         let out = truncate_with_ellipsis(&s, 6);
         // 3 kept clusters + ellipsis; all kept clusters are whole waves.
         assert_eq!(out, format!("{}...", wave.repeat(3)));
+    }
+
+    #[test]
+    fn wrap_words_preserves_words() {
+        let wrapped = wrap_words("one two three four five", 8);
+        assert!(wrapped.len() > 1);
+        assert!(wrapped.iter().all(|line| line.chars().count() <= 8));
+        assert_eq!(wrapped.join(" "), "one two three four five");
     }
 }

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -325,6 +325,11 @@ impl Config {
         self.orchestration.as_ref().is_some_and(|o| o.enabled)
     }
 
+    /// The agent's public identifier: its alias when set, otherwise its name.
+    pub fn agent_id(&self) -> &str {
+        self.agent.alias.as_deref().unwrap_or(&self.agent.name)
+    }
+
     /// Validate the configuration
     pub fn validate(&self) -> Result<(), crate::ConfigError> {
         validate_llm_api_key(&self.agent.llm, "agent.llm")?;

--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -1,6 +1,7 @@
-//! Shared SSE event types for the Aura ecosystem.
+//! Shared wire types for the aura HTTP surface: SSE event types and
+//! introspection response bodies.
 //!
-//! This crate defines the event types emitted by the aura web server and
+//! This crate defines the types produced by the aura web server and
 //! consumed by the aura CLI. It is intentionally lightweight — no agent,
 //! MCP, or provider dependencies — so both producer and consumer crates
 //! can depend on it without pulling in the full aura stack.
@@ -163,6 +164,34 @@ pub struct McpServerStatus {
     /// Failure reason when `status == "failed"`; omitted otherwise.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+}
+
+/// One orchestration worker row suitable for client display.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkerOverview {
+    pub name: String,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+/// One agent entry in the `GET /aura/info` response.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentInfo {
+    /// Agent identifier — matches the `id` field in `/v1/models` (alias or name).
+    pub id: String,
+    /// LLM model name (e.g., "gpt-4o").
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workers: Vec<WorkerOverview>,
+}
+
+/// Response body for `GET /aura/info`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServerInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_agent: Option<String>,
+    pub agents: Vec<AgentInfo>,
 }
 
 /// Worker phase for multi-agent orchestration.

--- a/crates/aura-web-server/Cargo.toml
+++ b/crates/aura-web-server/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 aura = { path = "../aura" }
 aura-config = { path = "../aura-config" }
+aura-events = { path = "../aura-events" }
 axum = { version = "0.8", features = ["json"] }
 tower-http = { version = "0.6", features = ["trace", "timeout"] }
 bytes = "1"

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -5,6 +5,7 @@ use aura::{
     approval_event_unsubscribe, request_progress_subscribe, tool_event_subscribe,
     tool_usage_subscribe,
 };
+use aura_events::{AgentInfo, ServerInfo};
 use axum::Json;
 use axum::body::Body;
 use axum::extract::State;
@@ -950,6 +951,22 @@ pub async fn health() -> Response {
     .into_response()
 }
 
+/// `GET /aura/info`: aura-native introspection. Off `/v1/` to keep the OpenAI surface clean.
+pub async fn info(State(state): State<Arc<AppState>>) -> Response {
+    let agents: Vec<AgentInfo> = state
+        .configs
+        .iter()
+        .filter(|config| !config.agent.hidden)
+        .map(aura::agent_info)
+        .collect();
+
+    Json(ServerInfo {
+        default_agent: state.default_agent.clone(),
+        agents,
+    })
+    .into_response()
+}
+
 /// OpenAI-compatible model listing endpoint.
 /// Each model `id` maps to an agent's `alias` (if set) or `name` from the TOML config.
 /// Filters out `hidden` agents
@@ -1553,6 +1570,117 @@ model = "gpt-4o"
         assert_eq!(data[0]["id"], "visible-agent");
         assert_eq!(data[0]["object"], "model");
         assert_eq!(data[0]["owned_by"], "openai");
+    }
+
+    // --- info endpoint tests ---
+
+    fn make_info_state(
+        configs: Vec<aura_config::Config>,
+        default_agent: Option<&str>,
+    ) -> Arc<AppState> {
+        Arc::new(AppState {
+            configs: Arc::new(configs),
+            tool_result_mode: crate::streaming::ToolResultMode::None,
+            tool_result_max_length: 0,
+            streaming_buffer_size: 32,
+            aura_custom_events: false,
+            aura_emit_reasoning: false,
+            streaming_timeout_secs: 0,
+            first_chunk_timeout_secs: 0,
+            shutdown_token: tokio_util::sync::CancellationToken::new(),
+            stream_shutdown_token: tokio_util::sync::CancellationToken::new(),
+            active_requests: Arc::new(crate::types::ActiveRequestTracker::new()),
+            default_agent: default_agent.map(str::to_owned),
+            additional_tools: Arc::new(Vec::new),
+            pending_approvals: aura::hitl::PendingApprovals::new(),
+        })
+    }
+
+    async fn parse_info_response(resp: Response) -> ServerInfo {
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    fn info_config(name: &str, agent_fields: &str, extra_tables: &str) -> aura_config::Config {
+        parse_config(&format!(
+            r#"
+[agent]
+name = "{name}"
+system_prompt = "p"
+{agent_fields}
+
+[agent.llm]
+provider = "openai"
+api_key = "test"
+model = "gpt-4o"
+
+{extra_tables}
+"#
+        ))
+    }
+
+    fn solo_info_config(name: &str) -> aura_config::Config {
+        info_config(name, "", "")
+    }
+
+    fn orch_info_config() -> aura_config::Config {
+        info_config(
+            "orch-agent",
+            r#"alias = "orch""#,
+            r#"
+[orchestration]
+enabled = true
+
+[orchestration.worker.planner]
+description = "Plans work"
+preamble = "p"
+
+[orchestration.worker.writer]
+description = "Writes summaries"
+preamble = "p"
+
+[orchestration.worker.writer.llm]
+provider = "openai"
+api_key = "test"
+model = "gpt-4o-mini"
+"#,
+        )
+    }
+
+    #[tokio::test]
+    async fn test_info_returns_agents_with_workers() {
+        let state = make_info_state(vec![orch_info_config()], None);
+        let resp = info(State(state)).await;
+        let info = parse_info_response(resp).await;
+
+        assert_eq!(info.agents.len(), 1);
+        let agent = &info.agents[0];
+        assert_eq!(agent.id, "orch");
+        assert_eq!(agent.model, "gpt-4o");
+        assert_eq!(agent.workers.len(), 2);
+        assert_eq!(agent.workers[0].name, "planner");
+        assert_eq!(agent.workers[0].model, None);
+        assert_eq!(agent.workers[1].name, "writer");
+        assert_eq!(agent.workers[1].model.as_deref(), Some("gpt-4o-mini"));
+    }
+
+    #[tokio::test]
+    async fn test_info_filters_hidden_agents_and_reports_default() {
+        let state = make_info_state(
+            vec![
+                info_config("hidden-agent", "hidden = true", ""),
+                solo_info_config("visible-agent"),
+            ],
+            Some("visible-agent"),
+        );
+        let resp = info(State(state)).await;
+        let info = parse_info_response(resp).await;
+
+        let ids: Vec<_> = info.agents.iter().map(|agent| agent.id.as_str()).collect();
+        assert_eq!(ids, ["visible-agent"]);
+        assert_eq!(info.default_agent.as_deref(), Some("visible-agent"));
     }
 
     // --- streaming / response builder tests ---

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -264,6 +264,7 @@ async fn run() -> std::io::Result<()> {
 
     let app = Router::new()
         .route("/health", get(handlers::health))
+        .route("/aura/info", get(handlers::info))
         .route("/v1/models", get(handlers::list_models))
         .route("/v1/chat/completions", post(handlers::chat_completions))
         .route(

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -63,7 +63,7 @@ pub use orchestration::tools::{
 pub use orchestration::{
     ArtifactsConfig, EventContext, OrchestrationConfig, OrchestrationStreamEvent, Orchestrator,
     OrchestratorEvent, OrchestratorFactory, Plan, PlanningResponse, RoutingMode, RunId, Task,
-    TaskIdentity, TaskJson, TaskState, TaskStatus, TimeoutsConfig,
+    TaskIdentity, TaskJson, TaskState, TaskStatus, TimeoutsConfig, agent_info, worker_overview,
 };
 pub use passthrough_tool::{PASSTHROUGH_MARKER, PassthroughTool};
 pub use provider_agent::{

--- a/crates/aura/src/orchestration/mod.rs
+++ b/crates/aura/src/orchestration/mod.rs
@@ -48,6 +48,7 @@ mod factory;
 mod frame_validation_tests;
 mod observer_wrapper;
 mod orchestrator;
+mod overview;
 mod persistence;
 mod persistence_wrapper;
 mod prompt_constants;
@@ -65,6 +66,7 @@ pub use events::{OrchestratorEvent, RoutingMode};
 pub use factory::OrchestratorFactory;
 pub use observer_wrapper::ObserverWrapper;
 pub use orchestrator::Orchestrator;
+pub use overview::{agent_info, worker_overview};
 pub use persistence::{
     ExecutionPersistence, RunManifest, RunStatus, TaskExecutionRecord, TaskSummary, ToolCallRecord,
     build_session_context, load_session_manifests,

--- a/crates/aura/src/orchestration/overview.rs
+++ b/crates/aura/src/orchestration/overview.rs
@@ -1,0 +1,122 @@
+//! Projections of an agent [`Config`] into the wire types served by
+//! `GET /aura/info` ([`AgentInfo`], [`WorkerOverview`]).
+
+use aura_config::Config;
+use aura_events::{AgentInfo, WorkerOverview};
+
+/// Project a config into its `/aura/info` agent entry: identifier, LLM model
+/// name, and worker overview.
+pub fn agent_info(config: &Config) -> AgentInfo {
+    AgentInfo {
+        id: config.agent_id().to_owned(),
+        model: config.agent.llm.model_info().1.to_owned(),
+        workers: worker_overview(config),
+    }
+}
+
+/// Summarize a config's orchestration workers, sorted by name. Empty when
+/// orchestration is disabled. A worker's `model` is set only when its LLM
+/// override resolves to a different model than the coordinator's.
+pub fn worker_overview(config: &Config) -> Vec<WorkerOverview> {
+    let Some(orch) = config.orchestration.as_ref().filter(|o| o.enabled) else {
+        return Vec::new();
+    };
+
+    let coordinator_model = config.agent.llm.model_info().1;
+    let mut workers: Vec<_> = orch
+        .workers
+        .iter()
+        .map(|(name, worker)| {
+            let worker_model = worker
+                .llm
+                .as_ref()
+                .unwrap_or(&config.agent.llm)
+                .model_info()
+                .1;
+            WorkerOverview {
+                name: name.clone(),
+                description: worker.description.clone(),
+                model: (worker_model != coordinator_model).then(|| worker_model.to_owned()),
+            }
+        })
+        .collect();
+    workers.sort_by(|a, b| a.name.cmp(&b.name));
+    workers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::worker_overview;
+    use aura_config::load_config_from_str;
+
+    #[test]
+    fn test_worker_overview_empty_when_orchestration_disabled() {
+        let config = load_config_from_str(
+            r#"
+[agent]
+name = "solo"
+system_prompt = "You are solo."
+[agent.llm]
+provider = "openai"
+model = "gpt-4o"
+api_key = "k"
+
+[orchestration]
+enabled = false
+
+[orchestration.worker.x]
+description = "Defined but disabled"
+preamble = "p"
+"#,
+        )
+        .expect("config should parse");
+
+        assert!(worker_overview(&config).is_empty());
+    }
+
+    #[test]
+    fn test_worker_overview_sorts_and_annotates_only_overridden_models() {
+        let config = load_config_from_str(
+            r#"
+[agent]
+name = "orch"
+system_prompt = "You are orch."
+[agent.llm]
+provider = "openai"
+model = "gpt-4o"
+api_key = "k"
+
+[orchestration]
+enabled = true
+
+[orchestration.worker.beta]
+description = "Runs a different model"
+preamble = "p"
+[orchestration.worker.beta.llm]
+provider = "openai"
+model = "gpt-4o-mini"
+api_key = "k"
+
+[orchestration.worker.alpha]
+description = "Inherits coordinator model"
+preamble = "p"
+
+[orchestration.worker.charlie]
+description = "Overrides to the same model"
+preamble = "p"
+[orchestration.worker.charlie.llm]
+provider = "openai"
+model = "gpt-4o"
+api_key = "k"
+"#,
+        )
+        .expect("config should parse");
+
+        let workers = worker_overview(&config);
+        let names: Vec<_> = workers.iter().map(|w| w.name.as_str()).collect();
+        assert_eq!(names, ["alpha", "beta", "charlie"]);
+        assert_eq!(workers[0].model, None);
+        assert_eq!(workers[1].model, Some("gpt-4o-mini".to_string()));
+        assert_eq!(workers[2].model, None);
+    }
+}

--- a/crates/aura/src/stream_events.rs
+++ b/crates/aura/src/stream_events.rs
@@ -7,7 +7,7 @@
 // Re-export everything from aura-events so existing consumers don't break
 pub use aura_events::{
     AgentContext, AuraStreamEvent, CorrelationContext, McpServerStatus, NumberOrString,
-    ProgressToken, WorkerPhase, format_named_sse,
+    ProgressToken, WorkerOverview, WorkerPhase, format_named_sse,
 };
 
 // Re-export orchestration event types

--- a/docs/streaming-api-guide.md
+++ b/docs/streaming-api-guide.md
@@ -49,6 +49,44 @@ TOOL_RESULT_MODE=aura AURA_CUSTOM_EVENTS=true cargo run --bin aura-web-server
 | `AURA_EMIT_REASONING` | `false` | Enable `aura.reasoning` events |
 | `SHUTDOWN_TIMEOUT_SECS` | `30` | Grace period (seconds) for in-flight streams on shutdown |
 
+## Server Info Endpoint
+
+`GET /aura/info` is an aura-native introspection endpoint. It returns the
+default agent and per-agent orchestration worker metadata. This endpoint is not
+OpenAI-compatible; it lives under `/aura/` to keep `/v1/models` clean.
+
+The CLI uses this at boot to display orchestration workers before the first
+prompt in HTTP mode.
+
+```bash
+curl http://localhost:8080/aura/info | jq
+```
+
+```json
+{
+  "default_agent": "orch",
+  "agents": [
+    {
+      "id": "orch",
+      "model": "gpt-4o",
+      "workers": [
+        { "name": "planner", "description": "Plans work" },
+        { "name": "writer", "description": "Writes summaries", "model": "gpt-4o-mini" }
+      ]
+    },
+    {
+      "id": "solo",
+      "model": "gpt-4o"
+    }
+  ]
+}
+```
+
+Each agent's `id` matches the `id` field in `/v1/models` (alias if set,
+otherwise agent name). The `workers` array is omitted for non-orchestration
+agents. Each worker's `model` is included only when it overrides the
+coordinator model.
+
 ## Custom AURA Events (Optional)
 
 Most custom AURA events are optional and require `AURA_CUSTOM_EVENTS=true`.


### PR DESCRIPTION
Expose orchestration worker metadata through a dedicated aura-native HTTP endpoint so the CLI can display the worker banner before the first prompt without polluting the OpenAI-compatible /v1/models response.

Add GET /aura/info to the web server: returns version, A2A availability, default agent, and per-agent worker overviews. The HTTP CLI fetches this at boot and filters by the selected model. Standalone mode reads local config as before. The SSE session_info event no longer carries workers; discovery is request-response, not mid-stream.

Fixes: #313