### PR TITLE
feat(orchestration): nudge agents approaching the turn depth limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ Tool names are not namespaced by server. If two servers register a tool with the
 
 `turn_depth` controls how many tool-calling rounds can happen in a single turn. Higher values allow multi-step tool workflows before final response generation. This acts as a failsafe to prevent models from spinning out in unbounded tool-call loops.
 
+`nudge_last_turn` and `nudge_turns_remaining` enable turn-limit nudging: as the agent approaches the `turn_depth` limit, a warning is appended to tool output telling it to wrap up and deliver its answer (orchestration workers are told to call `submit_result`) rather than lose all gathered work when the limit terminates the run. `nudge_last_turn = true` warns on the final turn; `nudge_turns_remaining = N` starts wrap-up warnings when N or fewer turns remain. Both default to off and can be enabled independently.
+
 `context_window` sets the context window size (in tokens) for the agent, used for usage percentage reporting in `aura.session_info` streaming events.
 
 The complete starter configuration is in [examples/reference.toml](examples/reference.toml). Minimal per-provider configs are in `examples/minimal/` and complete agent examples are in `examples/complete/`.

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -757,6 +757,15 @@ pub struct AgentConfig {
     /// `[orchestration.worker.<name>.skills]`.
     #[serde(default)]
     pub skills: SkillsConfig,
+    /// Nudge the agent on its final turn to submit its results instead of
+    /// calling more tools (default: false).
+    #[serde(default, deserialize_with = "lenient_bool::deserialize_bool")]
+    pub nudge_last_turn: bool,
+    /// Nudge the agent to start wrapping up when this many turns remain
+    /// before the turn-depth limit. `None` disables wrap-up nudging.
+    #[serde(default)]
+    #[serde(deserialize_with = "lenient_int::deserialize_option_usize")]
+    pub nudge_turns_remaining: Option<usize>,
 }
 
 fn default_turn_depth() -> Option<usize> {
@@ -787,6 +796,8 @@ impl Default for AgentConfig {
             scratchpad: None,
             hidden: bool::default(),
             skills: SkillsConfig::default(),
+            nudge_last_turn: false,
+            nudge_turns_remaining: None,
         }
     }
 }
@@ -841,6 +852,14 @@ pub struct AgentSettings {
     /// On-demand skill definitions loaded via the load_skill tool
     #[serde(default)]
     pub skills: Vec<SkillConfig>,
+    /// Nudge the agent on its final turn to submit its results instead of
+    /// calling more tools.
+    #[serde(default)]
+    pub nudge_last_turn: bool,
+    /// Nudge the agent to start wrapping up when this many turns remain
+    /// before the turn-depth limit. `None` disables wrap-up nudging.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nudge_turns_remaining: Option<usize>,
 }
 
 impl Default for AgentSettings {
@@ -855,6 +874,8 @@ impl Default for AgentSettings {
             enable_client_tools: false,
             client_tool_filter: None,
             skills: Vec::new(),
+            nudge_last_turn: false,
+            nudge_turns_remaining: None,
         }
     }
 }
@@ -941,6 +962,29 @@ mod tests {
     fn test_glob_match_star_only() {
         assert!(glob_match("*", "anything"));
         assert!(glob_match("*", ""));
+    }
+
+    #[test]
+    fn test_agent_nudge_flags_parse_and_default_off() {
+        let toml = r#"
+            [agent]
+            name = "test"
+            system_prompt = "test"
+            nudge_last_turn = true
+            nudge_turns_remaining = 3
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(config.agent.nudge_last_turn);
+        assert_eq!(config.agent.nudge_turns_remaining, Some(3));
+
+        let toml = r#"
+            [agent]
+            name = "test"
+            system_prompt = "test"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(!config.agent.nudge_last_turn);
+        assert_eq!(config.agent.nudge_turns_remaining, None);
     }
 
     #[test]

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -146,6 +146,9 @@ pub struct Agent {
     /// stream with `finish_reason: "tool_calls"` so the caller can execute
     /// the tool and resume in a follow-up request.
     pub(crate) client_tool_names: HashSet<String>,
+    /// Turn-limit nudge state shared with this agent's `TurnNudgeWrapper`
+    /// (see the `turn_nudge` module).
+    pub(crate) turn_nudge: Option<Arc<crate::turn_nudge::TurnNudgeState>>,
 }
 
 impl Agent {
@@ -341,18 +344,50 @@ impl Agent {
             ));
         }
 
-        let config = &config_owned;
-
         // Scratchpad bonus only applies when scratchpad was actually wired up
         // (enabled + context_window + a matching MCP tool).
-        let base_depth = config.agent.turn_depth.unwrap_or(DEFAULT_MAX_DEPTH);
-        let scratchpad_bonus = config
+        let base_depth = config_owned.agent.turn_depth.unwrap_or(DEFAULT_MAX_DEPTH);
+        let scratchpad_bonus = config_owned
             .scratchpad_tools_config
             .as_ref()
-            .and(config.agent.scratchpad.as_ref())
+            .and(config_owned.agent.scratchpad.as_ref())
             .map(|sp| sp.turn_depth_bonus)
             .unwrap_or(0);
         let max_depth = base_depth + scratchpad_bonus;
+
+        // Turn-limit nudging for single-agent mode. Orchestration workers wire
+        // their own state in `create_worker` (with submit_result wording); the
+        // top-level orchestration agent doesn't run rig's multi-turn loop
+        // itself, so it gets no nudge state.
+        let turn_nudge = if config_owned.orchestration_enabled() {
+            None
+        } else {
+            crate::turn_nudge::TurnNudgeState::new(
+                config_owned.agent.nudge_last_turn,
+                config_owned.agent.nudge_turns_remaining,
+                max_depth,
+            )
+        };
+        if let Some(ref state) = turn_nudge {
+            // First in the vec → `transform_output` runs LAST, so the nudge
+            // lands on the text the LLM actually sees (after any scratchpad
+            // pointer rewrite) and is never persisted as raw tool output.
+            let nudge: Arc<dyn crate::tool_wrapper::ToolWrapper> =
+                Arc::new(crate::turn_nudge::TurnNudgeWrapper::new(state.clone()));
+            config_owned.tool_wrapper = Some(match config_owned.tool_wrapper.take() {
+                Some(existing) => Arc::new(crate::tool_wrapper::ComposedWrapper::new(vec![
+                    nudge, existing,
+                ])),
+                None => nudge,
+            });
+            tracing::info!(
+                "  Turn-limit nudging: ENABLED (last_turn={}, wrap_up_threshold={:?})",
+                config_owned.agent.nudge_last_turn,
+                config_owned.agent.nudge_turns_remaining
+            );
+        }
+
+        let config = &config_owned;
         if scratchpad_bonus > 0 {
             tracing::info!(
                 "  Max turn depth: {} (base={}, scratchpad_bonus={})",
@@ -751,6 +786,7 @@ impl Agent {
             context_window: config.llm.context_window(),
             scratchpad_budget: agent_scratchpad_budget,
             client_tool_names,
+            turn_nudge,
         })
     }
 
@@ -1150,7 +1186,7 @@ impl Agent {
         query: &str,
     ) -> Pin<Box<dyn futures::stream::Stream<Item = Result<StreamItem, StreamError>> + Send>> {
         let stream = self.inner.stream_prompt(query, self.max_depth).await;
-        self.maybe_wrap_with_fallback(stream)
+        self.maybe_wrap_with_fallback(self.count_turns(stream))
     }
 
     /// Stream a chat query with conversation history - returns true streaming response with multi-turn tool support
@@ -1163,7 +1199,7 @@ impl Agent {
             .inner
             .stream_chat(query, chat_history, self.max_depth)
             .await;
-        self.maybe_wrap_with_fallback(stream)
+        self.maybe_wrap_with_fallback(self.count_turns(stream))
     }
 
     /// Stream a chat with explicit max_depth override.
@@ -1179,7 +1215,37 @@ impl Agent {
         max_depth: usize,
     ) -> Pin<Box<dyn futures::stream::Stream<Item = Result<StreamItem, StreamError>> + Send>> {
         let stream = self.inner.stream_chat(query, chat_history, max_depth).await;
-        self.maybe_wrap_with_fallback(stream)
+        self.maybe_wrap_with_fallback(self.count_turns(stream))
+    }
+
+    /// Feed per-turn completions into the turn-nudge state so its
+    /// `TurnNudgeWrapper` knows which turn is executing.
+    ///
+    /// Rig yields exactly one provider `Final` chunk per turn, which
+    /// `map_stream_item` converts to `StreamItem::TurnUsage` — counting those
+    /// tracks the turn number without touching the rig fork. Tool calls of
+    /// turn `N` execute before turn `N`'s `TurnUsage` arrives, so during tool
+    /// execution the current turn is `turns_completed + 1`. Counters are
+    /// reset here because an `Agent` can serve multiple sequential streams
+    /// (e.g. the CLI REPL). No-op passthrough when nudging is disabled.
+    fn count_turns(
+        &self,
+        stream: Pin<
+            Box<dyn futures::stream::Stream<Item = Result<StreamItem, StreamError>> + Send>,
+        >,
+    ) -> Pin<Box<dyn futures::stream::Stream<Item = Result<StreamItem, StreamError>> + Send>> {
+        use futures::StreamExt;
+
+        let Some(state) = self.turn_nudge.clone() else {
+            return stream;
+        };
+        state.reset();
+        Box::pin(stream.map(move |item| {
+            if matches!(item, Ok(StreamItem::TurnUsage(_))) {
+                state.record_turn_completed();
+            }
+            item
+        }))
     }
 
     /// Append a final `StreamItem::ScratchpadUsage` if this agent has a
@@ -1283,7 +1349,7 @@ impl Agent {
             )
             .await;
         (
-            self.append_scratchpad_usage(self.maybe_wrap_with_fallback(stream)),
+            self.append_scratchpad_usage(self.maybe_wrap_with_fallback(self.count_turns(stream))),
             cancel_tx,
             usage_state,
         )
@@ -1329,7 +1395,7 @@ impl Agent {
             )
             .await;
         (
-            self.append_scratchpad_usage(self.maybe_wrap_with_fallback(stream)),
+            self.append_scratchpad_usage(self.maybe_wrap_with_fallback(self.count_turns(stream))),
             cancel_tx,
             usage_state,
         )

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -146,8 +146,7 @@ pub struct Agent {
     /// stream with `finish_reason: "tool_calls"` so the caller can execute
     /// the tool and resume in a follow-up request.
     pub(crate) client_tool_names: HashSet<String>,
-    /// Turn-limit nudge state shared with this agent's `TurnNudgeWrapper`
-    /// (see the `turn_nudge` module).
+    /// Turn-limit nudge state shared with this agent's `TurnNudgeWrapper`.
     pub(crate) turn_nudge: Option<Arc<crate::turn_nudge::TurnNudgeState>>,
 }
 
@@ -355,10 +354,8 @@ impl Agent {
             .unwrap_or(0);
         let max_depth = base_depth + scratchpad_bonus;
 
-        // Turn-limit nudging for single-agent mode. Orchestration workers wire
-        // their own state in `create_worker` (with submit_result wording); the
-        // top-level orchestration agent doesn't run rig's multi-turn loop
-        // itself, so it gets no nudge state.
+        // Turn-limit nudging for single-agent mode; orchestration workers
+        // wire their own state in `create_worker`.
         let turn_nudge = if config_owned.orchestration_enabled() {
             None
         } else {
@@ -369,9 +366,8 @@ impl Agent {
             )
         };
         if let Some(ref state) = turn_nudge {
-            // First in the vec → `transform_output` runs LAST, so the nudge
-            // lands on the text the LLM actually sees (after any scratchpad
-            // pointer rewrite) and is never persisted as raw tool output.
+            // First in the vec → transform_output runs last, on the text the
+            // LLM actually sees (after any scratchpad pointer rewrite).
             let nudge: Arc<dyn crate::tool_wrapper::ToolWrapper> =
                 Arc::new(crate::turn_nudge::TurnNudgeWrapper::new(state.clone()));
             config_owned.tool_wrapper = Some(match config_owned.tool_wrapper.take() {
@@ -1218,16 +1214,10 @@ impl Agent {
         self.maybe_wrap_with_fallback(self.count_turns(stream))
     }
 
-    /// Feed per-turn completions into the turn-nudge state so its
-    /// `TurnNudgeWrapper` knows which turn is executing.
-    ///
-    /// Rig yields exactly one provider `Final` chunk per turn, which
-    /// `map_stream_item` converts to `StreamItem::TurnUsage` — counting those
-    /// tracks the turn number without touching the rig fork. Tool calls of
-    /// turn `N` execute before turn `N`'s `TurnUsage` arrives, so during tool
-    /// execution the current turn is `turns_completed + 1`. Counters are
-    /// reset here because an `Agent` can serve multiple sequential streams
-    /// (e.g. the CLI REPL). No-op passthrough when nudging is disabled.
+    /// Count completed turns into the turn-nudge state. Rig yields exactly
+    /// one `StreamItem::TurnUsage` per turn, and a turn's tool calls execute
+    /// before its `TurnUsage` arrives, so mid-turn the current turn is
+    /// `turns_completed + 1`. No-op when nudging is disabled.
     fn count_turns(
         &self,
         stream: Pin<

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -45,6 +45,7 @@ pub mod tool_error_detection;
 pub mod tool_event_broker;
 pub mod tool_wrapper;
 pub mod tools;
+pub mod turn_nudge;
 pub mod vector_dynamic;
 pub mod vector_store;
 

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -699,8 +699,6 @@ impl Orchestrator {
             tracing::info!("Worker {} turn_depth={}", task_id, resolved_depth);
         }
 
-        // Turn-limit nudging: workers get submit_result wording. The state is
-        // fed per-turn by `Agent::count_turns` on the worker's stream.
         let turn_nudge = crate::turn_nudge::TurnNudgeState::new_with_submit_tool(
             worker_config.agent.nudge_last_turn,
             worker_config.agent.nudge_turns_remaining,
@@ -713,9 +711,8 @@ impl Orchestrator {
         // also needs raw output — persistence's transform_output is a
         // passthrough that just caches the raw — and rewrites to the pointer.
         // Duplicate-guard and observer then see the pointer, which is what
-        // should surface to the LLM/UI. The turn-limit nudge goes first so it
-        // runs after everything else and lands on the text the LLM sees
-        // without being persisted as raw output.
+        // should surface to the LLM/UI. The turn-limit nudge goes first so
+        // it runs after everything else, on the text the LLM sees.
         let mut wrappers: Vec<Arc<dyn ToolWrapper>> = vec![observer_wrapper, duplicate_guard];
         wrappers.extend(scratchpad_tools);
         wrappers.push(persistence_wrapper);

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -672,16 +672,65 @@ impl Orchestrator {
             }
         }
 
+        // Resolution order: worker turn_depth → [agent].turn_depth → DEFAULT_MAX_DEPTH.
+        // Scratchpad bonus only applies when scratchpad was actually wired up.
+        let base_depth = worker_name
+            .and_then(|name| self.config.workers.get(name))
+            .and_then(|w| w.turn_depth)
+            .or(self.agent_config.agent.turn_depth)
+            .unwrap_or(crate::builder::DEFAULT_MAX_DEPTH);
+        let scratchpad_bonus = worker_config
+            .scratchpad_tools_config
+            .as_ref()
+            .and(effective_scratchpad.as_ref())
+            .map(|sp| sp.turn_depth_bonus)
+            .unwrap_or(0);
+        let resolved_depth = base_depth + scratchpad_bonus;
+        worker_config.agent.turn_depth = Some(resolved_depth);
+        if scratchpad_bonus > 0 {
+            tracing::info!(
+                "Worker {} turn_depth={} (base={}, scratchpad_bonus={})",
+                task_id,
+                resolved_depth,
+                base_depth,
+                scratchpad_bonus
+            );
+        } else {
+            tracing::info!("Worker {} turn_depth={}", task_id, resolved_depth);
+        }
+
+        // Turn-limit nudging: workers get submit_result wording. The state is
+        // fed per-turn by `Agent::count_turns` on the worker's stream.
+        let turn_nudge = crate::turn_nudge::TurnNudgeState::new_with_submit_tool(
+            worker_config.agent.nudge_last_turn,
+            worker_config.agent.nudge_turns_remaining,
+            resolved_depth,
+        );
+
         // ComposedWrapper applies transform_output in reverse-list order, so
         // the LAST entry runs FIRST on the raw tool output. Persistence must
         // see raw output (for debugging/retry), so it goes last. Scratchpad
         // also needs raw output — persistence's transform_output is a
         // passthrough that just caches the raw — and rewrites to the pointer.
         // Duplicate-guard and observer then see the pointer, which is what
-        // should surface to the LLM/UI.
+        // should surface to the LLM/UI. The turn-limit nudge goes first so it
+        // runs after everything else and lands on the text the LLM sees
+        // without being persisted as raw output.
         let mut wrappers: Vec<Arc<dyn ToolWrapper>> = vec![observer_wrapper, duplicate_guard];
         wrappers.extend(scratchpad_tools);
         wrappers.push(persistence_wrapper);
+        if let Some(ref state) = turn_nudge {
+            wrappers.insert(
+                0,
+                Arc::new(crate::turn_nudge::TurnNudgeWrapper::new(state.clone())),
+            );
+            tracing::info!(
+                "Worker {} turn-limit nudging enabled (last_turn={}, wrap_up_threshold={:?})",
+                task_id,
+                worker_config.agent.nudge_last_turn,
+                worker_config.agent.nudge_turns_remaining
+            );
+        }
 
         // HITL config gate. When `[hitl]` is configured, gate matching worker
         // tool calls behind the decision route, and pre-build the agent-callable
@@ -804,33 +853,6 @@ impl Orchestrator {
         // Disable orchestration in worker config to avoid nested orchestration
         worker_config.orchestration = None;
 
-        // Resolution order: worker turn_depth → [agent].turn_depth → DEFAULT_MAX_DEPTH.
-        // Scratchpad bonus only applies when scratchpad was actually wired up.
-        let base_depth = worker_name
-            .and_then(|name| self.config.workers.get(name))
-            .and_then(|w| w.turn_depth)
-            .or(self.agent_config.agent.turn_depth)
-            .unwrap_or(crate::builder::DEFAULT_MAX_DEPTH);
-        let scratchpad_bonus = worker_config
-            .scratchpad_tools_config
-            .as_ref()
-            .and(effective_scratchpad.as_ref())
-            .map(|sp| sp.turn_depth_bonus)
-            .unwrap_or(0);
-        let resolved_depth = base_depth + scratchpad_bonus;
-        worker_config.agent.turn_depth = Some(resolved_depth);
-        if scratchpad_bonus > 0 {
-            tracing::info!(
-                "Worker {} turn_depth={} (base={}, scratchpad_bonus={})",
-                task_id,
-                resolved_depth,
-                base_depth,
-                scratchpad_bonus
-            );
-        } else {
-            tracing::info!("Worker {} turn_depth={}", task_id, resolved_depth);
-        }
-
         if worker_config.scratchpad_tools_config.is_some()
             && let Some(ref mut preamble) = worker_config.preamble_override
         {
@@ -885,6 +907,7 @@ impl Orchestrator {
                 .as_ref()
                 .map(|sp| sp.budget.clone()),
             client_tool_names: Default::default(),
+            turn_nudge,
         };
 
         Ok(AgentWithPreamble {
@@ -2236,6 +2259,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 context_window: None,
                 scratchpad_budget: None,
                 client_tool_names: Default::default(),
+                turn_nudge: None,
             },
             preamble,
             escalation_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/aura/src/rig_builder.rs
+++ b/crates/aura/src/rig_builder.rs
@@ -55,6 +55,8 @@ impl RigBuilder {
             enable_client_tools: self.config.agent.enable_client_tools,
             client_tool_filter: self.config.agent.client_tool_filter.clone(),
             skills: Vec::new(),
+            nudge_last_turn: self.config.agent.nudge_last_turn,
+            nudge_turns_remaining: self.config.agent.nudge_turns_remaining,
         };
 
         AgentRuntimeConfig {

--- a/crates/aura/src/turn_nudge.rs
+++ b/crates/aura/src/turn_nudge.rs
@@ -1,38 +1,11 @@
-//! Turn-limit nudging — warns an agent that it is approaching its turn-depth
-//! limit so it wraps up and submits results instead of losing all work to a
+//! Turn-limit nudging — warns an agent nearing its turn-depth limit so it
+//! wraps up and submits results instead of losing all work to a
 //! `MaxDepthError`.
 //!
-//! # How it works
-//!
-//! Rig's multi-turn loop lives inside the rig fork, so aura cannot inject a
-//! message between turns directly. Instead the nudge rides on two aura-owned
-//! seams:
-//!
-//! 1. **Turn counting** — every rig turn ends with a provider `Final` chunk,
-//!    which `map_stream_item` converts to `StreamItem::TurnUsage`. The
-//!    `Agent::stream_*` methods count those into [`TurnNudgeState`]
-//!    (see `Agent::count_turns`).
-//! 2. **Injection** — [`TurnNudgeWrapper`] appends a notice to MCP tool
-//!    output when few turns remain. Rig feeds tool results back as the next
-//!    turn's prompt, so the model reads the nudge at the start of its next
-//!    turn.
-//!
-//! Enabled per agent via `[agent].nudge_last_turn` (final-turn "submit now"
-//! notice) and `[agent].nudge_turns_remaining` (start "wrap up" notices when
-//! that many turns remain). Wired for orchestration workers (in
-//! `create_worker`) and single-agent mode (in `Agent::new`); the coordinator
-//! is excluded.
-//!
-//! # Prototype limitations
-//!
-//! - Only MCP tool outputs carry the nudge (`tool_wrapper` doesn't wrap
-//!   native tools like scratchpad reads or `submit_result`). A turn that
-//!   calls no MCP tool gets no nudge — but a turn with no tool calls at all
-//!   ends the loop successfully anyway.
-//! - The state is per-`Agent`; concurrent streams on one `Agent` would share
-//!   a counter. All current callers build agents per request/task.
-//! - Ollama fallback tool parsing executes tools outside rig's loop and is
-//!   not nudged.
+//! `Agent::count_turns` tracks the turn number (one `StreamItem::TurnUsage`
+//! per rig turn); [`TurnNudgeWrapper`] appends a notice to MCP tool output,
+//! which rig feeds back as the next turn's prompt. Enabled via
+//! `[agent].nudge_last_turn` and `[agent].nudge_turns_remaining`.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -44,14 +17,8 @@ use crate::mcp_response::CallOutcome;
 use crate::tool_wrapper::{ToolCallContext, ToolWrapper, TransformOutputResult};
 
 /// Shared turn-limit tracking for one agent stream.
-///
-/// Turn math: rig's streaming loop (`rig-core` `prompt_request/streaming.rs`)
-/// breaks only when its pre-increment turn counter exceeds `max_depth + 1`,
-/// so it executes up to `max_depth + 2` turns before yielding
-/// `MaxDepthError`. A nudge appended to turn `T`'s tool output is read by
-/// the model at the start of turn `T + 1`.
 pub struct TurnNudgeState {
-    /// Total turns rig will execute for this agent before `MaxDepthError`.
+    /// Total turns rig will execute before `MaxDepthError`.
     max_turns: usize,
     nudge_last_turn: bool,
     /// Emit wrap-up notices once this many turns (or fewer) remain.
@@ -64,8 +31,7 @@ pub struct TurnNudgeState {
 }
 
 impl TurnNudgeState {
-    /// Build nudge state from the `[agent]` flags and the agent's resolved
-    /// turn depth. Returns `None` when both flags are off (nudging disabled).
+    /// Returns `None` when both flags are off (nudging disabled).
     pub fn new(
         nudge_last_turn: bool,
         nudge_turns_remaining: Option<usize>,
@@ -74,9 +40,7 @@ impl TurnNudgeState {
         Self::build(nudge_last_turn, nudge_turns_remaining, max_depth, false)
     }
 
-    /// Like [`Self::new`] but for agents that carry the orchestration
-    /// `submit_result` tool — the final-turn nudge tells the agent to call
-    /// it instead of answering in text.
+    /// Like [`Self::new`] but with `submit_result` wording for workers.
     pub fn new_with_submit_tool(
         nudge_last_turn: bool,
         nudge_turns_remaining: Option<usize>,
@@ -95,6 +59,8 @@ impl TurnNudgeState {
             return None;
         }
         Some(Arc::new(Self {
+            // Rig's streaming loop breaks when its pre-increment counter
+            // exceeds max_depth + 1, i.e. it runs max_depth + 2 turns.
             max_turns: max_depth + 2,
             nudge_last_turn,
             wrap_up_threshold: nudge_turns_remaining,
@@ -104,30 +70,26 @@ impl TurnNudgeState {
         }))
     }
 
-    /// Reset counters at stream start (an `Agent` can serve multiple
-    /// sequential streams, e.g. the CLI REPL).
+    /// Reset counters at stream start.
     pub fn reset(&self) {
         self.turns_completed.store(0, Ordering::Release);
         self.last_nudged_turn.store(0, Ordering::Release);
     }
 
-    /// Record one completed rig turn (one `StreamItem::TurnUsage` observed).
+    /// Record one completed rig turn.
     pub fn record_turn_completed(&self) {
         self.turns_completed.fetch_add(1, Ordering::AcqRel);
     }
 
     /// Nudge text for the turn currently executing, or `None` when no nudge
     /// applies (or one was already issued this turn).
-    ///
-    /// Called from tool-output transformation, i.e. mid-turn: the current
-    /// turn number is `turns_completed + 1`, and `remaining` counts the
-    /// turns left *after* this one — the turns in which the model can still
-    /// act on the nudge.
     pub fn nudge_message(&self) -> Option<String> {
+        // Called mid-turn, so the current turn is turns_completed + 1.
+        // `remaining` counts turns left after this one — the nudge is read
+        // at the start of the next turn.
         let current_turn = self.turns_completed.load(Ordering::Acquire) + 1;
         let remaining = self.max_turns.saturating_sub(current_turn);
         if remaining == 0 {
-            // The loop is out of turns; a nudge could no longer be acted on.
             return None;
         }
 
@@ -145,8 +107,7 @@ impl TurnNudgeState {
             None
         }?;
 
-        // At most one nudge per turn: swap is safe because turn numbers are
-        // monotonically increasing within a stream.
+        // At most one nudge per turn.
         let previously_nudged = self.last_nudged_turn.swap(current_turn, Ordering::AcqRel);
         if previously_nudged == current_turn {
             return None;
@@ -189,10 +150,6 @@ impl TurnNudgeState {
 }
 
 /// ToolWrapper that appends turn-limit nudges to tool output.
-///
-/// Composed so its `transform_output` runs last (first in the wrapper list),
-/// after scratchpad interception — the nudge must land on the text the LLM
-/// actually sees, and must not be persisted as raw tool output.
 pub struct TurnNudgeWrapper {
     state: Arc<TurnNudgeState>,
 }

--- a/crates/aura/src/turn_nudge.rs
+++ b/crates/aura/src/turn_nudge.rs
@@ -1,0 +1,331 @@
+//! Turn-limit nudging — warns an agent that it is approaching its turn-depth
+//! limit so it wraps up and submits results instead of losing all work to a
+//! `MaxDepthError`.
+//!
+//! # How it works
+//!
+//! Rig's multi-turn loop lives inside the rig fork, so aura cannot inject a
+//! message between turns directly. Instead the nudge rides on two aura-owned
+//! seams:
+//!
+//! 1. **Turn counting** — every rig turn ends with a provider `Final` chunk,
+//!    which `map_stream_item` converts to `StreamItem::TurnUsage`. The
+//!    `Agent::stream_*` methods count those into [`TurnNudgeState`]
+//!    (see `Agent::count_turns`).
+//! 2. **Injection** — [`TurnNudgeWrapper`] appends a notice to MCP tool
+//!    output when few turns remain. Rig feeds tool results back as the next
+//!    turn's prompt, so the model reads the nudge at the start of its next
+//!    turn.
+//!
+//! Enabled per agent via `[agent].nudge_last_turn` (final-turn "submit now"
+//! notice) and `[agent].nudge_turns_remaining` (start "wrap up" notices when
+//! that many turns remain). Wired for orchestration workers (in
+//! `create_worker`) and single-agent mode (in `Agent::new`); the coordinator
+//! is excluded.
+//!
+//! # Prototype limitations
+//!
+//! - Only MCP tool outputs carry the nudge (`tool_wrapper` doesn't wrap
+//!   native tools like scratchpad reads or `submit_result`). A turn that
+//!   calls no MCP tool gets no nudge — but a turn with no tool calls at all
+//!   ends the loop successfully anyway.
+//! - The state is per-`Agent`; concurrent streams on one `Agent` would share
+//!   a counter. All current callers build agents per request/task.
+//! - Ollama fallback tool parsing executes tools outside rig's loop and is
+//!   not nudged.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::mcp_response::CallOutcome;
+use crate::tool_wrapper::{ToolCallContext, ToolWrapper, TransformOutputResult};
+
+/// Shared turn-limit tracking for one agent stream.
+///
+/// Turn math: rig's streaming loop (`rig-core` `prompt_request/streaming.rs`)
+/// breaks only when its pre-increment turn counter exceeds `max_depth + 1`,
+/// so it executes up to `max_depth + 2` turns before yielding
+/// `MaxDepthError`. A nudge appended to turn `T`'s tool output is read by
+/// the model at the start of turn `T + 1`.
+pub struct TurnNudgeState {
+    /// Total turns rig will execute for this agent before `MaxDepthError`.
+    max_turns: usize,
+    nudge_last_turn: bool,
+    /// Emit wrap-up notices once this many turns (or fewer) remain.
+    wrap_up_threshold: Option<usize>,
+    /// The agent has the orchestration `submit_result` tool.
+    has_submit_tool: bool,
+    turns_completed: AtomicUsize,
+    /// Turn number of the most recent nudge.
+    last_nudged_turn: AtomicUsize,
+}
+
+impl TurnNudgeState {
+    /// Build nudge state from the `[agent]` flags and the agent's resolved
+    /// turn depth. Returns `None` when both flags are off (nudging disabled).
+    pub fn new(
+        nudge_last_turn: bool,
+        nudge_turns_remaining: Option<usize>,
+        max_depth: usize,
+    ) -> Option<Arc<Self>> {
+        Self::build(nudge_last_turn, nudge_turns_remaining, max_depth, false)
+    }
+
+    /// Like [`Self::new`] but for agents that carry the orchestration
+    /// `submit_result` tool — the final-turn nudge tells the agent to call
+    /// it instead of answering in text.
+    pub fn new_with_submit_tool(
+        nudge_last_turn: bool,
+        nudge_turns_remaining: Option<usize>,
+        max_depth: usize,
+    ) -> Option<Arc<Self>> {
+        Self::build(nudge_last_turn, nudge_turns_remaining, max_depth, true)
+    }
+
+    fn build(
+        nudge_last_turn: bool,
+        nudge_turns_remaining: Option<usize>,
+        max_depth: usize,
+        has_submit_tool: bool,
+    ) -> Option<Arc<Self>> {
+        if !nudge_last_turn && nudge_turns_remaining.is_none() {
+            return None;
+        }
+        Some(Arc::new(Self {
+            max_turns: max_depth + 2,
+            nudge_last_turn,
+            wrap_up_threshold: nudge_turns_remaining,
+            has_submit_tool,
+            turns_completed: AtomicUsize::new(0),
+            last_nudged_turn: AtomicUsize::new(0),
+        }))
+    }
+
+    /// Reset counters at stream start (an `Agent` can serve multiple
+    /// sequential streams, e.g. the CLI REPL).
+    pub fn reset(&self) {
+        self.turns_completed.store(0, Ordering::Release);
+        self.last_nudged_turn.store(0, Ordering::Release);
+    }
+
+    /// Record one completed rig turn (one `StreamItem::TurnUsage` observed).
+    pub fn record_turn_completed(&self) {
+        self.turns_completed.fetch_add(1, Ordering::AcqRel);
+    }
+
+    /// Nudge text for the turn currently executing, or `None` when no nudge
+    /// applies (or one was already issued this turn).
+    ///
+    /// Called from tool-output transformation, i.e. mid-turn: the current
+    /// turn number is `turns_completed + 1`, and `remaining` counts the
+    /// turns left *after* this one — the turns in which the model can still
+    /// act on the nudge.
+    pub fn nudge_message(&self) -> Option<String> {
+        let current_turn = self.turns_completed.load(Ordering::Acquire) + 1;
+        let remaining = self.max_turns.saturating_sub(current_turn);
+        if remaining == 0 {
+            // The loop is out of turns; a nudge could no longer be acted on.
+            return None;
+        }
+
+        let message = if remaining == 1 {
+            if self.nudge_last_turn {
+                Some(self.last_turn_message())
+            } else if self.wrap_up_threshold.is_some_and(|n| n >= 1) {
+                Some(self.wrap_up_message(remaining))
+            } else {
+                None
+            }
+        } else if self.wrap_up_threshold.is_some_and(|n| remaining <= n) {
+            Some(self.wrap_up_message(remaining))
+        } else {
+            None
+        }?;
+
+        // At most one nudge per turn: swap is safe because turn numbers are
+        // monotonically increasing within a stream.
+        let previously_nudged = self.last_nudged_turn.swap(current_turn, Ordering::AcqRel);
+        if previously_nudged == current_turn {
+            return None;
+        }
+
+        tracing::info!(
+            current_turn,
+            remaining,
+            max_turns = self.max_turns,
+            "turn-limit nudge issued"
+        );
+        Some(message)
+    }
+
+    fn last_turn_message(&self) -> String {
+        let submit = if self.has_submit_tool {
+            "Call the `submit_result` tool NOW with your findings — do not call any other tools first"
+        } else {
+            "Respond with your final answer now — do not call any more tools"
+        };
+        format!(
+            "\n\n---\n[TURN LIMIT — FINAL TURN] Your next turn is the LAST one before \
+             this task is terminated and all work is lost. {submit}. Partial results \
+             are better than none."
+        )
+    }
+
+    fn wrap_up_message(&self, remaining: usize) -> String {
+        let submit = if self.has_submit_tool {
+            "submit your findings via the `submit_result` tool"
+        } else {
+            "deliver your final answer"
+        };
+        format!(
+            "\n\n---\n[TURN LIMIT WARNING] Only {remaining} turn(s) remain before this \
+             task is forcibly terminated. Start wrapping up: make only the most \
+             essential remaining tool calls, then {submit} before the limit is reached."
+        )
+    }
+}
+
+/// ToolWrapper that appends turn-limit nudges to tool output.
+///
+/// Composed so its `transform_output` runs last (first in the wrapper list),
+/// after scratchpad interception — the nudge must land on the text the LLM
+/// actually sees, and must not be persisted as raw tool output.
+pub struct TurnNudgeWrapper {
+    state: Arc<TurnNudgeState>,
+}
+
+impl TurnNudgeWrapper {
+    pub fn new(state: Arc<TurnNudgeState>) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ToolWrapper for TurnNudgeWrapper {
+    fn transform_output(
+        &self,
+        output: String,
+        _outcome: &CallOutcome,
+        ctx: &ToolCallContext,
+        _extracted: Option<&Value>,
+    ) -> TransformOutputResult {
+        match self.state.nudge_message() {
+            Some(nudge) => {
+                tracing::debug!(tool = %ctx.tool_name, "appending turn-limit nudge to tool output");
+                TransformOutputResult::new(format!("{output}{nudge}"))
+            }
+            None => TransformOutputResult::new(output),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn advance(state: &TurnNudgeState, turns: usize) {
+        for _ in 0..turns {
+            state.record_turn_completed();
+        }
+    }
+
+    #[test]
+    fn disabled_when_both_flags_off() {
+        assert!(TurnNudgeState::new(false, None, 10).is_none());
+    }
+
+    #[test]
+    fn last_turn_nudge_fires_only_on_penultimate_turn() {
+        // max_depth=3 → rig executes up to 5 turns. The nudge written during
+        // turn 4 is read at the start of turn 5 (the last).
+        let state = TurnNudgeState::new(true, None, 3).unwrap();
+
+        // Turns 1-3: no nudge.
+        for turn in 1..=3 {
+            assert!(
+                state.nudge_message().is_none(),
+                "unexpected nudge on turn {turn}"
+            );
+            state.record_turn_completed();
+        }
+        // Turn 4 (remaining = 1): final-turn nudge.
+        let msg = state.nudge_message().expect("expected final-turn nudge");
+        assert!(msg.contains("FINAL TURN"));
+        // Second tool call in the same turn: no repeat.
+        assert!(state.nudge_message().is_none());
+
+        // Turn 5 (remaining = 0): too late to act, no nudge.
+        state.record_turn_completed();
+        assert!(state.nudge_message().is_none());
+    }
+
+    #[test]
+    fn wrap_up_nudges_start_at_threshold_and_repeat_each_turn() {
+        // max_depth=4 → 6 turns total. Threshold 3 → nudges when remaining
+        // is 3, 2, and 1 (turns 3, 4, 5).
+        let state = TurnNudgeState::new(false, Some(3), 4).unwrap();
+
+        advance(&state, 1); // now in turn 2, remaining 4
+        assert!(state.nudge_message().is_none());
+
+        advance(&state, 1); // turn 3, remaining 3
+        let msg = state.nudge_message().expect("expected wrap-up nudge");
+        assert!(msg.contains("Only 3 turn(s) remain"));
+
+        advance(&state, 1); // turn 4, remaining 2
+        assert!(
+            state
+                .nudge_message()
+                .expect("expected wrap-up nudge")
+                .contains("Only 2 turn(s) remain")
+        );
+
+        advance(&state, 1); // turn 5, remaining 1 — wrap-up wording (last-turn flag off)
+        assert!(
+            state
+                .nudge_message()
+                .expect("expected wrap-up nudge")
+                .contains("Only 1 turn(s) remain")
+        );
+    }
+
+    #[test]
+    fn last_turn_message_wins_over_wrap_up_on_penultimate_turn() {
+        let state = TurnNudgeState::new(true, Some(2), 2).unwrap(); // 4 turns total
+        advance(&state, 2); // turn 3, remaining 1 — both flags apply
+        let msg = state.nudge_message().expect("expected nudge");
+        assert!(msg.contains("FINAL TURN"));
+    }
+
+    #[test]
+    fn submit_tool_wording_for_workers() {
+        let state = TurnNudgeState::new_with_submit_tool(true, Some(2), 2).unwrap();
+        advance(&state, 1); // turn 2, remaining 2 → wrap-up
+        assert!(
+            state
+                .nudge_message()
+                .expect("expected wrap-up nudge")
+                .contains("submit_result")
+        );
+        advance(&state, 1); // turn 3, remaining 1 → final
+        assert!(
+            state
+                .nudge_message()
+                .expect("expected final nudge")
+                .contains("submit_result")
+        );
+    }
+
+    #[test]
+    fn reset_clears_counters_between_streams() {
+        let state = TurnNudgeState::new(true, None, 1).unwrap(); // 3 turns total
+        advance(&state, 1); // turn 2, remaining 1
+        assert!(state.nudge_message().is_some());
+        state.reset();
+        // Back in turn 1 (remaining 2): no nudge.
+        assert!(state.nudge_message().is_none());
+    }
+}

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -174,6 +174,16 @@ Workflow:
 # deeper multi-step workflows but consume more tokens.
 turn_depth = 5
 
+# Turn-limit nudging: warn the agent in-conversation as it approaches the
+# turn_depth limit so it wraps up and delivers an answer instead of losing
+# all work when the limit terminates the run. Notices are appended to tool
+# output; orchestration workers are told to call `submit_result` instead.
+# Both settings default to off and can be enabled independently.
+# nudge_last_turn = true      # on the final turn, tell the agent to answer
+#                             # now and stop calling tools
+# nudge_turns_remaining = 3   # start wrap-up warnings when this many turns
+#                             # (or fewer) remain
+
 # ── LLM Provider ────────────────────────────────────────────────────
 [agent.llm]
 provider = "openai"


### PR DESCRIPTION
Fixes #379

## Problem

A worker that hits the turn depth limit mid-investigation fails with `MaxDepthError` and loses everything it gathered. The coordinator retasks it and the investigation starts over from zero. Prompts that ask for thorough investigation hit this routinely.

## Change

Warn the agent in-conversation as it approaches the limit, so it can wrap up and submit partial results instead of losing the task. Two independent `[agent]` flags:

```toml
[agent]
turn_depth = 10
nudge_last_turn = true       # on the final turn: submit results now
nudge_turns_remaining = 3    # start wrap-up notices when 3 or fewer turns remain
```

Workers inherit the flags from `[agent]` and get wording that tells them to call `submit_result`. Single-agent mode says to answer in text. The coordinator is excluded. A worker that calls `submit_result` on its literal last turn still succeeds, since the orchestrator already treats `MaxDepthError` as success when a decision was captured.

## How it works

Rig's multi-turn loop lives in the fork, so the nudge rides on two aura-owned seams instead:

1. `Agent::count_turns` tracks the current turn by counting the per-turn `StreamItem::TurnUsage` events on the stream.
2. A new `TurnNudgeWrapper` (`ToolWrapper`) appends the notice to MCP tool output. Rig feeds tool results back as the next turn's prompt, so the model reads the notice at the start of its next turn.

The wrapper runs last in the composed chain, after scratchpad pointer rewriting, so the notice lands on the text the LLM sees and is never persisted as raw tool output. At most one nudge is emitted per turn. The turn math accounts for rig 0.28 executing up to `max_depth + 2` turns before `MaxDepthError` (its loop breaks on `counter > max_depth + 1`).

## Scope and known limits

This is a prototype to gauge impact on task failure and retask rates.

- Only MCP tool outputs carry the nudge; native tools (scratchpad reads, `read_artifact`, `submit_result`) are not wrapped by `tool_wrapper`. A turn that calls no MCP tool gets no nudge that turn.
- Ollama fallback tool parsing executes outside rig's loop and is not nudged.
- Nudge state is per `Agent`. All current callers build agents per request or per task, so concurrent streams on one agent do not occur today.

## Testing

- 6 unit tests in `turn_nudge.rs` covering the turn math, once-per-turn dedup, threshold behavior, worker vs single-agent wording, and counter reset between streams
- Parse test in `aura-config` for the new flags and their defaults
- `cargo test --workspace` passes, clippy clean
