### PR TITLE
feat(config): support base_url for openai embeddings provider

### DIFF
--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -625,6 +625,9 @@ pub enum EmbeddingConfig {
     OpenAI {
         api_key: String,
         model: String,
+        /// Custom API endpoint for OpenAI-compatible embedding servers
+        #[serde(default)]
+        base_url: Option<String>,
     },
     Bedrock {
         model: String,
@@ -640,6 +643,7 @@ impl Default for EmbeddingConfig {
         EmbeddingConfig::OpenAI {
             api_key: String::new(),
             model: "text-embedding-3-small".to_string(),
+            base_url: None,
         }
     }
 }

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -115,9 +115,14 @@ budget_tokens = 8000
         let vector_store = &config.vector_stores[0];
         match &vector_store.store {
             crate::config::VectorStoreType::InMemory { embedding_model } => match embedding_model {
-                crate::config::EmbeddingConfig::OpenAI { api_key, model } => {
+                crate::config::EmbeddingConfig::OpenAI {
+                    api_key,
+                    model,
+                    base_url,
+                } => {
                     assert_eq!(model, "text-embedding-3-small");
                     assert_eq!(api_key, "test_embedding_key");
+                    assert_eq!(base_url, &None);
                 }
                 _ => panic!("Expected OpenAI embedding config"),
             },
@@ -442,6 +447,41 @@ model = "gpt-4"
         unsafe {
             std::env::remove_var("OPENAI_API_KEY");
             std::env::remove_var("TEST_API_KEY");
+        }
+    }
+
+    #[test]
+    fn test_embedding_config_custom_base_url() {
+        let config_str = r#"
+[[vector_stores]]
+name = "default"
+type = "in_memory"
+
+[vector_stores.embedding_model]
+provider = "openai"
+model = "text-embedding-3-small"
+api_key = "test_embedding_key"
+base_url = "http://localhost:8000/v1"
+
+[agent]
+name = "Test Assistant"
+system_prompt = "You are a test assistant."
+
+[agent.llm]
+provider = "openai"
+api_key = "test_openai_key"
+model = "gpt-4o-mini"
+"#;
+
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+        match &config.vector_stores[0].store {
+            crate::config::VectorStoreType::InMemory { embedding_model } => match embedding_model {
+                crate::config::EmbeddingConfig::OpenAI { base_url, .. } => {
+                    assert_eq!(base_url, &Some("http://localhost:8000/v1".to_string()));
+                }
+                _ => panic!("Expected OpenAI embedding config"),
+            },
+            _ => panic!("Expected InMemory vector store"),
         }
     }
 

--- a/crates/aura/src/orchestration/config.rs
+++ b/crates/aura/src/orchestration/config.rs
@@ -282,6 +282,7 @@ mod tests {
                 embedding_model: EmbeddingConfig::OpenAI {
                     api_key: "test".to_string(),
                     model: "text-embedding-3-small".to_string(),
+                    base_url: None,
                 },
                 url: "http://localhost:6334".to_string(),
                 collection_name: "mezmo_docs".to_string(),
@@ -304,6 +305,7 @@ mod tests {
                 embedding_model: EmbeddingConfig::OpenAI {
                     api_key: "test".to_string(),
                     model: "test".to_string(),
+                    base_url: None,
                 },
                 url: "http://localhost:6334".to_string(),
                 collection_name: "test_kb".to_string(),

--- a/crates/aura/src/vector_store.rs
+++ b/crates/aura/src/vector_store.rs
@@ -70,8 +70,16 @@ impl VectorStoreManager {
     fn create_openai_embedding_model(
         api_key: &str,
         model: &str,
+        base_url: Option<&str>,
     ) -> Result<OpenAIEmbeddingModel, BuilderError> {
-        let client = Client::new(api_key).map_err(|e| {
+        let mut client_builder = Client::<reqwest::Client>::builder().api_key(api_key);
+
+        if let Some(url) = base_url {
+            info!("Using custom embedding base URL: {}", url);
+            client_builder = client_builder.base_url(url);
+        }
+
+        let client = client_builder.build().map_err(|e| {
             BuilderError::VectorStoreError(format!("Failed to create OpenAI client: {e}"))
         })?;
         Ok(client.embedding_model(model))
@@ -140,8 +148,12 @@ impl VectorStoreManager {
 
         // Validate the embedding provider can be initialized
         match embedding {
-            EmbeddingConfig::OpenAI { api_key, model, .. } => {
-                Self::create_openai_embedding_model(api_key, model)?;
+            EmbeddingConfig::OpenAI {
+                api_key,
+                model,
+                base_url,
+            } => {
+                Self::create_openai_embedding_model(api_key, model, base_url.as_deref())?;
             }
             EmbeddingConfig::Bedrock {
                 model,
@@ -214,8 +226,13 @@ impl VectorStoreManager {
 
         // Create embedding model and Qdrant store based on provider
         let qdrant_store = match embedding {
-            EmbeddingConfig::OpenAI { api_key, model, .. } => {
-                let embedding_model = Self::create_openai_embedding_model(api_key, model)?;
+            EmbeddingConfig::OpenAI {
+                api_key,
+                model,
+                base_url,
+            } => {
+                let embedding_model =
+                    Self::create_openai_embedding_model(api_key, model, base_url.as_deref())?;
                 let store = QdrantVectorStore::new(qdrant_client, embedding_model, query_params);
                 QdrantStoreKind::OpenAI(store)
             }

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -110,6 +110,7 @@ Authorization = "Bearer {{ env.MCP_TOKEN }}"
 # provider = "openai"
 # model = "text-embedding-3-small"
 # api_key = "{{ env.OPENAI_API_KEY }}"
+# base_url = "http://localhost:8000/v1"  # optional: any OpenAI-compatible endpoint
 #
 # AWS Bedrock embeddings (uses AWS credentials, no API key needed):
 # [vector_stores.embedding_model]


### PR DESCRIPTION
Adds an optional base_url field to the OpenAI embedding config so vector stores can target any OpenAI-compatible embeddings endpoint (Azure OpenAI, LiteLLM, vLLM, TEI, Ollama). Mirrors the base_url override already supported by the LLM provider config.

Fixes: #364