### PR TITLE
fix(ci): scope sccache wrapper to the credentialed build

### DIFF
--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -66,8 +66,11 @@ check-cli-http-only: $(DOCKER_ENV) ## Verify the HTTP-only (no-default-features)
 	$(RUN) cargo test -p aura-cli --no-default-features
 
 .PHONY: update-lockfile
+# cargo update only re-resolves Cargo.lock and never compiles, so strip any
+# sccache wrapper the CI env injects: the S3-backed cache would demand AWS
+# creds this step lacks and time out on the IMDS fallback.
 update-lockfile: $(DOCKER_ENV) ## Regenerate Cargo.lock after version changes
-	$(RUN) cargo update --quiet --workspace
+	$(RUN) env -u RUSTC_WRAPPER -u RUSTC_WORKSPACE_WRAPPER cargo update --quiet --workspace
 
 .PHONY:clean-rust
 clean-rust: ## Clean up rust build artifacts

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -431,7 +431,6 @@ pipeline {
           parallel {
             stage('Build Linux Artifacts') {
               environment {
-                AURA_RUSTC_WRAPPER = 'sccache'
                 SCCACHE_BUCKET = "${BUILD_CACHE_BUCKET}"
                 SCCACHE_REGION = "${BUILD_CACHE_REGION}"
                 SCCACHE_S3_KEY_PREFIX = 'aura/sccache/'
@@ -446,7 +445,14 @@ pipeline {
                       secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
                     )
                   ]) {
-                    sh 'make build-binaries-linux'
+                    // sccache reaches its S3 cache with the credentials bound
+                    // above, so enable the wrapper only inside this block.
+                    // Stage-wide it would route the credential-free
+                    // set-version step through sccache and time out on the
+                    // IMDS credential fallback.
+                    withEnv(['AURA_RUSTC_WRAPPER=sccache']) {
+                      sh 'make build-binaries-linux'
+                    }
                   }
                 }
 


### PR DESCRIPTION
Fixes red main (Build Linux Artifacts): stage-wide `AURA_RUSTC_WRAPPER=sccache`
ran `set-version.sh` / `update-lockfile`'s `cargo update` under sccache without
the AWS creds bound (those wrap only the compile), so it hit S3, fell back to
IMDS, and timed out.

- Jenkinsfile: scope the wrapper to a `withEnv` around the credentialed build.
- rust.mk: `update-lockfile` strips the wrapper (cargo update never compiles).

Declarative linter passes.
