### PR TITLE
feat(telemetry): emit cli_session_ended on repl exit

### DIFF
--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -22,6 +22,7 @@ use crate::repl::conversations::ConversationStore;
 use crate::repl::history::ConversationHistory;
 use crate::repl::input_reader::{self, HISTORY_COUNT, HISTORY_DEPTH, LAST_READLINE_INPUT};
 use crate::repl::registry::{self, CommandContext, CommandOutcome};
+use crate::repl::telemetry_notice::{FirstMessageConsent, consent_on_first_message};
 use crate::tools;
 use crate::ui::markdown::{render_markdown, render_summary};
 use crate::ui::prompt::{
@@ -647,15 +648,17 @@ pub fn run_repl(
     }
     setup_terminal();
 
-    // If telemetry is already Enabled at launch (a recorded preference),
-    // capture the session-start event now. When `needs_consent`, this is
-    // deferred to the first-input gate so no event is emitted during the
-    // held `Unknown` state.
-    if matches!(telemetry.state(), aura_telemetry::TelemetryState::Enabled) {
-        capture_cli_session_started(telemetry, &config, is_standalone);
-    }
-    // Tracks whether the first-input consent gate still needs to run.
-    let mut consent_pending = needs_consent;
+    // Coordinate session telemetry here: Enabled sessions start now;
+    // Unknown sessions defer until the first submitted chat message.
+    let mut telemetry_lifecycle = ReplTelemetryLifecycle::new(
+        telemetry,
+        aura_telemetry::events::CliSessionStarted {
+            interactive: true,
+            standalone_mode: is_standalone,
+            client_tools_enabled: config.enable_client_tools,
+        },
+        needs_consent,
+    );
 
     // If resuming, replay the event log so the user sees the conversation
     let has_events = with_event_log(|log| !log.is_empty());
@@ -700,6 +703,10 @@ pub fn run_repl(
         .and_then(|s| s.load_pending_input())
         .unwrap_or_default();
     let mut auto_submit = false;
+
+    // Every outer-loop exit assigns this before the post-loop read;
+    // leaving it uninitialized lets the compiler prove complete coverage.
+    let exit_reason: aura_telemetry::events::ExitReason;
 
     loop {
         // Frame is already drawn (by setup or previous iteration).
@@ -792,7 +799,10 @@ pub fn run_repl(
                         backend,
                     };
                     match registry::dispatch(&input, &mut ctx) {
-                        Some(CommandOutcome::Exit) => break,
+                        Some(CommandOutcome::Exit) => {
+                            exit_reason = aura_telemetry::events::ExitReason::Quit;
+                            break;
+                        }
                         Some(CommandOutcome::Reinject(new_input)) => {
                             initial_input = new_input;
                             continue;
@@ -823,26 +833,10 @@ pub fn run_repl(
                 // were dispatched above and never grant consent. The decision
                 // is derived from the telemetry state those commands left
                 // behind, so the gate can't drift from the command parser.
-                if consent_pending {
-                    consent_pending = false;
-                    use crate::repl::telemetry_notice::{
-                        FirstMessageConsent, consent_on_first_message,
-                    };
-                    match consent_on_first_message(&telemetry.state()) {
-                        FirstMessageConsent::EnableAndCapture => {
-                            telemetry.enable();
-                            if let Err(e) =
-                                crate::config::save_telemetry_enabled_to_global_cli_toml(true)
-                            {
-                                eprintln!("warning: could not persist telemetry preference: {e}");
-                            }
-                            capture_cli_session_started(telemetry, &config, is_standalone);
-                        }
-                        FirstMessageConsent::CaptureOnly => {
-                            capture_cli_session_started(telemetry, &config, is_standalone);
-                        }
-                        FirstMessageConsent::Skip => {}
-                    }
+                if telemetry_lifecycle.on_first_message()
+                    && let Err(e) = crate::config::save_telemetry_enabled_to_global_cli_toml(true)
+                {
+                    eprintln!("warning: could not persist telemetry preference: {e}");
                 }
 
                 // One chat turn begins. Paired 1:1 with the completed event
@@ -1927,7 +1921,10 @@ pub fn run_repl(
                         backend,
                     };
                     match (pending.command.handler)(&mut ctx, &pending.args) {
-                        CommandOutcome::Exit => break,
+                        CommandOutcome::Exit => {
+                            exit_reason = aura_telemetry::events::ExitReason::Quit;
+                            break;
+                        }
                         CommandOutcome::Reinject(new_input) => {
                             initial_input = new_input;
                             continue;
@@ -1942,12 +1939,14 @@ pub fn run_repl(
             Err(ReadlineError::Eof) => {
                 // Ctrl-D — exit immediately
                 let _ = execute!(io::stdout(), cursor::MoveUp(1));
+                exit_reason = aura_telemetry::events::ExitReason::Eof;
                 break;
             }
             Err(ReadlineError::Interrupted) => {
                 // Ctrl-C — require double-press within 5 s to quit
                 if handle_ctrlc() {
                     let _ = execute!(io::stdout(), cursor::MoveUp(1));
+                    exit_reason = aura_telemetry::events::ExitReason::Interrupt;
                     break;
                 }
                 // First press: erase old frame and redraw with hint visible.
@@ -1972,10 +1971,13 @@ pub fn run_repl(
                 let _ = execute!(io::stdout(), cursor::MoveUp(1));
                 erase_input_frame();
                 eprintln!("Input error: {}", err);
+                exit_reason = aura_telemetry::events::ExitReason::Error;
                 break;
             }
         }
     }
+
+    telemetry_lifecycle.finish(exit_reason);
 
     // Save conversation on exit, or delete if conversation was never started
     if let Some(ref store) = conv_store {
@@ -2020,20 +2022,63 @@ pub fn run_repl(
     Ok(())
 }
 
-/// Capture `cli_session_started` once the REPL session is Enabled. The
-/// `interactive` flag is always true here (this is the REPL, not the
-/// one-shot path). Never called while `Unknown`/`Disabled`, so no event
-/// is emitted before consent.
-fn capture_cli_session_started(
-    telemetry: &aura_telemetry::TelemetryHandle,
-    config: &AppConfig,
-    is_standalone: bool,
-) {
-    telemetry.capture(aura_telemetry::events::CliSessionStarted {
-        interactive: true,
-        standalone_mode: is_standalone,
-        client_tools_enabled: config.enable_client_tools,
-    });
+/// Coordinates REPL telemetry ordering while leaving input handling and
+/// exit-reason selection in `run_repl`.
+struct ReplTelemetryLifecycle<'a> {
+    telemetry: &'a aura_telemetry::TelemetryHandle,
+    started_event: aura_telemetry::events::CliSessionStarted,
+    consent_pending: bool,
+}
+
+impl<'a> ReplTelemetryLifecycle<'a> {
+    fn new(
+        telemetry: &'a aura_telemetry::TelemetryHandle,
+        started_event: aura_telemetry::events::CliSessionStarted,
+        consent_pending: bool,
+    ) -> Self {
+        if matches!(telemetry.state(), aura_telemetry::TelemetryState::Enabled) {
+            telemetry.capture(started_event.clone());
+        }
+        Self {
+            telemetry,
+            started_event,
+            consent_pending,
+        }
+    }
+
+    /// Process the first submitted chat message, returning whether the newly
+    /// enabled preference should be persisted by the caller.
+    fn on_first_message(&mut self) -> bool {
+        if !self.consent_pending {
+            return false;
+        }
+        self.consent_pending = false;
+
+        match consent_on_first_message(&self.telemetry.state()) {
+            FirstMessageConsent::EnableAndCapture => {
+                self.telemetry.enable();
+                self.telemetry.capture(self.started_event.clone());
+                true
+            }
+            FirstMessageConsent::CaptureOnly => {
+                self.telemetry.capture(self.started_event.clone());
+                false
+            }
+            FirstMessageConsent::Skip => false,
+        }
+    }
+
+    /// Attempt the concluding event only while consent remains Enabled.
+    /// Runtime opt-out therefore suppresses it even if start was captured.
+    fn finish(&self, exit_reason: aura_telemetry::events::ExitReason) {
+        if matches!(
+            self.telemetry.state(),
+            aura_telemetry::TelemetryState::Enabled
+        ) {
+            self.telemetry
+                .capture(aura_telemetry::events::CliSessionEnded { exit_reason });
+        }
+    }
 }
 
 /// Streaming event handler for the interactive REPL: drives the live
@@ -3290,8 +3335,125 @@ impl StreamHandler for ReplStreamHandler {
 
 #[cfg(test)]
 mod tests {
-    use super::{COMMAND_ALIASES, command_hint};
+    use super::{COMMAND_ALIASES, ReplTelemetryLifecycle, command_hint};
     use crate::repl::registry;
+    use aura_telemetry::events::{CliSessionStarted, ExitReason};
+    use aura_telemetry::properties::{DeploymentMethod, OsFamily, Source};
+    use aura_telemetry::{DisableReason, TelemetryConfig, TelemetryState};
+    use serde_json::Value;
+    use std::path::PathBuf;
+    use std::time::Duration;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    struct TelemetryFixture {
+        handle: aura_telemetry::TelemetryHandle,
+        log_path: PathBuf,
+        _dir: TempDir,
+    }
+
+    fn telemetry_fixture(state: TelemetryState) -> TelemetryFixture {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("events.jsonl");
+        let config = TelemetryConfig {
+            endpoint: "http://127.0.0.1:1/no-such-host".into(),
+            api_key: "phc_test".into(),
+            install_id: Uuid::new_v4(),
+            install_id_path: None,
+            session_id: Uuid::new_v4(),
+            source: Source::Cli,
+            os_family: OsFamily::Linux,
+            deployment_method: DeploymentMethod::Local,
+            aura_version: "9.9.9-test",
+            inspection_log_path: Some(log_path.clone()),
+            state,
+            channel_capacity: 16,
+            batch_size: 16,
+            flush_interval: Duration::from_secs(60),
+            post_timeout: Duration::from_millis(200),
+            http_client: None,
+        };
+        TelemetryFixture {
+            handle: aura_telemetry::init(config),
+            log_path,
+            _dir: dir,
+        }
+    }
+
+    fn session_started_event() -> CliSessionStarted {
+        CliSessionStarted {
+            interactive: true,
+            standalone_mode: false,
+            client_tools_enabled: false,
+        }
+    }
+
+    fn logged_event_names(path: &PathBuf) -> Vec<String> {
+        std::fs::read_to_string(path)
+            .unwrap_or_default()
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).unwrap())
+            .map(|row| row["event"].as_str().unwrap().to_owned())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn telemetry_lifecycle_enabled_at_launch_emits_started_then_ended() {
+        let fixture = telemetry_fixture(TelemetryState::Enabled);
+        let lifecycle =
+            ReplTelemetryLifecycle::new(&fixture.handle, session_started_event(), false);
+
+        lifecycle.finish(ExitReason::Quit);
+        fixture.handle.shutdown(Duration::from_secs(2)).await;
+
+        assert_eq!(
+            logged_event_names(&fixture.log_path),
+            ["cli_session_started", "cli_session_ended"]
+        );
+    }
+
+    #[tokio::test]
+    async fn telemetry_lifecycle_first_message_enables_and_pairs_events() {
+        let fixture = telemetry_fixture(TelemetryState::Unknown);
+        let mut lifecycle =
+            ReplTelemetryLifecycle::new(&fixture.handle, session_started_event(), true);
+
+        assert!(lifecycle.on_first_message());
+        lifecycle.finish(ExitReason::Eof);
+        fixture.handle.shutdown(Duration::from_secs(2)).await;
+
+        assert_eq!(
+            logged_event_names(&fixture.log_path),
+            ["cli_session_started", "cli_session_ended"]
+        );
+    }
+
+    #[tokio::test]
+    async fn telemetry_lifecycle_unknown_quit_emits_nothing() {
+        let fixture = telemetry_fixture(TelemetryState::Unknown);
+        let lifecycle = ReplTelemetryLifecycle::new(&fixture.handle, session_started_event(), true);
+
+        lifecycle.finish(ExitReason::Quit);
+        fixture.handle.shutdown(Duration::from_secs(2)).await;
+
+        assert!(logged_event_names(&fixture.log_path).is_empty());
+    }
+
+    #[tokio::test]
+    async fn telemetry_lifecycle_disable_after_start_suppresses_ended() {
+        let fixture = telemetry_fixture(TelemetryState::Enabled);
+        let lifecycle =
+            ReplTelemetryLifecycle::new(&fixture.handle, session_started_event(), false);
+
+        fixture.handle.set_disabled(DisableReason::AuraDisabled);
+        lifecycle.finish(ExitReason::Interrupt);
+        fixture.handle.shutdown(Duration::from_secs(2)).await;
+
+        assert_eq!(
+            logged_event_names(&fixture.log_path),
+            ["cli_session_started"]
+        );
+    }
 
     #[test]
     fn intercepts_every_registered_command() {

--- a/crates/aura-telemetry/src/events.rs
+++ b/crates/aura-telemetry/src/events.rs
@@ -13,6 +13,8 @@
 
 use aura_telemetry_derive::Event as DeriveEvent;
 
+pub use crate::properties::ExitReason;
+
 /// Emitted once per interactive CLI session, when the user grants consent
 /// by sending their first chat message (or immediately on launch if
 /// telemetry was already `Enabled`).
@@ -66,4 +68,14 @@ pub struct ChatRequestCompleted {
     /// `true` if the turn completed without an error surfacing to the
     /// user; `false` if it errored or was cancelled.
     pub success: bool,
+}
+
+/// Emitted on REPL exit while telemetry remains enabled.
+/// Tracks exit paths and enables derived session-length and turn-volume analysis.
+#[derive(DeriveEvent, Debug, Clone)]
+#[aura_event(name = "cli_session_ended")]
+pub struct CliSessionEnded {
+    /// How the session ended (`/quit`, Ctrl-D, double Ctrl-C, or an
+    /// input error).
+    pub exit_reason: ExitReason,
 }

--- a/crates/aura-telemetry/src/properties.rs
+++ b/crates/aura-telemetry/src/properties.rs
@@ -89,6 +89,27 @@ impl DeploymentMethod {
     }
 }
 
+/// How an interactive REPL session ended. Values are code-controlled
+/// (never user input), so it is safe on the sealed allow-list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitReason {
+    Quit,
+    Eof,
+    Interrupt,
+    Error,
+}
+
+impl ExitReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Quit => "quit",
+            Self::Eof => "eof",
+            Self::Interrupt => "interrupt",
+            Self::Error => "error",
+        }
+    }
+}
+
 /// The Phase-1 sealed allow-list of values that may appear in an event's
 /// **property map** (i.e. the per-event key/value bag that PostHog
 /// receives under `properties`).
@@ -114,6 +135,8 @@ pub enum PropertyValue {
     AuraVersion,
     /// Session UUID — random per-process; not linked to install identity.
     SessionUuid(uuid::Uuid),
+    /// How an interactive REPL session ended.
+    ExitReason(ExitReason),
 }
 
 impl PropertyValue {
@@ -128,6 +151,7 @@ impl PropertyValue {
             Self::Static(s) => Value::String((*s).into()),
             Self::AuraVersion => Value::String(env!("CARGO_PKG_VERSION").into()),
             Self::SessionUuid(u) => Value::String(u.to_string()),
+            Self::ExitReason(v) => Value::String(v.as_str().into()),
         }
     }
 }
@@ -194,6 +218,12 @@ pub struct SessionUuid(pub uuid::Uuid);
 impl IntoTelemetryProperty for SessionUuid {
     fn into_telemetry_property(self) -> PropertyValue {
         PropertyValue::SessionUuid(self.0)
+    }
+}
+
+impl IntoTelemetryProperty for ExitReason {
+    fn into_telemetry_property(self) -> PropertyValue {
+        PropertyValue::ExitReason(self)
     }
 }
 
@@ -286,5 +316,21 @@ mod tests {
         // the shape — it's a non-empty string.
         let s = v.as_str().expect("AuraVersion should serialize as string");
         assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn exit_reason_renders_lowercase() {
+        assert_eq!(ExitReason::Quit.as_str(), "quit");
+        assert_eq!(ExitReason::Eof.as_str(), "eof");
+        assert_eq!(ExitReason::Interrupt.as_str(), "interrupt");
+        assert_eq!(ExitReason::Error.as_str(), "error");
+    }
+
+    #[test]
+    fn exit_reason_property_to_json_is_string() {
+        assert_eq!(
+            PropertyValue::ExitReason(ExitReason::Interrupt).to_json(),
+            json!("interrupt")
+        );
     }
 }

--- a/crates/aura-telemetry/tests/compile_fail/integer_field.stderr
+++ b/crates/aura-telemetry/tests/compile_fail/integer_field.stderr
@@ -6,6 +6,7 @@ error[E0277]: the trait bound `u64: IntoTelemetryProperty` is not satisfied
   |
   = help: the following other types implement trait `IntoTelemetryProperty`:
             &'static str
+            aura_telemetry::events::ExitReason
             aura_telemetry::properties::DeploymentMethod
             aura_telemetry::properties::OsFamily
             aura_telemetry::properties::SessionUuid

--- a/crates/aura-telemetry/tests/compile_fail/property_value_field.stderr
+++ b/crates/aura-telemetry/tests/compile_fail/property_value_field.stderr
@@ -6,6 +6,7 @@ error[E0277]: the trait bound `PropertyValue: IntoTelemetryProperty` is not sati
    |
    = help: the following other types implement trait `IntoTelemetryProperty`:
              &'static str
+             aura_telemetry::events::ExitReason
              aura_telemetry::properties::DeploymentMethod
              aura_telemetry::properties::OsFamily
              aura_telemetry::properties::SessionUuid

--- a/crates/aura-telemetry/tests/consent_state.rs
+++ b/crates/aura-telemetry/tests/consent_state.rs
@@ -7,8 +7,8 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use aura_telemetry::events::{ChatRequestStarted, CliSessionStarted};
-use aura_telemetry::properties::{DeploymentMethod, OsFamily, Source};
+use aura_telemetry::events::{ChatRequestStarted, CliSessionEnded, CliSessionStarted};
+use aura_telemetry::properties::{DeploymentMethod, ExitReason, OsFamily, Source};
 use aura_telemetry::{
     init, DisableReason, EnableOutcome, TelemetryConfig, TelemetryHandle, TelemetryState,
 };
@@ -265,5 +265,60 @@ async fn runtime_disable_then_enable_resumes_sending() {
     assert!(
         events.iter().any(|e| e["event"] == "cli_session_started"),
         "an event captured after re-enable must be sent; got {events:?}"
+    );
+}
+
+/// When `Enabled`, `cli_session_ended` reaches the wire, carrying its
+/// exit_reason and landing after `cli_session_started`.
+#[tokio::test]
+async fn session_ended_sent_after_started_when_enabled() {
+    let f = fixture(TelemetryState::Enabled).await;
+    f.handle.capture(session_event());
+    f.handle.capture(CliSessionEnded {
+        exit_reason: ExitReason::Quit,
+    });
+    f.handle.shutdown(Duration::from_secs(2)).await;
+
+    let reqs = f.server.received_requests().await.unwrap_or_default();
+    let events: Vec<Value> = reqs
+        .iter()
+        .flat_map(|r| {
+            let body: Value = serde_json::from_slice(&r.body).unwrap();
+            body["batch"].as_array().cloned().unwrap_or_default()
+        })
+        .collect();
+    let names: Vec<&str> = events
+        .iter()
+        .map(|e| e["event"].as_str().unwrap())
+        .collect();
+    let started = names.iter().position(|n| *n == "cli_session_started");
+    let ended = names.iter().position(|n| *n == "cli_session_ended");
+    assert!(
+        started.is_some() && ended.is_some() && started < ended,
+        "ended must follow started; got {names:?}"
+    );
+    let ended_event = events
+        .iter()
+        .find(|e| e["event"] == "cli_session_ended")
+        .unwrap();
+    assert_eq!(ended_event["properties"]["exit_reason"], "quit");
+}
+
+/// While `Unknown` (no consent), `cli_session_ended` is held and never
+/// sent — mirrors the guard `run_repl` applies at the call site.
+#[tokio::test]
+async fn session_ended_held_while_unknown() {
+    let f = fixture(TelemetryState::Unknown).await;
+    f.handle.capture(CliSessionEnded {
+        exit_reason: ExitReason::Eof,
+    });
+    f.handle.shutdown(Duration::from_secs(2)).await;
+    assert!(
+        f.server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty(),
+        "ended must not send while Unknown"
     );
 }

--- a/crates/aura-telemetry/tests/wire_format.rs
+++ b/crates/aura-telemetry/tests/wire_format.rs
@@ -13,6 +13,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use aura_telemetry::events::ChatRequestCompleted;
+use aura_telemetry::events::CliSessionEnded;
+use aura_telemetry::properties::ExitReason;
 use aura_telemetry::properties::{DeploymentMethod, OsFamily, Source};
 use aura_telemetry::{init, TelemetryConfig};
 use serde_json::Value;
@@ -372,4 +374,49 @@ async fn channel_full_drops_record_to_inspection_log() {
         assert_eq!(drop["sent"], false);
         assert_eq!(drop["event"], "chat_request_completed");
     }
+}
+
+#[tokio::test]
+async fn cli_session_ended_payload_shape_is_correct() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/batch/"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let dir = tempdir().unwrap();
+    let cfg = TelemetryConfig {
+        endpoint: server.uri(),
+        api_key: "phc_test_key".into(),
+        install_id: Uuid::new_v4(),
+        install_id_path: None,
+        session_id: Uuid::new_v4(),
+        source: Source::Cli,
+        os_family: OsFamily::Linux,
+        deployment_method: DeploymentMethod::Local,
+        aura_version: "9.9.9-test",
+        inspection_log_path: Some(dir.path().join("events.jsonl")),
+        state: aura_telemetry::TelemetryState::Enabled,
+        channel_capacity: 16,
+        batch_size: 1,
+        flush_interval: Duration::from_millis(50),
+        post_timeout: Duration::from_millis(500),
+        http_client: None,
+    };
+    let handle = init(cfg);
+    handle.capture(CliSessionEnded {
+        exit_reason: ExitReason::Quit,
+    });
+    handle.shutdown(Duration::from_secs(2)).await;
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert_eq!(requests.len(), 1, "one batch should be sent");
+    let body: Value = serde_json::from_slice(&requests[0].body).expect("body is json");
+    let event = &body["batch"][0];
+    assert_eq!(event["event"], "cli_session_ended");
+    assert_eq!(event["properties"]["exit_reason"], "quit");
+    // Envelope still present.
+    assert_eq!(event["properties"]["aura_source"], "cli");
+    assert!(event["properties"]["session_id"].is_string());
 }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -79,9 +79,16 @@ server-side IP capture and geo-IP are explicitly suppressed (`$ip: ""`,
 | `cli_session_started` | `interactive`, `standalone_mode`, `client_tools_enabled` (all booleans) | Tells us which run modes to prioritise for UX/perf work, and how often the audit-sensitive client-tools path is used. |
 | `chat_request_started` | none beyond the envelope | Turn volume, the core adoption signal that justifies continued investment. |
 | `chat_request_completed` | `success` (boolean) | Turn success rate surfaces reliability regressions to fix. |
+| `cli_session_ended` | `exit_reason` (`quit` \| `eof` \| `interrupt` \| `error`) | When telemetry remains enabled through REPL exit, provides a best-effort counterpart to `cli_session_started`; their timestamps can yield session length, and the exit path distinguishes clean completion (`quit`/`eof`) from abnormal termination (`interrupt`/`error`). |
 
 The `chat_request_*` pair fires once per chat turn, the same way regardless
 of HTTP or standalone backend (no double-reporting).
+
+Session length and turn volume are **derived** in analysis from these
+events' timestamps and `session_id` — they are not carried as event
+properties. Session pairing is not guaranteed: `/telemetry disable` during a
+session suppresses its ending event, and best-effort delivery means transport
+failures or a full telemetry channel can drop events.
 
 ## What is **not** collected
 


### PR DESCRIPTION
Adds a `cli_session_ended` PostHog telemetry event with a sealed `ExitReason` property.

The CLI now emits the event for quit, EOF, double interrupt, and input-error exits through the existing telemetry crate. Obeys all existing opt-in/opt-out behavior.

Validated with the full `aura-cli` and `aura-telemetry` test suites, CLI build, formatting, and clippy with the existing `large_enum_variant` baseline allowance.