### PR TITLE
ci: scope abortPrevious to non-main branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,10 @@ pipeline {
     timeout time: 1, unit: 'HOURS'
     timestamps()
     ansiColor 'xterm'
-    disableConcurrentBuilds(abortPrevious: true)
+    // On main, don't abort: a release build pushes a [skip ci] version commit
+    // that spawns a follow-on build, and aborting would mark the still-publishing
+    // release build as superseded. Non-main branches still abort stale builds.
+    disableConcurrentBuilds(abortPrevious: env.BRANCH_NAME != DEFAULT_BRANCH)
     buildDiscarder(
       logRotator(
         numToKeepStr: env.BRANCH_NAME == DEFAULT_BRANCH ? '30' : '5',


### PR DESCRIPTION
`disableConcurrentBuilds(abortPrevious: true)` applied on main too, so release
builds self-superseded: the `[skip ci]` version commit semantic-release pushes
triggers a follow-on build, and abortPrevious marks the still-publishing release
build `NOT_BUILT` (see main #246).

Gate it on `env.BRANCH_NAME != DEFAULT_BRANCH`: non-main still aborts stale
builds; main only serializes (queues), so release builds finish clean.

Declarative linter passes.
