### PR TITLE
ci: sign and notarize macos binaries

### DIFF
--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -157,8 +157,38 @@ build-binaries-linux: ## Build binaries for linux (amd64 + arm64, PROFILE=releas
 build-binaries-darwin: ## Build binaries for darwin (amd64 + arm64, PROFILE=release|debug)
 	$(MAKE) build-binary-darwin-amd64 build-binary-darwin-arm64
 
+# Signing identity and notarytool credentials for the darwin binaries.
+# Supply on the make command line or via the environment. CODESIGN_IDENTITY is
+# the SHA-1 hash of the Developer ID Application certificate in the keychain.
+CODESIGN_IDENTITY ?=
+NOTARY_APPLE_ID ?=
+NOTARY_PASSWORD ?=
+NOTARY_TEAM_ID ?=
+
+# The darwin binaries produced by build-release-binaries-darwin.
+DARWIN_RELEASE_BINARIES := \
+	aura-darwin-amd64 aura-web-server-darwin-amd64 \
+	aura-darwin-arm64 aura-web-server-darwin-arm64
+
+.PHONY: sign-release-binaries-darwin
+sign-release-binaries-darwin: $(DIST_DIR) $(DOCKER_ENV) ## Codesign and notarize the darwin release binaries (requires CODESIGN_IDENTITY, NOTARY_APPLE_ID, NOTARY_PASSWORD, NOTARY_TEAM_ID)
+	@[ -n "$(CODESIGN_IDENTITY)" ] || { echo "error: CODESIGN_IDENTITY is required" >&2; exit 1; }
+	@[ -n "$(NOTARY_APPLE_ID)" ] || { echo "error: NOTARY_APPLE_ID is required" >&2; exit 1; }
+	@[ -n "$(NOTARY_PASSWORD)" ] || { echo "error: NOTARY_PASSWORD is required" >&2; exit 1; }
+	@[ -n "$(NOTARY_TEAM_ID)" ] || { echo "error: NOTARY_TEAM_ID is required" >&2; exit 1; }
+	$(RUN) bash -c "\
+		$(call require_host,Darwin,) \
+		cd $(DIST_DIR) && for bin in $(DARWIN_RELEASE_BINARIES); do \
+			echo signing \$$bin; \
+			codesign --force --timestamp --options runtime --sign '$(CODESIGN_IDENTITY)' \$$bin; \
+			echo notarizing \$$bin; \
+			ditto -c -k \$$bin \$$bin.zip; \
+			xcrun notarytool submit \$$bin.zip --apple-id '$(NOTARY_APPLE_ID)' --password '$(NOTARY_PASSWORD)' --team-id '$(NOTARY_TEAM_ID)' --wait; \
+			rm -f \$$bin.zip; \
+		done"
+
 .PHONY: build-checksums
-build-checksums: ## Write sha256 checksums for the binaries in dist
+build-checksums: ## Write sha256 checksums for the release binaries in dist
 	cd $(DIST_DIR) && sha256sum aura-* > checksums.txt
 
 # Every binary a complete release must contain, across all platforms.

--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -192,6 +192,38 @@ build-binaries-linux: ## Build binaries for linux (amd64 + arm64, PROFILE=releas
 build-binaries-darwin: ## Build binaries for darwin (amd64 + arm64, PROFILE=release|debug)
 	$(MAKE) build-binary-darwin-amd64 build-binary-darwin-arm64
 
+# Signing identity and notarytool credentials for the darwin binaries.
+# Supply on the make command line or via the environment. CODESIGN_IDENTITY is
+# the SHA-1 hash of the Developer ID Application certificate in the keychain.
+CODESIGN_IDENTITY ?=
+NOTARY_APPLE_ID ?=
+NOTARY_PASSWORD ?=
+NOTARY_TEAM_ID ?=
+
+# The darwin binaries produced by build-release-binaries-darwin.
+DARWIN_RELEASE_BINARIES := \
+	aura-darwin-amd64 aura-web-server-darwin-amd64 \
+	aura-darwin-arm64 aura-web-server-darwin-arm64
+
+.PHONY: sign-release-binaries-darwin
+sign-release-binaries-darwin: $(DIST_DIR) $(DOCKER_ENV) ## Codesign and notarize the darwin release binaries (requires CODESIGN_IDENTITY, NOTARY_APPLE_ID, NOTARY_PASSWORD, NOTARY_TEAM_ID)
+	@[ -n "$(CODESIGN_IDENTITY)" ] || { echo "error: CODESIGN_IDENTITY is required" >&2; exit 1; }
+	@[ -n "$(NOTARY_APPLE_ID)" ] || { echo "error: NOTARY_APPLE_ID is required" >&2; exit 1; }
+	@[ -n "$(NOTARY_PASSWORD)" ] || { echo "error: NOTARY_PASSWORD is required" >&2; exit 1; }
+	@[ -n "$(NOTARY_TEAM_ID)" ] || { echo "error: NOTARY_TEAM_ID is required" >&2; exit 1; }
+	$(RUN) bash -c "\
+		$(call require_host,Darwin,) \
+		set -eo pipefail; \
+		cd $(DIST_DIR) && for bin in $(DARWIN_RELEASE_BINARIES); do \
+			echo signing \$$bin; \
+			codesign --force --timestamp --options runtime --sign '$(CODESIGN_IDENTITY)' \$$bin; \
+			echo notarizing \$$bin; \
+			ditto -c -k \$$bin \$$bin.zip; \
+			xcrun notarytool submit \$$bin.zip --apple-id '$(NOTARY_APPLE_ID)' --password '$(NOTARY_PASSWORD)' --team-id '$(NOTARY_TEAM_ID)' --wait 2>&1 | tee \$$bin.notary.log; \
+			grep -q 'status: Accepted' \$$bin.notary.log || { echo error: notarization not accepted for \$$bin >&2; exit 1; }; \
+			rm -f \$$bin.zip \$$bin.notary.log; \
+		done"
+
 .PHONY: build-checksums
 build-checksums: ## Write sha256 checksums for the release artifacts (binaries + any packages) in dist
 	@# The *.deb/*.rpm globs overlap aura-* (nfpm's rpm and web-server package

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -479,6 +479,7 @@ pipeline {
                 SCCACHE_BUCKET = "${BUILD_CACHE_BUCKET}"
                 SCCACHE_REGION = "${BUILD_CACHE_REGION}"
                 SCCACHE_S3_KEY_PREFIX = 'aura/sccache/'
+                SIGNING_KEYCHAIN = "/tmp/aura-signing-release-${BUILD_SLUG}.keychain-db"
               }
 
               steps {
@@ -500,6 +501,40 @@ pipeline {
                       sh 'make build-binaries-darwin'
                     }
                   }
+
+                  withCredentials([
+                    certificate(
+                      credentialsId: 'apple-signing-certificate',
+                      keystoreVariable: 'APPLE_CERT_P12',
+                      passwordVariable: 'APPLE_CERT_PASSWORD'
+                    ),
+                    string(credentialsId: 'apple-notarytool-password', variable: 'NOTARY_PASSWORD')
+                  ]) {
+                    withEnv([
+                      'NOTARY_APPLE_ID=apps+dev@logdna.com',
+                      'NOTARY_TEAM_ID=TT7664HMU3'
+                    ]) {
+                      // Sign and notarize via a throwaway keychain; the stage post
+                      // step deletes it.
+                      sh '''
+                        set -eu
+                        KEYCHAIN_PW="aura-ci"
+                        security create-keychain -p "$KEYCHAIN_PW" "$SIGNING_KEYCHAIN"
+                        security set-keychain-settings "$SIGNING_KEYCHAIN"
+                        security unlock-keychain -p "$KEYCHAIN_PW" "$SIGNING_KEYCHAIN"
+                        security list-keychains -d user -s "$SIGNING_KEYCHAIN" $(security list-keychains -d user | sed 's/"//g')
+                        security import "$APPLE_CERT_P12" -f pkcs12 -k "$SIGNING_KEYCHAIN" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign
+                        security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PW" "$SIGNING_KEYCHAIN" >/dev/null
+                        CODESIGN_IDENTITY=$(security find-identity -v -p codesigning "$SIGNING_KEYCHAIN" | awk '/Developer ID Application/ {print $2; exit}')
+                        if [ -z "$CODESIGN_IDENTITY" ]; then
+                          echo "no valid Developer ID Application identity in keychain" >&2
+                          security find-identity -p codesigning "$SIGNING_KEYCHAIN" >&2
+                          exit 1
+                        fi
+                        make sign-release-binaries-darwin CODESIGN_IDENTITY="$CODESIGN_IDENTITY"
+                      '''
+                    }
+                  }
                 }
 
                 stash(
@@ -511,6 +546,7 @@ pipeline {
 
               post {
                 always {
+                  sh 'security delete-keychain "$SIGNING_KEYCHAIN" 2>/dev/null || true'
                   sh 'make clean'
                 }
               }


### PR DESCRIPTION
To ensure macos binaries will pass Gatekeeping regardless of how they are retrieved, sign and notarize macos binaries.

Closes: #323