### PR TITLE
build: include aura-cli in default tests and guard integration runs

### DIFF
--- a/.makefiles/aura.mk
+++ b/.makefiles/aura.mk
@@ -54,8 +54,8 @@ test-integration-local:: $(REPORT_DIR) ## Start local aura infra, run integratio
 
 # --- STDIO integration tests (no Docker infra needed; local child process) ---
 
-.PHONY:test-integration-stdio-local
-test-integration-stdio-local: $(REPORT_DIR) ## Run STDIO MCP integration tests locally
+.PHONY:test-stdio-local
+test-stdio-local: $(REPORT_DIR) ## Run STDIO MCP integration tests locally
 	@echo "Running STDIO MCP integration tests..."
 	@cargo test --package aura --features integration-stdio --no-fail-fast -- --test-threads=1
 

--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -1,6 +1,7 @@
 lint:: lint-rust fmt-rust
 clean:: clean-rust clean-node clean-report
 build:: build-rust
+test:: test-rust
 
 CARGO_BIN_DIR ?= .bin
 NEXTEST_BIN = $(CARGO_BIN_DIR)/cargo-nextest
@@ -18,6 +19,10 @@ $(REPORT_DIR):
 .PHONY:build-rust
 build-rust: $(DOCKER_ENV) ## Build all rust targets
 	$(RUN) cargo build --workspace $(if $(AURA_RELEASE),--release,) $(if $(IS_CI),--quiet,)
+
+.PHONY:test-rust
+test-rust: $(DOCKER_ENV) ## Run workspace unit + doc tests (no external infra)
+	$(RUN) cargo test --workspace $(if $(IS_CI),--quiet,)
 
 .PHONY:coverage
 coverage: $(DOCKER_ENV) $(REPORT_DIR) $(GRCOV_BIN) ## Run the local test suite with code coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ Confirmed sequential as of Rig 0.28: the streaming handler `.await`s each tool c
 
 ```bash
 make build                  # Build release binary
-cargo test --workspace      # Run all tests (the `make test` hook is empty)
+make test                   # Run workspace unit + doc tests
 make docker-build           # Build Docker image
 make lint                   # Run clippy + fmt check
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Environment setup, build instructions, project structure, and Make targets are d
    make lint
    ```
 
-   (`make ci` bundles the fmt-check and lint hooks, but its `test` hook is currently empty, so always run `cargo test --workspace` yourself.)
+   (`make ci` bundles all three: fmt-check, test, and lint.)
 
 4. Push your branch and open a pull request.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default-members = [
     "crates/aura-telemetry-derive",
     "crates/aura-web-server",
     "crates/aura-test-utils",
+    "crates/aura-cli",
 ]
 resolver = "3"
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,7 +77,8 @@ Make targets are composed from modular includes under `.makefiles/` (rust, docke
 | `make fmt`             | Format code with rustfmt                       |
 | `make fmt-check`       | Check formatting (CI mode)                     |
 | `make lint`            | Run clippy with warnings as errors             |
-| `make ci`              | Run fmt-check and lint (the `test` hook is empty; run `cargo test --workspace` separately) |
+| `make test`            | Run workspace unit + doc tests                 |
+| `make ci`              | Run fmt-check, test, and lint                  |
 | `make coverage`        | Run the test suite with code coverage          |
 | `make lint-commits`    | Lint commits on the current branch against main |
 | `make clean`           | Clean build artifacts                          |
@@ -122,7 +123,7 @@ make test-integration-scratchpad-local
 
 # STDIO MCP tests (local only, no Compose/up/down variants; runs the
 # aura crate's integration-stdio feature)
-make test-integration-stdio-local
+make test-stdio-local
 ```
 
 Integration tests run single-threaded (`--test-threads=1`) due to LLM API rate limits.

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ help:                 ## Show this help, includes list of all actions.
 build:: $(BUILD_ENV)  ## Build all workspace binaries
 
 .PHONY:test
-test::                ## Run all tests targets
+test::                ## Run workspace unit + doc tests (integration suites are separate)
 
 .PHONY:setup
 setup::              ## Setup local depencies for development

--- a/crates/aura-cli/src/backend/mod.rs
+++ b/crates/aura-cli/src/backend/mod.rs
@@ -19,7 +19,7 @@ use crate::config::AppConfig;
 /// `Direct` (behind `standalone-cli` feature) builds an agent in-process
 /// from TOML config and consumes the native stream directly.
 pub enum Backend {
-    Http(http::HttpBackend),
+    Http(Box<http::HttpBackend>),
     #[cfg(feature = "standalone-cli")]
     Direct(direct::DirectBackend),
 }
@@ -47,7 +47,7 @@ impl Backend {
             return Ok(Self::Direct(direct));
         }
 
-        Ok(Self::Http(http::HttpBackend::new(config.clone())))
+        Ok(Self::Http(Box::new(http::HttpBackend::new(config.clone()))))
     }
 
     /// Send a streaming chat completion and process the response, invoking

--- a/crates/aura-web-server/tests/integration_guard.rs
+++ b/crates/aura-web-server/tests/integration_guard.rs
@@ -1,0 +1,21 @@
+//! Featureless `cargo test -p aura-web-server` compiles every `#![cfg(feature =
+//! "integration-*")]` suite away; this ignored test surfaces that instead of a misleading green "0 passed".
+
+#[cfg(not(any(
+    feature = "integration",
+    feature = "integration-a2a",
+    feature = "integration-streaming",
+    feature = "integration-header-forwarding",
+    feature = "integration-mcp",
+    feature = "integration-events",
+    feature = "integration-cancellation",
+    feature = "integration-progress",
+    feature = "integration-vector",
+    feature = "integration-orchestration",
+    feature = "integration-orchestration-sre",
+    feature = "integration-scratchpad",
+)))]
+#[test]
+#[ignore = "no integration feature enabled — the aura-web-server suites need one; \
+            prefer the make test-integration-* targets, or pass --features integration"]
+fn integration_suite_requires_a_feature_flag() {}


### PR DESCRIPTION
Wires the workspace so root `cargo`/`make` commands actually cover
aura-cli, and hardens the integration-test entry points against silent
gaps.

## Changes

- `aura-cli` joins `default-members`, so root `cargo build` / `cargo
  test` cover the whole workspace (CLI regressions now show up in a
  plain workspace run).
- `make test` aggregates `cargo test --workspace` via a new `test-rust`
  hook, so `make ci` runs the tests its help text already claims.
- Renames the self-contained STDIO suite to `test-stdio-local` so it no
  longer implies the Compose / up / down siblings the Docker-backed
  suites carry.
- Adds an ignored marker test in aura-web-server that surfaces when no
  integration feature is set, instead of a misleading green zero-test
  run.

## Benchmark: cost of adding aura-cli to default-members

Clean debug builds of the `default-members` set, with and without
aura-cli:

| Build                    | Crate-units | Distinct crates |
| ------------------------ | ----------- | --------------- |
| clean, without aura-cli  | 403         | 359             |
| clean, with aura-cli     | 436         | 390             |
| delta                    | +33 (~8%)   | +31             |

Every net-new crate is a small terminal-UI / REPL lib (crossterm,
rustyline, termimad, crokey, ...). There is no new async runtime and no
extra AWS / LLM / MCP stack: that heavy stack is already shared.
Wall-clock delta was within run-to-run noise, so crate count is the
reliable signal.

Keeping aura-cli in the default set also aligns the default feature set
with `cargo test --workspace` (which always includes it), avoiding a
feature-unification recompile of ~85 shared crates when alternating the
two.

## Verification

`cargo test --workspace`: 1568 passed, 16 ignored, 0 failed. The marker
test shows as 1 ignored with no feature and 0 tests with a suite
feature enabled.

Refs #334