### PR TITLE
ci: ensure version is set before building artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Release binaries
 /dist/
 
+# Written by the release config's verifyReleaseCmd
+/.next-release-version
+
 # IDE
 .vscode/
 .idea/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -394,10 +394,31 @@ pipeline {
       }
 
       stages {
+        stage('Compute Release Version') {
+          steps {
+            withCredentials(RELEASE_CREDENTIALS) {
+              script {
+                try {
+                  sh 'npm run release:dry -- --plugins @semantic-release/commit-analyzer @semantic-release/exec'
+                  env.NEXT_RELEASE_VERSION = fileExists('.next-release-version') ? readFile('.next-release-version').trim() : ''
+                } finally {
+                  sh 'rm -f .next-release-version'
+                }
+                echo env.NEXT_RELEASE_VERSION ? "Release version: ${env.NEXT_RELEASE_VERSION}" : 'No release version determined; skipping build'
+              }
+            }
+          }
+        }
+
         stage('Build Release Artifacts') {
+          when {
+            expression { env.NEXT_RELEASE_VERSION }
+          }
+
           parallel {
             stage('Build Linux Artifacts') {
               steps {
+                sh './scripts/set-version.sh "$NEXT_RELEASE_VERSION"'
                 sh 'make build-binaries-linux'
 
                 stash(
@@ -421,6 +442,7 @@ pipeline {
               }
 
               steps {
+                sh './scripts/set-version.sh "$NEXT_RELEASE_VERSION"'
                 sh 'make build-binaries-darwin'
 
                 stash(
@@ -440,6 +462,10 @@ pipeline {
         }
 
         stage('Semantic Release') {
+          when {
+            expression { env.NEXT_RELEASE_VERSION }
+          }
+
           steps {
             sh 'rm -rf dist'
             sh 'mkdir -p dist'

--- a/release.config.js
+++ b/release.config.js
@@ -27,6 +27,7 @@ module.exports = {
 
   // https://github.com/semantic-release/exec
   prepareCmd: `./scripts/set-version.sh \${nextRelease.version}`,
+  verifyReleaseCmd: `echo \${nextRelease.version} > .next-release-version`,
   // https://github.com/esatterwhite/semantic-release-docker
   dockerProject: 'mezmo',
   dockerImage: 'aura',


### PR DESCRIPTION
We need to ensure the version is updated before building artifacts otherwise they display the previous version when invoked with the `--version` flag.

Fixes: #352