### PR TITLE
doc: split readme into development and contributing docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,8 @@ aura/
 - **Diagnostic logs**: opt-in via `--log-file <path>` / `AURA_LOG_FILE` / `cli.toml` `log_file` (precedence: CLI > env > project > global > none). Events are appended to the file (no rotation — user-managed) in **both REPL and one-shot mode**, so stdout stays a clean pipe. Default filter is `warn,aura=info,aura_cli=info,aura_config=info,rig::agent::prompt_request=info`; override with `RUST_LOG`.
 - **OpenTelemetry (standalone only)**: when running in standalone mode, the CLI installs an OTel layer when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Trace shape mirrors the web server — `agent.stream` root span via `direct.rs`, with `agent.turn` / `mcp.tool_call` / `orchestration.*` nesting under it. CLI omits the HTTP-infrastructure spans (`chat_completions`, `streaming_completion`) since it has no HTTP layer.
 - **Single shared tokio runtime**: `main` owns one `tokio::runtime::Runtime` and threads it into `Backend::from_config`, `run_oneshot`, and `run_repl`. `logging::init` runs inside `rt.enter()` so the OTLP gRPC exporter can call `Handle::current()` during `with_tonic()` construction; the `BatchSpanProcessor` worker lives on the same runtime that handles every subsequent request. `main` calls `aura::logging::shutdown_tracer()` via `rt.block_on(...)` before returning to flush buffered spans.
-- SSE event parsing uses shared types from `aura-events` crate (not in `default-members`, build explicitly with `cargo build -p aura-cli`)
+- SSE event parsing uses shared types from the `aura-events` crate
+- `aura-cli` is not in the workspace `default-members`, so a plain `cargo build` skips it; build it explicitly with `cargo build -p aura-cli`
 - See `crates/aura-cli/README.md` for full documentation
 
 ### Shared Event Types (`aura-events`)
@@ -173,17 +174,17 @@ The `tool_event_broker` uses a FIFO queue for correlating `tool_call_id` between
 - Look for `.await` between `on_tool_call` and `on_tool_result` (ensures sequential)
 - Check for `FuturesUnordered` or parallel execution patterns (would break FIFO)
 
-Confirmed sequential as of Rig 0.28: the streaming handler `.await`s each tool call inline. See `docs/rig-tool-execution-order.md`.
+Confirmed sequential as of Rig 0.28: the streaming handler `.await`s each tool call inline. See `docs/rig-fork-changes.md`.
 
 ## CI/CD
 
 **Status**: Jenkins/Makefile complete, Helm charts and K8s manifests in `deployment/`
 
 ```bash
-make build          # Build release binary
-make test           # Run all tests
-make docker-build   # Build Docker image
-make lint           # Run clippy + fmt check
+make build                  # Build release binary
+cargo test --workspace      # Run all tests (the `make test` hook is empty)
+make docker-build           # Build Docker image
+make lint                   # Run clippy + fmt check
 ```
 
 ## Code Comment Conventions
@@ -239,15 +240,22 @@ make lint           # Run clippy + fmt check
   Types: `feat`, `fix`, `doc`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`
   Breaking changes: add `!` after type/scope and include a `BREAKING CHANGE:` footer.
   If fixing an issue, include `Fixes: #<issue number>` in the footer.
+  If the change relates to a tracked ticket, include `Ref: LOG-XXXXXX` in the footer; otherwise omit it (commitlint does not require it).
 
 ## Documentation
 
-- `README.md` - User-facing documentation
-- `crates/aura-cli/README.md` - CLI usage, backends, features, and build instructions
-- `CHANGELOG.md` - Auto-generated version history
+Which docs go where: put new documentation in the file that owns the topic.
+
+- `README.md` - User-facing only: what AURA is, quick start, usage (web server, A2A, client-side tools), and configuration reference. No table of contents (GitHub generates one). No build-from-source, testing, architecture, or contributor content; link to `DEVELOPMENT.md` / `CONTRIBUTING.md` instead.
+- `DEVELOPMENT.md` - Developer-facing: prerequisites, building from source, project structure, Make targets, testing (unit + integration suites and feature flags), and the architecture overview.
+- `CONTRIBUTING.md` - Contribution process only: CLA, workflow, code quality standards, commit conventions, PR and review process. Build/test details belong in `DEVELOPMENT.md`; link, don't duplicate.
+- `docs/` - Deep-dive guides for a single subsystem or protocol (streaming, request lifecycle, HITL, A2A, Ollama, telemetry, tracing, breaking changes). ADRs in `docs/adr/`, design docs in `docs/design/`.
+- `crates/*/README.md` - Crate-specific usage and build instructions (e.g. `crates/aura-cli/README.md`)
+- `CHANGELOG.md` - Auto-generated version history; never edit by hand
+
+Key deep-dive guides:
+
 - `docs/streaming-api-guide.md` - SSE streaming, custom events, and orchestration events
 - `docs/ollama-guide.md` - Ollama configuration, fallback tool parsing, and local model guidance
 - `docs/request-lifecycle.md` - Request flow, lifecycle, timeout, cancellation, and shutdown
-- `docs/rig-tool-execution-order.md` - Tool execution order analysis
-- `docs/rig-fork-changes.md` - Rig fork changes and rationale
-- `docs/orchestration-tickets.md` - Epic ticket table, dependency graph, research references, implementation plan
+- `docs/rig-fork-changes.md` - Rig fork changes, tool execution order, and rationale

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,174 +1,37 @@
 # Contributing to AURA
 
-Thank you for your interest in contributing to AURA! This guide will help you get started, whether you're fixing a bug, adding a feature, improving documentation, or proposing an idea.
+Thank you for contributing! Bug reports, features, documentation, example configurations, tests, reviews, and issue triage are all welcome.
 
-Contributions of all kinds are welcome and appreciated.
+Setup, build, test, and architecture documentation lives in [DEVELOPMENT.md](DEVELOPMENT.md). This guide covers the contribution process itself.
 
-## Table of Contents
+## The Short Version
 
-- [Contributing to AURA](#contributing-to-aura)
-  - [Table of Contents](#table-of-contents)
-  - [Code of Conduct](#code-of-conduct)
-  - [Contributor License Agreement](#contributor-license-agreement)
-  - [Getting Help](#getting-help)
-  - [Ways to Contribute](#ways-to-contribute)
-  - [Development Setup](#development-setup)
-    - [Prerequisites](#prerequisites)
-    - [Getting Started](#getting-started)
-  - [Project Structure](#project-structure)
-  - [Development Workflow](#development-workflow)
-    - [Branch Strategy](#branch-strategy)
-    - [Typical Workflow](#typical-workflow)
-    - [Useful Make Targets](#useful-make-targets)
-  - [Code Quality Standards](#code-quality-standards)
-    - [Formatting](#formatting)
-    - [Linting](#linting)
-    - [General Guidelines](#general-guidelines)
-  - [Testing](#testing)
-    - [Unit Tests (Required)](#unit-tests-required)
-    - [Integration Tests (Encouraged)](#integration-tests-encouraged)
-    - [Writing Tests](#writing-tests)
-  - [Commit Message Convention](#commit-message-convention)
-    - [Format](#format)
-    - [Types](#types)
-    - [Examples](#examples)
-    - [Breaking Changes](#breaking-changes)
-    - [Important Notes](#important-notes)
-  - [Submitting a Pull Request](#submitting-a-pull-request)
-    - [Before You Submit](#before-you-submit)
-    - [After You Submit](#after-you-submit)
-    - [PR Guidelines](#pr-guidelines)
-    - [PR Template](#pr-template)
-  - [Review Process](#review-process)
-  - [Documentation](#documentation)
-  - [Reporting Issues](#reporting-issues)
-  - [License](#license)
+1. Fork the repo (external contributors) or branch from `main` (maintainers).
+2. Make a focused change: one logical change per PR, with tests.
+3. Run `make fmt-check`, `cargo test --workspace`, and `make lint` before pushing.
+4. Write [Conventional Commits](#commit-messages); verify with `make lint-commits`.
+5. Open a PR explaining what and why. A maintainer reviews, then rebase-merges.
 
-## Code of Conduct
-
-This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report any concerns to the maintainers.
-
-## Contributor License Agreement
-
-All contributors — both individual and corporate — must agree to the [Mezmo Contributor License Agreement (CLA)](CLA.md) before their contributions can be accepted. The CLA ensures that you grant the necessary rights for your contributions to be included in the project while you retain ownership of your work.
-
-By submitting a pull request, commit, or other contribution to this repository after being presented with the CLA, you accept and agree to its terms. If you are contributing on behalf of your employer, please ensure you have authorization to accept the agreement on their behalf.
-
-Organizations with ten (10) or more contributors may contact [cla@mezmo.com](mailto:cla@mezmo.com) to execute a separate Corporate Contributor License Agreement covering all authorized contributors within the organization.
-
-For any questions about the CLA or licensing, please reach out to [cla@mezmo.com](mailto:cla@mezmo.com).
+Contributions require agreement to the [CLA](#contributor-license-agreement), and this project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Getting Help
 
-- **GitHub Discussions** — Ask questions, share ideas, or discuss approaches before opening a PR: [Discussions](https://github.com/mezmo/aura/discussions)
-- **GitHub Issues** — Report bugs or request features: [Issues](https://github.com/mezmo/aura/issues)
+- **[Community Slack](https://mezmo.com/r/slack-aura)**: ask questions, share ideas, or discuss approaches before opening a PR.
+- **[GitHub Issues](https://github.com/mezmo/aura/issues)**: report bugs or request features.
 
-## Ways to Contribute
+## Contributor License Agreement
 
-There are many ways to contribute beyond writing code:
+All contributors, both individual and corporate, must agree to the [Mezmo Contributor License Agreement (CLA)](CLA.md) before their contributions can be accepted. The CLA ensures that you grant the necessary rights for your contributions to be included in the project while you retain ownership of your work.
 
-- **Report bugs** — Found something broken? [Open an issue](#reporting-issues).
-- **Suggest features** — Have an idea? Start a [Discussion](https://github.com/mezmo/aura/discussions) or open an issue.
-- **Improve documentation** — Typo fixes, clarifications, new guides, and examples are always welcome.
-- **Add example configurations** — Share useful agent configurations in `examples/`.
-- **Write tests** — Help increase test coverage with unit or integration tests.
-- **Review pull requests** — Thoughtful reviews help maintain quality and are a great way to learn the codebase.
-- **Triage issues** — Help reproduce bugs, clarify reports, or identify duplicates.
+By submitting a pull request, commit, or other contribution to this repository after being presented with the CLA, you accept and agree to its terms. If you are contributing on behalf of your employer, please ensure you have authorization to accept the agreement on their behalf.
 
-## Development Setup
-
-### Prerequisites
-
-- **Rust (nightly)** — AURA requires the nightly toolchain. The repo includes a `rust-toolchain.toml` that handles this automatically.
-- **Docker and Docker Compose** — Required for integration tests and containerized builds.
-- **Git** — For version control and contributing via pull requests.
-- **Node.js (22+)** -- *Optional* Used in various CI processes (commit linting, release generation, etc)
-
-### Getting Started
-
-1. **Fork the repository** on GitHub (external contributors) or clone directly (maintainers).
-
-2. **Clone your fork:**
-
-   ```bash
-   git clone https://github.com/<your-username>/aura.git
-   cd aura
-   ```
-
-3. **Install Rust** (if you don't have it):
-
-   ```bash
-   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-   ```
-
-   The nightly toolchain will be installed automatically when you first build, thanks to `rust-toolchain.toml`.
-
-4. **Set up your configuration:**
-
-   ```bash
-   cp examples/reference.toml config.toml
-   cp .env.example .env
-   ```
-
-   Edit `.env` with your API keys. At minimum, you'll need an `OPENAI_API_KEY` if you plan to run the server or integration tests.
-
-5. **Build the project:**
-
-   ```bash
-   cargo build --workspace
-   ```
-
-6. **Verify everything works:**
-
-   ```bash
-   cargo test --workspace
-   ```
-
-   This runs unit tests across the workspace.
-
-## Project Structure
-
-Understanding the crate layout will help you navigate the codebase:
-
-```text
-aura/
-├── crates/
-│   ├── aura/                # Core agent builder library and orchestration
-│   ├── aura-cli/            # Interactive terminal client (HTTP + standalone modes)
-│   ├── aura-config/         # TOML parser and config loader
-│   ├── aura-events/         # Shared SSE event types (lightweight, no agent deps)
-│   ├── aura-web-server/     # OpenAI-compatible HTTP/SSE server
-│   └── aura-test-utils/     # Shared testing utilities
-├── compose/                 # Docker Compose files for testing
-├── configs/                 # Integration test and example configurations
-├── deployment/              # Helm charts and K8s manifests
-├── docs/                    # Architecture and protocol documentation
-├── examples/                # Example TOML configurations
-│   ├── reference.toml       # Complete annotated configuration
-│   ├── minimal/             # Bare minimum per-provider configs
-│   └── complete/            # Full agent composition examples
-└── scripts/                 # CI and utility scripts
-```
-
-**Key architectural docs** to read before diving into the code:
-
-- [docs/streaming-api-guide.md](docs/streaming-api-guide.md) — SSE protocol, event types, and client handling
-- [docs/request-lifecycle.md](docs/request-lifecycle.md) — Request flow, timeouts, and cancellation
-- [docs/rig-fork-changes.md](docs/rig-fork-changes.md) — Why we use a Rig.rs fork and what changed
-- [docs/rig-tool-execution-order.md](docs/rig-tool-execution-order.md) — Tool execution ordering (important for `tool_event_broker.rs`)
+Organizations with ten (10) or more contributors may contact [cla@mezmo.com](mailto:cla@mezmo.com) to execute a separate Corporate Contributor License Agreement covering all authorized contributors within the organization. For any questions about the CLA or licensing, reach out to [cla@mezmo.com](mailto:cla@mezmo.com).
 
 ## Development Workflow
 
-### Branch Strategy
+Environment setup, build instructions, project structure, and Make targets are documented in [DEVELOPMENT.md](DEVELOPMENT.md).
 
-- **External contributors**: Fork the repo and create a feature branch in your fork.
-- **Maintainers**: Create branches directly in the repository.
-
-All changes are merged to `main` via **rebase merging** to maintain a linear commit history.
-
-### Typical Workflow
-
-1. **Create a branch** from the latest `main`:
+1. Create a branch from the latest `main`:
 
    ```bash
    git checkout main
@@ -176,134 +39,39 @@ All changes are merged to `main` via **rebase merging** to maintain a linear com
    git checkout -b feat/your-feature-name
    ```
 
-2. **Make your changes**, keeping commits focused and atomic.
+2. Make your changes, keeping commits focused and atomic.
 
-3. **Run quality checks** before pushing:
+3. Run quality checks before pushing:
 
    ```bash
    make fmt-check
    cargo test --workspace
+   make lint
    ```
 
-4. **Push your branch** and open a pull request.
+   (`make ci` bundles the fmt-check and lint hooks, but its `test` hook is currently empty, so always run `cargo test --workspace` yourself.)
 
-### Useful Make Targets
+4. Push your branch and open a pull request.
 
-| Command              | Description                           |
-| -------------------- | ------------------------------------- |
-| `make build`         | Build all workspace crates            |
-| `make fmt`           | Format code with rustfmt              |
-| `make fmt-check`     | Check formatting (CI mode)            |
-| `make lint`          | Run clippy with warnings as errors    |
-| `make test`          | Run cargo tests + integration tests   |
-| `make ci`            | Run all checks: fmt-check, test, lint |
-| `make clean`         | Clean build artifacts                 |
+All changes are merged to `main` via **rebase merging** to maintain a linear commit history, so every commit must follow the [commit message convention](#commit-messages).
 
-## Code Quality Standards
+## Code Quality
 
-### Formatting
-
-All code must be formatted with `rustfmt`:
-
-```bash
-cargo fmt --all
-```
-
-CI will reject unformatted code. Run `make fmt` before committing.
-
-### Linting
-
-All code must pass `clippy` with warnings treated as errors:
-
-```bash
-cargo clippy --all-targets --all-features -- -D warnings
-```
-
-### General Guidelines
-
+- Format with rustfmt (`make fmt`); CI rejects unformatted code.
+- Pass clippy with warnings as errors (`make lint`).
 - Follow existing patterns and conventions in the codebase.
-- Keep changes focused — one logical change per PR.
-- Avoid unnecessary refactoring alongside feature work. If refactoring is needed, submit it as a separate PR.
-- Write clear, descriptive variable and function names. Prefer readability over cleverness.
-- Add comments where the "why" isn't obvious from the code. Don't comment on the "what" — the code should speak for itself.
-- Ensure your changes don't introduce compiler warnings.
+- Avoid refactoring alongside feature work; submit refactors as separate PRs.
+- Prefer clear, descriptive names over cleverness. Comment the "why", not the "what".
+- Don't introduce compiler warnings.
 
 ## Testing
 
-### Unit Tests (Required)
+- **Unit tests are required.** `cargo test --workspace` must pass before you submit; it needs no external services or API keys. Prefer unit tests for internal or algorithmic changes.
+- **Integration tests are encouraged** for user-facing changes. They call real LLM APIs and need an `OPENAI_API_KEY` plus Docker; see [DEVELOPMENT.md](DEVELOPMENT.md#testing) for suites, feature flags, and commands.
 
-All contributors must run tests before submitting a PR:
+## Commit Messages
 
-```bash
-cargo test --workspace
-```
-
-Unit tests don't require any external services or API keys.
-
-### Integration Tests (Encouraged)
-
-Integration tests verify end-to-end behavior through the web server, including LLM interaction and MCP tool execution. They **require a real `OPENAI_API_KEY`** because they make actual API calls to OpenAI. MCP tool execution is handled by mock servers — no external tool APIs are called.
-
-If you have an API key and want to run integration tests locally:
-
-```bash
-# Start local test infrastructure (mock MCP servers + AURA)
-make test-integration-local-up
-
-# Run the integration test suite
-cargo test --package aura-web-server --features integration --no-fail-fast -- --test-threads=1
-
-# Tear down when done
-make test-integration-local-down
-
-# Or do it all in one command:
-make test-integration-local
-
-# Orchestration integration tests
-make test-integration-orchestration-local
-
-# SRE orchestration integration tests
-make test-integration-sre-orchestration-local
-
-# Scratchpad integration tests
-make test-integration-scratchpad-local
-```
-
-Integration tests run single-threaded (`--test-threads=1`) due to LLM API rate limits.
-
-**Feature flags** allow running specific test suites:
-
-| Flag                            | Suite                                         |
-| ------------------------------- | --------------------------------------------- |
-| `integration`                   | All integration tests                         |
-| `integration-streaming`         | Streaming functionality                       |
-| `integration-header-forwarding` | MCP header forwarding                         |
-| `integration-mcp`               | MCP tool execution                            |
-| `integration-events`            | Custom `aura.*` events                        |
-| `integration-cancellation`      | Request cancellation                          |
-| `integration-progress`          | MCP progress notifications                    |
-| `integration-vector`            | Vector store / RAG (requires external Qdrant) |
-
-Example — run only streaming tests:
-
-```bash
-cargo test --package aura-web-server --features integration-streaming --no-fail-fast -- --test-threads=1
-```
-
-### Writing Tests
-
-- **Unit tests**: Place `#[cfg(test)]` modules in the same file as the code they test.
-- **Integration tests**: Add to `crates/aura-web-server/tests/`. Use the `aura-test-utils` crate for shared test helpers.
-- If your change is user-facing, consider adding or updating integration tests.
-- If your change is internal/algorithmic, unit tests are preferred.
-
-## Commit Message Convention
-
-This project uses [Conventional Commits](https://www.conventionalcommits.org/) and enforces them via CI. **Every commit** on `main` must follow this format because we use rebase merging to maintain a linear history. 
-### Format
-
-The first line, which includes the type and description, must be entirely lowercase. The body
-and optional footer can use lower and upper casing.
+This project uses [Conventional Commits](https://www.conventionalcommits.org/), enforced by CI (`make lint-commits`):
 
 ```
 <type>(<optional scope>): <description>
@@ -313,7 +81,9 @@ and optional footer can use lower and upper casing.
 [optional footer(s)]
 ```
 
-### Types
+- The subject line must be entirely lowercase, under 72 characters, and not end with a period.
+- Use the body to explain **what** and **why**, not **how**.
+- If the change relates to a tracked ticket, include a `Ref: LOG-XXXXXX` footer; otherwise omit it (commitlint does not require it). Use `Fixes: #<issue number>` when the change closes a GitHub issue.
 
 | Type       | When to Use                                             |
 | ---------- | ------------------------------------------------------- |
@@ -327,7 +97,7 @@ and optional footer can use lower and upper casing.
 | `chore`    | Build process, tooling, or dependency updates           |
 | `ci`       | CI/CD configuration changes                             |
 
-### Examples
+Examples:
 
 ```
 feat(config): add support for gemini provider
@@ -335,13 +105,7 @@ feat(config): add support for gemini provider
 fix(streaming): correct sse event ordering on disconnect
 
 doc: add ollama troubleshooting guide
-
-test(mcp): add header forwarding integration tests
-
-refactor(provider-agent): simplify type-erased streaming dispatch
 ```
-
-### Breaking Changes
 
 For breaking changes, add `!` after the type/scope and include a `BREAKING CHANGE` footer:
 
@@ -352,59 +116,22 @@ BREAKING CHANGE: The [tools] config section has been renamed to [mcp.tools].
 Update your config.toml files accordingly.
 ```
 
-### Important Notes
+## Pull Requests
 
-- The commit message subject should be lowercase and not end with a period.
-- Keep the subject line under 72 characters.
-- Use the body to explain **what** and **why**, not **how**.
-- CI will reject commits that don't follow this convention.
+Before you submit:
 
-## Submitting a Pull Request
+1. Rebase on the latest `main` (`git fetch origin && git rebase origin/main`).
+2. Run the quality checks above, plus `make lint-commits`.
+3. Update documentation if your change affects user-facing behavior, configuration, or APIs (see [Updating Documentation](#updating-documentation)).
 
-### Before You Submit
+Guidelines:
 
-1. **Rebase on latest `main`** to ensure a clean history:
+- **Title**: clear and descriptive.
+- **Description**: explain what the PR does and why: context, approach, trade-offs considered, and testing performed.
+- **Size**: keep PRs focused and reasonably sized; break large changes into a series of smaller, reviewable PRs.
+- **Draft PRs**: open one if you want early feedback on work in progress.
 
-   ```bash
-   git fetch origin
-   git rebase origin/main
-   ```
-
-2. **Run tests locally:**
-
-   ```bash
-   cargo test --workspace
-   ```
-
-3. **Ensure all commits follow** the [Conventional Commits](#commit-message-convention) format.
-
-```bash
-> make lint-commits
-```
-
-4. **Update documentation** if your change affects user-facing behavior, configuration, or APIs.
-
-### After You Submit
-
-- Check the comments in the PR for:
-  - The status of automated checks
-  - Automated request to sign contributors agreement
-  - Feedback from other contributors
-
-### PR Guidelines
-
-- **Title**: Use a clear, descriptive title that summarizes the change.
-- **Description**: Explain what the PR does and why. Include:
-  - Context and motivation for the change
-  - Summary of the approach taken
-  - Any trade-offs or alternatives considered
-  - Testing performed (unit, integration, manual)
-- **Size**: Keep PRs focused and reasonably sized. Large changes should be broken into a series of smaller, reviewable PRs.
-- **Draft PRs**: If you want early feedback on a work-in-progress, open a draft PR.
-
-### PR Template
-
-When opening a PR, consider including:
+A suggested PR template:
 
 ```markdown
 ## What
@@ -422,46 +149,36 @@ Summary of the approach and any notable implementation details.
 ## Testing
 
 How this was tested (unit tests, integration tests, manual testing).
-
-## Checklist
-
-- [ ] Code follows existing patterns and conventions
-- [ ] `cargo test --workspace` passes locally
-- [ ] Commits follow Conventional Commits format
-- [ ] Documentation updated (if applicable)
-- [ ] Tests added or updated (if applicable)
 ```
+
+After you submit, watch the PR for automated check results, the CLA bot's request to sign the contributor agreement, and reviewer feedback.
 
 ## Review Process
 
 - All PRs require at least one maintainer review before merging.
-- Reviewers may request changes — this is normal and part of maintaining quality.
-- PRs are merged via **rebase merge** to maintain a linear commit history.
-- Be responsive to review feedback. If you disagree with a suggestion, explain your reasoning — constructive discussion improves outcomes.
-- After approval, a maintainer will merge your PR.
+- Reviewers may request changes; this is normal and part of maintaining quality. If you disagree with a suggestion, explain your reasoning.
+- After approval, a maintainer rebase-merges your PR.
 
-## Documentation
+## Updating Documentation
 
-Good documentation is as valuable as good code. If your change affects any of the following, please update the relevant docs:
+If your change affects any of the following, update the relevant docs (see the documentation map in [CLAUDE.md](CLAUDE.md)):
 
-- **Configuration options** — Update `examples/reference.toml` and the relevant `examples/` files.
-- **API behavior** — Update `docs/streaming-api-guide.md` or `docs/request-lifecycle.md`.
-- **New features** — Add usage examples to the README or create a new guide in `docs/`.
-- **Architecture changes** — Update the relevant doc in `docs/` and note any impacts in `CLAUDE.md`.
+- **Configuration options**: update `examples/reference.toml` and the relevant `examples/` files.
+- **API behavior**: update `docs/streaming-api-guide.md` or `docs/request-lifecycle.md`.
+- **New features**: add usage examples to the README or create a new guide in `docs/`.
+- **Build, testing, or architecture changes**: update `DEVELOPMENT.md` and the relevant doc in `docs/`, and note any impacts in `CLAUDE.md`.
 
 ## Reporting Issues
 
 When reporting a bug, please include:
 
-- **AURA version** (`cargo metadata --format-version=1 | jq -r '.packages[] | select(.name=="aura") | .version'` or check `Cargo.toml`)
-- **Rust toolchain version** (`rustc --version`)
+- **AURA version** (check `Cargo.toml`) and **Rust toolchain version** (`rustc --version`)
 - **Operating system and version**
-- **Steps to reproduce** the issue
-- **Expected behavior** vs. **actual behavior**
+- **Steps to reproduce**, plus **expected** vs. **actual** behavior
 - **Relevant logs** (set `RUST_LOG=debug` or `RUST_LOG=aura=trace` for verbose output)
-- **Configuration** (sanitized — remove API keys and secrets)
+- **Configuration** (sanitized: remove API keys and secrets)
 
-For feature requests, describe the use case and the problem you're trying to solve. Starting a [Discussion](https://github.com/mezmo/aura/discussions) first is a great way to refine ideas before opening a formal issue.
+For feature requests, describe the use case and the problem you're trying to solve. Raising the idea in the [community Slack](https://mezmo.com/r/slack-aura) first is a great way to refine it before opening a formal issue.
 
 ## License
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,204 @@
+# Developing AURA
+
+How to build, test, and navigate the AURA codebase. For the contribution process (CLA, commit conventions, pull requests), see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Prerequisites
+
+- **Rust (nightly)**: the repo's `rust-toolchain.toml` installs the right toolchain automatically on first build.
+- **Docker and Docker Compose**: required for integration tests and containerized builds.
+- **Node.js 22+** (optional): used by CI tooling such as commit linting and release generation.
+
+## Building from Source
+
+1. Install Rust if you don't have it:
+
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   ```
+
+2. Clone and configure:
+
+   ```bash
+   git clone https://github.com/mezmo/aura.git
+   cd aura
+   cp examples/reference.toml config.toml
+   cp .env.example .env
+   ```
+
+   Edit `.env` with your API keys. At minimum you'll need an `OPENAI_API_KEY` to run the server or integration tests. Keep secrets in environment variables and reference them in TOML using `{{ env.VAR_NAME }}`.
+
+3. Build and verify:
+
+   ```bash
+   cargo build --workspace
+   cargo test --workspace
+   ```
+
+4. Run the web server:
+
+   ```bash
+   cargo run --bin aura-web-server
+   ```
+
+Note: `aura-cli` is not in the workspace `default-members`, so a plain `cargo build` skips it. Build it explicitly with `cargo build -p aura-cli`.
+
+## Project Structure
+
+```text
+aura/
+├── crates/
+│   ├── aura/                # Core agent builder library and orchestration
+│   ├── aura-cli/            # Interactive terminal client (HTTP + standalone modes)
+│   ├── aura-config/         # TOML parser and config loader
+│   ├── aura-events/         # Shared SSE event types (lightweight, no agent deps)
+│   ├── aura-telemetry/      # Anonymous CLI telemetry (see docs/telemetry.md)
+│   ├── aura-telemetry-derive/ # Derive macros for aura-telemetry
+│   ├── aura-test-utils/     # Shared testing utilities
+│   └── aura-web-server/     # OpenAI-compatible HTTP/SSE server
+├── compose/                 # Docker Compose (integration + orchestration overlays)
+├── configs/                 # Integration test and example configurations
+├── deployment/              # Helm charts and K8s manifests
+├── docs/                    # Architecture and protocol documentation
+├── examples/                # Example TOML configurations
+│   ├── reference.toml       # Complete annotated configuration
+│   ├── minimal/             # Bare minimum per-provider configs
+│   └── complete/            # Full agent composition examples
+├── scripts/                 # CI and utility scripts
+└── tests/                   # Integration test fixtures and helpers
+```
+
+## Make Targets
+
+Make targets are composed from modular includes under `.makefiles/` (rust, docker, node, aura, commitlint). Run `make help` for the full list. The most useful:
+
+| Command                | Description                                    |
+| ---------------------- | ---------------------------------------------- |
+| `make build`           | Build all workspace crates                     |
+| `make fmt`             | Format code with rustfmt                       |
+| `make fmt-check`       | Check formatting (CI mode)                     |
+| `make lint`            | Run clippy with warnings as errors             |
+| `make ci`              | Run fmt-check and lint (the `test` hook is empty; run `cargo test --workspace` separately) |
+| `make coverage`        | Run the test suite with code coverage          |
+| `make lint-commits`    | Lint commits on the current branch against main |
+| `make clean`           | Clean build artifacts                          |
+| `make docker-build`    | Build the Docker image (full release)          |
+| `make docker-test`     | Run the Docker build's lint/test stage         |
+| `make start` / `make stop` | Start/stop the Docker Compose setup        |
+
+## Testing
+
+### Unit Tests
+
+```bash
+cargo test --workspace
+```
+
+Unit tests don't require any external services or API keys.
+
+Config validation is covered by `cargo test -p aura-config`, including `test_all_shipped_configs_parse`, which validates every `.toml` file in `configs/`, `examples/`, and `quickstart.toml`.
+
+### Integration Tests
+
+Web server integration tests live under `crates/aura-web-server/tests/`. They verify end-to-end behavior through the web server, including LLM interaction and MCP tool execution. They **require a real `OPENAI_API_KEY`** because they make actual API calls to OpenAI. MCP tool execution is handled by mock servers, so no external tool APIs are called.
+
+```bash
+# Start local test infrastructure (mock MCP servers + AURA)
+make test-integration-local-up
+
+# Run the integration test suite
+cargo test --package aura-web-server --features integration --no-fail-fast -- --test-threads=1
+
+# Tear down when done
+make test-integration-local-down
+
+# Or do it all in one command:
+make test-integration-local
+
+# Other suites, same pattern (each also has a Docker Compose variant
+# without the -local suffix, plus -local-up / -local-down helpers):
+make test-integration-orchestration-local
+make test-integration-sre-orchestration-local
+make test-integration-scratchpad-local
+
+# STDIO MCP tests (local only, no Compose/up/down variants; runs the
+# aura crate's integration-stdio feature)
+make test-integration-stdio-local
+```
+
+Integration tests run single-threaded (`--test-threads=1`) due to LLM API rate limits.
+
+**Feature flags** (`crates/aura-web-server/Cargo.toml`) select specific suites:
+
+| Flag                            | Suite                                                    |
+| ------------------------------- | -------------------------------------------------------- |
+| `integration`                   | All base integration tests (parent flag)                 |
+| `integration-a2a`               | A2A protocol endpoints                                   |
+| `integration-streaming`         | Streaming functionality                                  |
+| `integration-header-forwarding` | MCP header forwarding                                    |
+| `integration-mcp`               | MCP tool execution                                       |
+| `integration-events`            | Custom `aura.*` events                                   |
+| `integration-cancellation`      | Request cancellation                                     |
+| `integration-progress`          | MCP progress notifications                               |
+| `integration-orchestration`     | Orchestration (separate from parent `integration`)       |
+| `integration-orchestration-sre` | SRE orchestration (requires k8s-sre-mcp server config)   |
+| `integration-scratchpad`        | Scratchpad (separate from parent `integration`; requires scratchpad-test-mcp server config) |
+| `integration-vector`            | Vector store / RAG (requires external Qdrant)            |
+
+Example, run only the streaming tests:
+
+```bash
+cargo test --package aura-web-server --features integration-streaming --no-fail-fast -- --test-threads=1
+```
+
+Detailed test guidance: [crates/aura-web-server/README.md](crates/aura-web-server/README.md).
+
+### Writing Tests
+
+- **Unit tests**: place `#[cfg(test)]` modules in the same file as the code they test. Preferred for internal/algorithmic changes.
+- **Integration tests**: add to `crates/aura-web-server/tests/`, using the `aura-test-utils` crate for shared helpers. Consider adding or updating one when your change is user-facing.
+
+## Architecture
+
+AURA separates concerns across crates:
+
+- `aura`: runtime agent building, MCP integration, orchestration, and vector workflows.
+- `aura-config`: typed TOML parsing and validation.
+- `aura-events`: shared SSE event types (`AuraStreamEvent`, `OrchestrationStreamEvent`) — lightweight, no agent dependencies.
+- `aura-web-server`: OpenAI-compatible REST/SSE serving layer.
+- `aura-cli`: interactive terminal client with HTTP and standalone modes.
+
+This separation means:
+
+- Embeddable core: use `aura` directly in any Rust application without config file dependencies.
+- Shared event types: `aura-events` can be consumed by any Rust client without pulling in the full agent stack.
+- Testable boundaries: each crate has focused responsibilities and clear interfaces.
+
+Key architectural characteristics:
+
+- Dynamic MCP tool discovery at runtime.
+- Automatic schema sanitization (anyOf, missing types, optional parameters) driven by OpenAI function-calling requirements — MCP tool schemas are transformed at discovery time to conform to OpenAI's strict subset of JSON Schema.
+- Header forwarding support (`headers_from_request`) for per-request MCP auth delegation. See [examples/reference.toml](examples/reference.toml) for a practical example.
+- Config-driven composition with embeddable Rust core.
+
+Prompt routing and execution model:
+
+- `build_streaming_agent()` routes requests based on `orchestration.enabled`.
+- Direct Mode (`orchestration.enabled = false`): single `Agent` handles the turn.
+- Orchestration Mode (`orchestration.enabled = true`): `Orchestrator` coordinates worker execution.
+- Both `Agent` and `Orchestrator` implement `StreamingAgent`, so they are interchangeable at the API boundary.
+
+Orchestrator components and loop:
+
+- Coordinator agent: plans task DAGs and consolidates worker outputs via continuation.
+- Worker agents: per-task instances with filtered MCP tools and vector stores.
+- Persistence/event layers: track plan state, task outcomes, and stream orchestration events.
+- Loop: Plan -> Execute (dependency waves) -> Continue (respond / plan again / clarify).
+
+### Further Reading
+
+Worth reading before diving into the code:
+
+- [docs/streaming-api-guide.md](docs/streaming-api-guide.md): SSE protocol, event types, and client handling.
+- [docs/request-lifecycle.md](docs/request-lifecycle.md): request flow, timeouts, cancellation, and shutdown.
+- [docs/rig-fork-changes.md](docs/rig-fork-changes.md): why AURA uses a Rig.rs fork, what changed, and tool execution ordering (important for `tool_event_broker.rs`).
+- [docs/tracing-spans.md](docs/tracing-spans.md): OpenTelemetry span layout and trace parenting.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,25 @@
 # AURA
 
-[![Slack](https://img.shields.io/badge/Slack-Join%20the%20community-4A154B?logo=slack&logoColor=white)](https://mezmo.com/r/slack-aura)
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue)](LICENSE)
-[![Rust](https://img.shields.io/badge/Rust-1.85%2B-orange?logo=rust)](https://www.rust-lang.org)
-[![MCP](https://img.shields.io/badge/MCP-compatible-green)](https://modelcontextprotocol.io)
+[![Join the AURA community on Slack](https://img.shields.io/badge/Slack-Join%20the%20community-4A154B?logo=slack&logoColor=white "Join the AURA community on Slack")](https://mezmo.com/r/slack-aura)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue "Apache License, Version 2.0")](LICENSE)
+[![Rust 1.85+](https://img.shields.io/badge/Rust-1.85%2B-orange?logo=rust "Built with Rust 1.85 or later")](https://www.rust-lang.org)
+[![MCP compatible](https://img.shields.io/badge/MCP-compatible-green "Model Context Protocol compatible")](https://modelcontextprotocol.io)
 
-AURA is an agentic harness that turns an LLM model into a reliable, autonomous service capable of executing real SRE work. AURA provides the guardrails, API servers, state management, authentication, streaming, error handling, and tool integrations necessary to run AI SRE agents safely in production.
+AURA is an agentic harness that turns LLM models into a reliable, autonomous service capable of executing real SRE work. AURA provides the guardrails, API servers, state management, authentication, streaming, error handling, and tool integrations necessary to run AI SRE agents safely in production.
 
-Key capabilities:
+With AURA you can:
 
-- Declarative agent composition via TOML with multi-provider LLM support and multi-agent serving
-- Dynamic [MCP](https://modelcontextprotocol.io) tool discovery via HTTP streamable, SSE, and STDIO transports
-- Automatic schema sanitization for OpenAI function-calling compatibility
-- Vector search integration with Qdrant and AWS Bedrock Knowledge Base
-- Embeddable Rust core independent from configuration layer
-- Multi-agent orchestration with coordinator/worker architecture and DAG-based parallel execution
-- Dependency-aware multi-wave execution with plan/execute loops
-- [A2A protocol](https://github.com/a2a-protocol) support for agent-to-agent interoperability
-
-## Table of Contents
-
-- [Quick Start](#quick-start)
-- [Project Structure](#project-structure)
-- [Development Setup](#development-setup)
-- [Usage](#usage)
-  - [Web API Server](#web-api-server)
-  - [Client-Side Tools](#client-side-tools)
-- [Configuration](#configuration)
-  - [Multiple Agents](#multiple-agents)
-  - [Configuration Sections](#configuration-sections)
-  - [Orchestration](#orchestration)
-  - [Human-in-the-loop approval gates](#human-in-the-loop-approval-gates)
-  - [Scratchpad (Context Window Management)](#scratchpad-context-window-management)
-  - [Skills (On-Demand Instructions)](#skills-on-demand-instructions)
-  - [Ollama](#ollama)
-  - [Observability](#observability)
-- [Development and Testing](#development-and-testing)
-- [Testing](#testing)
-- [Documentation](#documentation)
-- [Architecture](#architecture)
+- Run entirely on your own infrastructure, including air-gapped and highly-regulated environments
+- Define orchestrated clusters of production agents in one simple, human-readable TOML file: models, per-agent prompts, tools, and guardrails
+- Run on the LLM backends you already use (OpenAI, Anthropic, Bedrock, Gemini, Ollama, OpenRouter), switch providers with a one-section edit, or mix models per worker
+- Give agents real tools: point a config at any MCP server (HTTP streamable, SSE, or STDIO) and its tools are discovered and callable at runtime
+- Require human approval (webhook or in-conversation) before sensitive tool calls execute
+- Survive huge tool outputs without context floods: oversized results are parked on disk and the agent pulls in only the slices it needs
+- Fan complex requests out to user-defined specialist workers: a coordinator plans a task DAG, runs independent tasks in parallel, and consolidates the results
+- Ground answers in your own data with vector search (Qdrant, AWS Bedrock Knowledge Base) and teach agents task-specific procedures with on-demand skills
+- Chat from the terminal with or without a server: the CLI runs agents in-process from a config, or connects to any OpenAI-compatible API
+- Interoperate with other agents over the A2A protocol, or embed the Rust core directly in your own application
+- Serve every agent as an OpenAI-compatible API, so existing clients and SDKs (LibreChat, OpenWebUI, …) work unchanged
 
 ## Quick Start
 
@@ -60,55 +41,11 @@ Prefer a browser? Open <http://localhost:3080> to chat in LibreChat, or <http://
 - **[Kubernetes SRE](examples/quickstart-k8s-sre/README.md)** — AI-powered SRE agent on KIND with Kubernetes and Prometheus MCP servers
 - **[Example Configs](examples/README.md)** — Minimal per-provider configs and complete agent compositions
 
-## Project Structure
-
-```text
-aura/
-├── crates/
-│   ├── aura/                # Core library (agent builder + orchestration)
-│   ├── aura-cli/            # Interactive terminal client (HTTP + standalone modes)
-│   ├── aura-config/         # TOML parser and config loader
-│   ├── aura-events/         # Shared SSE event types
-│   ├── aura-test-utils/     # Shared testing utilities
-│   └── aura-web-server/     # OpenAI-compatible HTTP/SSE server
-├── compose/                 # Docker Compose (integration + orchestration overlays)
-├── configs/                 # E2E test and orchestration configurations
-├── deployment/              # Helm charts and K8s manifests
-├── docs/                    # Architecture and protocol documentation
-├── examples/                # Example and reference configurations
-├── scripts/                 # CI and utility scripts
-└── tests/                   # Integration test fixtures and helpers
-```
-
-## Development Setup
-
-For building AURA from source without Docker.
-
-1. Install Rust if needed:
-   ```bash
-   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-   ```
-2. Clone and configure:
-   ```bash
-   cd aura
-   cp examples/reference.toml config.toml
-   ```
-3. Set required environment variables:
-   ```bash
-   export OPENAI_API_KEY="your-api-key"
-   ```
-4. Build and run:
-   ```bash
-   cargo run --bin aura-web-server
-   ```
-
-Security: keep secrets in environment variables and reference them in TOML using `{{ env.VAR_NAME }}`.
-
 ## Usage
 
 ### Web API Server
 
-Run the web server:
+Run the web server (to build and run from source, see [DEVELOPMENT.md](DEVELOPMENT.md)):
 
 ```bash
 # Default: reads config.toml
@@ -145,7 +82,7 @@ Core server options:
 | `--port`                     | `PORT`                     | `8080`        | Bind port                           |
 | `--server-url`               | `AURA_SERVER_URL`          | host/port     | Canonical public origin published in the A2A agent card (see below) |
 | `--streaming-timeout-secs`   | `STREAMING_TIMEOUT_SECS`   | `900`         | Max SSE request duration            |
-| `--first-chunk-timeout-secs` | `FIRST_CHUNK_TIMEOUT_SECS` | `30`          | Max time to first provider chunk    |
+| `--first-chunk-timeout-secs` | `FIRST_CHUNK_TIMEOUT_SECS` | `90`          | Max time to first provider chunk    |
 | `--streaming-buffer-size`    | `STREAMING_BUFFER_SIZE`    | `400`         | SSE backpressure buffer             |
 | `--aura-custom-events`       | `AURA_CUSTOM_EVENTS`       | `false`       | Enable `aura.*` events              |
 | `--aura-emit-reasoning`      | `AURA_EMIT_REASONING`      | `false`       | Enable `aura.reasoning`             |
@@ -407,14 +344,6 @@ url = "http://localhost:8081/mcp"
 headers = { "Authorization" = "Bearer {{ env.MCP_TOKEN }}" }
 ```
 
-Validate built-in config examples and tests:
-
-```bash
-cargo test -p aura-config
-```
-
-This runs all config validation tests, including `test_all_shipped_configs_parse` which validates every `.toml` file in `configs/`, `examples/`, and `quickstart.toml`.
-
 To validate your own config file, start the web server or CLI — both validate the config immediately and exit with a clear error if parsing fails, before binding to any port or entering the REPL:
 
 ```bash
@@ -623,59 +552,10 @@ OpenTelemetry support is enabled by default via the `otel` feature in both `aura
 
 AURA emits spans using the [OpenInference](https://github.com/Arize-ai/openinference/tree/main/spec) semantic convention (`llm.*`, `tool.*`, `input.*`, `output.*`) rather than the `gen_ai.*` conventions. Any `gen_ai.*` attributes from underlying provider libraries (Rig.rs) are automatically translated to OpenInference equivalents at export time. This makes AURA traces natively compatible with [Phoenix](https://github.com/Arize-ai/phoenix) and other OpenInference-aware observability tools.
 
-## Development and Testing
+## Development and Contributing
 
-Quick commands:
-
-```bash
-# Full local quality checks
-make ci
-
-# Individual checks
-make fmt
-make fmt-check
-make test
-make lint
-
-# Build targets
-make build
-```
-
-## Testing
-
-Web server integration tests live under `crates/aura-web-server/tests/`.
-
-Run integration workflows:
-
-```bash
-# Standard integration suites
-make test-integration
-
-# Local integration run against locally started test infra
-make test-integration-local
-
-# Orchestration-specific integration suites
-make test-integration-orchestration
-
-# Local orchestration integration run
-make test-integration-orchestration-local
-
-# SRE orchestration integration suites
-make test-integration-sre-orchestration
-
-# Local SRE orchestration integration run
-make test-integration-sre-orchestration-local
-```
-
-Integration test feature flags (`crates/aura-web-server/Cargo.toml`):
-
-- Parent flag: `integration`
-- Suite flags: `integration-streaming`, `integration-header-forwarding`, `integration-mcp`, `integration-events`, `integration-cancellation`, `integration-progress`
-- Orchestration suite: `integration-orchestration` (separate from parent `integration`)
-- SRE orchestration suite: `integration-orchestration-sre` (requires k8s-sre-mcp server config)
-- Optional suite: `integration-vector` (requires external Qdrant setup)
-
-Detailed test guidance: [crates/aura-web-server/README.md](crates/aura-web-server/README.md).
+- [DEVELOPMENT.md](DEVELOPMENT.md): building from source, project structure, Make targets, testing, and architecture.
+- [CONTRIBUTING.md](CONTRIBUTING.md): how to contribute, including the CLA, commit conventions, and the PR process.
 
 ## Documentation
 
@@ -691,45 +571,6 @@ Detailed test guidance: [crates/aura-web-server/README.md](crates/aura-web-serve
 - [docs/breaking-changes/20260410-agent-llm-toml-configuration.md](docs/breaking-changes/20260410-agent-llm-toml-configuration.md): breaking configuration changes from 10 April 2026 — field migrations from `[agent]` to `[llm]` and Ollama parameter consolidation.
 - [docs/a2a-implementation.md](docs/a2a-implementation.md): A2A protocol endpoints, transport modes (REST and JSON-RPC), task lifecycle, and testing examples.
 - [docs/telemetry.md](docs/telemetry.md): anonymous, opt-out CLI telemetry — the three-state consent model, exactly what is and isn't collected, kill switches, and how to audit it.
-
-## Architecture
-
-AURA separates concerns across crates:
-
-- `aura`: runtime agent building, MCP integration, orchestration, and vector workflows.
-- `aura-config`: typed TOML parsing and validation.
-- `aura-events`: shared SSE event types (`AuraStreamEvent`, `OrchestrationStreamEvent`) — lightweight, no agent dependencies.
-- `aura-web-server`: OpenAI-compatible REST/SSE serving layer.
-- `aura-cli`: interactive terminal client with HTTP and standalone modes.
-
-This separation means:
-
-- Embeddable core: use `aura` directly in any Rust application without config file dependencies.
-- Shared event types: `aura-events` can be consumed by any Rust client without pulling in the full agent stack.
-- Testable boundaries: each crate has focused responsibilities and clear interfaces.
-
-Key architectural characteristics:
-
-- Dynamic MCP tool discovery at runtime.
-- Automatic schema sanitization (anyOf, missing types, optional parameters) driven by OpenAI function-calling requirements — MCP tool schemas are transformed at discovery time to conform to OpenAI's strict subset of JSON Schema.
-- Header forwarding support (`headers_from_request`) for per-request MCP auth delegation.  See [examples/reference.toml](examples/reference.toml) for a practical example.
-- Config-driven composition with embeddable Rust core.
-
-Prompt routing and execution model:
-
-- `build_streaming_agent()` routes requests based on `orchestration.enabled`.
-- Direct Mode (`orchestration.enabled = false`): single `Agent` handles the turn.
-- Orchestration Mode (`orchestration.enabled = true`): `Orchestrator` coordinates worker execution.
-- Both `Agent` and `Orchestrator` implement `StreamingAgent`, so they are interchangeable at the API boundary.
-
-Orchestrator components and loop:
-
-- Coordinator agent: plans task DAGs and consolidates worker outputs via continuation.
-- Worker agents: per-task instances with filtered MCP tools and vector stores.
-- Persistence/event layers: track plan state, task outcomes, and stream orchestration events.
-- Loop: Plan -> Execute (dependency waves) -> Continue (respond / plan again / clarify).
-
-Request execution and cancellation flow are documented in [docs/request-lifecycle.md](docs/request-lifecycle.md).
 
 ## License
 

--- a/crates/aura-web-server/README.md
+++ b/crates/aura-web-server/README.md
@@ -18,7 +18,7 @@ OpenAI-compatible web API server that exposes AURA agents through a standard cha
 
 ## Quick Start
 
-**For full setup instructions, see the [main README](../../README.md#setup).**
+**For full setup instructions, see [DEVELOPMENT.md](../../DEVELOPMENT.md#building-from-source).**
 
 ```bash
 # Build the server
@@ -144,18 +144,29 @@ Integration tests verify streaming and tool execution functionality. Tests use a
 
 ### Running Tests
 
+The easiest path is `make test-integration-local`, which starts the server and mock MCP infrastructure with the environment the tests expect, runs the full suite, and tears everything down.
+
+To run the pieces manually instead:
+
 ```bash
-# 1. Start the server with test config (in one terminal)
+# 1. Start the server with test config (in one terminal). The full
+# integration suite includes the A2A tests, which require A2A enabled
+# and the agent-card URL pinned to the address the tests check:
+AURA_ENABLE_A2A=true \
+AURA_SERVER_URL=http://localhost:8080 \
 CONFIG_PATH=crates/aura-web-server/tests/test-config.toml \
   cargo run --bin aura-web-server
 
-# 2. Run tests (in another terminal)
+# 2. Run tests (in another terminal). The test files are feature-gated,
+# so a --features flag is required; without one, zero tests run.
 # All integration tests
-cargo test --package aura-web-server --tests
+cargo test --package aura-web-server --features integration --no-fail-fast -- --test-threads=1
 
-# Or a specific test suite
-cargo test --package aura-web-server --test streaming_tests
+# Or a specific suite via its feature flag
+cargo test --package aura-web-server --features integration-streaming --no-fail-fast -- --test-threads=1
 ```
+
+The full list of suite feature flags, plus the `make test-integration-*` workflows that manage the test infrastructure for you, is in [DEVELOPMENT.md](../../DEVELOPMENT.md#testing).
 
 ### Prerequisites
 

--- a/crates/aura/src/streaming_request_hook.rs
+++ b/crates/aura/src/streaming_request_hook.rs
@@ -14,7 +14,7 @@
 //! - `on_stream_completion_response_finish`: Captures usage, emits `aura.tool_usage` for pending tools
 //!
 //! This relies on Rig's streaming mode executing tools sequentially.
-//! See `docs/rig-tool-execution-order.md` for analysis.
+//! See `docs/rig-fork-changes.md` for analysis.
 //!
 //! # Usage
 //!

--- a/crates/aura/src/tool_event_broker.rs
+++ b/crates/aura/src/tool_event_broker.rs
@@ -16,7 +16,7 @@
 //! ## Sequential Execution Guarantee
 //!
 //! This design relies on Rig's streaming mode executing tools sequentially.
-//! See `docs/rig-tool-execution-order.md` for analysis.
+//! See `docs/rig-fork-changes.md` for analysis.
 //! The FIFO queue is safe because: hook fires → tool executes → hook fires → next tool.
 
 use crate::request_cancellation::RequestId;

--- a/docs/request-lifecycle.md
+++ b/docs/request-lifecycle.md
@@ -70,14 +70,14 @@ Client POST /v1/chat/completions
 
 | Setting | Default | Env Variable | Purpose |
 |---------|---------|--------------|---------|
-| First chunk timeout | 30 sec | `FIRST_CHUNK_TIMEOUT_SECS` | Max wait for first provider chunk |
+| First chunk timeout | 90 sec | `FIRST_CHUNK_TIMEOUT_SECS` | Max wait for first provider chunk |
 | Stream timeout | 15 min | `STREAMING_TIMEOUT_SECS` | Max request duration |
 | Shutdown grace period | 30 sec | `SHUTDOWN_TIMEOUT_SECS` | Time for in-flight requests to finish on shutdown |
 | Heartbeat | 15 sec | — | Disconnect detection |
 
 ### Rationale
 
-- **First chunk timeout (30 sec)**: Catches provider connection failures early. If the LLM hasn't sent any data within this window, the request is aborted rather than hanging for the full stream timeout.
+- **First chunk timeout (90 sec)**: Catches provider connection failures early. If the LLM hasn't sent any data within this window, the request is aborted rather than hanging for the full stream timeout. The window is sized for reasoning models, which can legitimately take over a minute before the first chunk.
 - **Stream timeout (15 min)**: Supports long-running MCP tools. Set to 0 to disable (not recommended).
 - **Heartbeat (15 sec)**: Standard SSE keepalive. Detects disconnect during silent tool execution.
 
@@ -109,7 +109,7 @@ pending_tool_calls: RwLock<HashMap<String, VecDeque<String>>>
 
 This design relies on **Rig 0.28 streaming mode executing tools sequentially**. The FIFO ordering is guaranteed because each tool completes before the next begins.
 
-**Critical**: If upgrading Rig, verify sequential execution is preserved. See `docs/rig-tool-execution-order.md` for validation methodology.
+**Critical**: If upgrading Rig, verify sequential execution is preserved. See `docs/rig-fork-changes.md` for validation methodology.
 
 ---
 

--- a/docs/streaming-api-guide.md
+++ b/docs/streaming-api-guide.md
@@ -43,7 +43,7 @@ TOOL_RESULT_MODE=aura AURA_CUSTOM_EVENTS=true cargo run --bin aura-web-server
 | `TOOL_RESULT_MODE` | `none` | `none`, `open-web-ui`, or `aura` |
 | `TOOL_RESULT_MAX_LENGTH` | `1000` | Max chars for tool results (0 = no truncation) |
 | `STREAMING_TIMEOUT_SECS` | `900` | Request timeout in seconds (0 = no timeout) |
-| `FIRST_CHUNK_TIMEOUT_SECS` | `30` | Max seconds to wait for first provider chunk before aborting |
+| `FIRST_CHUNK_TIMEOUT_SECS` | `90` | Max seconds to wait for first provider chunk before aborting |
 | `STREAMING_BUFFER_SIZE` | `400` | Chunks to buffer before backpressure |
 | `AURA_CUSTOM_EVENTS` | `false` | Enable optional custom `aura.*` events. HITL approval lifecycle events are emitted regardless because clients may need to act on them. |
 | `AURA_EMIT_REASONING` | `false` | Enable `aura.reasoning` events |


### PR DESCRIPTION
Moves architecture, build, Makefile, and testing documentation out of README.md and CONTRIBUTING.md into a new DEVELOPMENT.md, trims CONTRIBUTING.md down to the contribution process itself, and adds a which-docs-go-where map to CLAUDE.md. 

The README also gets a new capability-focused header, loses its redundant table of contents (GitHub will build us one), and its badges gain alt and title attributes. 

Review-driven accuracy fixes are included: 
- the FIRST_CHUNK_TIMEOUT_SECS default is 90 (not 30)
- the web-server integration test recipe now includes the required feature flags and A2A environment variables, 
- contributors are pointed at cargo test --workspace since the make test hook is empty. 

Stale references to the removed docs/rig-tool-execution-order.md (including two Rust doc comments) now point at docs/rig-fork-changes.md. 

The Ref: footer is documented as optional now that commitlint no longer requires it.