### PR TITLE
chore(ci): Only run CI for PRs, on main, or when manually triggered

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,11 +54,11 @@ pipeline {
     GITHUB_ACTION = 'yes'
   }
 
+
   post {
     always {
       script {
         jiraSendBuildInfo site: 'logdna.atlassian.net'
-        sh 'ls -alh -R report'
         archiveArtifacts allowEmptyArchive: true, artifacts: 'report/ci/**', caseSensitive: false, followSymlinks: false
         sh 'make clean'
         if (env.SANITY_BUILD == 'true') {
@@ -76,6 +76,25 @@ pipeline {
   }
 
   stages {
+    stage('Check CI run conditions') {
+      when {
+        beforeAgent true
+        not {
+          anyOf {
+            branch DEFAULT_BRANCH
+            changeRequest()
+            triggeredBy cause: "UserIdCause"
+          }
+        }
+      }
+
+      steps {
+        script {
+          currentBuild.result = 'ABORTED'
+          error("Aborting the build due to no open PR")
+        }
+      }
+    }
 
     stage('Setup') {
       steps{


### PR DESCRIPTION
This change updates CI to not run for commits on branches that are not
also PRs. This is to reduce contention of the OSS workers with PRs, as
typically branches without PRs are under heavy development.
