### PR TITLE
feat(session-store): add storage traits with in-memory default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "aws-sdk-bedrockagentruntime",
  "aws-sdk-bedrockruntime",
  "base64",
+ "bytes",
  "chrono",
  "futures",
  "gemini-tokenizer",

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -3141,8 +3141,8 @@ impl StreamHandler for ReplStreamHandler {
         };
 
         // Resolve the approval: in-process registry (standalone) or HTTP POST
-        // (web-server mode). The registry path is synchronous (mutex + oneshot
-        // send); the HTTP path is fire-and-forget async.
+        // (web-server mode). Both paths post the decision fire-and-forget from
+        // a spawned task.
         #[cfg(feature = "standalone-cli")]
         let resolved_locally = if let Some(ref registry) = self.pending_approvals {
             let decision = match &response {
@@ -3157,13 +3157,23 @@ impl StreamHandler for ReplStreamHandler {
             };
             match aura::hitl::DecisionId::parse(&decision_id) {
                 Ok(id) => {
-                    if let Err(aura::hitl::ResolveError::NotFound) = registry.resolve(&id, decision)
-                    {
-                        eprintln!(
-                            "warning: approval decision was not found \
-                             (it may have already expired or been cancelled)."
-                        );
-                    }
+                    let registry = registry.clone();
+                    // Instrument so the resolve's store/bus events stay
+                    // parented to the stream's trace.
+                    let resolve = tracing::Instrument::instrument(
+                        async move {
+                            if let Err(aura::hitl::ResolveError::NotFound) =
+                                registry.resolve(&id, decision).await
+                            {
+                                eprintln!(
+                                    "warning: approval decision was not found \
+                                     (it may have already expired or been cancelled)."
+                                );
+                            }
+                        },
+                        tracing::Span::current(),
+                    );
+                    tokio::spawn(resolve);
                 }
                 Err(e) => {
                     eprintln!("error: invalid decision id '{decision_id}': {e}");

--- a/crates/aura-web-server/src/a2a/shared_task_store.rs
+++ b/crates/aura-web-server/src/a2a/shared_task_store.rs
@@ -4,16 +4,18 @@ use a2a_server::{InMemoryTaskStore, TaskStore};
 use async_trait::async_trait;
 use std::sync::Arc;
 
+/// Wrapper over the backing [`TaskStore`] adding AURA's artifact-merge fix to
+/// `update`.
 #[derive(Clone)]
-pub struct SharedTaskStore(Arc<InMemoryTaskStore>);
+pub struct SharedTaskStore(Arc<dyn TaskStore>);
 
 impl SharedTaskStore {
     pub fn new() -> Self {
-        Self(Arc::new(InMemoryTaskStore::new()))
+        Self::from_store(Arc::new(InMemoryTaskStore::new()))
     }
 
-    pub fn inner_store(&self) -> Arc<InMemoryTaskStore> {
-        self.0.clone()
+    pub fn from_store(store: Arc<dyn TaskStore>) -> Self {
+        Self(store)
     }
 }
 

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -45,18 +45,29 @@ impl Drop for RequestResourceGuard {
     fn drop(&mut self) {
         use aura::{request_progress_unsubscribe, tool_event_unsubscribe, tool_usage_unsubscribe};
 
-        self.pending_approvals.cancel_request(&self.request_id);
+        // Synchronous so parked awaits cancel even when the runtime is
+        // shutting down and the spawn below never polls.
+        self.pending_approvals
+            .cancel_request_local(&self.request_id);
 
         // Use try_current to avoid panic during runtime shutdown
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             let id = self.request_id.clone();
-            handle.spawn(async move {
-                RequestCancellation::unregister(&id);
-                approval_event_unsubscribe(&id).await;
-                request_progress_unsubscribe(&id).await;
-                tool_event_unsubscribe(&id).await;
-                tool_usage_unsubscribe(&id).await;
-            });
+            let pending_approvals = self.pending_approvals.clone();
+            // Instrument with the span current at drop so cleanup events
+            // stay parented to the request's trace.
+            let cleanup = tracing::Instrument::instrument(
+                async move {
+                    pending_approvals.cancel_request(&id).await;
+                    RequestCancellation::unregister(&id);
+                    approval_event_unsubscribe(&id).await;
+                    request_progress_unsubscribe(&id).await;
+                    tool_event_unsubscribe(&id).await;
+                    tool_usage_unsubscribe(&id).await;
+                },
+                tracing::Span::current(),
+            );
+            handle.spawn(cleanup);
         }
         // If no runtime, cleanup is best-effort (server is shutting down anyway)
     }
@@ -1020,7 +1031,11 @@ pub async fn resolve_approval(
         }
     };
     let decision = aura::hitl::ApprovalDecision::from(body);
-    match state.pending_approvals.resolve(&decision_id, decision) {
+    match state
+        .pending_approvals
+        .resolve(&decision_id, decision)
+        .await
+    {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(aura::hitl::ResolveError::NotFound) => error_response(
             StatusCode::NOT_FOUND,
@@ -1900,7 +1915,8 @@ model = "gpt-4o-mini"
             let decision_id = req.decision_id;
             let handle = state
                 .pending_approvals
-                .register(req, Duration::from_secs(60));
+                .register(req, Duration::from_secs(60))
+                .await;
 
             let response = app
                 .oneshot(

--- a/crates/aura-web-server/src/lib.rs
+++ b/crates/aura-web-server/src/lib.rs
@@ -2,5 +2,6 @@
 
 pub mod a2a;
 pub mod handlers;
+pub mod session_store;
 pub mod streaming;
 pub mod types;

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -17,6 +17,7 @@ use tracing::{error, info};
 
 use aura_web_server::a2a::{AuraAgentExecutor, AuraRequestHandler, SharedTaskStore};
 use aura_web_server::handlers;
+use aura_web_server::session_store::{InMemorySessionStore, SessionStore};
 use aura_web_server::streaming;
 use aura_web_server::types;
 
@@ -254,6 +255,15 @@ async fn run() -> std::io::Result<()> {
 
     let shutdown_timeout_secs = args.shutdown_timeout_secs;
 
+    let session_store: Arc<dyn SessionStore> = Arc::new(InMemorySessionStore::new());
+    // Fail fast at startup if the session-state backend is unreachable.
+    if let Err(e) = session_store.ping().await {
+        error!("Session store unreachable: {e}");
+        return Err(std::io::Error::other(format!(
+            "session store unreachable: {e}"
+        )));
+    }
+
     let app_state = Arc::new(AppState {
         configs: configs_arc,
         tool_result_mode: args.tool_result_mode,
@@ -269,7 +279,10 @@ async fn run() -> std::io::Result<()> {
         active_requests: active_requests.clone(),
         default_agent: args.default_agent.clone(),
         additional_tools: Arc::new(Vec::new),
-        pending_approvals: aura::hitl::PendingApprovals::new(),
+        pending_approvals: aura::hitl::PendingApprovals::with_backend(
+            session_store.approvals(),
+            session_store.bus(),
+        ),
     });
 
     info!(
@@ -299,8 +312,7 @@ async fn run() -> std::io::Result<()> {
     // REST at /a2a/v1/message:send, /a2a/v1/tasks/
     // Agent card at /.well-known/agent-card.json
     let app = if args.enable_a2a {
-        // forcing an in-memory store for now. TBD: a resilient location
-        let task_store = SharedTaskStore::new();
+        let task_store = SharedTaskStore::from_store(session_store.tasks());
         let executor = AuraAgentExecutor::new(app_state.clone(), task_store.clone());
         let base_url = advertised_base_url(args.server_url.as_deref(), &args.host, args.port);
         let agent_card = executor.build_agent_card(&base_url);

--- a/crates/aura-web-server/src/session_store.rs
+++ b/crates/aura-web-server/src/session_store.rs
@@ -1,0 +1,75 @@
+//! The session-store factory: one backend handing out the capability handles
+//! for cross-pod session state ([`ApprovalStore`] and [`EventBus`] from
+//! `aura::session_store`, plus the upstream `a2a_server::TaskStore`).
+//!
+//! See `docs/design/session-storage.md` and
+//! `docs/adr/2026-07-08-session-storage.md`.
+
+use std::sync::Arc;
+
+use a2a_server::{InMemoryTaskStore, TaskStore};
+use async_trait::async_trait;
+use aura::session_store::{
+    ApprovalStore, EventBus, InMemoryApprovalStore, InMemoryEventBus, SessionStoreError,
+};
+
+/// A pluggable backend for cross-pod session state, handing out one handle
+/// per capability.
+#[async_trait]
+pub trait SessionStore: Send + Sync {
+    /// Durable parked HITL approvals.
+    fn approvals(&self) -> Arc<dyn ApprovalStore>;
+
+    /// Durable A2A tasks (the upstream `a2a_server::TaskStore` trait).
+    fn tasks(&self) -> Arc<dyn TaskStore>;
+
+    /// Allows for cross-pod pub/sub (in-memory SessionStore would be single-pod only).
+    fn bus(&self) -> Arc<dyn EventBus>;
+
+    /// Cheap liveness check.
+    async fn ping(&self) -> Result<(), SessionStoreError>;
+}
+
+/// The default backend: every capability is process-local, so state is scoped
+/// to one pod.
+pub struct InMemorySessionStore {
+    approvals: Arc<InMemoryApprovalStore>,
+    tasks: Arc<InMemoryTaskStore>,
+    bus: Arc<InMemoryEventBus>,
+}
+
+impl InMemorySessionStore {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            approvals: Arc::new(InMemoryApprovalStore::new()),
+            tasks: Arc::new(InMemoryTaskStore::new()),
+            bus: Arc::new(InMemoryEventBus::new()),
+        }
+    }
+}
+
+impl Default for InMemorySessionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SessionStore for InMemorySessionStore {
+    fn approvals(&self) -> Arc<dyn ApprovalStore> {
+        self.approvals.clone()
+    }
+
+    fn tasks(&self) -> Arc<dyn TaskStore> {
+        self.tasks.clone()
+    }
+
+    fn bus(&self) -> Arc<dyn EventBus> {
+        self.bus.clone()
+    }
+
+    async fn ping(&self) -> Result<(), SessionStoreError> {
+        Ok(())
+    }
+}

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -19,6 +19,7 @@ aws-sdk-bedrockagentruntime = { workspace = true }
 
 rmcp = { workspace = true }
 base64 = "0.22"
+bytes = "1"
 futures = "0.3"
 sse-stream = "0.2"
 reqwest = { workspace = true }

--- a/crates/aura/src/hitl/decision.rs
+++ b/crates/aura/src/hitl/decision.rs
@@ -57,7 +57,7 @@ impl fmt::Display for DecisionId {
 }
 
 /// The terminal human (or webhook) decision on a gated call.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ApprovalDecision {
     Approved,
     Denied { reason: Option<String> },

--- a/crates/aura/src/hitl/registry.rs
+++ b/crates/aura/src/hitl/registry.rs
@@ -1,47 +1,76 @@
-//! The per-process registry that parks conversational approvals (Route B) and
-//! the decision a later request resolves them with.
+//! The registry that parks conversational approvals (Route B) and the decision
+//! a later request resolves them with.
 //!
 //! This is the first mutable chat-path state that crosses request boundaries:
 //! an approval is registered during one request's stream and resolved by a
 //! `POST /v1/approvals/{id}` arriving as a different request. It follows the A2A
-//! `SharedTaskStore` idiom — a `Clone` newtype over an `Arc`, constructed once
-//! in `main`, not a global static.
+//! global static.
+//!
+//! State is split along the serialization boundary:
+//!
+//! - the [`ParkedApproval`] record lives in an [`ApprovalStore`], and the
+//!   decision travels over an [`EventBus`] topic, so with a shared backend a
+//!   decision can be resolved by any process; while
+//! - the `oneshot` wake handle that resumes the suspended tool call is
+//!   inherently process-local and stays in this registry's in-RAM map, fired
+//!   by a per-approval bus subscription.
 
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
+use futures::StreamExt;
 use tokio::sync::oneshot;
+use tokio::task::AbortHandle;
 use tokio::time::Instant;
+use tracing::warn;
+
+use crate::session_store::{
+    ApprovalStore, EventBus, InMemoryApprovalStore, InMemoryEventBus, SessionStoreError,
+    Subscription,
+};
 
 use super::decision::{ApprovalDecision, AwaitingDecision, DecisionId, Timestamp};
 use super::protocol::ApprovalRequest;
 
-/// The cross-request registry of parked conversational approvals.
-///
-/// Clone newtype over an `Arc`. Cloned onto `AppState` and into each per-request
-/// build context; a decision must land on the process that parked the call.
+/// Bus topic carrying the decision for one parked approval.
+fn approval_topic(id: &DecisionId) -> String {
+    format!("approval:{id}")
+}
+
+/// The cross-request registry of parked conversational approvals. A `Clone`
+/// newtype over an `Arc`.
 #[derive(Clone)]
 pub struct PendingApprovals(Arc<PendingApprovalsInner>);
 
 struct PendingApprovalsInner {
-    // `std::sync::Mutex`: every operation is a synchronous map op (insert /
-    // remove / oneshot send); nothing awaits while holding the lock. The
-    // `BTreeMap` is keyed on `DecisionId` (UUID v7, time-ordered), so iteration
-    // is chronological registration order — oldest pending approval first.
-    entries: Mutex<BTreeMap<DecisionId, PendingEntry>>,
+    store: Arc<dyn ApprovalStore>,
+    bus: Arc<dyn EventBus>,
+    // Process-local wake handles. `std::sync::Mutex`: every operation is a
+    // synchronous map op; nothing awaits while holding the lock.
+    wakes: Mutex<BTreeMap<DecisionId, WakeEntry>>,
 }
 
-/// One parked approval: a serialization-ready core plus the runtime-only wake
-/// handle. The split is what lets durable parking (#209) persist
-/// [`ParkedApproval`] as-is later, without serializing the oneshot.
-struct PendingEntry {
-    parked: ParkedApproval,
+/// The process-local half of one parked approval: its wake handle and bus
+/// subscription.
+struct WakeEntry {
+    request_id: String,
     wake: oneshot::Sender<ApprovalDecision>,
+    subscription: Option<AbortHandle>,
+}
+
+impl WakeEntry {
+    /// Stop the bus-subscription task.
+    fn abort_subscription(&self) {
+        if let Some(subscription) = &self.subscription {
+            subscription.abort();
+        }
+    }
 }
 
 /// The serializable record of a parked approval. Carries everything needed to
 /// re-render and re-validate the approval after a restart.
+#[derive(Clone)]
 pub struct ParkedApproval {
     pub request: ApprovalRequest,
     pub registered_at: Timestamp,
@@ -53,85 +82,194 @@ pub struct ParkedApproval {
 #[non_exhaustive]
 pub enum ResolveError {
     /// No live entry for that id: unknown, already resolved, or expired all
-    /// collapse to a missing map entry.
+    /// collapse to a missing store entry.
     NotFound,
+    /// The backing session store failed; no decision was recorded.
+    Store(SessionStoreError),
 }
 
 impl PendingApprovals {
-    /// Create an empty registry. Constructed once in `main`.
+    /// Create a registry over the in-memory backend.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_backend(
+            Arc::new(InMemoryApprovalStore::new()),
+            Arc::new(InMemoryEventBus::new()),
+        )
+    }
+
+    /// Create a registry over an explicit store/bus backend.
+    #[must_use]
+    pub fn with_backend(store: Arc<dyn ApprovalStore>, bus: Arc<dyn EventBus>) -> Self {
         Self(Arc::new(PendingApprovalsInner {
-            entries: Mutex::new(BTreeMap::new()),
+            store,
+            bus,
+            wakes: Mutex::new(BTreeMap::new()),
         }))
     }
 
-    /// Register a parked approval, returning the await handle. Holds the paired
-    /// `oneshot::Sender` in the entry.
+    /// Park an approval, returning the await handle.
+    ///
+    /// Store or bus faults do not fail registration: the call parks anyway,
+    /// cannot be resolved, and fails closed at its timeout.
     #[must_use]
-    pub fn register(&self, request: ApprovalRequest, timeout: Duration) -> AwaitingDecision {
+    pub async fn register(&self, request: ApprovalRequest, timeout: Duration) -> AwaitingDecision {
         let id = request.decision_id;
+        let request_id = request.request_id.clone();
         let now = chrono::Utc::now();
         let (tx, rx) = oneshot::channel();
-        let entry = PendingEntry {
-            parked: ParkedApproval {
-                request,
-                registered_at: now,
-                expires_at: now
-                    + chrono::Duration::from_std(timeout).expect("approval timeout fits in chrono"),
-            },
-            wake: tx,
+        let parked = ParkedApproval {
+            request,
+            registered_at: now,
+            expires_at: now
+                + chrono::Duration::from_std(timeout).expect("approval timeout fits in chrono"),
         };
-        self.0
-            .entries
-            .lock()
-            .expect("registry lock poisoned")
-            .insert(id, entry);
+
+        // Subscribe before the store insert: once `store.register` returns,
+        // any process may resolve and publish, and the wake must already be
+        // listening for the decision.
+        let subscription = match self.0.bus.subscribe(&approval_topic(&id)).await {
+            Ok(decisions) => {
+                let inner = Arc::downgrade(&self.0);
+                // Instrument with the registering request's span so the wake
+                // (and any decode warning) lands in the parked call's trace.
+                let task = tracing::Instrument::instrument(
+                    wake_on_decision(inner, id, decisions),
+                    tracing::Span::current(),
+                );
+                Some(tokio::spawn(task).abort_handle())
+            }
+            Err(err) => {
+                warn!(
+                    decision_id = %id, error = %err,
+                    "approval wake subscription failed; the parked call cannot be woken and will fail closed",
+                );
+                None
+            }
+        };
+        self.0.wakes.lock().expect("registry lock poisoned").insert(
+            id,
+            WakeEntry {
+                request_id,
+                wake: tx,
+                subscription,
+            },
+        );
+        if let Err(err) = self.0.store.register(parked).await {
+            warn!(
+                decision_id = %id, error = %err,
+                "parked approval not persisted; it cannot be resolved and will fail closed",
+            );
+        }
         AwaitingDecision::new(id, rx, Instant::now() + timeout)
     }
 
-    /// Resolve a parked approval, waking its await. Removes the entry, so a
-    /// `DecisionId` resolves at most once in-process.
-    pub fn resolve(&self, id: &DecisionId, decision: ApprovalDecision) -> Result<(), ResolveError> {
-        let entry = self
+    /// Resolve a parked approval: record the decision in the store (at most
+    /// once per `DecisionId`) and publish it on the bus, waking the parked
+    /// await wherever it lives.
+    pub async fn resolve(
+        &self,
+        id: &DecisionId,
+        decision: ApprovalDecision,
+    ) -> Result<(), ResolveError> {
+        self.0.store.resolve(id, decision.clone()).await?;
+        let payload = serde_json::to_vec(&decision).expect("ApprovalDecision serializes to JSON");
+        if let Err(err) = self
             .0
-            .entries
-            .lock()
-            .expect("registry lock poisoned")
-            .remove(id);
-        match entry {
-            Some(entry) => {
-                let _ = entry.wake.send(decision);
-                Ok(())
-            }
-            None => Err(ResolveError::NotFound),
+            .bus
+            .publish(&approval_topic(id), payload.into())
+            .await
+        {
+            // The decision is recorded but the wake may be lost; the parked
+            // await times out and fails closed.
+            warn!(decision_id = %id, error = %err, "approval decision publish failed");
         }
+        Ok(())
     }
 
     /// Expire a parked approval after timeout/cancellation so later ingress
     /// returns [`ResolveError::NotFound`].
-    pub fn remove(&self, id: &DecisionId) {
-        self.0
-            .entries
+    pub async fn remove(&self, id: &DecisionId) {
+        if let Some(entry) = self
+            .0
+            .wakes
             .lock()
             .expect("registry lock poisoned")
-            .remove(id);
+            .remove(id)
+        {
+            entry.abort_subscription();
+        }
+        if let Err(err) = self.0.store.remove(id).await {
+            warn!(decision_id = %id, error = %err, "parked approval removal failed");
+        }
     }
 
-    /// Cancel every approval parked under a request id (stream drop / shutdown);
-    /// their awaits resolve to `Cancelled`.
-    pub fn cancel_request(&self, request_id: &str) {
+    /// Synchronously drop the wake handles parked under a request id; their
+    /// awaits resolve to `Cancelled`. Leaves store entries in place — use
+    /// [`Self::cancel_request`] to also clean the store.
+    pub fn cancel_request_local(&self, request_id: &str) {
         self.0
-            .entries
+            .wakes
             .lock()
             .expect("registry lock poisoned")
-            .retain(|_, entry| entry.parked.request.request_id != request_id);
+            .retain(|_, entry| {
+                if entry.request_id == request_id {
+                    entry.abort_subscription();
+                    false
+                } else {
+                    true
+                }
+            });
+    }
+
+    /// Cancel every approval parked under a request id (stream drop /
+    /// shutdown); their awaits resolve to `Cancelled`.
+    pub async fn cancel_request(&self, request_id: &str) {
+        self.cancel_request_local(request_id);
+        if let Err(err) = self.0.store.cancel_request(request_id).await {
+            warn!(request_id, error = %err, "approval store cancel_request failed");
+        }
     }
 }
 
 impl Default for PendingApprovals {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Wait for a decision on one approval's bus topic and fire its local wake
+/// handle. One short-lived task per parked approval; ends after the first
+/// decision, when aborted (entry removed without a decision), or when the bus
+/// closes the topic.
+async fn wake_on_decision(
+    inner: Weak<PendingApprovalsInner>,
+    id: DecisionId,
+    mut decisions: Subscription,
+) {
+    while let Some(payload) = decisions.next().await {
+        let decision = match serde_json::from_slice::<ApprovalDecision>(&payload) {
+            Ok(decision) => decision,
+            Err(err) => {
+                warn!(
+                    decision_id = %id, error = %err,
+                    "undecodable approval decision payload ignored",
+                );
+                continue;
+            }
+        };
+        let Some(inner) = inner.upgrade() else {
+            return;
+        };
+        if let Some(entry) = inner
+            .wakes
+            .lock()
+            .expect("registry lock poisoned")
+            .remove(&id)
+        {
+            let _ = entry.wake.send(decision);
+        }
+        return;
     }
 }
 
@@ -169,11 +307,12 @@ mod tests {
         let registry = PendingApprovals::new();
         let req = test_request("req-1");
         let id = req.decision_id;
-        let handle = registry.register(req, Duration::from_secs(60));
+        let handle = registry.register(req, Duration::from_secs(60)).await;
         let cancel = RequestCancelToken::unbound();
 
         registry
             .resolve(&id, ApprovalDecision::Approved)
+            .await
             .expect("resolve succeeds");
 
         assert_eq!(
@@ -187,7 +326,7 @@ mod tests {
         let registry = PendingApprovals::new();
         let req = test_request("req-2");
         let id = req.decision_id;
-        let handle = registry.register(req, Duration::from_secs(60));
+        let handle = registry.register(req, Duration::from_secs(60)).await;
         let cancel = RequestCancelToken::unbound();
 
         registry
@@ -197,6 +336,7 @@ mod tests {
                     reason: Some("not safe".into()),
                 },
             )
+            .await
             .expect("resolve succeeds");
 
         assert_eq!(
@@ -207,30 +347,116 @@ mod tests {
         );
     }
 
-    #[test]
-    fn resolve_unknown_id_returns_not_found() {
+    #[tokio::test]
+    async fn resolve_unknown_id_returns_not_found() {
         let registry = PendingApprovals::new();
         let unknown = DecisionId::generate();
         assert_eq!(
-            registry.resolve(&unknown, ApprovalDecision::Approved),
+            registry.resolve(&unknown, ApprovalDecision::Approved).await,
             Err(ResolveError::NotFound)
         );
     }
 
-    #[test]
-    fn resolve_twice_returns_not_found_on_second() {
+    #[tokio::test]
+    async fn resolve_twice_returns_not_found_on_second() {
         let registry = PendingApprovals::new();
         let req = test_request("req-3");
         let id = req.decision_id;
-        let _handle = registry.register(req, Duration::from_secs(60));
+        let _handle = registry.register(req, Duration::from_secs(60)).await;
 
         registry
             .resolve(&id, ApprovalDecision::Approved)
+            .await
             .expect("first resolve succeeds");
         assert_eq!(
-            registry.resolve(&id, ApprovalDecision::Approved),
+            registry.resolve(&id, ApprovalDecision::Approved).await,
             Err(ResolveError::NotFound)
         );
+    }
+
+    #[tokio::test]
+    async fn remove_makes_resolve_return_not_found() {
+        let registry = PendingApprovals::new();
+        let req = test_request("req-remove");
+        let id = req.decision_id;
+        let _handle = registry.register(req, Duration::from_secs(60)).await;
+
+        registry.remove(&id).await;
+
+        assert_eq!(
+            registry.resolve(&id, ApprovalDecision::Approved).await,
+            Err(ResolveError::NotFound)
+        );
+    }
+
+    /// Resolve records the decision in the store even when the parked await
+    /// is already gone (the waiter dropped between park and decision).
+    #[tokio::test]
+    async fn resolve_succeeds_after_awaiting_handle_dropped() {
+        let registry = PendingApprovals::new();
+        let req = test_request("req-dropped");
+        let id = req.decision_id;
+        let handle = registry.register(req, Duration::from_secs(60)).await;
+        drop(handle);
+
+        assert_eq!(
+            registry.resolve(&id, ApprovalDecision::Approved).await,
+            Ok(())
+        );
+    }
+
+    /// An undecodable payload on the approval topic is ignored; a valid
+    /// decision published afterwards still wakes the parked call.
+    #[tokio::test(start_paused = true)]
+    async fn undecodable_decision_payload_is_ignored() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let bus: Arc<dyn EventBus> = Arc::new(InMemoryEventBus::new());
+        let registry = PendingApprovals::with_backend(store, bus.clone());
+        let cancel = RequestCancelToken::unbound();
+
+        let req = test_request("req-garbage");
+        let id = req.decision_id;
+        let handle = registry.register(req, Duration::from_secs(60)).await;
+
+        bus.publish(&approval_topic(&id), bytes::Bytes::from_static(b"not json"))
+            .await
+            .expect("publish succeeds");
+        registry
+            .resolve(&id, ApprovalDecision::Approved)
+            .await
+            .expect("resolve succeeds");
+
+        assert_eq!(
+            handle.outcome(&cancel).await,
+            ApprovalOutcome::Decided(ApprovalDecision::Approved)
+        );
+    }
+
+    /// The synchronous half of cancellation: wake handles drop (awaits
+    /// cancel) while store entries remain until the async half runs.
+    #[tokio::test(start_paused = true)]
+    async fn cancel_request_local_cancels_await_but_keeps_store_entry() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let registry =
+            PendingApprovals::with_backend(store.clone(), Arc::new(InMemoryEventBus::new()));
+        let req = test_request("req-local");
+        let id = req.decision_id;
+        let handle = registry.register(req, Duration::from_secs(60)).await;
+        let cancel = RequestCancelToken::unbound();
+
+        registry.cancel_request_local("req-local");
+
+        assert_eq!(
+            handle.outcome(&cancel).await,
+            ApprovalOutcome::Cancelled(CancelReason::SenderDropped)
+        );
+        assert!(
+            store.get(&id).await.unwrap().is_some(),
+            "store entry remains for the async half"
+        );
+
+        registry.cancel_request("req-local").await;
+        assert!(store.get(&id).await.unwrap().is_none());
     }
 
     #[tokio::test(start_paused = true)]
@@ -238,20 +464,27 @@ mod tests {
         let registry = PendingApprovals::new();
         let req_a = test_request("req-cancel");
         let req_b = test_request("req-keep");
+        let id_a = req_a.decision_id;
         let id_b = req_b.decision_id;
-        let handle_a = registry.register(req_a, Duration::from_secs(60));
-        let handle_b = registry.register(req_b, Duration::from_secs(60));
+        let handle_a = registry.register(req_a, Duration::from_secs(60)).await;
+        let handle_b = registry.register(req_b, Duration::from_secs(60)).await;
         let cancel = RequestCancelToken::unbound();
 
-        registry.cancel_request("req-cancel");
+        registry.cancel_request("req-cancel").await;
 
         assert_eq!(
             handle_a.outcome(&cancel).await,
             ApprovalOutcome::Cancelled(CancelReason::SenderDropped)
         );
+        assert_eq!(
+            registry.resolve(&id_a, ApprovalDecision::Approved).await,
+            Err(ResolveError::NotFound),
+            "cancelled approval must be gone from the store too",
+        );
 
         registry
             .resolve(&id_b, ApprovalDecision::Approved)
+            .await
             .expect("unrelated entry survives");
         assert_eq!(
             handle_b.outcome(&cancel).await,
@@ -259,21 +492,48 @@ mod tests {
         );
     }
 
-    #[test]
-    fn register_sets_expires_at_from_timeout() {
-        let registry = PendingApprovals::new();
+    #[tokio::test]
+    async fn register_sets_expires_at_from_timeout() {
+        let store = Arc::new(InMemoryApprovalStore::new());
+        let registry =
+            PendingApprovals::with_backend(store.clone(), Arc::new(InMemoryEventBus::new()));
         let req = test_request("req-ts");
         let id = req.decision_id;
         let timeout = Duration::from_secs(300);
         let before = chrono::Utc::now();
-        let _handle = registry.register(req, timeout);
+        let _handle = registry.register(req, timeout).await;
         let after = chrono::Utc::now();
 
-        let entries = registry.0.entries.lock().unwrap();
-        let entry = entries.get(&id).expect("entry exists");
-        let delta = entry.parked.expires_at - entry.parked.registered_at;
+        let parked = store.get(&id).await.unwrap().expect("entry exists");
+        let delta = parked.expires_at - parked.registered_at;
         assert_eq!(delta, chrono::Duration::from_std(timeout).unwrap());
-        assert!(entry.parked.registered_at >= before);
-        assert!(entry.parked.registered_at <= after);
+        assert!(parked.registered_at >= before);
+        assert!(parked.registered_at <= after);
+    }
+
+    /// The cross-pod seam: two registries (as two pods) sharing one store and
+    /// bus. An approval parked on one is resolved through the other, and the
+    /// parking side's await wakes.
+    #[tokio::test(start_paused = true)]
+    async fn resolve_on_shared_backend_wakes_other_registry() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let bus: Arc<dyn EventBus> = Arc::new(InMemoryEventBus::new());
+        let pod_a = PendingApprovals::with_backend(store.clone(), bus.clone());
+        let pod_b = PendingApprovals::with_backend(store, bus);
+        let cancel = RequestCancelToken::unbound();
+
+        let req = test_request("req-cross");
+        let id = req.decision_id;
+        let handle = pod_a.register(req, Duration::from_secs(60)).await;
+
+        pod_b
+            .resolve(&id, ApprovalDecision::Approved)
+            .await
+            .expect("resolve on the other pod succeeds");
+
+        assert_eq!(
+            handle.outcome(&cancel).await,
+            ApprovalOutcome::Decided(ApprovalDecision::Approved)
+        );
     }
 }

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -111,7 +111,7 @@ impl DecisionRoute {
                     + chrono::Duration::from_std(*timeout)
                         .expect("approval timeout fits in chrono");
                 let pending_event = events::pending(&request, &expires_at);
-                let handle = registry.register(request, *timeout);
+                let handle = registry.register(request, *timeout).await;
 
                 approval_event_broker::publish(
                     &request_id,
@@ -124,7 +124,7 @@ impl DecisionRoute {
                     outcome,
                     ApprovalOutcome::TimedOut { .. } | ApprovalOutcome::Cancelled(_)
                 ) {
-                    registry.remove(&decision_id);
+                    registry.remove(&decision_id).await;
                 }
 
                 let completed_event =
@@ -372,6 +372,7 @@ mod tests {
             tokio::task::yield_now().await;
             if registry
                 .resolve(&decision_id, ApprovalDecision::Approved)
+                .await
                 .is_ok()
             {
                 break;
@@ -423,6 +424,7 @@ mod tests {
                         reason: Some("too risky".into()),
                     },
                 )
+                .await
                 .is_ok()
             {
                 break;
@@ -471,7 +473,9 @@ mod tests {
             other => panic!("expected TimedOut, got {:?}", other),
         }
         assert_eq!(
-            registry.resolve(&decision_id, ApprovalDecision::Approved),
+            registry
+                .resolve(&decision_id, ApprovalDecision::Approved)
+                .await,
             Err(ResolveError::NotFound),
             "late decisions for timed-out approvals must be rejected as expired",
         );

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -34,6 +34,7 @@ pub mod request_progress;
 pub mod rig_builder;
 mod schema_sanitize; // Private - MCP schema sanitization for OpenAI compatibility
 pub mod scratchpad;
+pub mod session_store;
 pub mod skill_tool;
 pub mod stream_events;
 pub mod streaming;

--- a/crates/aura/src/session_store/memory.rs
+++ b/crates/aura/src/session_store/memory.rs
@@ -1,0 +1,305 @@
+//! In-memory (single-process) implementations of the session-store
+//! capabilities: the default backend, with all state scoped to the process.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use tokio::sync::broadcast;
+
+use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
+
+use super::{ApprovalStore, EventBus, SessionStoreError, Subscription};
+
+/// Buffered payloads per topic before slow subscribers start lagging.
+const TOPIC_CAPACITY: usize = 64;
+
+/// The parked-approval registry as a plain map.
+#[derive(Default)]
+pub struct InMemoryApprovalStore {
+    // `std::sync::Mutex`: every operation is a synchronous map op; nothing
+    // awaits while holding the lock.
+    entries: Mutex<BTreeMap<DecisionId, ParkedApproval>>,
+}
+
+impl InMemoryApprovalStore {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<DecisionId, ParkedApproval>> {
+        self.entries.lock().expect("approval store lock poisoned")
+    }
+}
+
+#[async_trait]
+impl ApprovalStore for InMemoryApprovalStore {
+    async fn register(&self, parked: ParkedApproval) -> Result<(), SessionStoreError> {
+        self.lock().insert(parked.request.decision_id, parked);
+        Ok(())
+    }
+
+    async fn get(&self, id: &DecisionId) -> Result<Option<ParkedApproval>, SessionStoreError> {
+        Ok(self.lock().get(id).cloned())
+    }
+
+    async fn resolve(
+        &self,
+        id: &DecisionId,
+        _decision: ApprovalDecision,
+    ) -> Result<(), ResolveError> {
+        // Removal under the lock is the at-most-once guarantee.
+        match self.lock().remove(id) {
+            Some(_) => Ok(()),
+            None => Err(ResolveError::NotFound),
+        }
+    }
+
+    async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError> {
+        self.lock().remove(id);
+        Ok(())
+    }
+
+    async fn cancel_request(&self, request_id: &str) -> Result<(), SessionStoreError> {
+        self.lock()
+            .retain(|_, parked| parked.request.request_id != request_id);
+        Ok(())
+    }
+}
+
+/// A local `tokio::broadcast` registry keyed by topic. Single-pod pub/sub:
+/// publish and subscribe never leave the process.
+#[derive(Default)]
+pub struct InMemoryEventBus {
+    // Shared with each subscription's `SubscriptionGuard`.
+    topics: Arc<Mutex<HashMap<String, broadcast::Sender<Bytes>>>>,
+}
+
+impl InMemoryEventBus {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Owns a topic receiver and removes the topic entry when the last
+/// subscriber drops, so abandoned topics do not accumulate.
+struct SubscriptionGuard {
+    rx: broadcast::Receiver<Bytes>,
+    topics: Arc<Mutex<HashMap<String, broadcast::Sender<Bytes>>>>,
+    topic: String,
+}
+
+impl Drop for SubscriptionGuard {
+    fn drop(&mut self) {
+        let mut topics = self.topics.lock().expect("event bus lock poisoned");
+        // `self.rx` is still alive here, so a count of 1 means we are the
+        // last subscriber. Subscribe/publish also lock the map, so the check
+        // and removal are atomic with respect to them.
+        if let Some(sender) = topics.get(&self.topic)
+            && sender.receiver_count() <= 1
+        {
+            topics.remove(&self.topic);
+        }
+    }
+}
+
+#[async_trait]
+impl EventBus for InMemoryEventBus {
+    async fn publish(&self, topic: &str, payload: Bytes) -> Result<(), SessionStoreError> {
+        let mut topics = self.topics.lock().expect("event bus lock poisoned");
+        if let Some(sender) = topics.get(topic)
+            && sender.send(payload).is_err()
+        {
+            // No live subscribers: fire-and-forget semantics, and the dead
+            // topic entry can go.
+            topics.remove(topic);
+        }
+        Ok(())
+    }
+
+    async fn subscribe(&self, topic: &str) -> Result<Subscription, SessionStoreError> {
+        let rx = {
+            let mut topics = self.topics.lock().expect("event bus lock poisoned");
+            topics
+                .entry(topic.to_string())
+                .or_insert_with(|| broadcast::channel(TOPIC_CAPACITY).0)
+                .subscribe()
+        };
+        let mut guard = SubscriptionGuard {
+            rx,
+            topics: Arc::clone(&self.topics),
+            topic: topic.to_string(),
+        };
+        Ok(Box::pin(async_stream::stream! {
+            loop {
+                match guard.rx.recv().await {
+                    Ok(payload) => yield payload,
+                    // A lagged subscriber skips missed payloads but stays
+                    // subscribed.
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+
+    use super::*;
+    use crate::hitl::{
+        AgentScope, ApprovalItem, ApprovalOrigin, ApprovalRequest, PROTOCOL_VERSION,
+    };
+
+    fn parked(request_id: &str) -> ParkedApproval {
+        let now = chrono::Utc::now();
+        ParkedApproval {
+            request: ApprovalRequest {
+                version: PROTOCOL_VERSION,
+                decision_id: DecisionId::generate(),
+                request_id: request_id.to_string(),
+                scope: AgentScope::Single { session_id: None },
+                origin: ApprovalOrigin::ConfigGate {
+                    matched_pattern: "test_*".to_string(),
+                },
+                items: vec![ApprovalItem {
+                    tool_name: "test_tool".to_string(),
+                    arguments: serde_json::json!({}),
+                }],
+            },
+            registered_at: now,
+            expires_at: now + chrono::Duration::seconds(60),
+        }
+    }
+
+    #[tokio::test]
+    async fn approval_store_register_get_resolve() {
+        let store = InMemoryApprovalStore::new();
+        let entry = parked("req-1");
+        let id = entry.request.decision_id;
+
+        store.register(entry).await.unwrap();
+        assert!(store.get(&id).await.unwrap().is_some());
+
+        store
+            .resolve(&id, ApprovalDecision::Approved)
+            .await
+            .unwrap();
+        assert!(store.get(&id).await.unwrap().is_none());
+        assert_eq!(
+            store.resolve(&id, ApprovalDecision::Approved).await,
+            Err(ResolveError::NotFound),
+        );
+    }
+
+    #[tokio::test]
+    async fn approval_store_cancel_request_removes_only_matching() {
+        let store = InMemoryApprovalStore::new();
+        let cancel = parked("req-cancel");
+        let keep = parked("req-keep");
+        let keep_id = keep.request.decision_id;
+        store.register(cancel).await.unwrap();
+        store.register(keep).await.unwrap();
+
+        store.cancel_request("req-cancel").await.unwrap();
+
+        assert!(store.get(&keep_id).await.unwrap().is_some());
+        assert_eq!(store.lock().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn event_bus_delivers_to_subscriber() {
+        let bus = InMemoryEventBus::new();
+        let mut sub = bus.subscribe("topic-a").await.unwrap();
+
+        bus.publish("topic-a", Bytes::from_static(b"hello"))
+            .await
+            .unwrap();
+
+        assert_eq!(sub.next().await.unwrap(), Bytes::from_static(b"hello"));
+    }
+
+    #[tokio::test]
+    async fn event_bus_publish_without_subscribers_is_ok() {
+        let bus = InMemoryEventBus::new();
+        bus.publish("nobody-home", Bytes::from_static(b"x"))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn event_bus_topic_cleaned_up_when_last_subscriber_drops() {
+        let bus = InMemoryEventBus::new();
+        let sub_a = bus.subscribe("topic-b").await.unwrap();
+        let sub_b = bus.subscribe("topic-b").await.unwrap();
+        assert_eq!(bus.topics.lock().unwrap().len(), 1);
+
+        drop(sub_a);
+        assert_eq!(bus.topics.lock().unwrap().len(), 1);
+        drop(sub_b);
+        assert!(bus.topics.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn event_bus_fans_out_to_all_subscribers() {
+        let bus = InMemoryEventBus::new();
+        let mut sub_a = bus.subscribe("topic-fan").await.unwrap();
+        let mut sub_b = bus.subscribe("topic-fan").await.unwrap();
+
+        bus.publish("topic-fan", Bytes::from_static(b"payload"))
+            .await
+            .unwrap();
+
+        assert_eq!(sub_a.next().await.unwrap(), Bytes::from_static(b"payload"));
+        assert_eq!(sub_b.next().await.unwrap(), Bytes::from_static(b"payload"));
+    }
+
+    #[tokio::test]
+    async fn event_bus_lagged_subscriber_skips_but_stays_subscribed() {
+        let bus = InMemoryEventBus::new();
+        let mut sub = bus.subscribe("topic-lag").await.unwrap();
+
+        // Overflow the topic buffer without polling the subscriber, then
+        // publish a sentinel: the lagged stream must skip forward and keep
+        // yielding rather than end.
+        for i in 0..(TOPIC_CAPACITY * 2) {
+            bus.publish("topic-lag", Bytes::from(format!("m{i}")))
+                .await
+                .unwrap();
+        }
+        bus.publish("topic-lag", Bytes::from_static(b"sentinel"))
+            .await
+            .unwrap();
+
+        let mut saw_sentinel = false;
+        for _ in 0..=TOPIC_CAPACITY {
+            if sub.next().await.expect("stream stays open") == Bytes::from_static(b"sentinel") {
+                saw_sentinel = true;
+                break;
+            }
+        }
+        assert!(saw_sentinel, "subscription must survive lagging");
+    }
+
+    #[tokio::test]
+    async fn event_bus_topics_are_independent() {
+        let bus = InMemoryEventBus::new();
+        let mut sub_a = bus.subscribe("topic-a").await.unwrap();
+        let mut sub_b = bus.subscribe("topic-b").await.unwrap();
+
+        bus.publish("topic-a", Bytes::from_static(b"for-a"))
+            .await
+            .unwrap();
+        bus.publish("topic-b", Bytes::from_static(b"for-b"))
+            .await
+            .unwrap();
+
+        assert_eq!(sub_a.next().await.unwrap(), Bytes::from_static(b"for-a"));
+        assert_eq!(sub_b.next().await.unwrap(), Bytes::from_static(b"for-b"));
+    }
+}

--- a/crates/aura/src/session_store/mod.rs
+++ b/crates/aura/src/session_store/mod.rs
@@ -1,0 +1,77 @@
+//! Pluggable cross-pod session-state capabilities: a durable store for parked
+//! HITL approvals and a pub/sub event bus.
+//!
+//! The in-memory implementations are the default; a networked backend (e.g.
+//! Redis/Valkey) implements the same traits to make a load-balanced multi-pod
+//! deployment behave like one process.
+//!
+//! See `docs/design/session-storage.md` and
+//! `docs/adr/2026-07-08-session-storage.md`.
+
+mod memory;
+
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::Stream;
+
+use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
+
+pub use memory::{InMemoryApprovalStore, InMemoryEventBus};
+
+/// A fault in the backing session-store/bus backend (connection, protocol,
+/// serialization at the backend boundary).
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum SessionStoreError {
+    #[error("session store backend error: {0}")]
+    Backend(String),
+}
+
+/// Durable storage for parked conversational HITL approvals, over the
+/// serializable [`ParkedApproval`] record.
+#[async_trait]
+pub trait ApprovalStore: Send + Sync {
+    /// Persist a parked approval, keyed by its `DecisionId`. Backends with
+    /// native expiry should TTL the entry from `expires_at` so abandoned
+    /// approvals self-clean.
+    async fn register(&self, parked: ParkedApproval) -> Result<(), SessionStoreError>;
+
+    /// Look up a parked approval.
+    async fn get(&self, id: &DecisionId) -> Result<Option<ParkedApproval>, SessionStoreError>;
+
+    /// Record a terminal decision and remove the parked entry, atomically —
+    /// at-most-once resolution is enforced here, in the store.
+    async fn resolve(
+        &self,
+        id: &DecisionId,
+        decision: ApprovalDecision,
+    ) -> Result<(), ResolveError>;
+
+    /// Remove a parked entry.
+    async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError>;
+
+    /// Remove every approval parked under a request id.
+    async fn cancel_request(&self, request_id: &str) -> Result<(), SessionStoreError>;
+}
+
+/// The payload stream returned by [`EventBus::subscribe`].
+pub type Subscription = Pin<Box<dyn Stream<Item = Bytes> + Send>>;
+
+/// Cross-pod pub/sub.
+///
+/// Payloads are opaque bytes; topic naming and payload encoding belong to the
+/// publishing subsystem.
+#[async_trait]
+pub trait EventBus: Send + Sync {
+    /// Publish a payload to a topic. Fire-and-forget; delivery is
+    /// best-effort and publishing to a topic with no subscribers is not an
+    /// error.
+    async fn publish(&self, topic: &str, payload: Bytes) -> Result<(), SessionStoreError>;
+
+    /// Subscribe to a topic, receiving every payload published after this
+    /// call returns. The stream ends when the subscription is dropped or the
+    /// backend closes the topic.
+    async fn subscribe(&self, topic: &str) -> Result<Subscription, SessionStoreError>;
+}

--- a/docs/design/session-storage.md
+++ b/docs/design/session-storage.md
@@ -7,11 +7,18 @@ default, one shipped networked backend, store plus event bus as distinct
 capabilities). This note carries the trait method sets, the backend key/topic
 schema, the config and wire formats, the wiring changes, and the phased rollout.
 
-**Status:** living design note, current as of 2026-07-08. The ADR holds the
-durable decision. Nothing here is built yet — the Rust signatures, key schema, and
-diagrams below describe intended design, not code that exists. References to
-existing aura code (file:line, module paths) are where-to-look pointers and move as
-the code does.
+**Status:** living design note, current as of 2026-07-13. The ADR holds the
+durable decision. **Phase 1 of §11 (traits + in-memory refactor) is implemented:**
+`aura::session_store` defines `ApprovalStore` and `EventBus` with in-memory impls,
+`PendingApprovals` rides on them (wake handles stay local, decisions travel over the
+bus), and the web server's `SessionStore` factory
+(`crates/aura-web-server/src/session_store.rs`) composes them with the upstream A2A
+`TaskStore`. The factory lives in the web-server crate rather than `aura` because
+`a2a_server::TaskStore` is a web-server-only dependency; the capability traits stay
+in `aura` so CLI standalone needs no A2A dependency. The Redis/Valkey backend
+(phases 2–4), the `[session_store]` config surface (§8), `ParkedApproval` serde
+derives, and Helm wiring (§10) are not built yet. References to existing aura code
+(file:line, module paths) are where-to-look pointers and move as the code does.
 
 **Goal of iteration 1:** make the state AURA _already has_ work across pods, so a
 load-balanced multi-replica deployment (Helm prod runs 3–10 replicas, no session
@@ -135,7 +142,7 @@ with a code comment pointing at "durable parking".
 
 Two capabilities. A backend may provide one or both; Redis/Valkey provides both.
 
-```
+```text
     ┌─────────────────────────── SessionStore (factory) ───────────────────────────┐
     │                                                                              │
     │   approvals() ─────▶ ApprovalStore   (durable parked HITL approvals)         │
@@ -264,7 +271,7 @@ the human is watching `aura.approval_pending`), but the **decision can arrive on
 pod**. So we do _not_ need to move the stream — we need the decision to reach the parking
 pod. Store + bus does exactly that.
 
-```
+```text
  Pod A (parks)                          Redis/Valkey                    Pod B (resolves)
  ───────────────                        ─────────────                   ────────────────
  tool gated, decide()
@@ -438,10 +445,10 @@ behind `PendingApprovals` gains the store/bus handles.
 
 ## 11. Phased rollout
 
-1. **Traits + in-memory refactor (no behavior change).** Introduce `SessionStore`,
-   `ApprovalStore`, `EventBus`; move today's structures behind them; A2A already has
-   `TaskStore`. Ship with `backend = memory`. This is a pure refactor — existing tests are
-   the guard.
+1. **Traits + in-memory refactor (no behavior change).** ✅ **Implemented
+   (2026-07-13).** Introduce `SessionStore`, `ApprovalStore`, `EventBus`; move today's
+   structures behind them; A2A already has `TaskStore`. Ship with `backend = memory`.
+   This is a pure refactor — existing tests are the guard.
 2. **Redis/Valkey backend — A2A task store.** Smallest, highest-value cross-pod win
    (`message:send` + poll works across pods). No bus needed for the poll path.
 3. **Redis/Valkey backend — HITL approvals (store + wake bus).** Cross-pod conversational
@@ -481,6 +488,35 @@ phases 2 and 3 are independent and can land in either order; phase 4 needs both.
   decide per-subsystem.
 - **At-most-once resolve across pods** must be enforced in the store (Lua/`MULTI`), not in
   application code, since two `POST /v1/approvals/{id}` could race on different pods.
+- **Register faults: fail fast vs park-and-time-out.** `PendingApprovals::register` is
+  infallible: store/bus faults are warn-logged and the call parks anyway, failing closed at
+  its timeout. Safe, but when `subscribe` fails the park is _provably_ unwakeable at
+  registration time, and the user still sees a `Pending` event and waits out the full
+  timeout. With a networked backend (phase 3), consider short-circuiting to an immediate
+  terminal outcome (or failing the gate) instead of emitting `Pending` for a dead park.
+- **Resolve atomicity across store + bus.** `PendingApprovals::resolve` records the
+  decision in the store, then publishes the wake. In-memory, both futures complete on
+  their first poll, so the pair runs without a yield point and cannot be interrupted.
+  With a networked backend, the resolving request can be dropped between the two calls
+  (client disconnect mid-await) — decision consumed, wake never published, parked side
+  fails closed at its timeout. Phase 3: shield the store+publish pair in a spawned task,
+  or accept and document the window.
+- **Teardown latency behind store I/O.** The request `Drop` guard cancels wake handles
+  synchronously (`cancel_request_local`), but the spawned cleanup task awaits
+  `ApprovalStore::cancel_request` before `RequestCancellation::unregister` and the
+  event-broker unsubscribes run. A slow networked store stretches that tail cleanup —
+  bound store calls with client-side timeouts when picking the phase-3 driver config.
+- **Trace context across the bus.** Bus payloads carry no OTel trace context, so on a
+  cross-pod resolve the parking pod's wake cannot link to the resolving request's trace
+  (in-process, the wake task is instrumented with the registering request's span). Phase 3
+  should decide whether decision payloads carry W3C `traceparent` for span links, or the
+  two traces stay correlated only by `decision_id` attributes.
+- **Surfacing swallowed backend faults.** The warn-only paths (`register` store/bus faults,
+  `resolve` publish failure, `Drop`-guard cleanup failures) are unreachable with the
+  in-memory backend but become real operational signals in phase 3 — add metrics/counters
+  so operators detect a degraded backend without log-diving. Document the approvals API
+  contract alongside: `204` means the decision was persisted and consumed at-most-once;
+  delivery to the parked waiter is best-effort, backstopped by the fail-closed timeout.
 - **Serialization format** for `ParkedApproval` / `Task` — JSON (debuggable) vs MessagePack
   (compact). Start with JSON.
 - **Multi-tenant / multi-deployment** sharing one cluster — the `key_prefix` covers naming;


### PR DESCRIPTION
Phase 1 of docs/design/session-storage.md. Today, parked HITL approvals and A2A tasks live in one pod's memory, so an approval decision or task poll that lands on a different pod can't find them. This change introduces the storage traits that will let that state move to a shared backend, and puts the existing in-memory structures behind them. In-memory stays the default, so single-pod servers, CLI standalone, and tests behave exactly as before.

What's new:

- Two capability traits in aura::session_store: ApprovalStore, a durable home for parked approvals, and EventBus, pub/sub used to wake the process that parked a call when its decision arrives. In-memory implementations of both ship as the default backend.
- PendingApprovals rides on those traits: the serializable approval record goes to the store, decisions travel over the bus, and only the non-serializable wake handle stays in-process. With a shared backend, an approval parked on one pod can be resolved from another (covered by a two-registry test).
- The web server builds one session-store backend at startup and wires HITL approvals and the A2A task store from it.

Semantics worth knowing as a reviewer:

- Resolving is persistence-first: a 204 means the decision was recorded and consumed at most once. Delivering the wake to the parked call is best-effort; a lost wake fails closed when the parked call times out.
- Teardown is preserved: request cleanup still cancels parked approvals synchronously (even mid-shutdown), and the store cleanup follows in a background task.
- The new background tasks are instrumented with the current tracing span, so OTel trace parenting is unchanged despite the added async spawns.

Also adds tests around cancellation, expiry, bus fan-out/lag, and the 204 contract. The design doc marks phase 1 implemented and records the open questions this surfaced for the networked backend: fail-fast registration, resolve atomicity across store and bus, teardown latency behind store I/O, trace context over the bus, and metrics for swallowed backend faults.

Fixes: #327