### PR TITLE
fix(compose): pin math-mcp to 6eed9eb before build:stdio removal

### DIFF
--- a/compose/math-mcp/Dockerfile
+++ b/compose/math-mcp/Dockerfile
@@ -9,6 +9,7 @@ RUN npm install -g mcp-proxy
 RUN apk add --no-cache git curl \
     && git clone https://github.com/EthanHenrickson/math-mcp.git \
     && cd math-mcp \
+    && git checkout 6eed9eb \
     && npm install \
     && npm run build:stdio \
     && apk del git

--- a/examples/quickstart-orchestration-math/math-mcp/Dockerfile
+++ b/examples/quickstart-orchestration-math/math-mcp/Dockerfile
@@ -9,6 +9,7 @@ RUN npm install -g mcp-proxy
 RUN apk add --no-cache git curl \
     && git clone https://github.com/EthanHenrickson/math-mcp.git \
     && cd math-mcp \
+    && git checkout 6eed9eb \
     && npm install \
     && npm run build:stdio \
     && apk del git


### PR DESCRIPTION
The upstream `EthanHenrickson/math-mcp` repo removed the `build:stdio` npm script in v0.1.3 (commit `ed07ae6`), breaking the math-mcp Docker image build and any `make test-integration-orchestration-local` run.

This pins the clone to `6eed9eb` ("Remove Smithery as a MCP provider"), the last commit that has the `build:stdio` script. The script is just `tsc` with no Smithery dependency, so the pin is safe and reproducible.

Verified on a freshly purged Docker Desktop: `make test-integration-orchestration-local-up` builds both images and brings all three services (math-mcp, mock-mcp, aura-web-server) to healthy.