### PR TITLE
chore(ci): clean up cargo cache after every macos step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -267,6 +267,12 @@ pipeline {
                           allowEmpty: false
                         )
                       }
+
+                      post {
+                        always {
+                          sh 'make clean'
+                        }
+                      }
                     }
                   }
                 }
@@ -403,6 +409,12 @@ pipeline {
                   includes: 'dist/**',
                   allowEmpty: false
                 )
+              }
+
+              post {
+                always {
+                  sh 'make clean'
+                }
               }
             }
           }


### PR DESCRIPTION
Our macos instance runs on a dedicated host which means storage is persisted, so we need to carefully manage disk usage.

Related: #297