### PR TITLE
Mshearer/321 cargo chef/sccache s3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -67,6 +67,8 @@ Session.vim
 # Build artifacts and caches
 .cache/
 .build/
+.cargo/
+.rustup/
 
 # Rig source (if present)
 /rig-source/

--- a/.makefiles/aura.mk
+++ b/.makefiles/aura.mk
@@ -6,9 +6,11 @@ start: ## Start the docker compose setup
 stop: ## Stop the docker compose setup
 	docker compose -p aura-$(BUILD_SLUG) -f compose/base.yml -f compose/dev.yml down
 
+COMPOSE_BUILD ?= --build
+
 .PHONY:test-integration
 test-integration: $(REPORT_DIR) ## run CI test suite via docker compose
-	docker compose -p aura-test-$(BUILD_SLUG) -f compose/base.yml -f compose/test.yml up --remove-orphans --exit-code-from aura-integration-test --build
+	docker compose -p aura-test-$(BUILD_SLUG) -f compose/base.yml -f compose/test.yml up --remove-orphans --exit-code-from aura-integration-test $(COMPOSE_BUILD)
 
 .PHONY:test-integration-down
 test-integration-down:  ## Cleanup integration test containers
@@ -16,6 +18,20 @@ test-integration-down:  ## Cleanup integration test containers
 		-f compose/base.yml \
 		-f compose/test.yml \
 		down --remove-orphans --volumes --rmi=local 2>/dev/null || true
+	@$(MAKE) clean-preloaded-images
+
+# Hooked into clean:: because a build that fails before the integration lane
+# never reaches test-integration-down; the pipeline's post-build make clean is
+# the only step guaranteed to run.
+clean:: clean-preloaded-images
+.PHONY:clean-preloaded-images
+clean-preloaded-images: ## Remove the per-build preloaded image tags
+	@# down --rmi=local skips custom-tagged images; without this, per-build
+	@# tags accumulate multi-GB images on reused fleet agents. Empty vars
+	@# mean a local run, whose dev-tagged images stay.
+	-@if [ -n "$(AURA_TEST_IMAGE)" ] || [ -n "$(AURA_SERVER_IMAGE)" ]; then \
+		docker rmi -f $(AURA_TEST_IMAGE) $(AURA_SERVER_IMAGE) || true; \
+	fi
 
 .PHONY:test-integration-local-up
 test-integration-local-up:  ## Start local aura infra for testing

--- a/.makefiles/docker.mk
+++ b/.makefiles/docker.mk
@@ -29,3 +29,86 @@ lint-docker: | $(REPORT_DIR)
 	ret=$$? ; \
 	sed ${SED_INPLACE} 's/"file":"-"/"file":"Dockerfile"/g' report/ci/hadolint.json ; \
 	exit $$ret
+
+.PHONY: build-images
+build-images: | $(REPORT_DIR) ## Build server+test images via buildx with an S3 layer cache
+	@set -euo pipefail; \
+	: "$${AWS_ACCESS_KEY_ID}"; \
+	: "$${AWS_SECRET_ACCESS_KEY}"; \
+	: "$${BUILD_CACHE_BUCKET}"; \
+	: "$${BUILD_CACHE_REGION}"; \
+	: "$${BUILD_CACHE_PREFIX}"; \
+	: "$${CACHE_BUILDER}"; \
+	: "$${AURA_SERVER_IMAGE}"; \
+	: "$${AURA_TEST_IMAGE}"; \
+	cleanup_builder() { \
+		docker buildx rm "$${CACHE_BUILDER}" >/dev/null 2>&1 || true; \
+		for log in $(REPORT_DIR)/buildx-cached-build-*.log; do \
+			[ -f "$$log" ] || continue; \
+			{ sed -E 's/(AKIA|ASIA)[A-Z0-9]{16}/\1_REDACTED/g' "$$log" > "$$log.tmp" && mv "$$log.tmp" "$$log"; } || true; \
+		done; \
+	}; \
+	trap cleanup_builder EXIT; \
+	trap 'exit 1' HUP INT TERM; \
+	printf 'Jenkins node: %s\n' "$${NODE_NAME:-unknown}"; \
+	printf 'S3 prefix: s3://%s/%s\n' "$${BUILD_CACHE_BUCKET}" "$${BUILD_CACHE_PREFIX}"; \
+	docker buildx version; \
+	docker buildx rm "$${CACHE_BUILDER}" >/dev/null 2>&1 || true; \
+	docker buildx create \
+		--name "$${CACHE_BUILDER}" \
+		--driver docker-container \
+		--driver-opt env.AWS_ACCESS_KEY_ID="$${AWS_ACCESS_KEY_ID}" \
+		--driver-opt env.AWS_SECRET_ACCESS_KEY="$${AWS_SECRET_ACCESS_KEY}" \
+		--platform linux/amd64; \
+	docker buildx inspect "$${CACHE_BUILDER}" --bootstrap; \
+	probe_spec="type=s3,region=$${BUILD_CACHE_REGION},bucket=$${BUILD_CACHE_BUCKET},prefix=$${BUILD_CACHE_PREFIX},name=auth-probe"; \
+	printf 'FROM busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d\nRUN echo cache-auth-probe\n' \
+		| docker buildx build \
+			--builder "$${CACHE_BUILDER}" \
+			--platform linux/amd64 \
+			--progress=plain \
+			--cache-to "$${probe_spec},mode=max" \
+			--output type=cacheonly \
+			- 2>&1 \
+		| tee $(REPORT_DIR)/buildx-cached-build-probe.log; \
+	manifest_hash=$$(cat Cargo.toml Cargo.lock crates/*/Cargo.toml | { sha256sum 2>/dev/null || shasum -a 256; } | cut -d' ' -f1); \
+	build_target() { \
+		local target=$$1 cache_name=$$2 tag=$$3 extra_args=$${4:-}; \
+		local log="$(REPORT_DIR)/buildx-cached-build-$${target}.log"; \
+		local cache_spec="type=s3,region=$${BUILD_CACHE_REGION},bucket=$${BUILD_CACHE_BUCKET},prefix=$${BUILD_CACHE_PREFIX},name=$${cache_name}"; \
+		local started finished; \
+		started=$$(date +%s); \
+		docker buildx build \
+			--builder "$${CACHE_BUILDER}" \
+			--platform linux/amd64 \
+			--progress=plain \
+			--pull \
+			$$extra_args \
+			--target "$${target}" \
+			--cache-from "$${cache_spec}" \
+			--cache-to "$${cache_spec},mode=max" \
+			--load \
+			-t "$${tag}" \
+			-f Dockerfile . 2>&1 \
+			| tee "$$log"; \
+		finished=$$(date +%s); \
+		local cached_steps cache_imports; \
+		cached_steps=$$(grep -c 'CACHED' "$$log" || true); \
+		cached_steps=$${cached_steps:-0}; \
+		cache_imports=$$(grep -c 'importing cache manifest' "$$log" || true); \
+		cache_imports=$${cache_imports:-0}; \
+		{ \
+			printf 'Target: %s\n' "$$target"; \
+			printf 'Image tag: %s\n' "$$tag"; \
+			printf 'Cached steps: %s\n' "$$cached_steps"; \
+			printf 'Cache manifest imports: %s\n' "$$cache_imports"; \
+			printf 'Deps manifest hash: %s\n' "$$manifest_hash"; \
+			printf 'Build seconds: %s\n' "$$((finished - started))"; \
+		} | tee -a "$$log"; \
+	}; \
+	build_target test test-amd64 "$${AURA_TEST_IMAGE}" \
+		"--build-arg NEXTEST_VERSION=$(NEXTEST_VERSION) --build-arg GRCOV_VERSION=$(GRCOV_VERSION)"; \
+	build_target server server-amd64 "$${AURA_SERVER_IMAGE}"; \
+	docker image ls --format '{{.Repository}}:{{.Tag}} {{.Size}}' \
+		| grep -F -e "$${AURA_SERVER_IMAGE}" -e "$${AURA_TEST_IMAGE}" || true
+

--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -4,6 +4,7 @@ build:: build-rust
 
 CARGO_BIN_DIR ?= .bin
 NEXTEST_BIN = $(CARGO_BIN_DIR)/cargo-nextest
+NEXTEST_VERSION ?= 0.9.133
 GRCOV_VERSION ?= v0.10.7
 GRCOV_BIN = $(CARGO_BIN_DIR)/grcov
 PATH := $(CARGO_BIN_DIR):$(PATH)
@@ -39,8 +40,13 @@ coverage: $(DOCKER_ENV) $(REPORT_DIR) $(GRCOV_BIN) ## Run the local test suite w
 		--llvm \
 		--branch \
 		--source-dir . \
-		|| touch $(TARGET_DIR)/.coverage-failed
+		|| touch $(TARGET_DIR)/.grcov-failed
 
+	@# Hit/miss/non-cacheable counters land in the lane log when the
+	@# coverage compile ran through sccache.
+	-@if [ -n "$(RUSTC_WORKSPACE_WRAPPER)" ] || [ -n "$(RUSTC_WRAPPER)" ]; then \
+		sccache --show-stats || true; \
+	fi
 	@if [ -f $(TARGET_DIR)/.nextest-failed ] || [ -f $(TARGET_DIR)/.grcov-failed ]; then \
 		rm -f $(TARGET_DIR)/.nextest-failed $(TARGET_DIR)/.grcov-failed; \
 		exit 1; \
@@ -66,6 +72,11 @@ update-lockfile: $(DOCKER_ENV) ## Regenerate Cargo.lock after version changes
 .PHONY:clean-rust
 clean-rust: ## Clean up rust build artifacts
 	$(RUN_NO_ENV) cargo clean
+
+clean:: clean-toolchain-cache
+.PHONY:clean-toolchain-cache
+clean-toolchain-cache: ## Remove the workspace-scoped cargo and rustup homes
+	$(RUN_NO_ENV) rm -rf .cargo .rustup
 
 .PHONY:clean-report
 clean-report:  ## Clear out the report directory
@@ -112,7 +123,10 @@ build-binary-linux-amd64: $(DIST_DIR) $(DOCKER_ENV) ## Build binaries for linux/
 	$(RUN) bash -c "\
 		$(call require_host,Linux,x86_64) \
 		cargo build $(CARGO_PROFILE_FLAG) --bin aura-web-server && \
-		cargo build $(CARGO_PROFILE_FLAG) -p aura-cli --bin aura"
+		cargo build $(CARGO_PROFILE_FLAG) -p aura-cli --bin aura; \
+		rc=\$$?; \
+		if [ -n \"\$$RUSTC_WRAPPER\" ]; then sccache --show-stats || true; fi; \
+		exit \$$rc"
 	cp target/$(PROFILE)/aura-web-server $(DIST_DIR)/aura-web-server-linux-amd64
 	cp target/$(PROFILE)/aura $(DIST_DIR)/aura-linux-amd64
 
@@ -125,7 +139,10 @@ build-binary-linux-arm64: $(DIST_DIR) $(DOCKER_ENV) ## Build binaries for linux/
 		export CC_aarch64_unknown_linux_gnu=/usr/bin/aarch64-linux-gnu-gcc; \
 		export CXX_aarch64_unknown_linux_gnu=/usr/bin/aarch64-linux-gnu-g++; \
 		cargo build $(CARGO_PROFILE_FLAG) --target aarch64-unknown-linux-gnu --bin aura-web-server && \
-		cargo build $(CARGO_PROFILE_FLAG) --target aarch64-unknown-linux-gnu -p aura-cli --bin aura"
+		cargo build $(CARGO_PROFILE_FLAG) --target aarch64-unknown-linux-gnu -p aura-cli --bin aura; \
+		rc=\$$?; \
+		if [ -n \"\$$RUSTC_WRAPPER\" ]; then sccache --show-stats || true; fi; \
+		exit \$$rc"
 	cp target/aarch64-unknown-linux-gnu/$(PROFILE)/aura-web-server $(DIST_DIR)/aura-web-server-linux-arm64
 	cp target/aarch64-unknown-linux-gnu/$(PROFILE)/aura $(DIST_DIR)/aura-linux-arm64
 
@@ -169,13 +186,23 @@ EXPECTED_BINARIES := \
 	aura-darwin-arm64 aura-web-server-darwin-arm64
 
 .PHONY: verify-binaries
-verify-binaries: build-checksums ## Verify every expected binary is present and checksummed correctly
+verify-binaries: build-checksums $(DOCKER_ENV) ## Verify every expected binary is present and checksummed correctly
 	@cd $(DIST_DIR) && \
 	for f in $(EXPECTED_BINARIES); do \
 		[ -f "$$f" ] || { echo "error: missing binary: $$f" >&2; exit 1; }; \
 		grep -q " $$f\$$" checksums.txt || { echo "error: $$f absent from checksums.txt" >&2; exit 1; }; \
 	done
 	cd $(DIST_DIR) && sha256sum -c checksums.txt
+	@# Execution smoke for the pair the runner container can actually run;
+	@# cross-arch artifacts are covered by presence + checksum only. The
+	@# chmod restores the executable bit, which stash/unstash can drop.
+	@if [ "$(ENABLE_DOCKER)" = "true" ]; then \
+		chmod +x $(DIST_DIR)/aura-linux-amd64 $(DIST_DIR)/aura-web-server-linux-amd64 && \
+		$(RUN) ./dist/aura-linux-amd64 --version && \
+		$(RUN) ./dist/aura-web-server-linux-amd64 --version; \
+	else \
+		echo "skipping execution smoke: runner container disabled"; \
+	fi
 
 clean:: clean-dist
 
@@ -198,7 +225,7 @@ $(NEXTEST_BIN): $(CARGO_BIN_DIR)
 		*) echo "Unsupported platform"; exit 1;; \
 	esac; \
 	echo "Downloading for $$plat"; \
-	curl -LsSf "https://get.nexte.st/latest/$$plat" | tar zxf - -C $(CARGO_BIN_DIR); \
+	curl -LsSf "https://get.nexte.st/$(NEXTEST_VERSION)/$$plat" | tar zxf - -C $(CARGO_BIN_DIR); \
 	chmod +x $@; \
 	touch $@
 
@@ -231,4 +258,3 @@ $(GRCOV_BIN): | $(CARGO_BIN_DIR)
 	curl -LsSf "https://github.com/mozilla/grcov/releases/download/$(GRCOV_VERSION)/grcov-$$target.tar.bz2" | tar xjf - -C $(CARGO_BIN_DIR); \
 	chmod +x "$@"; \
 	touch "$@"
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,71 @@
 # hadolint global ignore=DL3008
-### 000 Rust
-FROM rust:1.95 AS core
+# Compiler cache for cargo invocations that run outside the layer cache
+# (mounted-workspace builds, the in-container coverage compile). Opt-in via
+# RUSTC_WRAPPER / RUSTC_WORKSPACE_WRAPPER; inert when those are unset.
+ARG SCCACHE_VERSION=0.16.0
+ARG SCCACHE_SHA256=aec995a83ad3dff3d14b6314e08858b7b73d35ca85a5bcf3d3a9ec07dee35588
 
-# Native build deps for crates that compile C/C++ from source. sentencepiece-sys
-# (pulled in via gemini-tokenizer) builds its C++ library with cmake, so cmake
-# and a C++ compiler are required on top of the base C toolchain.
+### 000 Chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.95@sha256:00c3c07c51d092325df88f0df2d626cd4302e12933f179ba154509cc314d6c2a AS chef
+
+### 001 Core
+# sentencepiece-sys builds its C++ library from source.
+FROM chef AS core
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake g++ g++-aarch64-linux-gnu \
   && rm -rf /var/lib/apt/lists/*
 
-### 001 Runner
+### 002 Sccache
+# Download once; runner and test-tools COPY the binary from here.
+FROM core AS sccache-dl
+ARG SCCACHE_VERSION
+ARG SCCACHE_SHA256
+RUN <<EOR
+  set -e
+  curl -fsSL -o /tmp/sccache.tar.gz "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+  printf '%s  /tmp/sccache.tar.gz\n' "${SCCACHE_SHA256}" > /tmp/sccache.tar.gz.sha256
+  sha256sum -c /tmp/sccache.tar.gz.sha256
+  tar -xzf /tmp/sccache.tar.gz --strip-components=1 -C /usr/local/bin --wildcards '*/sccache'
+  rm /tmp/sccache.tar.gz /tmp/sccache.tar.gz.sha256
+  sccache --version
+EOR
+
+### 003 Planner
+# Manifests are the dependency cache key; source is copied after cook.
+FROM core AS planner
+WORKDIR /usr/src/app
+COPY Cargo.toml Cargo.lock ./
+COPY crates/aura/Cargo.toml         crates/aura/Cargo.toml
+COPY crates/aura-cli/Cargo.toml     crates/aura-cli/Cargo.toml
+COPY crates/aura-config/Cargo.toml  crates/aura-config/Cargo.toml
+COPY crates/aura-events/Cargo.toml  crates/aura-events/Cargo.toml
+COPY crates/aura-telemetry/Cargo.toml crates/aura-telemetry/Cargo.toml
+COPY crates/aura-telemetry-derive/Cargo.toml crates/aura-telemetry-derive/Cargo.toml
+COPY crates/aura-test-utils/Cargo.toml crates/aura-test-utils/Cargo.toml
+COPY crates/aura-web-server/Cargo.toml crates/aura-web-server/Cargo.toml
+# cargo chef needs a target file for every workspace manifest.
+RUN for crate in aura aura-cli aura-config aura-events aura-telemetry aura-telemetry-derive aura-test-utils aura-web-server; do \
+      mkdir -p "crates/$crate/src" && \
+      printf 'pub fn _chef_stub() {}\n' > "crates/$crate/src/lib.rs"; \
+    done && \
+    for crate in aura-cli aura-web-server; do \
+      printf 'fn main() {}\n' > "crates/$crate/src/main.rs"; \
+    done
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Separate cooks isolate the debug/coverage and release fingerprints.
+
+### 004 Cook-debug
+# The single dependency cook behind every CI compile on change requests.
+FROM core AS cook-debug
+WORKDIR /usr/src/app
+COPY --from=planner /usr/src/app/recipe.json recipe.json
+ENV RUSTFLAGS="--allow=warnings -Cinstrument-coverage"
+ENV CARGO_TARGET_DIR=/usr/src/app/target
+RUN cargo chef cook --workspace --all-targets --features integration --recipe-path recipe.json
+
+### 005 Runner
+# Mounted-workspace Cargo commands need the native dependencies from core.
 FROM core AS runner
 
 RUN groupadd --gid 1000 aura \
@@ -19,113 +75,171 @@ ENV PATH="${PATH}:/home/aura/.bin"
 WORKDIR /home/aura
 
 RUN <<EOR
+  set -e
   apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates libssl3 curl nodejs npm \
     libc6-dev-arm64-cross
   rm -rf /var/lib/apt/lists/*
 EOR
 
-# Install pinned MCP test fixture for STDIO integration tests.
-# Verified at build time; tests invoke `mcp-server-everything` directly.
+# Pinned STDIO integration fixture.
 RUN npm install -g @modelcontextprotocol/server-everything@2026.1.26 \
   && command -v mcp-server-everything
+
+COPY --from=sccache-dl /usr/local/bin/sccache /usr/local/bin/sccache
 
 USER 1000
 
 RUN <<EOR
+  set -e
   rustup component add rustfmt clippy llvm-tools
   rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
 EOR
 
-### 0002 test
-FROM runner AS test
+### 006 Test-tools
+# Install tools before source COPY so source changes keep this layer cached.
+FROM cook-debug AS test-tools
 
-# Copy workspace files
-COPY --chown=aura:aura Cargo.toml Cargo.lock ./
-COPY crates/ ./crates/
-# needed for make operations
-COPY .git ./.git
-COPY .makefiles ./.makefiles
-COPY .config.mk .config.mk ./
-COPY Makefile Makefile ./
+USER root
+# cook-debug writes these paths as root.
+RUN chown -R 1000:1000 /usr/local/cargo /usr/src/app
 
+COPY --from=sccache-dl /usr/local/bin/sccache /usr/local/bin/sccache
+
+USER 1000
+# Prebuilt tool binaries — nothing compiles from source in the PR image.
+# ARG defaults cover direct docker builds; make build-images passes the
+# pins from .makefiles/rust.mk, the source of truth.
+ARG NEXTEST_VERSION=0.9.133
+ARG GRCOV_VERSION=v0.10.7
 RUN <<EOR
-  git config --global --add safe.directory /home/aura
-  cargo install --locked --force cargo-nextest
-  cargo install --locked grcov
+  set -e
+  curl -fsSL -o /tmp/nextest.tar.gz "https://get.nexte.st/${NEXTEST_VERSION}/linux"
+  tar -xzf /tmp/nextest.tar.gz -C /usr/local/cargo/bin
+  curl -fsSL -o /tmp/grcov.tar.bz2 "https://github.com/mozilla/grcov/releases/download/${GRCOV_VERSION}/grcov-x86_64-unknown-linux-gnu.tar.bz2"
+  tar -xjf /tmp/grcov.tar.bz2 -C /usr/local/cargo/bin
+  rm -f /tmp/nextest.tar.gz /tmp/grcov.tar.bz2
+  chmod +x /usr/local/cargo/bin/cargo-nextest /usr/local/cargo/bin/grcov
+  cargo nextest --version
+  grcov --version
 EOR
 
-# 003: linting & testing
-FROM core AS release-lint-test
+### 007 Test
+# Keep this setup in sync with runner.
+FROM test-tools AS test
+
+USER root
+RUN groupadd --gid 1000 aura && useradd --uid 1000 --gid aura --shell /bin/bash --create-home aura
+
+RUN <<EOR
+  set -e
+  apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libssl3 curl nodejs npm
+  rm -rf /var/lib/apt/lists/*
+EOR
+
+# Pinned STDIO integration fixture.
+RUN npm install -g @modelcontextprotocol/server-everything@2026.1.26 \
+  && command -v mcp-server-everything
+
+USER aura
+
+# grcov reads llvm-tools' profdata; lint + nightly rustfmt are runner-only.
+RUN rustup component add llvm-tools
+
+WORKDIR /home/aura
+# No .git: worktree pointer files are invalid inside the image.
+COPY --chown=aura:aura Cargo.toml Cargo.lock ./
+COPY crates/ ./crates/
+COPY .makefiles ./.makefiles
+COPY .config.mk ./
+COPY Makefile ./
+
+### 008 Lint-test
+# Local-dev target only; CI lints through the runner image and tests through compose.
+FROM core AS lint-test
 
 WORKDIR /usr/src/app
-
-# Copy workspace files
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ ./crates/
 
-# Install rustfmt and clippy
-# Run formatting check, tests, and linting
-# Note: These commands will fail the build if any check fails
-# --lib runs only unit tests (in src/), skips integration tests (in tests/ dirs)
-# Integration tests require running servers and are executed separately via run_tests.sh
+# --lib skips integration tests, which require compose services.
 RUN <<EOR
+  set -e
   rustup component add rustfmt clippy
   cargo fmt --all -- --check
   cargo clippy --all-targets --all-features -- -D warnings
   cargo test --workspace --lib
 EOR
 
-
-# 004: release-build - Release compilation
-FROM core AS release-build
-
+### 009 Debug-build
+# Server binary for the integration lane. --workspace keeps the cook's
+# feature union, and the inherited RUSTFLAGS keep its fingerprints, so
+# only workspace crates compile here.
+FROM cook-debug AS debug-build
 WORKDIR /usr/src/app
-
-# Copy workspace files
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ ./crates/
 
-# Build the web server and CLI binaries in release mode
+RUN cargo build --workspace --bin aura-web-server
+
+### 010 Cook-release
+FROM core AS cook-release
+WORKDIR /usr/src/app
+COPY --from=planner /usr/src/app/recipe.json recipe.json
+ENV CARGO_TARGET_DIR=/usr/src/app/target
+RUN cargo chef cook --release --bin aura-web-server --recipe-path recipe.json \
+ && cargo chef cook --release -p aura-cli --bin aura --recipe-path recipe.json
+
+### 011 Release-build
+# Source changes only recompile workspace crates.
+FROM cook-release AS release-build
+WORKDIR /usr/src/app
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ ./crates/
+
 RUN <<EOR
-  cargo clean
+  set -e
   cargo build --release --bin aura-web-server
   cargo build --release -p aura-cli --bin aura
 EOR
 
-# 005: release - Runtime stage with newer glibc
-FROM debian:trixie-slim AS release
+### 012 Runtime
+# Shared runtime shell; server and release differ only in the binaries they carry.
+FROM debian:trixie-slim AS runtime
 
-# Install runtime dependencies
-# Create app user for security
 RUN <<EOR
+  set -e
   apt-get update && apt-get install -y --no-install-recommends ca-certificates libssl3 curl
   rm -rf /var/lib/apt/lists/*
   useradd -r -s /bin/false appuser
 EOR
 
-# Create app directory, config directory, and skills directory
 WORKDIR /app
 RUN mkdir -p /app/config /app/skills && chown -R appuser:appuser /app
 
-# Copy binaries from release-build stage
-COPY --from=release-build /usr/src/app/target/release/aura-web-server /app/
-COPY --from=release-build /usr/src/app/target/release/aura /app/
-
-# Switch to app user
 USER appuser
-
-# Expose port
 EXPOSE 3030
 
-# Set default environment variables
 ENV HOST=0.0.0.0
 ENV PORT=3030
 ENV CONFIG_PATH=/app/config/config.toml
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:3030/health || exit 1
 
-# Run the web server
 CMD ["./aura-web-server"]
+
+### 013 Server
+# Integration-lane server image (debug profile).
+FROM runtime AS server
+
+COPY --from=debug-build /usr/src/app/target/debug/aura-web-server /app/
+
+### 014 Release
+# Published image. Must stay the final stage: the feature-build and
+# post-merge publish lanes build the default target.
+FROM runtime AS release
+
+COPY --from=release-build /usr/src/app/target/release/aura-web-server /app/
+COPY --from=release-build /usr/src/app/target/release/aura /app/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
   }
 
   parameters {
-    string(name: 'SANITY_BUILD', defaultValue: '', description: 'This a scheduled sanity build that skips releasing.')
+    string(name: 'SANITY_BUILD', defaultValue: '', description: 'This is a scheduled sanity build that skips releasing.')
   }
 
   tools {
@@ -33,7 +33,7 @@ pipeline {
     timeout time: 1, unit: 'HOURS'
     timestamps()
     ansiColor 'xterm'
-    disableConcurrentBuilds()
+    disableConcurrentBuilds(abortPrevious: true)
     buildDiscarder(
       logRotator(
         numToKeepStr: env.BRANCH_NAME == DEFAULT_BRANCH ? '30' : '5',
@@ -52,6 +52,12 @@ pipeline {
     GIT_COMMITTER_EMAIL = 'bot@mezmo.com'
     ENABLE_DOCKER = 'true'
     GITHUB_ACTION = 'yes'
+    // Image tags produced by Build Images and consumed by compose; derived
+    // once here so make and compose never re-derive the slug.
+    AURA_SERVER_IMAGE = "local/aura-server:${BUILD_SLUG}"
+    AURA_TEST_IMAGE = "local/aura-test:${BUILD_SLUG}"
+    BUILD_CACHE_BUCKET = 'ci-oss-build-cache-483535019806-us-east-1-an'
+    BUILD_CACHE_REGION = 'us-east-1'
   }
 
 
@@ -101,6 +107,52 @@ pipeline {
         sh 'make setup'
       }
     } // end setup
+
+    stage('Build Images') {
+      // Preloaded tags are consumed by the Test Suite stage.
+      when {
+        beforeAgent true
+        not {
+          changelog '\\[skip ci\\]'
+        }
+      }
+
+      options {
+        // Seed runs pay two cold dependency cooks plus S3 uploads.
+        timeout(time: 50, unit: 'MINUTES')
+      }
+
+      environment {
+        BUILD_CACHE_PREFIX = 'aura/buildkit/'
+        CACHE_BUILDER = "aura-s3-${BUILD_SLUG}"
+      }
+
+      steps {
+        script {
+          // Authenticated pulls avoid Docker Hub rate limits on shared fleet egress.
+          docker.withRegistry(
+              'https://index.docker.io/v1/',
+              'dockerhub-token-mezmo'
+          ) {
+            withCredentials([
+              aws(
+                credentialsId: 'oss-aws-build-cache',
+                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+              )
+            ]) {
+              sh 'make build-images'
+            }
+          }
+        }
+      }
+
+      post {
+        always {
+          sh 'docker buildx rm "$CACHE_BUILDER" >/dev/null 2>&1 || true'
+        }
+      }
+    }
 
     stage('ChangeSet Validation') {
       parallel {
@@ -201,17 +253,36 @@ pipeline {
         }
       }
 
-      stages {
-        stage('Test Suite: Parallel') {
-          parallel {
-            stage('Integration Tests') {
-              environment {
-                MOCK_MCP_IMAGE = 'mezmo/aura-mock-mcp:latest'
-              }
-              steps {
-                sh 'mkdir -p report'
+      parallel {
+        stage('Integration Tests') {
+          environment {
+            MOCK_MCP_IMAGE = 'mezmo/aura-mock-mcp:latest'
+            // The plain daemon cannot read the S3 layer cache, so a rebuild
+            // would be a silent ~30min uncached build. --no-build consumes
+            // the Build Images tags and fails fast if one is missing.
+            COMPOSE_BUILD = '--no-build'
+            // sccache for the in-container coverage compile; compose maps
+            // this AURA_ toggle onto the cargo wrapper.
+            AURA_RUSTC_WORKSPACE_WRAPPER = 'sccache'
+            SCCACHE_BUCKET = "${BUILD_CACHE_BUCKET}"
+            SCCACHE_REGION = "${BUILD_CACHE_REGION}"
+            SCCACHE_S3_KEY_PREFIX = 'aura/sccache/'
+          }
+          steps {
+            sh 'mkdir -p report'
+            script {
+              // Authenticated pulls avoid Docker Hub rate limits on shared fleet egress.
+              docker.withRegistry(
+                  'https://index.docker.io/v1/',
+                  'dockerhub-token-mezmo'
+              ) {
                 withCredentials([
                   string(credentialsId: 'openai-api-key', variable: 'OPENAI_API_KEY'),
+                  aws(
+                    credentialsId: 'oss-aws-build-cache',
+                    accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                    secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                  )
                 ]) {
                   withReport('coverage', 'make test-integration') {
                     junit testResults: 'report/ci/junit.xml', allowEmptyResults: true
@@ -229,121 +300,63 @@ pipeline {
                   }
                 }
               }
-              post {
-                always {
-                  publishHTML target: [
-                    allowMissing: false,
-                    alwaysLinkToLastBuild: false,
-                    keepAll: true,
-                    reportDir: 'report/ci/html',
-                    reportFiles: '*.html',
-                    reportName: "coverage-${BUILD_TAG}"
-                  ]
-                }
-              }
-            }
-
-            stage('Release Test') {
-              when {
-                not {
-                  expression { CURRENT_BRANCH == DEFAULT_BRANCH }
-                }
-              }
-
-              stages {
-                stage('Build Release Artifacts') {
-                  stages {
-                    stage('Build Linux Artifacts') {
-                      steps {
-                        sh 'make build-binaries-linux PROFILE=debug'
-
-                        stash(
-                          name: 'linux-release-artifacts',
-                          includes: 'dist/**',
-                          allowEmpty: false
-                        )
-                      }
-                    }
-
-                    stage('Build Darwin Artifacts') {
-                      agent {
-                        node {
-                          label 'ec2-fleet-oss-macos'
-                          customWorkspace("/tmp/workspace/${BUILD_SLUG}-darwin")
-                        }
-                      }
-
-                      environment {
-                        ENABLE_DOCKER = 'false'
-                      }
-
-                      steps {
-                        sh 'make build-binaries-darwin PROFILE=debug'
-
-                        stash(
-                          name: 'darwin-release-artifacts',
-                          includes: 'dist/**',
-                          allowEmpty: false
-                        )
-                      }
-
-                      post {
-                        always {
-                          sh 'make clean'
-                        }
-                      }
-                    }
-                  }
-                }
-
-                stage('Verify Release Artifacts') {
-                  steps {
-                    sh 'rm -rf dist'
-                    sh 'mkdir -p dist'
-
-                    unstash 'linux-release-artifacts'
-                    unstash 'darwin-release-artifacts'
-
-                    sh 'make verify-binaries'
-                  }
-                }
-
-                stage('Semantic Release Dry Run') {
-                  environment {
-                    GIT_BRANCH = "${CURRENT_BRANCH}"
-                    BRANCH_NAME = "${CURRENT_BRANCH}"
-                    CHANGE_ID = ''
-                  }
-
-                  steps {
-                    script {
-                      def releaseCmd = 'npm run release:dry'
-                      if (env.CHANGE_FORK) {
-                        sh "git checkout -B ${CURRENT_BRANCH}"
-                        releaseCmd = "npm run release:dry -- --repository-url=file://${env.WORKSPACE} --plugins @semantic-release/commit-analyzer @semantic-release/release-notes-generator"
-                      }
-                      docker.withRegistry(
-                          'https://index.docker.io/v1/',
-                          'dockerhub-token-mezmo'
-                      ) {
-                        withCredentials(RELEASE_CREDENTIALS) {
-                          buildx {
-                            withReport('Release Test', releaseCmd)
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
             }
           }
-
           post {
             always {
-              sh 'make test-integration-down'
+              publishHTML target: [
+                allowMissing: false,
+                alwaysLinkToLastBuild: false,
+                keepAll: true,
+                reportDir: 'report/ci/html',
+                reportFiles: '*.html',
+                reportName: "coverage-${BUILD_TAG}"
+              ]
             }
           }
+        }
+
+        // Cheap release preview: confirms commits parse and a version
+        // computes, with no image build (that happens at main Release).
+        // The file:// repo and plugin list keep it credential-free.
+        stage('Release Dry Run') {
+          when {
+            beforeAgent true
+            not {
+              expression { CURRENT_BRANCH == DEFAULT_BRANCH }
+            }
+          }
+
+          agent {
+            node {
+              label 'ec2-fleet-oss'
+              customWorkspace("/tmp/workspace/${BUILD_SLUG}-dryrun")
+            }
+          }
+
+          tools {
+            nodejs 'NodeJS 24'
+          }
+
+          environment {
+            GIT_BRANCH = "${CURRENT_BRANCH}"
+            BRANCH_NAME = "${CURRENT_BRANCH}"
+            CHANGE_ID = ''
+            ENABLE_DOCKER = 'false'
+          }
+
+          steps {
+            // package-lock=false in .npmrc means npm ci cannot be used.
+            sh 'npm install'
+            sh "git checkout -B ${CURRENT_BRANCH}"
+            withReport('Release Test', "npm run release:dry -- --repository-url=file://${env.WORKSPACE} --plugins @semantic-release/commit-analyzer")
+          }
+        }
+      }
+
+      post {
+        always {
+          sh 'make test-integration-down'
         }
       }
     }
@@ -417,9 +430,25 @@ pipeline {
 
           parallel {
             stage('Build Linux Artifacts') {
+              environment {
+                AURA_RUSTC_WRAPPER = 'sccache'
+                SCCACHE_BUCKET = "${BUILD_CACHE_BUCKET}"
+                SCCACHE_REGION = "${BUILD_CACHE_REGION}"
+                SCCACHE_S3_KEY_PREFIX = 'aura/sccache/'
+              }
               steps {
                 sh './scripts/set-version.sh "$NEXT_RELEASE_VERSION"'
-                sh 'make build-binaries-linux'
+                script {
+                  withCredentials([
+                    aws(
+                      credentialsId: 'oss-aws-build-cache',
+                      accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                      secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                    )
+                  ]) {
+                    sh 'make build-binaries-linux'
+                  }
+                }
 
                 stash(
                   name: 'linux-release-artifacts',

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ slugify = $(shell echo '$(1)' | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]
 
 # Provide standard defaults - set overrides in .config.mk
 SHELL=/bin/bash -o pipefail
-TARGET_DIR = target
+TARGET_DIR = $(or $(CARGO_TARGET_DIR),target)
 COVERAGE_DIR := report
 REPORT_DIR = $(COVERAGE_DIR)/ci
 AURA_AUTO_DOWNLOAD ?= true
@@ -15,11 +15,11 @@ CI ?=
 BUILD_TAG ?= 1
 IS_CI := $(if $(filter true, $(CI)), true,)
 ALWAYS_TIMESTAMP_VERSION ?= false
-APP_NAME ?= $(shell git remote -v | awk '/origin/ && /fetch/ { sub(/\.git/, ""); n=split($$2, origin, "/"); print origin[n]}')
+APP_NAME ?= $(shell git remote -v 2>/dev/null | awk '/origin/ && /fetch/ { sub(/\.git/, ""); n=split($$2, origin, "/"); print origin[n]}')
 ## Define sources for rendering and templating
-GIT_SHA1 ?= $(shell git log --pretty=format:'%h' -n 1)
-GIT_BRANCH ?= $(shell git branch --show-current)
-GIT_URL ?= $(shell git remote get-url origin)
+GIT_SHA1 ?= $(shell git log --pretty=format:'%h' -n 1 2>/dev/null)
+GIT_BRANCH ?= $(shell git branch --show-current 2>/dev/null)
+GIT_URL ?= $(shell git remote get-url origin 2>/dev/null)
 GIT_INFO ?= $(TMP_DIR)/.git-info.$(GIT_SHA1)
 BUILD_URL ?= localbuild://${USER}@$(shell uname -n | sed "s/'//g")
 BUILD_DATESTAMP ?= $(shell date -u '+%Y%m%dT%H%M%SZ')
@@ -34,7 +34,14 @@ DOCKER ?= docker
 DOCKER_FILE := $(PROJECT_ROOT)/Dockerfile
 DOCKER_RUN := $(DOCKER) run --rm -i
 DOCKER_ENV = $(TARGET_DIR)/aura-env
-RUNNER_CMD = $(DOCKER_RUN) --env-file=$(DOCKER_ENV) $(if $(filter true, $(IS_CI)), ,-t) -v $(PWD):/home/aura $(AURA_RUNNER_IMAGE)
+# The env-file CARGO_HOME/RUSTUP_HOME paths are host-side and invalid inside
+# the container, so pin them to the mounted workspace. -e overrides the
+# env-file values.
+RUNNER_TOOLCHAIN_ENV := -e CARGO_HOME=/home/aura/.cargo -e RUSTUP_HOME=/home/aura/.rustup
+# Compiler-cache passthrough, gated on the CI toggle so local $(RUN) is
+# unchanged. Bare -e copies AWS values from the host environment.
+SCCACHE_RUN_ENV = $(if $(AURA_RUSTC_WRAPPER),-e RUSTC_WRAPPER=$(AURA_RUSTC_WRAPPER) -e SCCACHE_BUCKET -e SCCACHE_REGION -e SCCACHE_S3_KEY_PREFIX -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY,)
+RUNNER_CMD = $(DOCKER_RUN) --env-file=$(DOCKER_ENV) $(RUNNER_TOOLCHAIN_ENV) $(SCCACHE_RUN_ENV) $(if $(filter true, $(IS_CI)), ,-t) -v $(PWD):/home/aura $(AURA_RUNNER_IMAGE)
 RUNNER_NO_ENV_CMD = $(DOCKER_RUN) $(if $(filter true, $(IS_CI)),,-t) -v $(PWD):/home/aura $(AURA_RUNNER_IMAGE)
 DOCKER_RUN_BUILD_ENV := $(RUNNER_CMD)
 BUILD_SLUG := $(call slugify, $(BUILD_TAG))
@@ -130,7 +137,7 @@ docker-build::        ## Build Docker image (full release)
 
 .PHONY:docker-test
 docker-test::         ## Run Docker build with test stage (base)
-	$(DOCKER) build --target release-lint-test -t $(APP_NAME):test .
+	$(DOCKER) build --target lint-test -t $(APP_NAME):test .
 
 .PHONY:docker-build-release
 docker-build-release:: ## Build Docker release stage only

--- a/compose/base.yml
+++ b/compose/base.yml
@@ -41,9 +41,14 @@ services:
       start_period: 15s
 
   aura-web-server:
+    # CI preloads this tag from the Build Images stage; without --build,
+    # compose uses it as-is. Local flows build it: the tag is created on
+    # first use and refreshed whenever --build is passed.
+    image: ${AURA_SERVER_IMAGE:-local/aura-server:dev}
     build:
       context: ../
       dockerfile: Dockerfile
+      target: server
     environment:
       # API keys (passed from host environment or .env file)
       OPENAI_API_KEY: ${OPENAI_API_KEY}

--- a/compose/test.yml
+++ b/compose/test.yml
@@ -23,6 +23,9 @@ services:
       AURA_SERVER_URL: http://aura-web-server:8080
 
   aura-integration-test:
+    # CI preloads this tag from the Build Images stage; without --build,
+    # compose uses it as-is.
+    image: ${AURA_TEST_IMAGE:-local/aura-test:dev}
     build:
       context: ../
       dockerfile: Dockerfile
@@ -34,6 +37,20 @@ services:
       CI: true
       ENABLE_DOCKER: false
       AURA_AUTO_DOWNLOAD: false
+      # Compiler cache for the in-container coverage compile. Opt-in: CI
+      # sets the AURA_ toggle plus the SCCACHE_/AWS_ values; the empty
+      # defaults leave cargo behavior unchanged (an empty wrapper var is
+      # treated as unset). The workspace wrapper, not RUSTC_WRAPPER, so
+      # the deps baked by cook-debug keep their fingerprints.
+      RUSTC_WORKSPACE_WRAPPER: ${AURA_RUSTC_WORKSPACE_WRAPPER:-}
+      SCCACHE_BUCKET: ${SCCACHE_BUCKET:-}
+      SCCACHE_REGION: ${SCCACHE_REGION:-}
+      SCCACHE_S3_KEY_PREFIX: ${SCCACHE_S3_KEY_PREFIX:-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      # sccache refuses incremental compiles, and incremental state cannot
+      # survive the ephemeral container anyway.
+      CARGO_INCREMENTAL: "0"
     volumes:
       # Shared volume for marker files (written by slow_task, read by tests)
       # Uses /tmp since that's where slow_task writes marker files

--- a/crates/aura-web-server/tests/aura_events_test.rs
+++ b/crates/aura-web-server/tests/aura_events_test.rs
@@ -60,7 +60,7 @@ fn find_tool_complete_events(events: &[SseEvent]) -> Vec<&SseEvent> {
 /// Test 1: Verify aura.tool_requested events are emitted when AURA_CUSTOM_EVENTS=true
 ///
 /// This test requires the server to be started with AURA_CUSTOM_EVENTS=true
-/// which is configured in run_tests.sh
+/// which is configured in compose/base.yml
 #[tokio::test]
 async fn test_aura_tool_requested_events_emitted() {
     let client = reqwest::Client::new();


### PR DESCRIPTION
Adds cargo chef and sccache to speed up builds and changes our PR flow in anticipation to moving towards doing quick feedback CI on PRs, release builds (cargo release profile) on the automated merge to main with publish.

Long term goal is going to main produces a docker build but its not promoted to "stable" as a GH release until we manually cut a stable release.