### PR TITLE
fix(cli): show welcome banner when no .welcome file on disk

### DIFF
--- a/crates/aura-cli/src/ui/welcome.rs
+++ b/crates/aura-cli/src/ui/welcome.rs
@@ -51,7 +51,7 @@ impl WelcomeState {
     /// bright, high-contrast complement of the art's dominant hue.  Otherwise
     /// a random palette color is used.
     pub fn pick() -> Option<Self> {
-        let content = pick_welcome_file()?;
+        let content = resolve_welcome_content()?;
         let (text_color, art_color) = if content.contains('\x1b') {
             let complement = complementary_text_color(&content);
             let (_, fallback) = random_color_pair();
@@ -605,21 +605,21 @@ fn interpolate_tokens(content: String, status: &str) -> String {
 }
 
 /// Load the `.welcome` file from the current directory (preferred) or
-/// `~/.aura/` (fallback), and interpolate env vars.
-fn pick_welcome_file() -> Option<String> {
+/// `~/.aura/` (fallback), and interpolate env vars. For read-only filesystems,
+/// fall back to the color built-in welcome message.
+fn resolve_welcome_content() -> Option<String> {
     let aura_dir = aura_home_dir();
     seed_home_welcome(&aura_dir);
 
-    let cwd_welcome = Path::new(".welcome");
-    let home_welcome = aura_dir.join(".welcome");
+    let cwd_content = fs::read_to_string(Path::new(".welcome")).ok();
+    let home_content = fs::read_to_string(aura_dir.join(".welcome")).ok();
+    let non_empty = |c: String| Some(c).filter(|c| !c.trim().is_empty());
 
-    let content = if cwd_welcome.exists() {
-        fs::read_to_string(cwd_welcome).ok()
-    } else {
-        fs::read_to_string(&home_welcome).ok()
-    };
+    let content = cwd_content
+        .and_then(non_empty)
+        .or_else(|| home_content.and_then(non_empty))
+        .unwrap_or_else(|| BUILTIN_WELCOME_FILES[0].1.to_string());
 
-    let content = content.filter(|c| !c.trim().is_empty())?;
     Some(interpolate_tokens(content, &super::state::startup_status()))
 }
 


### PR DESCRIPTION
The welcome banner content is embedded in the CLI binary, but it was only ever read back from disk after seeding `~/.aura/.welcome`. In the Docker release image the runtime user (`appuser`) has no writable home directory, so seeding fails silently and, with no `.welcome` in the working dir either, the banner was skipped entirely. This change falls back to the embedded content when neither the cwd nor the seeded home file is readable, so the banner renders in the container and on any read-only filesystem. The resolution logic is extracted into `resolve_welcome_content` with unit tests covering the source precedence.

Fixes #294