### PR TITLE
fix(cli): stop double-printing agent details on /model selection

### DIFF
--- a/crates/aura-cli/src/repl/commands.rs
+++ b/crates/aura-cli/src/repl/commands.rs
@@ -30,9 +30,12 @@ fn set_model_and_print_overview(
     if let Some(store) = conv_store {
         store.save_model(&model_id);
     }
-    println!("Model set to: {model_id}");
-    if let Some(agent) = rt.block_on(backend.startup_agent_overview()) {
-        crate::ui::agent_overview::print_agent_overview(&agent);
+    // The overview already names the agent and model, so print it alone;
+    // fall back to a plain confirmation when no overview is available
+    // (e.g. HTTP mode against a non-AURA server).
+    match rt.block_on(backend.startup_agent_overview()) {
+        Some(agent) => crate::ui::agent_overview::print_agent_overview(&agent),
+        None => println!("Model set to: {model_id}"),
     }
 }
 


### PR DESCRIPTION
The agent overview printed after /model already names the agent and model, so the "Model set to:" line duplicated it. Print the overview alone, and keep the plain confirmation only as a fallback when no overview is available (e.g. HTTP mode against a non-AURA server).

Fixes: #336