### PR TITLE
perf(ci): run clippy against the warmed test-image deps

### DIFF
--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -60,6 +60,11 @@ nextest: $(DOCKER_ENV) $(NEXTEST_BIN) $(REPORT_DIR)
 lint-rust: | $(DOCKER_ENV) $(REPORT_DIR)  ## lint rust code via clippy
 	$(RUN) cargo clippy $(if $(IS_CI),-q,) --all-targets --all-features $(if $(IS_CI),--message-format=json,) -- -D warnings $(if $(IS_CI),> $(REPORT_DIR)/clippy.json,)
 
+.PHONY:lint-rust-ci
+lint-rust-ci: | $(REPORT_DIR)  ## lint rust code via clippy against the prebuilt AURA_TEST_IMAGE (CI only; needs `make build-images` first)
+	$(if $(AURA_TEST_IMAGE),,$(error AURA_TEST_IMAGE is not set; run make build-images first))
+	$(DOCKER) run --rm $(AURA_TEST_IMAGE) cargo clippy -q --all-targets --all-features --message-format=json -- -D warnings > $(REPORT_DIR)/clippy.json
+
 .PHONY: check-cli-http-only
 check-cli-http-only: $(DOCKER_ENV) ## Verify the HTTP-only (no-default-features) aura-cli still builds
 	$(RUN) cargo clippy -p aura-cli --no-default-features --all-targets -- -D warnings

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,8 +144,10 @@ RUN npm install -g @modelcontextprotocol/server-everything@2026.1.26 \
 
 USER aura
 
-# grcov reads llvm-tools' profdata; lint + nightly rustfmt are runner-only.
-RUN rustup component add llvm-tools
+# grcov reads llvm-tools' profdata. clippy rides this image's cook-debug
+# deps for CI lint; rustfmt stays runner-only (fmt-check doesn't compile,
+# so it gains nothing from these cached deps).
+RUN rustup component add llvm-tools clippy
 
 WORKDIR /home/aura
 # No .git: worktree pointer files are invalid inside the image.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,7 +207,7 @@ pipeline {
         stage("Rust Lint") {
           steps {
             withChecks('clippy') {
-              sh script: "make lint-rust", returnStatus: true
+              sh script: "make lint-rust-ci", returnStatus: true
               recordIssues( // needs to be in same block as withChecks
                 tool: cargo(pattern: 'report/ci/clippy.json'),
                 id: 'clippy',

--- a/crates/aura-cli/src/repl/conversations.rs
+++ b/crates/aura-cli/src/repl/conversations.rs
@@ -239,7 +239,7 @@ impl ConversationStore {
         }
 
         // Sort newest first
-        entries.sort_by(|a, b| b.2.cmp(&a.2));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.2));
         entries.into_iter().map(|(u, n, _)| (u, n)).collect()
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.95.0"
 components = ["cargo", "clippy", "rust-analyzer", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
Clippy / lint stage is still taking 4+ min as its a fresh build. 1st pass at making it build off of warm deps.