### PR TITLE
(NO MERGE) Measure current main CI baseline

### DIFF
--- a/docs/ci-baseline-probe.md
+++ b/docs/ci-baseline-probe.md
@@ -1,0 +1,3 @@
+# CI baseline probe
+
+This temporary documentation-only change triggers the current `main` pull-request pipeline for a baseline timing measurement. Do not merge this pull request.


### PR DESCRIPTION
Temporary documentation-only PR to measure current main CI duration before the caching work. Do not merge.