### PR TITLE
ci: include aura-cli in default workspace members

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,6 @@ aura/
 - **OpenTelemetry (standalone only)**: when running in standalone mode, the CLI installs an OTel layer when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Trace shape mirrors the web server — `agent.stream` root span via `direct.rs`, with `agent.turn` / `mcp.tool_call` / `orchestration.*` nesting under it. CLI omits the HTTP-infrastructure spans (`chat_completions`, `streaming_completion`) since it has no HTTP layer.
 - **Single shared tokio runtime**: `main` owns one `tokio::runtime::Runtime` and threads it into `Backend::from_config`, `run_oneshot`, and `run_repl`. `logging::init` runs inside `rt.enter()` so the OTLP gRPC exporter can call `Handle::current()` during `with_tonic()` construction; the `BatchSpanProcessor` worker lives on the same runtime that handles every subsequent request. `main` calls `aura::logging::shutdown_tracer()` via `rt.block_on(...)` before returning to flush buffered spans.
 - SSE event parsing uses shared types from the `aura-events` crate
-- `aura-cli` is not in the workspace `default-members`, so a plain `cargo build` skips it; build it explicitly with `cargo build -p aura-cli`
 - See `crates/aura-cli/README.md` for full documentation
 
 ### Shared Event Types (`aura-events`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default-members = [
     "crates/aura-telemetry-derive",
     "crates/aura-web-server",
     "crates/aura-test-utils",
+    "crates/aura-cli",
 ]
 resolver = "3"
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,8 +40,6 @@ How to build, test, and navigate the AURA codebase. For the contribution process
    cargo run --bin aura-web-server
    ```
 
-Note: `aura-cli` is not in the workspace `default-members`, so a plain `cargo build` skips it. Build it explicitly with `cargo build -p aura-cli`.
-
 ## Project Structure
 
 ```text

--- a/crates/aura-cli/src/backend/http.rs
+++ b/crates/aura-cli/src/backend/http.rs
@@ -13,13 +13,13 @@ use crate::config::AppConfig;
 /// This wraps the existing `ChatClient` + `process_stream` pattern.
 /// Zero behavioral change from the original code.
 pub struct HttpBackend {
-    client: ChatClient,
+    client: Box<ChatClient>,
 }
 
 impl HttpBackend {
     pub fn new(config: AppConfig) -> Self {
         Self {
-            client: ChatClient::new(config),
+            client: Box::new(ChatClient::new(config)),
         }
     }
 


### PR DESCRIPTION
Refs: #321, #340

Adds `crates/aura-cli` to `[workspace].default-members` so repo-root
`cargo clippy --all-targets --all-features` (run from the Dockerfile
`release-lint-test` stage and in `make lint-rust`) lints the standalone
CLI. `aura-cli` was a workspace member before this; it just wasn't
in the default set used by the lint and `cargo build` invocations.

The consequent `clippy::large_enum_variant` on `Backend::Http` (288 B
vs Direct's 56 B) is fixed by boxing the private `HttpBackend::client`
field instead of the public enum variant — the public `Backend::Http`
payload type stays unchanged (preserves the API surface for any
downstream consumer of `aura_cli::backend::Backend`), and the variant
drops from 288 B to 8 B, well below clippy's `large_enum_variant`
threshold. Allocation: one `Box<ChatClient>` at CLI startup, freed at
process exit; match sites auto-deref through the field type unchanged.

Removes two stale-doc lines because the post-merge state no longer
requires the "build aura-cli explicitly" workaround.

This slice implements #340 finding #1 plus #5. Findings #2–#4 (make
test wiring, STDIO suite rename, integration-test guard) stay out of
scope and remain open against #340.

Build cost: +33 crate-units (~8%), per #340 measurement.

Single squashed commit on `mshearer/340-aura-cli-default-members`.
