### PR TITLE
feat: serve a token-gated aura-bootstrap configuration agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,12 +291,48 @@ system_prompt = "..."
 
 Aliases must be unique across all loaded configs. If two configs share the same `name` and neither has an alias, loading fails with a validation error.
 
+### Bootstrap Agent (conversational configuration)
+
+AURA can serve a built-in **`aura-bootstrap`** agent that builds and modifies the server's configuration conversationally — first-time setup and day-2 changes alike. It is **disabled by default** and enabled per config file:
+
+```toml
+[bootstrap]
+enabled = true
+
+# optional: run the bootstrap agent on a different LLM than [agent.llm]
+# [bootstrap.llm]
+# provider = "openai"
+# api_key = "{{ env.OPENAI_API_KEY }}"
+# model = "gpt-5.5"
+```
+
+The fastest way to get a working setup from nothing:
+
+```bash
+aura init --bootstrap                          # senses API keys, verifies the model live, writes config.toml
+AURA_BOOTSTRAP_TOKEN=<token> CONFIG_PATH=config.toml aura-web-server
+aura --api-url http://localhost:8080 --model aura-bootstrap --api-key <token>
+```
+
+In standalone mode (`aura` with no `--api-url`), the bootstrap agent is served in-process — no token handling needed, just switch to it with `/model aura-bootstrap`.
+
+The bootstrap agent interviews you (suggest-first: it proposes a sane setup and asks what to adjust), connects to your MCP servers to verify them and classify their tools, writes the **complete** configuration file — what it writes is exactly what runs, nothing is expanded at load time — and the running server applies it immediately (**hot reload**; in-flight requests finish on the old config). Every write leaves a timestamped backup next to the file.
+
+**Security model — read before enabling:**
+
+- The bootstrap token is **configuration admin on the server**. Anyone holding it can change providers, prompts, and attached MCP servers. Set it via `AURA_BOOTSTRAP_TOKEN`, or let the server generate one and print it to the startup logs (whoever can read the logs is considered authorized). Requests to the bootstrap agent without the token get a 401; the token rides the standard `Authorization: Bearer` header (so `aura --api-key` just works) or `x-aura-bootstrap-token` for deployments where a gateway overwrites `Authorization`.
+- Workers the agent creates are **read-only by default** (`read_only = true` on `[orchestration.worker.<name>]`), and the write tool mechanically refuses to allowlist MCP tools annotated as mutating — or tool names it never discovered, or glob patterns — onto read-only workers. Mutating capability requires an explicit operator request.
+- Literal API keys are rejected anywhere in a written config; secrets travel only as `{{ env.VAR }}` references.
+- `stdio` MCP transports in agent-written configs (which spawn processes on the server) are refused unless the server runs with `AURA_BOOTSTRAP_ALLOW_STDIO=true`.
+- `aura-bootstrap` is a reserved name; exactly one config file may enable `[bootstrap]`, and changes to the `[bootstrap]` table itself take effect on restart, not hot reload.
+
 ### Configuration Sections
 
 Configuration sections:
 
 - `[agent]`: identity, system prompt, and runtime behavior.
 - `[agent.llm]`: provider and model configuration for the agent.
+- `[bootstrap]`: the token-gated configuration agent (disabled by default).
 - `[[vector_stores]]`: optional vector search configuration.
 - `[mcp]` and `[mcp.servers.*]`: MCP configuration, schema sanitization, and transports.
 - `[hitl]` and `[hitl.route]`: optional approval gates for orchestration worker tool calls.

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -23,7 +23,7 @@ use aura_web_server::handlers::{self, CollectedResult, DeliveryMode};
 use aura_web_server::streaming::ToolResultMode;
 use aura_web_server::types::{
     ActiveRequestTracker, AppState, ChatCompletionRequest, ChatMessage, ChatMessageFunctionCall,
-    ChatMessageToolCall, ClientFunctionDefinition, ClientToolDefinition, Role,
+    ChatMessageToolCall, ClientFunctionDefinition, ClientToolDefinition, ConfigRegistry, Role,
 };
 
 use crate::api::stream::{StreamHandler, StreamResult, process_sse_events};
@@ -88,7 +88,7 @@ impl DirectBackend {
         }
 
         let app_state = Arc::new(AppState {
-            configs: Arc::new(configs),
+            configs: Arc::new(ConfigRegistry::new(configs)),
             tool_result_mode: ToolResultMode::Aura,
             tool_result_max_length: 0,
             streaming_buffer_size: 400,
@@ -123,6 +123,7 @@ impl DirectBackend {
     pub fn any_agent_enables_client_tools(&self) -> bool {
         self.app_state
             .configs
+            .snapshot()
             .iter()
             .any(|c| !c.orchestration_enabled() && c.agent.enable_client_tools)
     }
@@ -138,6 +139,7 @@ impl DirectBackend {
     pub(crate) fn model_ids(&self) -> Vec<String> {
         self.app_state
             .configs
+            .snapshot()
             .iter()
             .filter(|c| !c.agent.hidden)
             .map(|c| c.agent_id().to_string())
@@ -146,7 +148,7 @@ impl DirectBackend {
 
     /// Whether more than one agent config is loaded.
     pub fn has_multiple_configs(&self) -> bool {
-        self.app_state.configs.len() > 1
+        self.app_state.configs.snapshot().len() > 1
     }
 
     /// Check if `model_name` matches any loaded config's agent.name or agent.alias.
@@ -154,7 +156,7 @@ impl DirectBackend {
     /// Returns the canonical effective ID (alias or name) on match.
     pub fn find_matching_model(&self, model_name: &str) -> Option<String> {
         let lower = model_name.to_lowercase();
-        for config in self.app_state.configs.iter() {
+        for config in self.app_state.configs.snapshot().iter() {
             let effective_id = config.agent_id().to_string();
 
             // Match against effective ID, name, or alias independently
@@ -174,22 +176,21 @@ impl DirectBackend {
 
     /// Get the system prompt from the config matching `model` (or first config if None).
     pub fn get_config_system_prompt(&self, model: Option<&str>) -> Option<String> {
+        let configs = self.app_state.configs.snapshot();
         let config = if let Some(model_name) = model {
             let lower = model_name.to_lowercase();
-            self.app_state
-                .configs
+            configs
                 .iter()
                 .find(|c| c.agent_id().to_lowercase() == lower)
         } else {
-            self.app_state.configs.first()
+            configs.first()
         };
         config.map(|c| c.agent.system_prompt.clone())
     }
 
     /// Replace the system prompt in the config matching `model` (or first config if None).
-    /// Reconstructs AppState since it holds configs behind Arc.
     pub fn override_system_prompt(&mut self, model: Option<&str>, new_prompt: String) {
-        let mut configs: Vec<_> = (*self.app_state.configs).clone();
+        let mut configs: Vec<_> = (*self.app_state.configs.snapshot()).clone();
         let target = if let Some(model_name) = model {
             let lower = model_name.to_lowercase();
             configs
@@ -201,25 +202,7 @@ impl DirectBackend {
         if let Some(config) = target {
             config.agent.system_prompt = new_prompt;
         }
-
-        let old = &self.app_state;
-        self.app_state = Arc::new(AppState {
-            configs: Arc::new(configs),
-            tool_result_mode: old.tool_result_mode,
-            tool_result_max_length: old.tool_result_max_length,
-            streaming_buffer_size: old.streaming_buffer_size,
-            aura_custom_events: old.aura_custom_events,
-            aura_emit_reasoning: old.aura_emit_reasoning,
-            debug_provider_errors: old.debug_provider_errors,
-            streaming_timeout_secs: old.streaming_timeout_secs,
-            first_chunk_timeout_secs: old.first_chunk_timeout_secs,
-            shutdown_token: old.shutdown_token.clone(),
-            stream_shutdown_token: old.stream_shutdown_token.clone(),
-            active_requests: old.active_requests.clone(),
-            default_agent: old.default_agent.clone(),
-            additional_tools: additional_tools_factory(),
-            pending_approvals: old.pending_approvals.clone(),
-        });
+        self.app_state.configs.replace(configs);
     }
 
     /// Convert CLI messages to web server ChatMessage format, preserving
@@ -366,6 +349,7 @@ impl DirectBackend {
         let agents = self
             .app_state
             .configs
+            .snapshot()
             .iter()
             .filter(|config| !config.agent.hidden)
             .map(aura::agent_info)
@@ -436,7 +420,7 @@ mod tests {
     /// Construct a DirectBackend with test configs (no real TOML loading).
     fn make_backend(configs: Vec<aura_config::Config>) -> DirectBackend {
         let app_state = Arc::new(AppState {
-            configs: Arc::new(configs),
+            configs: Arc::new(ConfigRegistry::new(configs)),
             tool_result_mode: ToolResultMode::Aura,
             tool_result_max_length: 0,
             streaming_buffer_size: 400,

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -140,8 +140,7 @@ impl DirectBackend {
             anyhow::bail!("No agent config found in {}", config_path);
         }
 
-        aura::bootstrap::validate_roster(&config_pairs)
-            .map_err(|msg| anyhow::anyhow!("{msg}"))?;
+        aura::bootstrap::validate_roster(&config_pairs).map_err(|msg| anyhow::anyhow!("{msg}"))?;
         let bootstrap_declaration = config_pairs
             .iter()
             .find(|(_, c)| c.bootstrap.as_ref().is_some_and(|b| b.enabled))

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -89,6 +89,7 @@ impl DirectBackend {
 
         let app_state = Arc::new(AppState {
             configs: Arc::new(ConfigRegistry::new(configs)),
+            bootstrap: None,
             tool_result_mode: ToolResultMode::Aura,
             tool_result_max_length: 0,
             streaming_buffer_size: 400,
@@ -421,6 +422,7 @@ mod tests {
     fn make_backend(configs: Vec<aura_config::Config>) -> DirectBackend {
         let app_state = Arc::new(AppState {
             configs: Arc::new(ConfigRegistry::new(configs)),
+            bootstrap: None,
             tool_result_mode: ToolResultMode::Aura,
             tool_result_max_length: 0,
             streaming_buffer_size: 400,

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -45,10 +45,63 @@ fn additional_tools_factory() -> Arc<dyn Fn() -> Vec<Box<dyn aura::ToolDyn>> + S
     Arc::new(Vec::new)
 }
 
+/// A `(model, prompt)` pair stashed by `override_system_prompt` so the
+/// reload hook can re-apply it after swapping the roster from disk.
+type PromptOverride = Arc<std::sync::Mutex<Option<(Option<String>, String)>>>;
+
 /// Direct backend — holds AppState with loaded configs and CLI tool factory.
 pub struct DirectBackend {
     app_state: Arc<AppState>,
     extra_headers: HashMap<String, String>,
+    prompt_override: PromptOverride,
+}
+
+/// Hot-reload hook for standalone mode: re-load the config path from disk,
+/// swap the roster, and refresh the REPL's `/model` cache so the new agents
+/// are immediately listable.
+fn make_reload_hook(
+    registry: Arc<ConfigRegistry>,
+    config_path: String,
+    prompt_override: PromptOverride,
+) -> aura::bootstrap::ReloadHook {
+    Arc::new(move || {
+        let config_pairs =
+            aura_config::load_config_with_paths(&config_path).map_err(|e| e.to_string())?;
+        aura::bootstrap::validate_roster(&config_pairs)?;
+        let mut configs: Vec<aura_config::Config> =
+            config_pairs.into_iter().map(|(_, c)| c).collect();
+
+        // Re-apply the CLI --system-prompt override so a reload doesn't
+        // silently revert the session's prompt.
+        if let Some((ref model, ref prompt)) = *prompt_override.lock().expect("prompt lock") {
+            let target = if let Some(model_name) = model {
+                let lower = model_name.to_lowercase();
+                configs
+                    .iter_mut()
+                    .find(|c| c.agent_id().to_lowercase() == lower)
+            } else {
+                configs.first_mut()
+            };
+            if let Some(config) = target {
+                config.agent.system_prompt = prompt.clone();
+            }
+        }
+
+        let mut names: Vec<String> = configs
+            .iter()
+            .filter(|c| !c.agent.hidden)
+            .map(|c| c.agent_id().to_string())
+            .collect();
+        let count = names.len();
+        registry.replace(configs);
+        let summary = format!(
+            "Hot reload applied; {count} agent(s) now live: {}",
+            names.join(", ")
+        );
+        names.push(aura::bootstrap::BOOTSTRAP_AGENT_NAME.to_string());
+        crate::ui::prompt::refresh_model_cache(names);
+        Ok(summary)
+    })
 }
 
 impl DirectBackend {
@@ -81,15 +134,64 @@ impl DirectBackend {
             );
         }
 
-        let configs =
-            aura_config::load_config(config_path).context("Failed to load agent config")?;
-        if configs.is_empty() {
+        let config_pairs = aura_config::load_config_with_paths(config_path)
+            .context("Failed to load agent config")?;
+        if config_pairs.is_empty() {
             anyhow::bail!("No agent config found in {}", config_path);
         }
 
+        aura::bootstrap::validate_roster(&config_pairs)
+            .map_err(|msg| anyhow::anyhow!("{msg}"))?;
+        let bootstrap_declaration = config_pairs
+            .iter()
+            .find(|(_, c)| c.bootstrap.as_ref().is_some_and(|b| b.enabled))
+            .map(|(path, config)| (path.clone(), config.clone()));
+
+        let configs: Vec<aura_config::Config> =
+            config_pairs.into_iter().map(|(_, config)| config).collect();
+        let roster_names: Vec<String> = configs
+            .iter()
+            .filter(|c| !c.agent.hidden)
+            .map(|c| c.agent_id().to_string())
+            .collect();
+        let registry = Arc::new(ConfigRegistry::new(configs));
+        let prompt_override: PromptOverride = Arc::default();
+
+        // Standalone bootstrap host: same shared `prepare_request` routing as
+        // the web server. The token gate is an HTTP-layer boundary, so
+        // standalone generates a private token and presents it to itself on
+        // every request — the local operator already owns the config file.
+        let bootstrap = bootstrap_declaration.map(|(declaring_path, declaring)| {
+            let target = aura::bootstrap::ConfigTarget {
+                config_path: std::path::PathBuf::from(config_path),
+                target: declaring_path,
+            };
+            let reload = make_reload_hook(
+                registry.clone(),
+                config_path.to_string(),
+                prompt_override.clone(),
+            );
+            aura_web_server::types::BootstrapState {
+                agent_config: aura::bootstrap::bootstrap_agent_config(
+                    &declaring,
+                    &target,
+                    &roster_names,
+                ),
+                token: uuid::Uuid::new_v4().to_string(),
+                tools: aura::bootstrap::bootstrap_tools_factory(target, reload),
+            }
+        });
+
+        // Self-present the private token on every request so the shared
+        // routing in `prepare_request` admits bootstrap traffic.
+        let mut headers_map: HashMap<String, String> = extra_headers.into_iter().collect();
+        if let Some(bs) = &bootstrap {
+            headers_map.insert("x-aura-bootstrap-token".to_string(), bs.token.clone());
+        }
+
         let app_state = Arc::new(AppState {
-            configs: Arc::new(ConfigRegistry::new(configs)),
-            bootstrap: None,
+            configs: registry,
+            bootstrap,
             tool_result_mode: ToolResultMode::Aura,
             tool_result_max_length: 0,
             streaming_buffer_size: 400,
@@ -106,11 +208,10 @@ impl DirectBackend {
             pending_approvals: aura::hitl::PendingApprovals::new(),
         });
 
-        let headers_map = extra_headers.into_iter().collect();
-
         Ok(Self {
             app_state,
             extra_headers: headers_map,
+            prompt_override,
         })
     }
 
@@ -136,15 +237,21 @@ impl DirectBackend {
         self.app_state.pending_approvals.clone()
     }
 
-    /// Return the effective model ID for each loaded config.
+    /// Return the effective model ID for each loaded config, plus the
+    /// bootstrap agent when it is enabled.
     pub(crate) fn model_ids(&self) -> Vec<String> {
-        self.app_state
+        let mut ids: Vec<String> = self
+            .app_state
             .configs
             .snapshot()
             .iter()
             .filter(|c| !c.agent.hidden)
             .map(|c| c.agent_id().to_string())
-            .collect()
+            .collect();
+        if self.app_state.bootstrap.is_some() {
+            ids.push(aura::bootstrap::BOOTSTRAP_AGENT_NAME.to_string());
+        }
+        ids
     }
 
     /// Whether more than one agent config is loaded.
@@ -157,6 +264,9 @@ impl DirectBackend {
     /// Returns the canonical effective ID (alias or name) on match.
     pub fn find_matching_model(&self, model_name: &str) -> Option<String> {
         let lower = model_name.to_lowercase();
+        if self.app_state.bootstrap.is_some() && lower == aura::bootstrap::BOOTSTRAP_AGENT_NAME {
+            return Some(aura::bootstrap::BOOTSTRAP_AGENT_NAME.to_string());
+        }
         for config in self.app_state.configs.snapshot().iter() {
             let effective_id = config.agent_id().to_string();
 
@@ -190,7 +300,14 @@ impl DirectBackend {
     }
 
     /// Replace the system prompt in the config matching `model` (or first config if None).
+    ///
+    /// The override is stashed so the reload hook can re-apply it after
+    /// swapping the roster from disk — without this, a bootstrap-triggered
+    /// hot reload would silently revert the session's prompt.
     pub fn override_system_prompt(&mut self, model: Option<&str>, new_prompt: String) {
+        *self.prompt_override.lock().expect("prompt lock") =
+            Some((model.map(str::to_owned), new_prompt.clone()));
+
         let mut configs: Vec<_> = (*self.app_state.configs.snapshot()).clone();
         let target = if let Some(model_name) = model {
             let lower = model_name.to_lowercase();
@@ -441,6 +558,7 @@ mod tests {
         DirectBackend {
             app_state,
             extra_headers: HashMap::new(),
+            prompt_override: PromptOverride::default(),
         }
     }
 
@@ -451,6 +569,119 @@ mod tests {
         config.agent.alias = alias.map(|a| a.to_string());
         config.agent.system_prompt = system_prompt.to_string();
         config
+    }
+
+    // -----------------------------------------------------------------------
+    // standalone bootstrap host
+    // -----------------------------------------------------------------------
+
+    /// Complete config (ollama, no env deps) with the bootstrap agent enabled.
+    const BOOTSTRAP_ENABLED: &str = r#"
+[agent]
+name = "assistant"
+system_prompt = "You are helpful."
+
+[agent.llm]
+provider = "ollama"
+model = "qwen3:8b"
+
+[bootstrap]
+enabled = true
+"#;
+
+    #[tokio::test]
+    async fn from_toml_serves_bootstrap_agent_when_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, BOOTSTRAP_ENABLED).unwrap();
+
+        let backend = DirectBackend::from_toml(path.to_str().unwrap(), vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            backend.model_ids(),
+            vec!["assistant".to_string(), "aura-bootstrap".to_string()]
+        );
+        assert_eq!(
+            backend.find_matching_model("aura-bootstrap"),
+            Some("aura-bootstrap".to_string())
+        );
+        // The private token is self-presented so shared routing admits it.
+        assert!(backend.extra_headers.contains_key("x-aura-bootstrap-token"));
+    }
+
+    #[tokio::test]
+    async fn from_toml_without_bootstrap_serves_roster_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            BOOTSTRAP_ENABLED.replace("enabled = true", "enabled = false"),
+        )
+        .unwrap();
+
+        let backend = DirectBackend::from_toml(path.to_str().unwrap(), vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(backend.model_ids(), vec!["assistant".to_string()]);
+        assert_eq!(backend.find_matching_model("aura-bootstrap"), None);
+        assert!(!backend.extra_headers.contains_key("x-aura-bootstrap-token"));
+    }
+
+    #[tokio::test]
+    async fn from_toml_rejects_reserved_agent_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            BOOTSTRAP_ENABLED.replace("name = \"assistant\"", "name = \"aura-bootstrap\""),
+        )
+        .unwrap();
+
+        let err = DirectBackend::from_toml(path.to_str().unwrap(), vec![])
+            .await
+            .err()
+            .expect("expected reserved-name error");
+        assert!(err.to_string().contains("reserved"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn reload_hook_swaps_roster_and_reapplies_prompt_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, BOOTSTRAP_ENABLED).unwrap();
+
+        let registry = Arc::new(ConfigRegistry::new(vec![make_config(
+            "assistant",
+            None,
+            "old",
+        )]));
+        let prompt_override = PromptOverride::default();
+        *prompt_override.lock().unwrap() = Some((None, "session prompt".to_string()));
+        let hook = make_reload_hook(
+            registry.clone(),
+            path.to_str().unwrap().to_string(),
+            prompt_override,
+        );
+
+        std::fs::write(
+            &path,
+            BOOTSTRAP_ENABLED.replace("name = \"assistant\"", "name = \"renamed\""),
+        )
+        .unwrap();
+
+        let summary = hook().expect("reload should succeed");
+        assert!(summary.contains("renamed"), "got: {summary}");
+        assert_eq!(registry.snapshot()[0].agent.name, "renamed");
+        // The stashed --system-prompt override survives the swap.
+        assert_eq!(registry.snapshot()[0].agent.system_prompt, "session prompt");
+
+        // A broken on-disk config reports an error and leaves the roster.
+        std::fs::write(&path, "not [valid").unwrap();
+        assert!(hook().is_err());
+        assert_eq!(registry.snapshot()[0].agent.name, "renamed");
     }
 
     fn make_orch_config(name: &str, alias: Option<&str>, worker: &str) -> aura_config::Config {

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -47,12 +47,65 @@ fn additional_tools_factory() -> Arc<dyn Fn() -> Vec<Box<dyn aura::ToolDyn>> + S
     Arc::new(Vec::new)
 }
 
+/// A `(model, prompt)` pair stashed by `override_system_prompt` so the
+/// reload hook can re-apply it after swapping the roster from disk.
+type PromptOverride = Arc<std::sync::Mutex<Option<(Option<String>, String)>>>;
+
 /// Direct backend — holds AppState with loaded configs and CLI tool factory.
 pub struct DirectBackend {
     app_state: Arc<AppState>,
     extra_headers: HashMap<String, String>,
     /// Filesystem source of the loaded configs (file or directory).
     config_path: PathBuf,
+    prompt_override: PromptOverride,
+}
+
+/// Hot-reload hook for standalone mode: re-load the config path from disk,
+/// swap the roster, and refresh the REPL's `/model` cache so the new agents
+/// are immediately listable.
+fn make_reload_hook(
+    registry: Arc<ConfigRegistry>,
+    config_path: String,
+    prompt_override: PromptOverride,
+) -> aura::bootstrap::ReloadHook {
+    Arc::new(move || {
+        let config_pairs =
+            aura_config::load_config_with_paths(&config_path).map_err(|e| e.to_string())?;
+        aura::bootstrap::validate_roster(&config_pairs)?;
+        let mut configs: Vec<aura_config::Config> =
+            config_pairs.into_iter().map(|(_, c)| c).collect();
+
+        // Re-apply the CLI --system-prompt override so a reload doesn't
+        // silently revert the session's prompt.
+        if let Some((ref model, ref prompt)) = *prompt_override.lock().expect("prompt lock") {
+            let target = if let Some(model_name) = model {
+                let lower = model_name.to_lowercase();
+                configs
+                    .iter_mut()
+                    .find(|c| c.agent_id().to_lowercase() == lower)
+            } else {
+                configs.first_mut()
+            };
+            if let Some(config) = target {
+                config.agent.system_prompt = prompt.clone();
+            }
+        }
+
+        let mut names: Vec<String> = configs
+            .iter()
+            .filter(|c| !c.agent.hidden)
+            .map(|c| c.agent_id().to_string())
+            .collect();
+        let count = names.len();
+        registry.replace(configs);
+        let summary = format!(
+            "Hot reload applied; {count} agent(s) now live: {}",
+            names.join(", ")
+        );
+        names.push(aura::bootstrap::BOOTSTRAP_AGENT_NAME.to_string());
+        crate::ui::prompt::refresh_model_cache(names);
+        Ok(summary)
+    })
 }
 
 impl DirectBackend {
@@ -85,9 +138,9 @@ impl DirectBackend {
             );
         }
 
-        let configs =
-            aura_config::load_config(config_path).context("Failed to load agent config")?;
-        if configs.is_empty() {
+        let config_pairs = aura_config::load_config_with_paths(config_path)
+            .context("Failed to load agent config")?;
+        if config_pairs.is_empty() {
             anyhow::bail!("No agent config found in {}", config_path);
         }
 
@@ -95,16 +148,65 @@ impl DirectBackend {
         // fails the CLI boot rather than the first approval request.
         let hitl_webhook_hmac = aura::hitl::WebhookHmac::load_from_env()
             .context("Invalid HITL webhook HMAC configuration")?;
-        for config in &configs {
+        for (_, config) in &config_pairs {
             if let Some(hitl) = &config.hitl {
                 aura::hitl::validate_webhook_signing_config(hitl, hitl_webhook_hmac.as_ref())
                     .context("Invalid HITL webhook configuration")?;
             }
         }
 
+        aura::bootstrap::validate_roster(&config_pairs)
+            .map_err(|msg| anyhow::anyhow!("{msg}"))?;
+        let bootstrap_declaration = config_pairs
+            .iter()
+            .find(|(_, c)| c.bootstrap.as_ref().is_some_and(|b| b.enabled))
+            .map(|(path, config)| (path.clone(), config.clone()));
+
+        let configs: Vec<aura_config::Config> =
+            config_pairs.into_iter().map(|(_, config)| config).collect();
+        let roster_names: Vec<String> = configs
+            .iter()
+            .filter(|c| !c.agent.hidden)
+            .map(|c| c.agent_id().to_string())
+            .collect();
+        let registry = Arc::new(ConfigRegistry::new(configs));
+        let prompt_override: PromptOverride = Arc::default();
+
+        // Standalone bootstrap host: same shared `prepare_request` routing as
+        // the web server. The token gate is an HTTP-layer boundary, so
+        // standalone generates a private token and presents it to itself on
+        // every request — the local operator already owns the config file.
+        let bootstrap = bootstrap_declaration.map(|(declaring_path, declaring)| {
+            let target = aura::bootstrap::ConfigTarget {
+                config_path: std::path::PathBuf::from(config_path),
+                target: declaring_path,
+            };
+            let reload = make_reload_hook(
+                registry.clone(),
+                config_path.to_string(),
+                prompt_override.clone(),
+            );
+            aura_web_server::types::BootstrapState {
+                agent_config: aura::bootstrap::bootstrap_agent_config(
+                    &declaring,
+                    &target,
+                    &roster_names,
+                ),
+                token: uuid::Uuid::new_v4().to_string(),
+                tools: aura::bootstrap::bootstrap_tools_factory(target, reload),
+            }
+        });
+
+        // Self-present the private token on every request so the shared
+        // routing in `prepare_request` admits bootstrap traffic.
+        let mut headers_map: HashMap<String, String> = extra_headers.into_iter().collect();
+        if let Some(bs) = &bootstrap {
+            headers_map.insert("x-aura-bootstrap-token".to_string(), bs.token.clone());
+        }
+
         let app_state = Arc::new(AppState {
-            configs: Arc::new(ConfigRegistry::new(configs)),
-            bootstrap: None,
+            configs: registry,
+            bootstrap,
             tool_result_mode: ToolResultMode::Aura,
             tool_result_max_length: 0,
             streaming_buffer_size: 400,
@@ -124,12 +226,11 @@ impl DirectBackend {
             session_store: Arc::new(InMemorySessionStore::new()),
         });
 
-        let headers_map = extra_headers.into_iter().collect();
-
         Ok(Self {
             app_state,
             extra_headers: headers_map,
             config_path: PathBuf::from(config_path),
+            prompt_override,
         })
     }
 
@@ -162,15 +263,21 @@ impl DirectBackend {
         self.app_state.pending_approvals.clone()
     }
 
-    /// Return the effective model ID for each loaded config.
+    /// Return the effective model ID for each loaded config, plus the
+    /// bootstrap agent when it is enabled.
     pub(crate) fn model_ids(&self) -> Vec<String> {
-        self.app_state
+        let mut ids: Vec<String> = self
+            .app_state
             .configs
             .snapshot()
             .iter()
             .filter(|c| !c.agent.hidden)
             .map(|c| c.agent_id().to_string())
-            .collect()
+            .collect();
+        if self.app_state.bootstrap.is_some() {
+            ids.push(aura::bootstrap::BOOTSTRAP_AGENT_NAME.to_string());
+        }
+        ids
     }
 
     /// Whether more than one agent config is loaded.
@@ -183,6 +290,9 @@ impl DirectBackend {
     /// Returns the canonical effective ID (alias or name) on match.
     pub fn find_matching_model(&self, model_name: &str) -> Option<String> {
         let lower = model_name.to_lowercase();
+        if self.app_state.bootstrap.is_some() && lower == aura::bootstrap::BOOTSTRAP_AGENT_NAME {
+            return Some(aura::bootstrap::BOOTSTRAP_AGENT_NAME.to_string());
+        }
         for config in self.app_state.configs.snapshot().iter() {
             let effective_id = config.agent_id().to_string();
 
@@ -216,7 +326,14 @@ impl DirectBackend {
     }
 
     /// Replace the system prompt in the config matching `model` (or first config if None).
+    ///
+    /// The override is stashed so the reload hook can re-apply it after
+    /// swapping the roster from disk — without this, a bootstrap-triggered
+    /// hot reload would silently revert the session's prompt.
     pub fn override_system_prompt(&mut self, model: Option<&str>, new_prompt: String) {
+        *self.prompt_override.lock().expect("prompt lock") =
+            Some((model.map(str::to_owned), new_prompt.clone()));
+
         let mut configs: Vec<_> = (*self.app_state.configs.snapshot()).clone();
         let target = if let Some(model_name) = model {
             let lower = model_name.to_lowercase();
@@ -473,6 +590,7 @@ mod tests {
             // Synthetic: these configs were built in memory, not loaded
             // from disk, so point at a path that cannot exist.
             config_path: PathBuf::from("/nonexistent/in-memory-test-config.toml"),
+            prompt_override: PromptOverride::default(),
         }
     }
 
@@ -483,6 +601,119 @@ mod tests {
         config.agent.alias = alias.map(|a| a.to_string());
         config.agent.system_prompt = system_prompt.to_string();
         config
+    }
+
+    // -----------------------------------------------------------------------
+    // standalone bootstrap host
+    // -----------------------------------------------------------------------
+
+    /// Complete config (ollama, no env deps) with the bootstrap agent enabled.
+    const BOOTSTRAP_ENABLED: &str = r#"
+[agent]
+name = "assistant"
+system_prompt = "You are helpful."
+
+[agent.llm]
+provider = "ollama"
+model = "qwen3:8b"
+
+[bootstrap]
+enabled = true
+"#;
+
+    #[tokio::test]
+    async fn from_toml_serves_bootstrap_agent_when_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, BOOTSTRAP_ENABLED).unwrap();
+
+        let backend = DirectBackend::from_toml(path.to_str().unwrap(), vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            backend.model_ids(),
+            vec!["assistant".to_string(), "aura-bootstrap".to_string()]
+        );
+        assert_eq!(
+            backend.find_matching_model("aura-bootstrap"),
+            Some("aura-bootstrap".to_string())
+        );
+        // The private token is self-presented so shared routing admits it.
+        assert!(backend.extra_headers.contains_key("x-aura-bootstrap-token"));
+    }
+
+    #[tokio::test]
+    async fn from_toml_without_bootstrap_serves_roster_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            BOOTSTRAP_ENABLED.replace("enabled = true", "enabled = false"),
+        )
+        .unwrap();
+
+        let backend = DirectBackend::from_toml(path.to_str().unwrap(), vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(backend.model_ids(), vec!["assistant".to_string()]);
+        assert_eq!(backend.find_matching_model("aura-bootstrap"), None);
+        assert!(!backend.extra_headers.contains_key("x-aura-bootstrap-token"));
+    }
+
+    #[tokio::test]
+    async fn from_toml_rejects_reserved_agent_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            BOOTSTRAP_ENABLED.replace("name = \"assistant\"", "name = \"aura-bootstrap\""),
+        )
+        .unwrap();
+
+        let err = DirectBackend::from_toml(path.to_str().unwrap(), vec![])
+            .await
+            .err()
+            .expect("expected reserved-name error");
+        assert!(err.to_string().contains("reserved"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn reload_hook_swaps_roster_and_reapplies_prompt_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, BOOTSTRAP_ENABLED).unwrap();
+
+        let registry = Arc::new(ConfigRegistry::new(vec![make_config(
+            "assistant",
+            None,
+            "old",
+        )]));
+        let prompt_override = PromptOverride::default();
+        *prompt_override.lock().unwrap() = Some((None, "session prompt".to_string()));
+        let hook = make_reload_hook(
+            registry.clone(),
+            path.to_str().unwrap().to_string(),
+            prompt_override,
+        );
+
+        std::fs::write(
+            &path,
+            BOOTSTRAP_ENABLED.replace("name = \"assistant\"", "name = \"renamed\""),
+        )
+        .unwrap();
+
+        let summary = hook().expect("reload should succeed");
+        assert!(summary.contains("renamed"), "got: {summary}");
+        assert_eq!(registry.snapshot()[0].agent.name, "renamed");
+        // The stashed --system-prompt override survives the swap.
+        assert_eq!(registry.snapshot()[0].agent.system_prompt, "session prompt");
+
+        // A broken on-disk config reports an error and leaves the roster.
+        std::fs::write(&path, "not [valid").unwrap();
+        assert!(hook().is_err());
+        assert_eq!(registry.snapshot()[0].agent.name, "renamed");
     }
 
     fn make_orch_config(name: &str, alias: Option<&str>, worker: &str) -> aura_config::Config {

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -104,6 +104,7 @@ impl DirectBackend {
 
         let app_state = Arc::new(AppState {
             configs: Arc::new(ConfigRegistry::new(configs)),
+            bootstrap: None,
             tool_result_mode: ToolResultMode::Aura,
             tool_result_max_length: 0,
             streaming_buffer_size: 400,
@@ -447,6 +448,7 @@ mod tests {
     fn make_backend(configs: Vec<aura_config::Config>) -> DirectBackend {
         let app_state = Arc::new(AppState {
             configs: Arc::new(ConfigRegistry::new(configs)),
+            bootstrap: None,
             tool_result_mode: ToolResultMode::Aura,
             tool_result_max_length: 0,
             streaming_buffer_size: 400,

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -155,8 +155,7 @@ impl DirectBackend {
             }
         }
 
-        aura::bootstrap::validate_roster(&config_pairs)
-            .map_err(|msg| anyhow::anyhow!("{msg}"))?;
+        aura::bootstrap::validate_roster(&config_pairs).map_err(|msg| anyhow::anyhow!("{msg}"))?;
         let bootstrap_declaration = config_pairs
             .iter()
             .find(|(_, c)| c.bootstrap.as_ref().is_some_and(|b| b.enabled))

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -25,7 +25,7 @@ use aura_web_server::session_store::InMemorySessionStore;
 use aura_web_server::streaming::ToolResultMode;
 use aura_web_server::types::{
     ActiveRequestTracker, AppState, ChatCompletionRequest, ChatMessage, ChatMessageFunctionCall,
-    ChatMessageToolCall, ClientFunctionDefinition, ClientToolDefinition, Role,
+    ChatMessageToolCall, ClientFunctionDefinition, ClientToolDefinition, ConfigRegistry, Role,
 };
 
 use crate::api::stream::{StreamHandler, StreamResult, process_sse_events};
@@ -103,7 +103,7 @@ impl DirectBackend {
         }
 
         let app_state = Arc::new(AppState {
-            configs: Arc::new(configs),
+            configs: Arc::new(ConfigRegistry::new(configs)),
             tool_result_mode: ToolResultMode::Aura,
             tool_result_max_length: 0,
             streaming_buffer_size: 400,
@@ -149,6 +149,7 @@ impl DirectBackend {
     pub fn any_agent_enables_client_tools(&self) -> bool {
         self.app_state
             .configs
+            .snapshot()
             .iter()
             .any(|c| !c.orchestration_enabled() && c.agent.enable_client_tools)
     }
@@ -164,6 +165,7 @@ impl DirectBackend {
     pub(crate) fn model_ids(&self) -> Vec<String> {
         self.app_state
             .configs
+            .snapshot()
             .iter()
             .filter(|c| !c.agent.hidden)
             .map(|c| c.agent_id().to_string())
@@ -172,7 +174,7 @@ impl DirectBackend {
 
     /// Whether more than one agent config is loaded.
     pub fn has_multiple_configs(&self) -> bool {
-        self.app_state.configs.len() > 1
+        self.app_state.configs.snapshot().len() > 1
     }
 
     /// Check if `model_name` matches any loaded config's agent.name or agent.alias.
@@ -180,7 +182,7 @@ impl DirectBackend {
     /// Returns the canonical effective ID (alias or name) on match.
     pub fn find_matching_model(&self, model_name: &str) -> Option<String> {
         let lower = model_name.to_lowercase();
-        for config in self.app_state.configs.iter() {
+        for config in self.app_state.configs.snapshot().iter() {
             let effective_id = config.agent_id().to_string();
 
             // Match against effective ID, name, or alias independently
@@ -200,22 +202,21 @@ impl DirectBackend {
 
     /// Get the system prompt from the config matching `model` (or first config if None).
     pub fn get_config_system_prompt(&self, model: Option<&str>) -> Option<String> {
+        let configs = self.app_state.configs.snapshot();
         let config = if let Some(model_name) = model {
             let lower = model_name.to_lowercase();
-            self.app_state
-                .configs
+            configs
                 .iter()
                 .find(|c| c.agent_id().to_lowercase() == lower)
         } else {
-            self.app_state.configs.first()
+            configs.first()
         };
         config.map(|c| c.agent.system_prompt.clone())
     }
 
     /// Replace the system prompt in the config matching `model` (or first config if None).
-    /// Reconstructs AppState since it holds configs behind Arc.
     pub fn override_system_prompt(&mut self, model: Option<&str>, new_prompt: String) {
-        let mut configs: Vec<_> = (*self.app_state.configs).clone();
+        let mut configs: Vec<_> = (*self.app_state.configs.snapshot()).clone();
         let target = if let Some(model_name) = model {
             let lower = model_name.to_lowercase();
             configs
@@ -227,28 +228,7 @@ impl DirectBackend {
         if let Some(config) = target {
             config.agent.system_prompt = new_prompt;
         }
-
-        let old = &self.app_state;
-        self.app_state = Arc::new(AppState {
-            configs: Arc::new(configs),
-            tool_result_mode: old.tool_result_mode,
-            tool_result_max_length: old.tool_result_max_length,
-            streaming_buffer_size: old.streaming_buffer_size,
-            aura_custom_events: old.aura_custom_events,
-            aura_emit_reasoning: old.aura_emit_reasoning,
-            debug_provider_errors: old.debug_provider_errors,
-            streaming_timeout_secs: old.streaming_timeout_secs,
-            first_chunk_timeout_secs: old.first_chunk_timeout_secs,
-            stream_inactivity_timeout_secs: old.stream_inactivity_timeout_secs,
-            shutdown_token: old.shutdown_token.clone(),
-            stream_shutdown_token: old.stream_shutdown_token.clone(),
-            active_requests: old.active_requests.clone(),
-            default_agent: old.default_agent.clone(),
-            additional_tools: additional_tools_factory(),
-            pending_approvals: old.pending_approvals.clone(),
-            hitl_webhook_hmac: old.hitl_webhook_hmac.clone(),
-            session_store: old.session_store.clone(),
-        });
+        self.app_state.configs.replace(configs);
     }
 
     /// Convert CLI messages to web server ChatMessage format, preserving
@@ -395,6 +375,7 @@ impl DirectBackend {
         let agents = self
             .app_state
             .configs
+            .snapshot()
             .iter()
             .filter(|config| !config.agent.hidden)
             .map(aura::agent_info)
@@ -465,7 +446,7 @@ mod tests {
     /// Construct a DirectBackend with test configs (no real TOML loading).
     fn make_backend(configs: Vec<aura_config::Config>) -> DirectBackend {
         let app_state = Arc::new(AppState {
-            configs: Arc::new(configs),
+            configs: Arc::new(ConfigRegistry::new(configs)),
             tool_result_mode: ToolResultMode::Aura,
             tool_result_max_length: 0,
             streaming_buffer_size: 400,

--- a/crates/aura-cli/src/init.rs
+++ b/crates/aura-cli/src/init.rs
@@ -85,6 +85,12 @@ pub struct InitArgs {
     #[arg(long, default_value = "assistant")]
     pub name: String,
 
+    /// Enable the aura-bootstrap configuration agent in the generated config
+    /// (edit the config by chatting with it; token-gated, printed at server
+    /// startup)
+    #[arg(long)]
+    pub bootstrap: bool,
+
     /// Skip live model-list verification entirely (air-gapped / CI)
     #[arg(long)]
     pub offline: bool,
@@ -176,6 +182,6 @@ pub fn run_init(args: &InitArgs) -> Result<()> {
         .with_context(|| format!("failed to write {}", args.output.display()))?;
     println!("Wrote {}", args.output.display());
 
-    println!("{}", next_steps(&args.output, wrote_env));
+    println!("{}", next_steps(&args.output, wrote_env, spec.bootstrap));
     Ok(())
 }

--- a/crates/aura-cli/src/init.rs
+++ b/crates/aura-cli/src/init.rs
@@ -87,6 +87,12 @@ pub struct InitArgs {
     #[arg(long, default_value = "assistant")]
     pub name: String,
 
+    /// Enable the aura-bootstrap configuration agent in the generated config
+    /// (edit the config by chatting with it; token-gated, printed at server
+    /// startup)
+    #[arg(long)]
+    pub bootstrap: bool,
+
     /// Skip live model-list verification entirely (air-gapped / CI)
     #[arg(long)]
     pub offline: bool,
@@ -178,6 +184,6 @@ pub fn run_init(args: &InitArgs) -> Result<()> {
         .with_context(|| format!("failed to write {}", args.output.display()))?;
     println!("Wrote {}", args.output.display());
 
-    println!("{}", next_steps(&args.output, wrote_env));
+    println!("{}", next_steps(&args.output, wrote_env, spec.bootstrap));
     Ok(())
 }

--- a/crates/aura-cli/src/init/render.rs
+++ b/crates/aura-cli/src/init/render.rs
@@ -35,9 +35,17 @@ const CONFIG_TEMPLATE: &str = include_str!("config_template.toml");
 /// two commented-out workers (ops-engineer, runbook-engineer), and MCP
 /// server placeholders.
 pub(crate) fn render_config(spec: &ConfigSpec) -> String {
-    CONFIG_TEMPLATE
+    let mut rendered = CONFIG_TEMPLATE
         .replace("{{name}}", &toml_escape(&spec.name))
-        .replace("{{llm}}", &render_llm_block(spec))
+        .replace("{{llm}}", &render_llm_block(spec));
+    if spec.bootstrap {
+        rendered.push_str(
+            "\n# The aura-bootstrap configuration agent: edit this config by \
+             chatting with it.\n# Token-gated — the server prints the token \
+             at startup (or set AURA_BOOTSTRAP_TOKEN).\n[bootstrap]\nenabled = true\n",
+        );
+    }
+    rendered
 }
 
 /// Render a `.env` file for a user-provided API key. Only called when the
@@ -90,7 +98,7 @@ pub(crate) fn validate_rendered(spec: &ConfigSpec, rendered: &str) -> Result<()>
 }
 
 /// Human-readable next-steps shown after writing the files.
-pub(crate) fn next_steps(config_path: &Path, wrote_env: bool) -> String {
+pub(crate) fn next_steps(config_path: &Path, wrote_env: bool, bootstrap: bool) -> String {
     let dir = config_path.parent().filter(|p| !p.as_os_str().is_empty());
     let (run_prefix, config_for_run) = match dir {
         Some(d) => {
@@ -109,12 +117,20 @@ pub(crate) fn next_steps(config_path: &Path, wrote_env: bool) -> String {
     } else {
         ""
     };
+    let bootstrap_note = if bootstrap {
+        "\nThe aura-bootstrap agent is enabled: run `aura` in this directory \
+         and switch to it\nwith `/model aura-bootstrap` to build out this \
+         config conversationally. Over HTTP\nthe server prints its token at \
+         startup; pass it via --api-key."
+    } else {
+        ""
+    };
     format!(
         "\nNext steps:\n  \
            1. Add MCP servers to {config_for_run} to connect your observability stack\n  \
            2. {run_prefix}CONFIG_PATH={config_for_run} aura-web-server\n  \
            3. aura --api-url http://localhost:8080\n\
-         {env_note}",
+         {env_note}{bootstrap_note}",
     )
 }
 
@@ -129,6 +145,19 @@ mod tests {
         let spec1 = resolve(&args()).unwrap();
         let spec2 = resolve(&args()).unwrap();
         assert_eq!(render_config(&spec1), render_config(&spec2));
+    }
+
+    #[test]
+    fn bootstrap_table_rendered_only_when_enabled() {
+        let spec = resolve(&args()).unwrap();
+        assert!(!render_config(&spec).contains("[bootstrap]"));
+
+        let mut flagged = args();
+        flagged.bootstrap = true;
+        let spec = resolve(&flagged).unwrap();
+        let rendered = render_config(&spec);
+        assert!(rendered.contains("[bootstrap]\nenabled = true"), "got: {rendered}");
+        toml::from_str::<toml::Value>(&rendered).unwrap();
     }
 
     #[test]
@@ -205,19 +234,19 @@ mod tests {
 
     #[test]
     fn next_steps_mentions_config() {
-        let s = next_steps(Path::new("config.toml"), false);
+        let s = next_steps(Path::new("config.toml"), false, false);
         assert!(s.contains("config.toml"), "got: {s}");
     }
 
     #[test]
     fn next_steps_mentions_env_when_written() {
-        let s = next_steps(Path::new("config.toml"), true);
+        let s = next_steps(Path::new("config.toml"), true, false);
         assert!(s.contains(".env"), "got: {s}");
     }
 
     #[test]
     fn next_steps_cds_into_config_dir() {
-        let s = next_steps(Path::new("proj/config.toml"), false);
+        let s = next_steps(Path::new("proj/config.toml"), false, false);
         assert!(s.contains("cd proj"), "got: {s}");
         assert!(s.contains("CONFIG_PATH=config.toml"), "got: {s}");
     }

--- a/crates/aura-cli/src/init/render.rs
+++ b/crates/aura-cli/src/init/render.rs
@@ -156,7 +156,10 @@ mod tests {
         flagged.bootstrap = true;
         let spec = resolve(&flagged).unwrap();
         let rendered = render_config(&spec);
-        assert!(rendered.contains("[bootstrap]\nenabled = true"), "got: {rendered}");
+        assert!(
+            rendered.contains("[bootstrap]\nenabled = true"),
+            "got: {rendered}"
+        );
         toml::from_str::<toml::Value>(&rendered).unwrap();
     }
 

--- a/crates/aura-cli/src/init/spec.rs
+++ b/crates/aura-cli/src/init/spec.rs
@@ -34,6 +34,7 @@ pub(crate) struct ConfigSpec {
     pub(crate) region: Option<String>,
     pub(crate) base_url: Option<String>,
     pub(crate) name: String,
+    pub(crate) bootstrap: bool,
 }
 
 impl ConfigSpec {
@@ -265,6 +266,17 @@ pub(crate) fn resolve_spec<R: BufRead>(
         );
     }
 
+    // ---- bootstrap agent ----
+    // The flag wins outright; otherwise offer it interactively (default no —
+    // it is a standing admin surface, so enabling stays a deliberate choice).
+    let bootstrap = args.bootstrap
+        || prompter.ask_yes_no(
+            "\nEnable the aura-bootstrap agent? It lets you edit this config \
+             by chatting with it (token-gated; the token is printed at server \
+             startup).",
+            false,
+        )?;
+
     Ok(ConfigSpec {
         provider,
         model,
@@ -272,6 +284,7 @@ pub(crate) fn resolve_spec<R: BufRead>(
         region,
         base_url,
         name: args.name.clone(),
+        bootstrap,
     })
 }
 

--- a/crates/aura-cli/src/init/test_support.rs
+++ b/crates/aura-cli/src/init/test_support.rs
@@ -21,6 +21,7 @@ pub(crate) fn args() -> InitArgs {
         region: None,
         base_url: None,
         name: "assistant".to_string(),
+        bootstrap: false,
         offline: true,
         non_interactive: true,
         force: false,

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -646,6 +646,21 @@ pub fn run_repl(
     if let Some(agent) = startup_agent {
         crate::ui::agent_overview::print_agent_overview(&agent);
     }
+
+    if config
+        .model
+        .as_deref()
+        .is_some_and(|m| m.eq_ignore_ascii_case("aura-bootstrap"))
+    {
+        use crate::theme::Themed;
+        println!(
+            "\n  {} You're connected to the bootstrap configuration agent.\n  \
+             Describe what you want this AURA instance to do and it will\n  \
+             build a configuration for you.\n",
+            "aura-bootstrap".themed_with(crate::theme::theme().heading),
+        );
+    }
+
     setup_terminal();
 
     // Coordinate session telemetry here: Enabled sessions start now;

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -693,6 +693,21 @@ pub fn run_repl(
         crate::ui::agent_overview::print_agent_overview(&agent);
         crate::ui::agent_overview::print_startup_cta(&agent);
     }
+
+    if config
+        .model
+        .as_deref()
+        .is_some_and(|m| m.eq_ignore_ascii_case("aura-bootstrap"))
+    {
+        use crate::theme::Themed;
+        println!(
+            "\n  {} You're connected to the bootstrap configuration agent.\n  \
+             Describe what you want this AURA instance to do and it will\n  \
+             build a configuration for you.\n",
+            "aura-bootstrap".themed_with(crate::theme::theme().heading),
+        );
+    }
+
     setup_terminal();
 
     // Coordinate session telemetry here: Enabled sessions start now;

--- a/crates/aura-cli/src/ui/input_hint.rs
+++ b/crates/aura-cli/src/ui/input_hint.rs
@@ -116,11 +116,19 @@ fn persist_model_cache(models: &[String]) {
     let _ = fs::write(dir.join("models_cache"), models.join("\n"));
 }
 
-/// Seed the in-memory model cache.
+/// Seed the in-memory model cache. No-op when the cache is already
+/// populated; use [`refresh_model_cache`] to overwrite.
 pub fn seed_model_cache(models: Vec<String>) {
     if let Ok(mut g) = MODEL_CACHE.lock()
         && g.is_empty()
     {
+        *g = models;
+    }
+}
+
+/// Overwrite the in-memory model cache with a fresh roster.
+pub fn refresh_model_cache(models: Vec<String>) {
+    if let Ok(mut g) = MODEL_CACHE.lock() {
         *g = models;
     }
 }

--- a/crates/aura-cli/src/ui/prompt.rs
+++ b/crates/aura-cli/src/ui/prompt.rs
@@ -71,6 +71,6 @@ pub use super::mid_stream::{drain_stdin, poll_input, prepare_input_line, styled_
 
 // Re-export from input_hint.rs
 pub use super::input_hint::{
-    clear_input_hint, seed_model_cache, set_model_cache, set_model_error, set_model_fetch_config,
-    trigger_model_fetch, update_input_hint, validate_command_input,
+    clear_input_hint, refresh_model_cache, seed_model_cache, set_model_cache, set_model_error,
+    set_model_fetch_config, trigger_model_fetch, update_input_hint, validate_command_input,
 };

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -27,6 +27,29 @@ pub struct Config {
     /// it; presence of the table is the enable bit.
     #[serde(default)]
     pub hitl: Option<HitlConfig>,
+    /// Built-in `aura-bootstrap` agent configuration (TOML `[bootstrap]`
+    /// table). Absent or `enabled = false` (the default) means the
+    /// bootstrap agent is not served.
+    #[serde(default)]
+    pub bootstrap: Option<BootstrapConfig>,
+}
+
+/// Configuration for the built-in `aura-bootstrap` agent (TOML `[bootstrap]`
+/// table).
+///
+/// The bootstrap agent is a token-gated administrative agent served alongside
+/// the configured agents; it can read, validate, and write this server's
+/// configuration. Disabled by default.
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BootstrapConfig {
+    /// Serve the bootstrap agent. Default false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// LLM override for the bootstrap agent (TOML `[bootstrap.llm]`).
+    /// When omitted, the bootstrap agent runs on this file's `[agent.llm]`.
+    #[serde(default)]
+    pub llm: Option<LlmConfig>,
 }
 
 /// Reasoning effort level for GPT-5 models
@@ -334,6 +357,10 @@ impl Config {
     pub fn validate(&self) -> Result<(), crate::ConfigError> {
         validate_llm_api_key(&self.agent.llm, "agent.llm")?;
 
+        if let Some(bootstrap_llm) = self.bootstrap.as_ref().and_then(|b| b.llm.as_ref()) {
+            validate_llm_api_key(bootstrap_llm, "bootstrap.llm")?;
+        }
+
         if let Some(orch) = &self.orchestration {
             for (name, worker) in &orch.workers {
                 if let Some(worker_llm) = &worker.llm {
@@ -395,6 +422,7 @@ impl Config {
 
         if let Some(orch) = &self.orchestration {
             orch.validate_worker_names()?;
+            orch.validate_read_only_workers()?;
         }
 
         Ok(())

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -28,6 +28,29 @@ pub struct Config {
     /// it; presence of the table is the enable bit.
     #[serde(default)]
     pub hitl: Option<HitlConfig>,
+    /// Built-in `aura-bootstrap` agent configuration (TOML `[bootstrap]`
+    /// table). Absent or `enabled = false` (the default) means the
+    /// bootstrap agent is not served.
+    #[serde(default)]
+    pub bootstrap: Option<BootstrapConfig>,
+}
+
+/// Configuration for the built-in `aura-bootstrap` agent (TOML `[bootstrap]`
+/// table).
+///
+/// The bootstrap agent is a token-gated administrative agent served alongside
+/// the configured agents; it can read, validate, and write this server's
+/// configuration. Disabled by default.
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BootstrapConfig {
+    /// Serve the bootstrap agent. Default false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// LLM override for the bootstrap agent (TOML `[bootstrap.llm]`).
+    /// When omitted, the bootstrap agent runs on this file's `[agent.llm]`.
+    #[serde(default)]
+    pub llm: Option<LlmConfig>,
 }
 
 /// Reasoning effort level for GPT-5 models
@@ -340,6 +363,10 @@ impl Config {
     pub fn validate(&self) -> Result<(), crate::ConfigError> {
         validate_llm_api_key(&self.agent.llm, "agent.llm")?;
 
+        if let Some(bootstrap_llm) = self.bootstrap.as_ref().and_then(|b| b.llm.as_ref()) {
+            validate_llm_api_key(bootstrap_llm, "bootstrap.llm")?;
+        }
+
         if let Some(orch) = &self.orchestration {
             for (name, worker) in &orch.workers {
                 if let Some(worker_llm) = &worker.llm {
@@ -413,6 +440,7 @@ impl Config {
 
         if let Some(orch) = &self.orchestration {
             orch.validate_worker_names()?;
+            orch.validate_read_only_workers()?;
         }
 
         Ok(())

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -1991,6 +1991,7 @@ max_extraction_tokens = 4000
             llm: None,
             scratchpad: None,
             skills: None,
+            read_only: false,
         };
         let mut orch = OrchestrationConfig::default();
         for name in names {
@@ -2034,5 +2035,182 @@ max_extraction_tokens = 4000
         // No workers configured at all is fine.
         let orch = crate::OrchestrationConfig::default();
         assert!(orch.validate_worker_names().is_ok());
+    }
+
+    #[test]
+    fn test_orchestration_rejects_exact_duplicate_worker_header() {
+        // Defense-in-depth: the toml parser is expected to reject this at
+        // parse time, but we pin the behavior here so a future parser change
+        // doesn't silently regress into last-write-wins merging.
+        let config_str = r#"
+[agent]
+name = "Test"
+system_prompt = "Test"
+
+[agent.llm]
+provider = "ollama"
+model = "m"
+
+[orchestration]
+enabled = true
+
+[orchestration.worker.investigator]
+description = "first"
+preamble = "p"
+
+[orchestration.worker.investigator]
+description = "second"
+preamble = "p"
+"#;
+        assert!(
+            load_config_from_str(config_str).is_err(),
+            "duplicate [orchestration.worker.X] headers must be rejected"
+        );
+    }
+
+    // ========================================================================
+    // Read-only worker validation
+    // ========================================================================
+
+    fn read_only_worker_config(filter_lines: &str) -> String {
+        format!(
+            r#"
+[agent]
+name = "Test"
+system_prompt = "Test"
+
+[agent.llm]
+provider = "ollama"
+model = "m"
+
+[orchestration]
+enabled = true
+
+[orchestration.worker.watcher]
+description = "d"
+preamble = "p"
+read_only = true
+{filter_lines}
+"#
+        )
+    }
+
+    #[test]
+    fn test_read_only_worker_rejects_empty_mcp_filter() {
+        // Empty mcp_filter means "all MCP tools" at runtime, which a
+        // read-only worker must never get.
+        let err = load_config_from_str(&read_only_worker_config(""))
+            .expect_err("empty filter on read_only worker must be rejected")
+            .to_string();
+        assert!(err.contains("read_only"), "got: {err}");
+        assert!(err.contains("ALL MCP tools"), "got: {err}");
+    }
+
+    #[test]
+    fn test_read_only_worker_rejects_glob_filter() {
+        let err = load_config_from_str(&read_only_worker_config("mcp_filter = [\"list_*\"]"))
+            .expect_err("glob filter on read_only worker must be rejected")
+            .to_string();
+        assert!(err.contains("not glob patterns"), "got: {err}");
+    }
+
+    #[test]
+    fn test_read_only_worker_accepts_exact_names() {
+        load_config_from_str(&read_only_worker_config(
+            "mcp_filter = [\"list_pods\", \"get_logs\"]",
+        ))
+        .expect("exact-name filter on read_only worker should pass");
+    }
+
+    #[test]
+    fn test_non_read_only_worker_keeps_glob_and_empty_filters() {
+        // The restriction applies only to read_only workers; ordinary
+        // workers keep the documented empty/glob semantics.
+        let config = read_only_worker_config("mcp_filter = [\"mezmo_*\"]")
+            .replace("read_only = true", "read_only = false");
+        load_config_from_str(&config).expect("non-read-only glob filter should pass");
+    }
+
+    // ========================================================================
+    // [bootstrap] table
+    // ========================================================================
+
+    const MINIMAL_AGENT: &str = r#"
+[agent]
+name = "assistant"
+system_prompt = "You are helpful."
+
+[agent.llm]
+provider = "ollama"
+model = "qwen3:8b"
+"#;
+
+    #[test]
+    fn bootstrap_absent_by_default() {
+        let config = load_config_from_str(MINIMAL_AGENT).unwrap();
+        assert!(config.bootstrap.is_none());
+    }
+
+    #[test]
+    fn bootstrap_table_parses_enabled() {
+        let toml = format!("{MINIMAL_AGENT}\n[bootstrap]\nenabled = true\n");
+        let config = load_config_from_str(&toml).unwrap();
+        let bootstrap = config.bootstrap.expect("bootstrap table present");
+        assert!(bootstrap.enabled);
+        assert!(bootstrap.llm.is_none());
+    }
+
+    #[test]
+    fn bootstrap_enabled_defaults_false() {
+        let toml = format!("{MINIMAL_AGENT}\n[bootstrap]\n");
+        let config = load_config_from_str(&toml).unwrap();
+        assert!(!config.bootstrap.unwrap().enabled);
+    }
+
+    #[test]
+    fn bootstrap_llm_override_parses() {
+        let toml = format!(
+            "{MINIMAL_AGENT}\n[bootstrap]\nenabled = true\n\n\
+             [bootstrap.llm]\nprovider = \"ollama\"\nmodel = \"qwen3:32b\"\n"
+        );
+        let config = load_config_from_str(&toml).unwrap();
+        let llm = config.bootstrap.unwrap().llm.expect("llm override");
+        assert_eq!(llm.model_info(), ("ollama", "qwen3:32b"));
+    }
+
+    #[test]
+    fn bootstrap_llm_override_requires_api_key() {
+        let toml = format!(
+            "{MINIMAL_AGENT}\n[bootstrap]\nenabled = true\n\n\
+             [bootstrap.llm]\nprovider = \"openai\"\napi_key = \"\"\nmodel = \"gpt-5.1\"\n"
+        );
+        let err = load_config_from_str(&toml).unwrap_err();
+        assert!(err.to_string().contains("bootstrap.llm"), "got: {err}");
+    }
+
+    #[test]
+    fn bootstrap_rejects_unknown_fields() {
+        let toml = format!("{MINIMAL_AGENT}\n[bootstrap]\nenabledd = true\n");
+        assert!(load_config_from_str(&toml).is_err());
+    }
+
+    // ========================================================================
+    // per-worker read_only flag
+    // ========================================================================
+
+    #[test]
+    fn worker_read_only_defaults_false_and_parses_true() {
+        let toml = format!(
+            "{MINIMAL_AGENT}\n[orchestration]\nenabled = true\n\n\
+             [orchestration.worker.watcher]\n\
+             description = \"d\"\npreamble = \"p\"\nread_only = true\n\
+             mcp_filter = [\"list_pods\"]\n\n\
+             [orchestration.worker.doer]\n\
+             description = \"d\"\npreamble = \"p\"\n"
+        );
+        let config = load_config_from_str(&toml).unwrap();
+        let workers = &config.orchestration.unwrap().workers;
+        assert!(workers["watcher"].read_only);
+        assert!(!workers["doer"].read_only);
     }
 }

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -2079,6 +2079,7 @@ max_extraction_tokens = 4000
             llm: None,
             scratchpad: None,
             skills: None,
+            read_only: false,
         };
         let mut orch = OrchestrationConfig::default();
         for name in names {
@@ -2122,5 +2123,190 @@ max_extraction_tokens = 4000
         // No workers configured at all is fine.
         let orch = crate::OrchestrationConfig::default();
         assert!(orch.validate_worker_names().is_ok());
+    }
+
+    #[test]
+    fn test_orchestration_rejects_exact_duplicate_worker_header() {
+        // Defense-in-depth: the toml parser is expected to reject this at
+        // parse time, but we pin the behavior here so a future parser change
+        // doesn't silently regress into last-write-wins merging.
+        let config_str = r#"
+[agent]
+name = "Test"
+system_prompt = "Test"
+
+[agent.llm]
+provider = "ollama"
+model = "m"
+
+[orchestration]
+enabled = true
+
+[orchestration.worker.investigator]
+description = "first"
+preamble = "p"
+
+[orchestration.worker.investigator]
+description = "second"
+preamble = "p"
+"#;
+        assert!(
+            load_config_from_str(config_str).is_err(),
+            "duplicate [orchestration.worker.X] headers must be rejected"
+        );
+    }
+
+    // ========================================================================
+    // Read-only worker validation
+    // ========================================================================
+
+    fn read_only_worker_config(filter_lines: &str) -> String {
+        format!(
+            r#"
+[agent]
+name = "Test"
+system_prompt = "Test"
+
+[agent.llm]
+provider = "ollama"
+model = "m"
+
+[orchestration]
+enabled = true
+
+[orchestration.worker.watcher]
+description = "d"
+preamble = "p"
+read_only = true
+{filter_lines}
+"#
+        )
+    }
+
+    #[test]
+    fn test_read_only_worker_rejects_missing_mcp_filter() {
+        // A missing mcp_filter means "all MCP tools" at runtime, which a
+        // read-only worker must never get.
+        let err = load_config_from_str(&read_only_worker_config(""))
+            .expect_err("missing filter on read_only worker must be rejected")
+            .to_string();
+        assert!(err.contains("read_only"), "got: {err}");
+        assert!(err.contains("ALL MCP tools"), "got: {err}");
+    }
+
+    #[test]
+    fn test_read_only_worker_accepts_explicit_empty_mcp_filter() {
+        // An explicit empty filter is the no-tools assignment — nothing to
+        // mutate with, so it satisfies the read-only promise.
+        load_config_from_str(&read_only_worker_config("mcp_filter = []"))
+            .expect("explicit empty filter on read_only worker should pass");
+    }
+
+    #[test]
+    fn test_read_only_worker_rejects_glob_filter() {
+        let err = load_config_from_str(&read_only_worker_config("mcp_filter = [\"list_*\"]"))
+            .expect_err("glob filter on read_only worker must be rejected")
+            .to_string();
+        assert!(err.contains("not glob patterns"), "got: {err}");
+    }
+
+    #[test]
+    fn test_read_only_worker_accepts_exact_names() {
+        load_config_from_str(&read_only_worker_config(
+            "mcp_filter = [\"list_pods\", \"get_logs\"]",
+        ))
+        .expect("exact-name filter on read_only worker should pass");
+    }
+
+    #[test]
+    fn test_non_read_only_worker_keeps_glob_and_empty_filters() {
+        // The restriction applies only to read_only workers; ordinary
+        // workers keep the documented empty/glob semantics.
+        let config = read_only_worker_config("mcp_filter = [\"mezmo_*\"]")
+            .replace("read_only = true", "read_only = false");
+        load_config_from_str(&config).expect("non-read-only glob filter should pass");
+    }
+
+    // ========================================================================
+    // [bootstrap] table
+    // ========================================================================
+
+    const MINIMAL_AGENT: &str = r#"
+[agent]
+name = "assistant"
+system_prompt = "You are helpful."
+
+[agent.llm]
+provider = "ollama"
+model = "qwen3:8b"
+"#;
+
+    #[test]
+    fn bootstrap_absent_by_default() {
+        let config = load_config_from_str(MINIMAL_AGENT).unwrap();
+        assert!(config.bootstrap.is_none());
+    }
+
+    #[test]
+    fn bootstrap_table_parses_enabled() {
+        let toml = format!("{MINIMAL_AGENT}\n[bootstrap]\nenabled = true\n");
+        let config = load_config_from_str(&toml).unwrap();
+        let bootstrap = config.bootstrap.expect("bootstrap table present");
+        assert!(bootstrap.enabled);
+        assert!(bootstrap.llm.is_none());
+    }
+
+    #[test]
+    fn bootstrap_enabled_defaults_false() {
+        let toml = format!("{MINIMAL_AGENT}\n[bootstrap]\n");
+        let config = load_config_from_str(&toml).unwrap();
+        assert!(!config.bootstrap.unwrap().enabled);
+    }
+
+    #[test]
+    fn bootstrap_llm_override_parses() {
+        let toml = format!(
+            "{MINIMAL_AGENT}\n[bootstrap]\nenabled = true\n\n\
+             [bootstrap.llm]\nprovider = \"ollama\"\nmodel = \"qwen3:32b\"\n"
+        );
+        let config = load_config_from_str(&toml).unwrap();
+        let llm = config.bootstrap.unwrap().llm.expect("llm override");
+        assert_eq!(llm.model_info(), ("ollama", "qwen3:32b"));
+    }
+
+    #[test]
+    fn bootstrap_llm_override_requires_api_key() {
+        let toml = format!(
+            "{MINIMAL_AGENT}\n[bootstrap]\nenabled = true\n\n\
+             [bootstrap.llm]\nprovider = \"openai\"\napi_key = \"\"\nmodel = \"gpt-5.1\"\n"
+        );
+        let err = load_config_from_str(&toml).unwrap_err();
+        assert!(err.to_string().contains("bootstrap.llm"), "got: {err}");
+    }
+
+    #[test]
+    fn bootstrap_rejects_unknown_fields() {
+        let toml = format!("{MINIMAL_AGENT}\n[bootstrap]\nenabledd = true\n");
+        assert!(load_config_from_str(&toml).is_err());
+    }
+
+    // ========================================================================
+    // per-worker read_only flag
+    // ========================================================================
+
+    #[test]
+    fn worker_read_only_defaults_false_and_parses_true() {
+        let toml = format!(
+            "{MINIMAL_AGENT}\n[orchestration]\nenabled = true\n\n\
+             [orchestration.worker.watcher]\n\
+             description = \"d\"\npreamble = \"p\"\nread_only = true\n\
+             mcp_filter = [\"list_pods\"]\n\n\
+             [orchestration.worker.doer]\n\
+             description = \"d\"\npreamble = \"p\"\n"
+        );
+        let config = load_config_from_str(&toml).unwrap();
+        let workers = &config.orchestration.unwrap().workers;
+        assert!(workers["watcher"].read_only);
+        assert!(!workers["doer"].read_only);
     }
 }

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -70,6 +70,20 @@ fn check_legacy_top_level_llm(toml_str: &str) -> Result<(), ConfigError> {
 /// - Each config can be serialized and deserialized correctly.
 /// - Each config is uniquely identifiable by alias or name.
 pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Vec<Config>, ConfigError> {
+    Ok(load_config_with_paths(path)?
+        .into_iter()
+        .map(|(_, config)| config)
+        .collect())
+}
+
+/// [`load_config`], but each config is paired with the file it came from.
+///
+/// Callers that need to know which file declared something (e.g. the
+/// `[bootstrap]` table's write target) use this; everyone else uses
+/// `load_config`.
+pub fn load_config_with_paths<P: AsRef<Path>>(
+    path: P,
+) -> Result<Vec<(std::path::PathBuf, Config)>, ConfigError> {
     let path = path.as_ref();
 
     let configs = if path.is_dir() {
@@ -81,7 +95,7 @@ pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Vec<Config>, ConfigError> 
 
         let mut configs = Vec::new();
         for entry in entries {
-            configs.push(load_single_config(entry.path())?);
+            configs.push((entry.path(), load_single_config(entry.path())?));
         }
         if configs.is_empty() {
             return Err(ConfigError::Validation(
@@ -90,10 +104,11 @@ pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Vec<Config>, ConfigError> 
         }
         configs
     } else {
-        vec![load_single_config(path)?]
+        vec![(path.to_path_buf(), load_single_config(path)?)]
     };
 
-    validate_unique_identifiers(&configs)?;
+    let bare: Vec<Config> = configs.iter().map(|(_, c)| c.clone()).collect();
+    validate_unique_identifiers(&bare)?;
     Ok(configs)
 }
 

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -74,6 +74,20 @@ fn check_legacy_top_level_llm(toml_str: &str) -> Result<(), ConfigError> {
 /// - Each config can be serialized and deserialized correctly.
 /// - Each config is uniquely identifiable by alias or name.
 pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Vec<Config>, ConfigError> {
+    Ok(load_config_with_paths(path)?
+        .into_iter()
+        .map(|(_, config)| config)
+        .collect())
+}
+
+/// [`load_config`], but each config is paired with the file it came from.
+///
+/// Callers that need to know which file declared something (e.g. the
+/// `[bootstrap]` table's write target) use this; everyone else uses
+/// `load_config`.
+pub fn load_config_with_paths<P: AsRef<Path>>(
+    path: P,
+) -> Result<Vec<(std::path::PathBuf, Config)>, ConfigError> {
     let path = path.as_ref();
 
     let configs = if path.is_dir() {
@@ -85,7 +99,7 @@ pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Vec<Config>, ConfigError> 
 
         let mut configs = Vec::new();
         for entry in entries {
-            configs.push(load_single_config(entry.path())?);
+            configs.push((entry.path(), load_single_config(entry.path())?));
         }
         if configs.is_empty() {
             return Err(ConfigError::Validation(
@@ -94,10 +108,11 @@ pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Vec<Config>, ConfigError> 
         }
         configs
     } else {
-        vec![load_single_config(path)?]
+        vec![(path.to_path_buf(), load_single_config(path)?)]
     };
 
-    validate_unique_identifiers(&configs)?;
+    let bare: Vec<Config> = configs.iter().map(|(_, c)| c.clone()).collect();
+    validate_unique_identifiers(&bare)?;
     Ok(configs)
 }
 

--- a/crates/aura-config/src/orchestration.rs
+++ b/crates/aura-config/src/orchestration.rs
@@ -111,6 +111,11 @@ pub struct WorkerConfig {
     /// (no merging).
     #[serde(default)]
     pub skills: Option<SkillsConfig>,
+
+    /// Declares this worker read-only: it must never receive tools that
+    /// mutate state. Default false.
+    #[serde(default)]
+    pub read_only: bool,
 }
 
 // ============================================================================
@@ -354,6 +359,37 @@ impl OrchestrationConfig {
                      case-insensitively to avoid filesystem collisions in \
                      artifact persistence)",
                     existing, name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate read-only worker tool filters.
+    ///
+    /// `read_only = true` promises the worker can never mutate state, so its
+    /// `mcp_filter` must be an explicit allowlist of exact tool names. An
+    /// empty filter is rejected because empty means "all MCP tools" (the
+    /// documented backwards-compatible default), and glob patterns are
+    /// rejected because they can admit tools that did not exist when the
+    /// config was validated.
+    pub fn validate_read_only_workers(&self) -> Result<(), crate::ConfigError> {
+        for (name, worker) in self.workers.iter().filter(|(_, w)| w.read_only) {
+            if worker.mcp_filter.is_empty() {
+                return Err(crate::ConfigError::Validation(format!(
+                    "worker '{name}' is read_only but has an empty mcp_filter, \
+                     which grants ALL MCP tools; list the exact tool names the \
+                     worker may use"
+                )));
+            }
+            if let Some(entry) = worker
+                .mcp_filter
+                .iter()
+                .find(|e| e.contains(['*', '?', '[']))
+            {
+                return Err(crate::ConfigError::Validation(format!(
+                    "worker '{name}' is read_only; its mcp_filter must list \
+                     exact tool names, not glob patterns (got '{entry}')"
                 )));
             }
         }

--- a/crates/aura-config/src/orchestration.rs
+++ b/crates/aura-config/src/orchestration.rs
@@ -112,6 +112,11 @@ pub struct WorkerConfig {
     /// (no merging).
     #[serde(default)]
     pub skills: Option<SkillsConfig>,
+
+    /// Declares this worker read-only: it must never receive tools that
+    /// mutate state. Default false.
+    #[serde(default)]
+    pub read_only: bool,
 }
 
 // ============================================================================
@@ -358,6 +363,33 @@ impl OrchestrationConfig {
                      case-insensitively to avoid filesystem collisions in \
                      artifact persistence)",
                     existing, name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate read-only worker tool filters.
+    ///
+    /// `read_only = true` promises the worker can never mutate state, so its
+    /// `mcp_filter` must be an explicit allowlist of exact tool names. A
+    /// missing filter is rejected because `None` means "all MCP tools", and
+    /// glob patterns are rejected because they can admit tools that did not
+    /// exist when the config was validated. An explicit empty filter
+    /// (`mcp_filter = []`) grants no tools and is allowed.
+    pub fn validate_read_only_workers(&self) -> Result<(), crate::ConfigError> {
+        for (name, worker) in self.workers.iter().filter(|(_, w)| w.read_only) {
+            let Some(filter) = &worker.mcp_filter else {
+                return Err(crate::ConfigError::Validation(format!(
+                    "worker '{name}' is read_only but has no mcp_filter, \
+                     which grants ALL MCP tools; list the exact tool names the \
+                     worker may use"
+                )));
+            };
+            if let Some(entry) = filter.iter().find(|e| e.contains(['*', '?', '['])) {
+                return Err(crate::ConfigError::Validation(format!(
+                    "worker '{name}' is read_only; its mcp_filter must list \
+                     exact tool names, not glob patterns (got '{entry}')"
                 )));
             }
         }

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -643,6 +643,7 @@ mod tests {
     ) -> AuraAgentExecutor {
         let app_state = Arc::new(AppState {
             configs: Arc::new(crate::types::ConfigRegistry::new(configs)),
+            bootstrap: None,
             default_agent: default_agent.map(str::to_owned),
             tool_result_mode: ToolResultMode::default(),
             tool_result_max_length: 0,

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -669,6 +669,7 @@ mod tests {
             tools: None,
             orchestration: None,
             hitl: None,
+            bootstrap: None,
             agent: aura_config::AgentConfig {
                 name: name.to_owned(),
                 alias: alias.map(str::to_owned),

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -47,7 +47,7 @@ impl AuraAgentExecutor {
     }
 
     fn resolve_config(&self, requested_model: Option<&str>) -> Option<aura_config::Config> {
-        let configs = &self.app_state.configs;
+        let configs = self.app_state.configs.snapshot();
         // Single-config: always use it, ignore any requested_model (mirrors chat completions passthrough).
         if configs.len() == 1 {
             return configs.first().cloned();
@@ -642,7 +642,7 @@ mod tests {
         default_agent: Option<&str>,
     ) -> AuraAgentExecutor {
         let app_state = Arc::new(AppState {
-            configs: Arc::new(configs),
+            configs: Arc::new(crate::types::ConfigRegistry::new(configs)),
             default_agent: default_agent.map(str::to_owned),
             tool_result_mode: ToolResultMode::default(),
             tool_result_max_length: 0,

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -84,7 +84,7 @@ impl AuraAgentExecutor {
     }
 
     fn resolve_config(&self, requested_model: Option<&str>) -> Option<aura_config::Config> {
-        let configs = &self.app_state.configs;
+        let configs = self.app_state.configs.snapshot();
         // Single-config: always use it, ignore any requested_model (mirrors chat completions passthrough).
         if configs.len() == 1 {
             return configs.first().cloned();
@@ -722,7 +722,7 @@ mod tests {
         default_agent: Option<&str>,
     ) -> AuraAgentExecutor {
         let app_state = Arc::new(AppState {
-            configs: Arc::new(configs),
+            configs: Arc::new(crate::types::ConfigRegistry::new(configs)),
             default_agent: default_agent.map(str::to_owned),
             tool_result_mode: ToolResultMode::default(),
             tool_result_max_length: 0,

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -752,6 +752,7 @@ mod tests {
             tools: None,
             orchestration: None,
             hitl: None,
+            bootstrap: None,
             agent: aura_config::AgentConfig {
                 name: name.to_owned(),
                 alias: alias.map(str::to_owned),

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -723,6 +723,7 @@ mod tests {
     ) -> AuraAgentExecutor {
         let app_state = Arc::new(AppState {
             configs: Arc::new(crate::types::ConfigRegistry::new(configs)),
+            bootstrap: None,
             default_agent: default_agent.map(str::to_owned),
             tool_result_mode: ToolResultMode::default(),
             tool_result_max_length: 0,

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1102,6 +1102,7 @@ mod tests {
             tools: None,
             orchestration: None,
             hitl: None,
+            bootstrap: None,
             agent: aura_config::AgentConfig {
                 name: "test-agent".to_string(),
                 ..aura_config::AgentConfig::default()

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -258,13 +258,17 @@ pub async fn prepare_request(
     // assistant `tool_calls` and `role: "tool"` follow-up results).
     let (query, chat_history) = convert_chat_messages(&req.messages, has_client_tools)?;
 
+    // One roster snapshot per request: this request (including any stream it
+    // spawns) works against an immutable view, unaffected by hot reloads.
+    let configs = data.configs.snapshot();
+
     // Find the matching config: single-config passthrough > explicit model > DEFAULT_AGENT
     // Single-config servers accept any model field value (clients like LibreChat always send one).
     // Multi-config servers require the model field to match an alias or agent name.
-    let config = if data.configs.len() == 1 {
-        data.configs[0].clone()
+    let config = if configs.len() == 1 {
+        configs[0].clone()
     } else if let Some(model_name) = req.model.as_deref().or(data.default_agent.as_deref()) {
-        data.configs
+        configs
             .iter()
             .find(|c| c.agent.alias.as_deref().unwrap_or(&c.agent.name) == model_name)
             .cloned()
@@ -967,6 +971,7 @@ pub async fn health() -> Response {
 pub async fn info(State(state): State<Arc<AppState>>) -> Response {
     let agents: Vec<AgentInfo> = state
         .configs
+        .snapshot()
         .iter()
         .filter(|config| !config.agent.hidden)
         .map(aura::agent_info)
@@ -985,6 +990,7 @@ pub async fn info(State(state): State<Arc<AppState>>) -> Response {
 pub async fn list_models(State(state): State<Arc<AppState>>) -> Response {
     let models: Vec<serde_json::Value> = state
         .configs
+        .snapshot()
         .iter()
         .filter(|config| !config.agent.hidden)
         .map(|config| {
@@ -1525,7 +1531,7 @@ mod tests {
 
     fn make_state(configs: Vec<aura_config::Config>) -> Arc<AppState> {
         Arc::new(AppState {
-            configs: Arc::new(configs),
+            configs: Arc::new(crate::types::ConfigRegistry::new(configs)),
             tool_result_mode: crate::streaming::ToolResultMode::None,
             tool_result_max_length: 0,
             streaming_buffer_size: 32,
@@ -1597,7 +1603,7 @@ model = "gpt-4o"
         default_agent: Option<&str>,
     ) -> Arc<AppState> {
         Arc::new(AppState {
-            configs: Arc::new(configs),
+            configs: Arc::new(crate::types::ConfigRegistry::new(configs)),
             tool_result_mode: crate::streaming::ToolResultMode::None,
             tool_result_max_length: 0,
             streaming_buffer_size: 32,
@@ -1871,7 +1877,7 @@ model = "gpt-4o-mini"
 
         fn test_app_state() -> Arc<AppState> {
             Arc::new(AppState {
-                configs: Arc::new(vec![]),
+                configs: Arc::new(crate::types::ConfigRegistry::new(vec![])),
                 tool_result_mode: ToolResultMode::default(),
                 tool_result_max_length: 0,
                 streaming_buffer_size: 0,

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -80,6 +80,7 @@ impl Drop for RequestResourceGuard {
 pub enum PrepareError {
     BadRequest(String),
     NotFound(String),
+    Unauthorized(String),
     Internal(String),
 }
 
@@ -89,6 +90,7 @@ impl PrepareError {
         match self {
             PrepareError::BadRequest(msg) => msg,
             PrepareError::NotFound(msg) => msg,
+            PrepareError::Unauthorized(msg) => msg,
             PrepareError::Internal(msg) => msg,
         }
     }
@@ -104,6 +106,15 @@ impl PrepareError {
                 Json(ChatCompletionErrorResponse::ModelNotFound(model_name)),
             )
                 .into_response(),
+            PrepareError::Unauthorized(msg) => {
+                let mut response =
+                    error_response(StatusCode::UNAUTHORIZED, msg, "authentication_error");
+                response.headers_mut().insert(
+                    axum::http::header::WWW_AUTHENTICATE,
+                    axum::http::HeaderValue::from_static("Bearer"),
+                );
+                response
+            }
             PrepareError::Internal(msg) => {
                 error_response(StatusCode::INTERNAL_SERVER_ERROR, msg, "internal_error")
             }
@@ -262,26 +273,43 @@ pub async fn prepare_request(
     // spawns) works against an immutable view, unaffected by hot reloads.
     let configs = data.configs.snapshot();
 
-    // Find the matching config: single-config passthrough > explicit model > DEFAULT_AGENT
-    // Single-config servers accept any model field value (clients like LibreChat always send one).
-    // Multi-config servers require the model field to match an alias or agent name.
-    let config = if configs.len() == 1 {
-        configs[0].clone()
-    } else if let Some(model_name) = req.model.as_deref().or(data.default_agent.as_deref()) {
-        configs
-            .iter()
-            .find(|c| c.agent.alias.as_deref().unwrap_or(&c.agent.name) == model_name)
-            .cloned()
-            .ok_or_else(|| PrepareError::NotFound(model_name.to_string()))?
+    // The reserved bootstrap model name is checked BEFORE roster resolution
+    // (the single-config passthrough would otherwise route it to the normal
+    // agent). Reaching the bootstrap agent always requires its explicit name
+    // plus the token — the passthrough and DEFAULT_AGENT can never select it.
+    let (config, additional_tools) = if req
+        .model
+        .as_deref()
+        .is_some_and(|m| m.eq_ignore_ascii_case(aura::bootstrap::BOOTSTRAP_AGENT_NAME))
+    {
+        let Some(bootstrap) = data.bootstrap.as_ref() else {
+            return Err(PrepareError::NotFound(
+                aura::bootstrap::BOOTSTRAP_AGENT_NAME.to_string(),
+            ));
+        };
+        verify_bootstrap_token(&bootstrap.token, req_headers_map)?;
+        (bootstrap.agent_config.clone(), (bootstrap.tools)())
     } else {
-        return Err(PrepareError::BadRequest(
-            "you must provide a model parameter".to_string(),
-        ));
+        // Find the matching config: single-config passthrough > explicit model > DEFAULT_AGENT
+        // Single-config servers accept any model field value (clients like LibreChat always send one).
+        // Multi-config servers require the model field to match an alias or agent name.
+        let config = if configs.len() == 1 {
+            configs[0].clone()
+        } else if let Some(model_name) = req.model.as_deref().or(data.default_agent.as_deref()) {
+            configs
+                .iter()
+                .find(|c| c.agent.alias.as_deref().unwrap_or(&c.agent.name) == model_name)
+                .cloned()
+                .ok_or_else(|| PrepareError::NotFound(model_name.to_string()))?
+        } else {
+            return Err(PrepareError::BadRequest(
+                "you must provide a model parameter".to_string(),
+            ));
+        };
+        // Additional tools from the factory (e.g., CLI tools in standalone mode)
+        (config, (data.additional_tools)())
     };
     validate_hitl_delivery_mode(&config, req)?;
-
-    // Get additional tools from the factory (e.g., CLI tools in standalone mode)
-    let additional_tools = (data.additional_tools)();
 
     // Convert request-supplied client tool definitions once; both paths use them.
     let client_tools_vec: Option<Vec<aura::builder::ClientTool>> = req
@@ -360,6 +388,57 @@ fn validate_hitl_delivery_mode(
         ));
     }
     Ok(())
+}
+
+/// Verify the bootstrap token on a request addressed to the bootstrap agent.
+///
+/// Accepts `Authorization: Bearer <token>` (the CLI's `--api-key` sends this
+/// unmodified) **or** `x-aura-bootstrap-token: <token>` for deployments
+/// where a gateway injects its own Authorization header (oauth2-proxy, ALB
+/// OIDC, Istio, etc.). Either header matching the expected token is
+/// sufficient — the Bearer scheme comparison is case-insensitive per
+/// RFC 7235. Header keys are lowercase (axum `HeaderName` invariant).
+fn verify_bootstrap_token(
+    expected: &str,
+    req_headers_map: &HashMap<String, String>,
+) -> Result<(), PrepareError> {
+    let from_bearer = req_headers_map.get("authorization").and_then(|v| {
+        v.strip_prefix("Bearer ")
+            .or_else(|| v.strip_prefix("bearer "))
+            .or_else(|| v.strip_prefix("BEARER "))
+    });
+    let from_custom = req_headers_map
+        .get("x-aura-bootstrap-token")
+        .map(String::as_str);
+
+    let matched = [from_bearer, from_custom]
+        .into_iter()
+        .flatten()
+        .any(|token| constant_time_eq(token.trim(), expected));
+
+    if matched {
+        Ok(())
+    } else {
+        Err(PrepareError::Unauthorized(
+            "the aura-bootstrap agent requires a valid token (Authorization: \
+             Bearer <token> or x-aura-bootstrap-token). The token is set via \
+             AURA_BOOTSTRAP_TOKEN or printed in this server's startup logs."
+                .to_string(),
+        ))
+    }
+}
+
+/// Constant-time string comparison (length folded into the accumulator) so
+/// token verification doesn't leak prefix-match timing.
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    let mut diff = a.len() ^ b.len();
+    for i in 0..a.len().max(b.len()) {
+        let x = a.get(i).copied().unwrap_or(0);
+        let y = b.get(i).copied().unwrap_or(0);
+        diff |= (x ^ y) as usize;
+    }
+    diff == 0
 }
 
 /// Handle chat completions endpoint
@@ -988,7 +1067,7 @@ pub async fn info(State(state): State<Arc<AppState>>) -> Response {
 /// Each model `id` maps to an agent's `alias` (if set) or `name` from the TOML config.
 /// Filters out `hidden` agents
 pub async fn list_models(State(state): State<Arc<AppState>>) -> Response {
-    let models: Vec<serde_json::Value> = state
+    let mut models: Vec<serde_json::Value> = state
         .configs
         .snapshot()
         .iter()
@@ -1008,6 +1087,17 @@ pub async fn list_models(State(state): State<Arc<AppState>>) -> Response {
             })
         })
         .collect();
+
+    // The bootstrap agent is advertised for discoverability; chatting with
+    // it still requires the token.
+    if let Some(bootstrap) = &state.bootstrap {
+        models.push(serde_json::json!({
+            "id": aura::bootstrap::BOOTSTRAP_AGENT_NAME,
+            "object": "model",
+            "created": bootstrap.agent_config.agent.created_at / 1000,
+            "owned_by": "aura"
+        }));
+    }
 
     Json(serde_json::json!({
         "object": "list",
@@ -1135,6 +1225,123 @@ mod tests {
             metadata: None,
             tools: None,
         }
+    }
+
+    // ------------------------------------------------------------------
+    // bootstrap token gate
+    // ------------------------------------------------------------------
+
+    fn headers_with(key: &str, value: &str) -> HashMap<String, String> {
+        HashMap::from([(key.to_string(), value.to_string())])
+    }
+
+    #[test]
+    fn token_accepted_via_bearer_and_custom_header() {
+        let ok = headers_with("authorization", "Bearer secret-token");
+        assert!(verify_bootstrap_token("secret-token", &ok).is_ok());
+
+        let ok = headers_with("x-aura-bootstrap-token", "secret-token");
+        assert!(verify_bootstrap_token("secret-token", &ok).is_ok());
+    }
+
+    #[test]
+    fn token_rejected_when_wrong_or_missing() {
+        let wrong = headers_with("authorization", "Bearer nope");
+        assert!(matches!(
+            verify_bootstrap_token("secret-token", &wrong),
+            Err(PrepareError::Unauthorized(_))
+        ));
+
+        let missing = HashMap::new();
+        assert!(matches!(
+            verify_bootstrap_token("secret-token", &missing),
+            Err(PrepareError::Unauthorized(_))
+        ));
+    }
+
+    #[test]
+    fn constant_time_eq_handles_lengths_and_content() {
+        assert!(constant_time_eq("abc", "abc"));
+        assert!(!constant_time_eq("abc", "abd"));
+        assert!(!constant_time_eq("abc", "abcd"));
+        assert!(!constant_time_eq("", "a"));
+        assert!(constant_time_eq("", ""));
+    }
+
+    fn make_bootstrap_state(bootstrap: Option<crate::types::BootstrapState>) -> AppState {
+        AppState {
+            configs: Arc::new(crate::types::ConfigRegistry::new(vec![
+                aura_config::Config::default(),
+            ])),
+            bootstrap,
+            tool_result_mode: crate::streaming::ToolResultMode::None,
+            tool_result_max_length: 0,
+            streaming_buffer_size: 16,
+            aura_custom_events: false,
+            aura_emit_reasoning: false,
+            debug_provider_errors: false,
+            streaming_timeout_secs: 0,
+            first_chunk_timeout_secs: 0,
+            shutdown_token: CancellationToken::new(),
+            stream_shutdown_token: CancellationToken::new(),
+            active_requests: Arc::new(crate::types::ActiveRequestTracker::new()),
+            default_agent: None,
+            additional_tools: Arc::new(Vec::new),
+            pending_approvals: aura::hitl::PendingApprovals::new(),
+        }
+    }
+
+    fn bootstrap_request() -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: Some(aura::bootstrap::BOOTSTRAP_AGENT_NAME.to_string()),
+            messages: vec![msg(Role::User, "hello")],
+            max_tokens: None,
+            stream: Some(true),
+            metadata: None,
+            tools: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn bootstrap_model_is_not_found_when_disabled() {
+        // Even on a single-config server (where the passthrough accepts any
+        // model name), the reserved name must not route to the normal agent.
+        let state = make_bootstrap_state(None);
+        let mut req = bootstrap_request();
+        let err = prepare_request(&state, &mut req, "session", &HashMap::new())
+            .await
+            .err()
+            .expect("expected error");
+        assert!(matches!(err, PrepareError::NotFound(_)), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn bootstrap_model_requires_token_when_enabled() {
+        let bootstrap = crate::types::BootstrapState {
+            agent_config: aura_config::Config::default(),
+            token: "secret-token".to_string(),
+            tools: Arc::new(Vec::new),
+        };
+        let state = make_bootstrap_state(Some(bootstrap));
+
+        let mut req = bootstrap_request();
+        let err = prepare_request(&state, &mut req, "session", &HashMap::new())
+            .await
+            .err()
+            .expect("expected error");
+        assert!(matches!(err, PrepareError::Unauthorized(_)), "got: {err:?}");
+
+        let mut req = bootstrap_request();
+        let err = prepare_request(
+            &state,
+            &mut req,
+            "session",
+            &headers_with("authorization", "Bearer wrong"),
+        )
+        .await
+        .err()
+        .expect("expected error");
+        assert!(matches!(err, PrepareError::Unauthorized(_)), "got: {err:?}");
     }
 
     #[test]
@@ -1532,6 +1739,7 @@ mod tests {
     fn make_state(configs: Vec<aura_config::Config>) -> Arc<AppState> {
         Arc::new(AppState {
             configs: Arc::new(crate::types::ConfigRegistry::new(configs)),
+            bootstrap: None,
             tool_result_mode: crate::streaming::ToolResultMode::None,
             tool_result_max_length: 0,
             streaming_buffer_size: 32,
@@ -1604,6 +1812,7 @@ model = "gpt-4o"
     ) -> Arc<AppState> {
         Arc::new(AppState {
             configs: Arc::new(crate::types::ConfigRegistry::new(configs)),
+            bootstrap: None,
             tool_result_mode: crate::streaming::ToolResultMode::None,
             tool_result_max_length: 0,
             streaming_buffer_size: 32,
@@ -1878,6 +2087,7 @@ model = "gpt-4o-mini"
         fn test_app_state() -> Arc<AppState> {
             Arc::new(AppState {
                 configs: Arc::new(crate::types::ConfigRegistry::new(vec![])),
+                bootstrap: None,
                 tool_result_mode: ToolResultMode::default(),
                 tool_result_max_length: 0,
                 streaming_buffer_size: 0,

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1248,6 +1248,7 @@ mod tests {
             tools: None,
             orchestration: None,
             hitl: None,
+            bootstrap: None,
             agent: aura_config::AgentConfig {
                 name: "test-agent".to_string(),
                 ..aura_config::AgentConfig::default()

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -260,13 +260,17 @@ pub async fn prepare_request(
     // assistant `tool_calls` and `role: "tool"` follow-up results).
     let (query, chat_history) = convert_chat_messages(&req.messages, has_client_tools)?;
 
+    // One roster snapshot per request: this request (including any stream it
+    // spawns) works against an immutable view, unaffected by hot reloads.
+    let configs = data.configs.snapshot();
+
     // Find the matching config: single-config passthrough > explicit model > DEFAULT_AGENT
     // Single-config servers accept any model field value (clients like LibreChat always send one).
     // Multi-config servers require the model field to match an alias or agent name.
-    let config = if data.configs.len() == 1 {
-        data.configs[0].clone()
+    let config = if configs.len() == 1 {
+        configs[0].clone()
     } else if let Some(model_name) = req.model.as_deref().or(data.default_agent.as_deref()) {
-        data.configs
+        configs
             .iter()
             .find(|c| c.agent.alias.as_deref().unwrap_or(&c.agent.name) == model_name)
             .cloned()
@@ -993,6 +997,7 @@ pub async fn health(State(state): State<Arc<AppState>>) -> Response {
 pub async fn info(State(state): State<Arc<AppState>>) -> Response {
     let agents: Vec<AgentInfo> = state
         .configs
+        .snapshot()
         .iter()
         .filter(|config| !config.agent.hidden)
         .map(aura::agent_info)
@@ -1011,6 +1016,7 @@ pub async fn info(State(state): State<Arc<AppState>>) -> Response {
 pub async fn list_models(State(state): State<Arc<AppState>>) -> Response {
     let models: Vec<serde_json::Value> = state
         .configs
+        .snapshot()
         .iter()
         .filter(|config| !config.agent.hidden)
         .map(|config| {
@@ -1675,7 +1681,7 @@ mod tests {
 
     fn make_state(configs: Vec<aura_config::Config>) -> Arc<AppState> {
         Arc::new(AppState {
-            configs: Arc::new(configs),
+            configs: Arc::new(crate::types::ConfigRegistry::new(configs)),
             tool_result_mode: crate::streaming::ToolResultMode::None,
             tool_result_max_length: 0,
             streaming_buffer_size: 32,
@@ -1750,7 +1756,7 @@ model = "gpt-4o"
         default_agent: Option<&str>,
     ) -> Arc<AppState> {
         Arc::new(AppState {
-            configs: Arc::new(configs),
+            configs: Arc::new(crate::types::ConfigRegistry::new(configs)),
             tool_result_mode: crate::streaming::ToolResultMode::None,
             tool_result_max_length: 0,
             streaming_buffer_size: 32,
@@ -2085,7 +2091,7 @@ url = "http://127.0.0.1:9"
 
         fn test_app_state() -> Arc<AppState> {
             Arc::new(AppState {
-                configs: Arc::new(vec![]),
+                configs: Arc::new(crate::types::ConfigRegistry::new(vec![])),
                 tool_result_mode: ToolResultMode::default(),
                 tool_result_max_length: 0,
                 streaming_buffer_size: 0,

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -80,6 +80,7 @@ impl Drop for RequestResourceGuard {
 pub enum PrepareError {
     BadRequest(String),
     NotFound(String),
+    Unauthorized(String),
     Internal(String),
 }
 
@@ -89,6 +90,7 @@ impl PrepareError {
         match self {
             PrepareError::BadRequest(msg) => msg,
             PrepareError::NotFound(msg) => msg,
+            PrepareError::Unauthorized(msg) => msg,
             PrepareError::Internal(msg) => msg,
         }
     }
@@ -104,6 +106,15 @@ impl PrepareError {
                 Json(ChatCompletionErrorResponse::ModelNotFound(model_name)),
             )
                 .into_response(),
+            PrepareError::Unauthorized(msg) => {
+                let mut response =
+                    error_response(StatusCode::UNAUTHORIZED, msg, "authentication_error");
+                response.headers_mut().insert(
+                    axum::http::header::WWW_AUTHENTICATE,
+                    axum::http::HeaderValue::from_static("Bearer"),
+                );
+                response
+            }
             PrepareError::Internal(msg) => {
                 error_response(StatusCode::INTERNAL_SERVER_ERROR, msg, "internal_error")
             }
@@ -264,26 +275,43 @@ pub async fn prepare_request(
     // spawns) works against an immutable view, unaffected by hot reloads.
     let configs = data.configs.snapshot();
 
-    // Find the matching config: single-config passthrough > explicit model > DEFAULT_AGENT
-    // Single-config servers accept any model field value (clients like LibreChat always send one).
-    // Multi-config servers require the model field to match an alias or agent name.
-    let config = if configs.len() == 1 {
-        configs[0].clone()
-    } else if let Some(model_name) = req.model.as_deref().or(data.default_agent.as_deref()) {
-        configs
-            .iter()
-            .find(|c| c.agent.alias.as_deref().unwrap_or(&c.agent.name) == model_name)
-            .cloned()
-            .ok_or_else(|| PrepareError::NotFound(model_name.to_string()))?
+    // The reserved bootstrap model name is checked BEFORE roster resolution
+    // (the single-config passthrough would otherwise route it to the normal
+    // agent). Reaching the bootstrap agent always requires its explicit name
+    // plus the token — the passthrough and DEFAULT_AGENT can never select it.
+    let (config, additional_tools) = if req
+        .model
+        .as_deref()
+        .is_some_and(|m| m.eq_ignore_ascii_case(aura::bootstrap::BOOTSTRAP_AGENT_NAME))
+    {
+        let Some(bootstrap) = data.bootstrap.as_ref() else {
+            return Err(PrepareError::NotFound(
+                aura::bootstrap::BOOTSTRAP_AGENT_NAME.to_string(),
+            ));
+        };
+        verify_bootstrap_token(&bootstrap.token, req_headers_map)?;
+        (bootstrap.agent_config.clone(), (bootstrap.tools)())
     } else {
-        return Err(PrepareError::BadRequest(
-            "you must provide a model parameter".to_string(),
-        ));
+        // Find the matching config: single-config passthrough > explicit model > DEFAULT_AGENT
+        // Single-config servers accept any model field value (clients like LibreChat always send one).
+        // Multi-config servers require the model field to match an alias or agent name.
+        let config = if configs.len() == 1 {
+            configs[0].clone()
+        } else if let Some(model_name) = req.model.as_deref().or(data.default_agent.as_deref()) {
+            configs
+                .iter()
+                .find(|c| c.agent.alias.as_deref().unwrap_or(&c.agent.name) == model_name)
+                .cloned()
+                .ok_or_else(|| PrepareError::NotFound(model_name.to_string()))?
+        } else {
+            return Err(PrepareError::BadRequest(
+                "you must provide a model parameter".to_string(),
+            ));
+        };
+        // Additional tools from the factory (e.g., CLI tools in standalone mode)
+        (config, (data.additional_tools)())
     };
     validate_hitl_delivery_mode(&config, req)?;
-
-    // Get additional tools from the factory (e.g., CLI tools in standalone mode)
-    let additional_tools = (data.additional_tools)();
 
     // Convert request-supplied client tool definitions once; both paths use them.
     let client_tools_vec: Option<Vec<aura::builder::ClientTool>> = req
@@ -363,6 +391,57 @@ fn validate_hitl_delivery_mode(
         ));
     }
     Ok(())
+}
+
+/// Verify the bootstrap token on a request addressed to the bootstrap agent.
+///
+/// Accepts `Authorization: Bearer <token>` (the CLI's `--api-key` sends this
+/// unmodified) **or** `x-aura-bootstrap-token: <token>` for deployments
+/// where a gateway injects its own Authorization header (oauth2-proxy, ALB
+/// OIDC, Istio, etc.). Either header matching the expected token is
+/// sufficient — the Bearer scheme comparison is case-insensitive per
+/// RFC 7235. Header keys are lowercase (axum `HeaderName` invariant).
+fn verify_bootstrap_token(
+    expected: &str,
+    req_headers_map: &HashMap<String, String>,
+) -> Result<(), PrepareError> {
+    let from_bearer = req_headers_map.get("authorization").and_then(|v| {
+        v.strip_prefix("Bearer ")
+            .or_else(|| v.strip_prefix("bearer "))
+            .or_else(|| v.strip_prefix("BEARER "))
+    });
+    let from_custom = req_headers_map
+        .get("x-aura-bootstrap-token")
+        .map(String::as_str);
+
+    let matched = [from_bearer, from_custom]
+        .into_iter()
+        .flatten()
+        .any(|token| constant_time_eq(token.trim(), expected));
+
+    if matched {
+        Ok(())
+    } else {
+        Err(PrepareError::Unauthorized(
+            "the aura-bootstrap agent requires a valid token (Authorization: \
+             Bearer <token> or x-aura-bootstrap-token). The token is set via \
+             AURA_BOOTSTRAP_TOKEN or printed in this server's startup logs."
+                .to_string(),
+        ))
+    }
+}
+
+/// Constant-time string comparison (length folded into the accumulator) so
+/// token verification doesn't leak prefix-match timing.
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    let mut diff = a.len() ^ b.len();
+    for i in 0..a.len().max(b.len()) {
+        let x = a.get(i).copied().unwrap_or(0);
+        let y = b.get(i).copied().unwrap_or(0);
+        diff |= (x ^ y) as usize;
+    }
+    diff == 0
 }
 
 /// Handle chat completions endpoint
@@ -1014,7 +1093,7 @@ pub async fn info(State(state): State<Arc<AppState>>) -> Response {
 /// Each model `id` maps to an agent's `alias` (if set) or `name` from the TOML config.
 /// Filters out `hidden` agents
 pub async fn list_models(State(state): State<Arc<AppState>>) -> Response {
-    let models: Vec<serde_json::Value> = state
+    let mut models: Vec<serde_json::Value> = state
         .configs
         .snapshot()
         .iter()
@@ -1034,6 +1113,17 @@ pub async fn list_models(State(state): State<Arc<AppState>>) -> Response {
             })
         })
         .collect();
+
+    // The bootstrap agent is advertised for discoverability; chatting with
+    // it still requires the token.
+    if let Some(bootstrap) = &state.bootstrap {
+        models.push(serde_json::json!({
+            "id": aura::bootstrap::BOOTSTRAP_AGENT_NAME,
+            "object": "model",
+            "created": bootstrap.agent_config.agent.created_at / 1000,
+            "owned_by": "aura"
+        }));
+    }
 
     Json(serde_json::json!({
         "object": "list",
@@ -1281,6 +1371,126 @@ mod tests {
             metadata: None,
             tools: None,
         }
+    }
+
+    // ------------------------------------------------------------------
+    // bootstrap token gate
+    // ------------------------------------------------------------------
+
+    fn headers_with(key: &str, value: &str) -> HashMap<String, String> {
+        HashMap::from([(key.to_string(), value.to_string())])
+    }
+
+    #[test]
+    fn token_accepted_via_bearer_and_custom_header() {
+        let ok = headers_with("authorization", "Bearer secret-token");
+        assert!(verify_bootstrap_token("secret-token", &ok).is_ok());
+
+        let ok = headers_with("x-aura-bootstrap-token", "secret-token");
+        assert!(verify_bootstrap_token("secret-token", &ok).is_ok());
+    }
+
+    #[test]
+    fn token_rejected_when_wrong_or_missing() {
+        let wrong = headers_with("authorization", "Bearer nope");
+        assert!(matches!(
+            verify_bootstrap_token("secret-token", &wrong),
+            Err(PrepareError::Unauthorized(_))
+        ));
+
+        let missing = HashMap::new();
+        assert!(matches!(
+            verify_bootstrap_token("secret-token", &missing),
+            Err(PrepareError::Unauthorized(_))
+        ));
+    }
+
+    #[test]
+    fn constant_time_eq_handles_lengths_and_content() {
+        assert!(constant_time_eq("abc", "abc"));
+        assert!(!constant_time_eq("abc", "abd"));
+        assert!(!constant_time_eq("abc", "abcd"));
+        assert!(!constant_time_eq("", "a"));
+        assert!(constant_time_eq("", ""));
+    }
+
+    fn make_bootstrap_state(bootstrap: Option<crate::types::BootstrapState>) -> AppState {
+        AppState {
+            configs: Arc::new(crate::types::ConfigRegistry::new(vec![
+                aura_config::Config::default(),
+            ])),
+            bootstrap,
+            tool_result_mode: crate::streaming::ToolResultMode::None,
+            tool_result_max_length: 0,
+            streaming_buffer_size: 16,
+            aura_custom_events: false,
+            aura_emit_reasoning: false,
+            debug_provider_errors: false,
+            streaming_timeout_secs: 0,
+            first_chunk_timeout_secs: 0,
+            stream_inactivity_timeout_secs: 0,
+            shutdown_token: CancellationToken::new(),
+            stream_shutdown_token: CancellationToken::new(),
+            active_requests: Arc::new(crate::types::ActiveRequestTracker::new()),
+            default_agent: None,
+            additional_tools: Arc::new(Vec::new),
+            pending_approvals: aura::hitl::PendingApprovals::new(),
+            hitl_webhook_hmac: None,
+            session_store: Arc::new(crate::session_store::InMemorySessionStore::new()),
+        }
+    }
+
+    fn bootstrap_request() -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: Some(aura::bootstrap::BOOTSTRAP_AGENT_NAME.to_string()),
+            messages: vec![msg(Role::User, "hello")],
+            max_tokens: None,
+            stream: Some(true),
+            metadata: None,
+            tools: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn bootstrap_model_is_not_found_when_disabled() {
+        // Even on a single-config server (where the passthrough accepts any
+        // model name), the reserved name must not route to the normal agent.
+        let state = make_bootstrap_state(None);
+        let mut req = bootstrap_request();
+        let err = prepare_request(&state, &mut req, "session", &HashMap::new())
+            .await
+            .err()
+            .expect("expected error");
+        assert!(matches!(err, PrepareError::NotFound(_)), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn bootstrap_model_requires_token_when_enabled() {
+        let bootstrap = crate::types::BootstrapState {
+            agent_config: aura_config::Config::default(),
+            token: "secret-token".to_string(),
+            tools: Arc::new(Vec::new),
+        };
+        let state = make_bootstrap_state(Some(bootstrap));
+
+        let mut req = bootstrap_request();
+        let err = prepare_request(&state, &mut req, "session", &HashMap::new())
+            .await
+            .err()
+            .expect("expected error");
+        assert!(matches!(err, PrepareError::Unauthorized(_)), "got: {err:?}");
+
+        let mut req = bootstrap_request();
+        let err = prepare_request(
+            &state,
+            &mut req,
+            "session",
+            &headers_with("authorization", "Bearer wrong"),
+        )
+        .await
+        .err()
+        .expect("expected error");
+        assert!(matches!(err, PrepareError::Unauthorized(_)), "got: {err:?}");
     }
 
     #[test]
@@ -1682,6 +1892,7 @@ mod tests {
     fn make_state(configs: Vec<aura_config::Config>) -> Arc<AppState> {
         Arc::new(AppState {
             configs: Arc::new(crate::types::ConfigRegistry::new(configs)),
+            bootstrap: None,
             tool_result_mode: crate::streaming::ToolResultMode::None,
             tool_result_max_length: 0,
             streaming_buffer_size: 32,
@@ -1757,6 +1968,7 @@ model = "gpt-4o"
     ) -> Arc<AppState> {
         Arc::new(AppState {
             configs: Arc::new(crate::types::ConfigRegistry::new(configs)),
+            bootstrap: None,
             tool_result_mode: crate::streaming::ToolResultMode::None,
             tool_result_max_length: 0,
             streaming_buffer_size: 32,
@@ -2092,6 +2304,7 @@ url = "http://127.0.0.1:9"
         fn test_app_state() -> Arc<AppState> {
             Arc::new(AppState {
                 configs: Arc::new(crate::types::ConfigRegistry::new(vec![])),
+                bootstrap: None,
                 tool_result_mode: ToolResultMode::default(),
                 tool_result_max_length: 0,
                 streaming_buffer_size: 0,

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -22,7 +22,7 @@ use aura_web_server::streaming;
 use aura_web_server::types;
 
 use streaming::ToolResultMode;
-use types::{ActiveRequestTracker, AppState, ErrorDetail, ErrorResponse};
+use types::{ActiveRequestTracker, AppState, ConfigRegistry, ErrorDetail, ErrorResponse};
 
 /// CLI arguments for the web server
 #[derive(Parser, Debug)]
@@ -246,7 +246,7 @@ async fn run() -> std::io::Result<()> {
         info!("Default agent: '{}'", default_agent);
     }
 
-    let configs_arc = Arc::new(configs);
+    let configs_arc = Arc::new(ConfigRegistry::new(configs));
 
     // Two-phase shutdown: gate (immediate 503) → grace period → stream drain ([DONE])
     let shutdown_token = CancellationToken::new();

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -267,10 +267,7 @@ async fn run() -> std::io::Result<()> {
         info!("Default agent: '{}'", default_agent);
     }
 
-    let roster_names: Vec<String> = configs
-        .iter()
-        .map(|c| c.agent_id().to_string())
-        .collect();
+    let roster_names: Vec<String> = configs.iter().map(|c| c.agent_id().to_string()).collect();
     let configs_arc = Arc::new(ConfigRegistry::new(configs));
 
     // Token-gated aura-bootstrap agent, when exactly one config enabled it.

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -1,5 +1,4 @@
 use a2a_server::StaticAgentCard;
-use aura_config::load_config;
 use axum::Json;
 use axum::extract::{Request, State};
 use axum::http::StatusCode;
@@ -208,9 +207,18 @@ async fn run() -> std::io::Result<()> {
     info!("Starting Aura Web Server v{}", env!("CARGO_PKG_VERSION"));
     info!("Loading configuration from: {}", args.config);
 
-    let configs = match load_config(&args.config) {
-        Ok(cfgs) => cfgs,
+    let config_pairs = match aura_config::load_config_with_paths(&args.config) {
+        Ok(pairs) => pairs,
         Err(e) => {
+            if !std::path::Path::new(&args.config).exists() {
+                let msg = format!(
+                    "No configuration found at '{}'. Generate a starter config with \
+                     `aura init`, then start the server again.",
+                    args.config
+                );
+                error!("{msg}");
+                return Err(std::io::Error::new(std::io::ErrorKind::NotFound, msg));
+            }
             error!("Failed to load configuration: {}", e);
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -219,11 +227,24 @@ async fn run() -> std::io::Result<()> {
         }
     };
 
-    for config in &configs {
+    for (_, config) in &config_pairs {
         let id = config.agent.alias.as_deref().unwrap_or(&config.agent.name);
         let (provider, model) = config.agent.llm.model_info();
         info!("Loaded agent '{}' ({}/{})", id, provider, model);
     }
+
+    // Bootstrap-specific roster invariants (reserved name + single enabler).
+    if let Err(msg) = aura::bootstrap::validate_roster(&config_pairs) {
+        error!("{msg}");
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, msg));
+    }
+    let bootstrap_declaration = config_pairs
+        .iter()
+        .find(|(_, c)| c.bootstrap.as_ref().is_some_and(|b| b.enabled))
+        .map(|(path, config)| (path.clone(), config.clone()));
+
+    let configs: Vec<aura_config::Config> =
+        config_pairs.into_iter().map(|(_, config)| config).collect();
 
     // Validate DEFAULT_AGENT matches a loaded config
     if let Some(ref default_agent) = args.default_agent {
@@ -246,7 +267,82 @@ async fn run() -> std::io::Result<()> {
         info!("Default agent: '{}'", default_agent);
     }
 
+    let roster_names: Vec<String> = configs
+        .iter()
+        .map(|c| c.agent_id().to_string())
+        .collect();
     let configs_arc = Arc::new(ConfigRegistry::new(configs));
+
+    // Token-gated aura-bootstrap agent, when exactly one config enabled it.
+    // The agent lives outside the registry: hot reloads never touch it, so a
+    // bootstrap conversation survives the configs it applies. Its token and
+    // LLM are fixed at startup — [bootstrap] changes take effect on restart.
+    let bootstrap_state = bootstrap_declaration.map(|(declaring_path, declaring)| {
+        let token = match std::env::var("AURA_BOOTSTRAP_TOKEN") {
+            Ok(t) if !t.trim().is_empty() => {
+                tracing::warn!("Bootstrap agent enabled; token taken from AURA_BOOTSTRAP_TOKEN");
+                t.trim().to_string()
+            }
+            _ => {
+                let token = uuid::Uuid::new_v4().to_string();
+                // Printed to logs by design: whoever can read this server's
+                // logs is authorized to administer its configuration.
+                tracing::warn!(
+                    "Bootstrap agent enabled; no AURA_BOOTSTRAP_TOKEN set — generated \
+                     token: {token}"
+                );
+                token
+            }
+        };
+        tracing::warn!(
+            "Chat with the bootstrap agent: aura --api-url http://{}:{} \
+             --model {} --api-key <token>",
+            args.host,
+            args.port,
+            aura::bootstrap::BOOTSTRAP_AGENT_NAME,
+        );
+
+        let target = aura::bootstrap::ConfigTarget {
+            config_path: std::path::PathBuf::from(&args.config),
+            target: declaring_path,
+        };
+
+        // Hot reload: re-load from disk and swap the roster. Captures the
+        // registry (not the AppState) to avoid a reference cycle.
+        let registry = configs_arc.clone();
+        let reload_path = args.config.clone();
+        let default_agent = args.default_agent.clone();
+        let reload: aura::bootstrap::ReloadHook = Arc::new(move || {
+            let config_pairs =
+                aura_config::load_config_with_paths(&reload_path).map_err(|e| e.to_string())?;
+            aura::bootstrap::validate_roster(&config_pairs)?;
+            let configs: Vec<aura_config::Config> =
+                config_pairs.into_iter().map(|(_, c)| c).collect();
+            let names: Vec<String> = configs.iter().map(|c| c.agent_id().to_string()).collect();
+            if let Some(da) = &default_agent
+                && !names.iter().any(|n| n == da)
+            {
+                tracing::warn!("DEFAULT_AGENT '{da}' no longer matches any agent after hot reload");
+            }
+            let count = names.len();
+            registry.replace(configs);
+            tracing::warn!("Hot reload applied: {count} agent(s) now live");
+            Ok(format!(
+                "Hot reload applied; {count} agent(s) now live: {}",
+                names.join(", ")
+            ))
+        });
+
+        types::BootstrapState {
+            agent_config: aura::bootstrap::bootstrap_agent_config(
+                &declaring,
+                &target,
+                &roster_names,
+            ),
+            token,
+            tools: aura::bootstrap::bootstrap_tools_factory(target, reload),
+        }
+    });
 
     // Two-phase shutdown: gate (immediate 503) → grace period → stream drain ([DONE])
     let shutdown_token = CancellationToken::new();
@@ -266,6 +362,7 @@ async fn run() -> std::io::Result<()> {
 
     let app_state = Arc::new(AppState {
         configs: configs_arc,
+        bootstrap: bootstrap_state,
         tool_result_mode: args.tool_result_mode,
         tool_result_max_length: args.tool_result_max_length,
         streaming_buffer_size: args.streaming_buffer_size,

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -24,7 +24,7 @@ use aura_web_server::streaming;
 use aura_web_server::types;
 
 use streaming::ToolResultMode;
-use types::{ActiveRequestTracker, AppState, ErrorDetail, ErrorResponse};
+use types::{ActiveRequestTracker, AppState, ConfigRegistry, ErrorDetail, ErrorResponse};
 
 /// CLI arguments for the web server
 #[derive(Parser, Debug)]
@@ -348,7 +348,7 @@ async fn run() -> std::io::Result<()> {
         info!("Default agent: '{}'", default_agent);
     }
 
-    let configs_arc = Arc::new(configs);
+    let configs_arc = Arc::new(ConfigRegistry::new(configs));
 
     // Two-phase shutdown: gate (immediate 503) → grace period → stream drain ([DONE])
     let shutdown_token = CancellationToken::new();
@@ -393,7 +393,7 @@ async fn run() -> std::io::Result<()> {
     })?;
     // With a secret configured, a plaintext webhook URL fails at boot rather
     // than on the first approval request.
-    for config in configs_arc.iter() {
+    for config in configs_arc.snapshot().iter() {
         if let Some(hitl) = &config.hitl {
             aura::hitl::validate_webhook_signing_config(hitl, ingress_hmac.as_ref()).map_err(
                 |e| {

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -1,4 +1,3 @@
-use aura_config::load_config;
 use axum::Json;
 use axum::extract::{Request, State};
 use axum::http::StatusCode;
@@ -309,9 +308,18 @@ async fn run() -> std::io::Result<()> {
     info!("Starting Aura Web Server v{}", env!("CARGO_PKG_VERSION"));
     info!("Loading configuration from: {}", args.config);
 
-    let configs = match load_config(&args.config) {
-        Ok(cfgs) => cfgs,
+    let config_pairs = match aura_config::load_config_with_paths(&args.config) {
+        Ok(pairs) => pairs,
         Err(e) => {
+            if !std::path::Path::new(&args.config).exists() {
+                let msg = format!(
+                    "No configuration found at '{}'. Generate a starter config with \
+                     `aura init`, then start the server again.",
+                    args.config
+                );
+                error!("{msg}");
+                return Err(std::io::Error::new(std::io::ErrorKind::NotFound, msg));
+            }
             error!("Failed to load configuration: {}", e);
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -320,12 +328,25 @@ async fn run() -> std::io::Result<()> {
         }
     };
 
-    for config in &configs {
+    for (_, config) in &config_pairs {
         let id = config.agent.alias.as_deref().unwrap_or(&config.agent.name);
         let (provider, model) = config.agent.llm.model_info();
         info!("Loaded agent '{}' ({}/{})", id, provider, model);
         warn_timeout_relationships(id, config, &args);
     }
+
+    // Bootstrap-specific roster invariants (reserved name + single enabler).
+    if let Err(msg) = aura::bootstrap::validate_roster(&config_pairs) {
+        error!("{msg}");
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, msg));
+    }
+    let bootstrap_declaration = config_pairs
+        .iter()
+        .find(|(_, c)| c.bootstrap.as_ref().is_some_and(|b| b.enabled))
+        .map(|(path, config)| (path.clone(), config.clone()));
+
+    let configs: Vec<aura_config::Config> =
+        config_pairs.into_iter().map(|(_, config)| config).collect();
 
     // Validate DEFAULT_AGENT matches a loaded config
     if let Some(ref default_agent) = args.default_agent {
@@ -348,7 +369,82 @@ async fn run() -> std::io::Result<()> {
         info!("Default agent: '{}'", default_agent);
     }
 
+    let roster_names: Vec<String> = configs
+        .iter()
+        .map(|c| c.agent_id().to_string())
+        .collect();
     let configs_arc = Arc::new(ConfigRegistry::new(configs));
+
+    // Token-gated aura-bootstrap agent, when exactly one config enabled it.
+    // The agent lives outside the registry: hot reloads never touch it, so a
+    // bootstrap conversation survives the configs it applies. Its token and
+    // LLM are fixed at startup — [bootstrap] changes take effect on restart.
+    let bootstrap_state = bootstrap_declaration.map(|(declaring_path, declaring)| {
+        let token = match std::env::var("AURA_BOOTSTRAP_TOKEN") {
+            Ok(t) if !t.trim().is_empty() => {
+                tracing::warn!("Bootstrap agent enabled; token taken from AURA_BOOTSTRAP_TOKEN");
+                t.trim().to_string()
+            }
+            _ => {
+                let token = uuid::Uuid::new_v4().to_string();
+                // Printed to logs by design: whoever can read this server's
+                // logs is authorized to administer its configuration.
+                tracing::warn!(
+                    "Bootstrap agent enabled; no AURA_BOOTSTRAP_TOKEN set — generated \
+                     token: {token}"
+                );
+                token
+            }
+        };
+        tracing::warn!(
+            "Chat with the bootstrap agent: aura --api-url http://{}:{} \
+             --model {} --api-key <token>",
+            args.host,
+            args.port,
+            aura::bootstrap::BOOTSTRAP_AGENT_NAME,
+        );
+
+        let target = aura::bootstrap::ConfigTarget {
+            config_path: std::path::PathBuf::from(&args.config),
+            target: declaring_path,
+        };
+
+        // Hot reload: re-load from disk and swap the roster. Captures the
+        // registry (not the AppState) to avoid a reference cycle.
+        let registry = configs_arc.clone();
+        let reload_path = args.config.clone();
+        let default_agent = args.default_agent.clone();
+        let reload: aura::bootstrap::ReloadHook = Arc::new(move || {
+            let config_pairs =
+                aura_config::load_config_with_paths(&reload_path).map_err(|e| e.to_string())?;
+            aura::bootstrap::validate_roster(&config_pairs)?;
+            let configs: Vec<aura_config::Config> =
+                config_pairs.into_iter().map(|(_, c)| c).collect();
+            let names: Vec<String> = configs.iter().map(|c| c.agent_id().to_string()).collect();
+            if let Some(da) = &default_agent
+                && !names.iter().any(|n| n == da)
+            {
+                tracing::warn!("DEFAULT_AGENT '{da}' no longer matches any agent after hot reload");
+            }
+            let count = names.len();
+            registry.replace(configs);
+            tracing::warn!("Hot reload applied: {count} agent(s) now live");
+            Ok(format!(
+                "Hot reload applied; {count} agent(s) now live: {}",
+                names.join(", ")
+            ))
+        });
+
+        types::BootstrapState {
+            agent_config: aura::bootstrap::bootstrap_agent_config(
+                &declaring,
+                &target,
+                &roster_names,
+            ),
+            token,
+            tools: aura::bootstrap::bootstrap_tools_factory(target, reload),
+        }
+    });
 
     // Two-phase shutdown: gate (immediate 503) → grace period → stream drain ([DONE])
     let shutdown_token = CancellationToken::new();
@@ -409,6 +505,7 @@ async fn run() -> std::io::Result<()> {
 
     let app_state = Arc::new(AppState {
         configs: configs_arc,
+        bootstrap: bootstrap_state,
         tool_result_mode: args.tool_result_mode,
         tool_result_max_length: args.tool_result_max_length,
         streaming_buffer_size: args.streaming_buffer_size,

--- a/crates/aura-web-server/src/main.rs
+++ b/crates/aura-web-server/src/main.rs
@@ -369,10 +369,7 @@ async fn run() -> std::io::Result<()> {
         info!("Default agent: '{}'", default_agent);
     }
 
-    let roster_names: Vec<String> = configs
-        .iter()
-        .map(|c| c.agent_id().to_string())
-        .collect();
+    let roster_names: Vec<String> = configs.iter().map(|c| c.agent_id().to_string()).collect();
     let configs_arc = Arc::new(ConfigRegistry::new(configs));
 
     // Token-gated aura-bootstrap agent, when exactly one config enabled it.

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -104,9 +104,22 @@ impl ConfigRegistry {
     }
 }
 
+/// Runtime state for the built-in `aura-bootstrap` agent, held outside the
+/// [`ConfigRegistry`].
+pub struct BootstrapState {
+    /// The served agent (assembled by `aura::bootstrap::bootstrap_agent_config`).
+    pub agent_config: aura_config::Config,
+    /// The admin token accepted on requests addressed to the bootstrap agent.
+    pub token: String,
+    /// Factory for the agent's configuration tools (read / inspect / write).
+    pub tools: Arc<dyn Fn() -> Vec<Box<dyn aura::ToolDyn>> + Send + Sync>,
+}
+
 /// Application state
 pub struct AppState {
     pub configs: Arc<ConfigRegistry>,
+    /// Token-gated bootstrap agent.
+    pub bootstrap: Option<BootstrapState>,
     pub tool_result_mode: ToolResultMode,
     /// Maximum length for tool results (0 = no truncation)
     pub tool_result_max_length: usize,

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -73,9 +73,40 @@ impl Drop for ActiveRequestGuard {
     }
 }
 
+/// Hot-reloadable agent roster.
+///
+/// Every request takes one [`snapshot`](Self::snapshot) and works against
+/// that immutable `Arc<Vec<Config>>` for its whole lifetime; in-flight
+/// streams keep the roster they started with alive until they finish.
+/// [`replace`](Self::replace) swaps the roster for subsequent requests.
+/// Writes are rare (human-driven), so a plain `RwLock` around the `Arc`
+/// is plenty.
+pub struct ConfigRegistry {
+    inner: std::sync::RwLock<Arc<Vec<aura_config::Config>>>,
+}
+
+impl ConfigRegistry {
+    pub fn new(configs: Vec<aura_config::Config>) -> Self {
+        Self {
+            inner: std::sync::RwLock::new(Arc::new(configs)),
+        }
+    }
+
+    /// The current roster. Brief read lock, then lock-free access.
+    pub fn snapshot(&self) -> Arc<Vec<aura_config::Config>> {
+        self.inner.read().expect("config registry poisoned").clone()
+    }
+
+    /// Swap in a new roster; requests already holding a snapshot are
+    /// unaffected.
+    pub fn replace(&self, configs: Vec<aura_config::Config>) {
+        *self.inner.write().expect("config registry poisoned") = Arc::new(configs);
+    }
+}
+
 /// Application state
 pub struct AppState {
-    pub configs: Arc<Vec<aura_config::Config>>,
+    pub configs: Arc<ConfigRegistry>,
     pub tool_result_mode: ToolResultMode,
     /// Maximum length for tool results (0 = no truncation)
     pub tool_result_max_length: usize,
@@ -325,6 +356,24 @@ pub struct ErrorDetail {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn config_registry_snapshot_is_isolated_from_replace() {
+        let mut first = aura_config::Config::default();
+        first.agent.name = "first".to_string();
+        let mut second = aura_config::Config::default();
+        second.agent.name = "second".to_string();
+
+        let registry = ConfigRegistry::new(vec![first]);
+        let before = registry.snapshot();
+
+        registry.replace(vec![second]);
+
+        // The pre-replace snapshot still sees the old roster; new snapshots
+        // see the new one.
+        assert_eq!(before[0].agent.name, "first");
+        assert_eq!(registry.snapshot()[0].agent.name, "second");
+    }
 
     #[tokio::test]
     async fn test_active_request_tracker_immediate_drain() {

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -74,9 +74,40 @@ impl Drop for ActiveRequestGuard {
     }
 }
 
+/// Hot-reloadable agent roster.
+///
+/// Every request takes one [`snapshot`](Self::snapshot) and works against
+/// that immutable `Arc<Vec<Config>>` for its whole lifetime; in-flight
+/// streams keep the roster they started with alive until they finish.
+/// [`replace`](Self::replace) swaps the roster for subsequent requests.
+/// Writes are rare (human-driven), so a plain `RwLock` around the `Arc`
+/// is plenty.
+pub struct ConfigRegistry {
+    inner: std::sync::RwLock<Arc<Vec<aura_config::Config>>>,
+}
+
+impl ConfigRegistry {
+    pub fn new(configs: Vec<aura_config::Config>) -> Self {
+        Self {
+            inner: std::sync::RwLock::new(Arc::new(configs)),
+        }
+    }
+
+    /// The current roster. Brief read lock, then lock-free access.
+    pub fn snapshot(&self) -> Arc<Vec<aura_config::Config>> {
+        self.inner.read().expect("config registry poisoned").clone()
+    }
+
+    /// Swap in a new roster; requests already holding a snapshot are
+    /// unaffected.
+    pub fn replace(&self, configs: Vec<aura_config::Config>) {
+        *self.inner.write().expect("config registry poisoned") = Arc::new(configs);
+    }
+}
+
 /// Application state
 pub struct AppState {
-    pub configs: Arc<Vec<aura_config::Config>>,
+    pub configs: Arc<ConfigRegistry>,
     pub tool_result_mode: ToolResultMode,
     /// Maximum length for tool results (0 = no truncation)
     pub tool_result_max_length: usize,
@@ -332,6 +363,24 @@ pub struct ErrorDetail {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn config_registry_snapshot_is_isolated_from_replace() {
+        let mut first = aura_config::Config::default();
+        first.agent.name = "first".to_string();
+        let mut second = aura_config::Config::default();
+        second.agent.name = "second".to_string();
+
+        let registry = ConfigRegistry::new(vec![first]);
+        let before = registry.snapshot();
+
+        registry.replace(vec![second]);
+
+        // The pre-replace snapshot still sees the old roster; new snapshots
+        // see the new one.
+        assert_eq!(before[0].agent.name, "first");
+        assert_eq!(registry.snapshot()[0].agent.name, "second");
+    }
 
     #[tokio::test]
     async fn test_active_request_tracker_immediate_drain() {

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -105,9 +105,22 @@ impl ConfigRegistry {
     }
 }
 
+/// Runtime state for the built-in `aura-bootstrap` agent, held outside the
+/// [`ConfigRegistry`].
+pub struct BootstrapState {
+    /// The served agent (assembled by `aura::bootstrap::bootstrap_agent_config`).
+    pub agent_config: aura_config::Config,
+    /// The admin token accepted on requests addressed to the bootstrap agent.
+    pub token: String,
+    /// Factory for the agent's configuration tools (read / inspect / write).
+    pub tools: Arc<dyn Fn() -> Vec<Box<dyn aura::ToolDyn>> + Send + Sync>,
+}
+
 /// Application state
 pub struct AppState {
     pub configs: Arc<ConfigRegistry>,
+    /// Token-gated bootstrap agent.
+    pub bootstrap: Option<BootstrapState>,
     pub tool_result_mode: ToolResultMode,
     /// Maximum length for tool results (0 = no truncation)
     pub tool_result_max_length: usize,

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -58,6 +58,7 @@ uuid = { workspace = true }
 
 regex = "1"
 async-stream = "0.3"
+toml = "0.8"
 strum = { workspace = true }
 
 # Tokenization for scratchpad context budget
@@ -74,6 +75,5 @@ integration-stdio = []
 
 [dev-dependencies]
 tempfile = "3.23.0"
-toml = "0.8"
 tokio = { version = "1.45", features = ["test-util", "macros", "rt"] }
 

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -64,6 +64,7 @@ uuid = { workspace = true }
 
 regex = "1"
 async-stream = "0.3"
+toml = "0.8"
 strum = { workspace = true }
 
 # Tokenization for scratchpad context budget
@@ -80,6 +81,5 @@ integration-stdio = []
 
 [dev-dependencies]
 tempfile = "3.23.0"
-toml = "0.8"
 tokio = { version = "1.45", features = ["test-util", "macros", "rt"] }
 

--- a/crates/aura/src/bootstrap.rs
+++ b/crates/aura/src/bootstrap.rs
@@ -1,0 +1,1642 @@
+//! The built-in `aura-bootstrap` agent: a token-gated configuration
+//! assistant served alongside the configured agents.
+//!
+//! Enabled via the `[bootstrap]` TOML table (disabled by default), the
+//! bootstrap agent carries three built-in tools — `read_config`,
+//! `inspect_mcp_servers`, and `write_config` — that let it build a fresh
+//! configuration conversationally and make targeted day-2 modifications.
+//! Configs are **agent-authored**: `write_config` validates mechanically
+//! (strict parse, env-resolution check, secret-literal rejection,
+//! read-only-worker enforcement, atomic write with timestamped backup) but
+//! expands nothing. What the agent writes is exactly what runs.
+//!
+//! After a successful write the host's [`ReloadHook`] is invoked so the
+//! running server can swap in the new roster in-process (hot reload); the
+//! hook's outcome is appended to the tool result so the model can react —
+//! and, on failure, restore from the backup it just created.
+//!
+//! Safety boundaries enforced here rather than by prompt alone:
+//! - workers marked `read_only = true` may only be assigned MCP tools that
+//!   `inspect_mcp_servers` discovered in this conversation and that no
+//!   server annotated as mutating (fail-closed: undiscovered names are
+//!   rejected, and same-named tools on different servers merge
+//!   most-restrictive). Glob and empty filters are rejected earlier by
+//!   config validation, and worker construction re-checks annotations at
+//!   runtime for configs that arrive by other paths;
+//! - literal credentials are rejected wherever they appear (api keys, MCP
+//!   header values, stdio env maps — any credential-looking key); secrets
+//!   travel only as `{{ env.* }}` references and the on-disk file is
+//!   written from the raw input so they stay references;
+//! - `stdio` MCP transports (arbitrary command execution at attach time)
+//!   are rejected unless the operator set `AURA_BOOTSTRAP_ALLOW_STDIO=true`;
+//! - no agent may take the reserved `aura-bootstrap` name.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use aura_config::{Config, McpConfig, McpServerConfig};
+use tracing::{info, warn};
+
+/// Reserved model/agent name under which the bootstrap agent is served.
+pub const BOOTSTRAP_AGENT_NAME: &str = "aura-bootstrap";
+
+/// Env var that permits `stdio` MCP transports in agent-written configs.
+pub const ALLOW_STDIO_ENV: &str = "AURA_BOOTSTRAP_ALLOW_STDIO";
+
+/// Framework prompt for the bootstrap agent (compile-time include).
+const BOOTSTRAP_PROMPT: &str = include_str!("prompts/bootstrap_prompt.md");
+
+/// Env-var names surfaced (presence only, never values) to the bootstrap
+/// agent so it can steer the operator toward `{{ env.* }}` references that
+/// will actually resolve.
+const KNOWN_KEY_VARS: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "GEMINI_API_KEY",
+    "MEZMO_API_KEY",
+    "AWS_PROFILE",
+    "AWS_REGION",
+];
+
+/// Whether the operator allowed stdio MCP transports for this process.
+pub fn stdio_allowed_from_env() -> bool {
+    crate::env_flags::bool_env(ALLOW_STDIO_ENV, false)
+}
+
+/// Invoked after every successful `write_config`; returns a human-readable
+/// summary of the applied roster, or an error message. Either way the text
+/// is appended to the tool result so the model sees the outcome.
+pub type ReloadHook = Arc<dyn Fn() -> Result<String, String> + Send + Sync>;
+
+/// Where the bootstrap agent reads and writes configuration.
+#[derive(Debug, Clone)]
+pub struct ConfigTarget {
+    /// `CONFIG_PATH` as the server was started with (file or directory).
+    pub config_path: PathBuf,
+    /// Default write target: the file that declared `[bootstrap]`.
+    pub target: PathBuf,
+}
+
+impl ConfigTarget {
+    /// Single-file deployment helper.
+    pub fn single_file(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        Self {
+            config_path: path.clone(),
+            target: path,
+        }
+    }
+
+    fn is_dir(&self) -> bool {
+        self.config_path.is_dir()
+    }
+
+    /// Resolve an optional `file` tool argument to a concrete path.
+    ///
+    /// In single-file mode only the default target is addressable. In
+    /// directory mode the name must be a plain `*.toml` filename inside the
+    /// config directory — no separators, no traversal.
+    fn resolve_file(&self, file: Option<&str>) -> Result<PathBuf, String> {
+        let Some(name) = file else {
+            return Ok(self.target.clone());
+        };
+        let name = name.trim();
+        if !self.is_dir() {
+            let default_name = self.target.file_name().and_then(|n| n.to_str());
+            if Some(name) == default_name {
+                return Ok(self.target.clone());
+            }
+            return Err(format!(
+                "this instance loads a single config file ({}); the `file` \
+                 argument is only available for directory deployments",
+                self.target.display()
+            ));
+        }
+        if name.contains(['/', '\\']) || name.contains("..") || !name.ends_with(".toml") {
+            return Err(format!(
+                "invalid file name '{name}': must be a plain *.toml filename \
+                 inside the config directory"
+            ));
+        }
+        Ok(self.config_path.join(name))
+    }
+
+    /// All `*.toml` files in the deployment (just the target in file mode).
+    fn config_files(&self) -> Vec<PathBuf> {
+        if !self.is_dir() {
+            return vec![self.target.clone()];
+        }
+        let mut files: Vec<PathBuf> = fs::read_dir(&self.config_path)
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|ext| ext == "toml"))
+            .collect();
+        files.sort();
+        files
+    }
+}
+
+// ============================================================================
+// Tool discovery / classification signals
+// ============================================================================
+
+/// Annotation signals for one discovered MCP tool.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ToolSignal {
+    /// `readOnlyHint` from the server, if provided.
+    pub read_only: Option<bool>,
+    /// `destructiveHint` from the server, if provided.
+    pub destructive: Option<bool>,
+}
+
+impl ToolSignal {
+    /// Extract the annotation signals from a discovered MCP tool.
+    pub fn of_tool(tool: &rmcp::model::Tool) -> Self {
+        Self {
+            read_only: tool.annotations.as_ref().and_then(|a| a.read_only_hint),
+            destructive: tool.annotations.as_ref().and_then(|a| a.destructive_hint),
+        }
+    }
+
+    /// Whether the server itself declared this tool unsafe for read-only
+    /// workers. Annotations are restrictive-only signals: they can bar a
+    /// tool from read-only workers, never admit one.
+    pub fn declared_mutating(&self) -> bool {
+        self.destructive == Some(true) || self.read_only == Some(false)
+    }
+
+    /// Most-restrictive merge for same-named tools discovered on different
+    /// servers: a mutating signal from either side survives, and agreement
+    /// is required for a positive read-only/non-destructive claim.
+    fn merge_most_restrictive(self, other: Self) -> Self {
+        Self {
+            read_only: match (self.read_only, other.read_only) {
+                (Some(false), _) | (_, Some(false)) => Some(false),
+                (Some(true), Some(true)) => Some(true),
+                _ => None,
+            },
+            destructive: match (self.destructive, other.destructive) {
+                (Some(true), _) | (_, Some(true)) => Some(true),
+                (Some(false), Some(false)) => Some(false),
+                _ => None,
+            },
+        }
+    }
+}
+
+/// Discovery results shared between `inspect_mcp_servers` and
+/// `write_config` across the bootstrap conversation (the cache lives in the
+/// tools factory, so it survives across requests).
+pub type SignalCache = Arc<Mutex<HashMap<String, ToolSignal>>>;
+
+// ============================================================================
+// Shared error type (the tools report outcomes as Ok(message) so the model
+// reliably sees them; the Error type exists to satisfy the trait)
+// ============================================================================
+
+#[derive(Debug)]
+pub struct BootstrapToolError(String);
+
+impl std::fmt::Display for BootstrapToolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for BootstrapToolError {}
+
+// ============================================================================
+// read_config tool
+// ============================================================================
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct ReadConfigArgs {
+    /// File to read in a directory deployment (plain *.toml name).
+    /// Omit for the default configuration file.
+    #[serde(default)]
+    pub file: Option<String>,
+}
+
+/// Returns the raw on-disk configuration (env references intact — the disk
+/// file never holds secrets) so the agent can ground modifications in what
+/// actually exists.
+pub struct ReadConfigTool {
+    target: ConfigTarget,
+}
+
+impl ReadConfigTool {
+    pub fn new(target: ConfigTarget) -> Self {
+        Self { target }
+    }
+}
+
+impl crate::RigTool for ReadConfigTool {
+    const NAME: &'static str = "read_config";
+
+    type Error = BootstrapToolError;
+    type Args = ReadConfigArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> crate::RigToolDefinition {
+        crate::RigToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Read this instance's configuration file as it exists on disk \
+                          (secrets appear as {{ env.VAR }} references). Call this before \
+                          proposing or modifying configuration."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "file": {
+                        "type": "string",
+                        "description": "Specific *.toml file in a directory deployment; \
+                                        omit for the default configuration file"
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let path = match self.target.resolve_file(args.file.as_deref()) {
+            Ok(p) => p,
+            Err(e) => return Ok(format!("READ_CONFIG FAILED: {e}")),
+        };
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(format!(
+                    "READ_CONFIG FAILED: cannot read {}: {e}",
+                    path.display()
+                ));
+            }
+        };
+        let mut out = String::new();
+        if self.target.is_dir() {
+            let names: Vec<String> = self
+                .target
+                .config_files()
+                .iter()
+                .filter_map(|p| p.file_name().and_then(|n| n.to_str()).map(String::from))
+                .collect();
+            out.push_str(&format!(
+                "Directory deployment at {} — files: {}\n\n",
+                self.target.config_path.display(),
+                names.join(", ")
+            ));
+        }
+        out.push_str(&format!(
+            "# {}\n\n```toml\n{}\n```",
+            path.display(),
+            content.trim_end()
+        ));
+        Ok(out)
+    }
+}
+
+// ============================================================================
+// inspect_mcp_servers tool
+// ============================================================================
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct InspectArgs {
+    /// TOML containing the `[mcp.servers.<name>]` tables to inspect (for
+    /// servers not yet written to the config). Omit to inspect the servers
+    /// in the current configuration file(s).
+    #[serde(default)]
+    pub servers_toml: Option<String>,
+}
+
+/// Deserialization helper: extracts `[mcp]` from a TOML fragment or a full
+/// candidate config without requiring the rest of the document.
+#[derive(serde::Deserialize)]
+struct McpFragment {
+    mcp: Option<McpConfig>,
+}
+
+/// Connects to MCP servers and reports every discovered tool with its
+/// annotation signals, for classification and connectivity verification.
+/// Results are cached for `write_config`'s read-only-worker enforcement.
+pub struct InspectMcpTool {
+    target: ConfigTarget,
+    signals: SignalCache,
+    allow_stdio: bool,
+}
+
+impl InspectMcpTool {
+    pub fn new(target: ConfigTarget, signals: SignalCache, allow_stdio: bool) -> Self {
+        Self {
+            target,
+            signals,
+            allow_stdio,
+        }
+    }
+
+    /// Gather the MCP config to inspect from the argument or from disk.
+    fn gather_mcp(&self, servers_toml: Option<&str>) -> Result<McpConfig, String> {
+        if let Some(fragment) = servers_toml {
+            let resolved = aura_config::resolve_env_vars(fragment)
+                .map_err(|e| format!("env resolution failed: {e}"))?;
+            let parsed: McpFragment =
+                toml::from_str(&resolved).map_err(|e| format!("TOML parse failed: {e}"))?;
+            return parsed
+                .mcp
+                .filter(|m| !m.servers.is_empty())
+                .ok_or_else(|| "no [mcp.servers.<name>] tables found in the input".to_string());
+        }
+        // From disk: merge servers across the deployment's files.
+        let mut merged = McpConfig::default();
+        for path in self.target.config_files() {
+            let raw = fs::read_to_string(&path)
+                .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+            let resolved = aura_config::resolve_env_vars(&raw)
+                .map_err(|e| format!("env resolution failed for {}: {e}", path.display()))?;
+            let parsed: McpFragment = toml::from_str(&resolved)
+                .map_err(|e| format!("TOML parse failed for {}: {e}", path.display()))?;
+            if let Some(mcp) = parsed.mcp {
+                merged.sanitize_schemas = mcp.sanitize_schemas;
+                merged.servers.extend(mcp.servers);
+            }
+        }
+        if merged.servers.is_empty() {
+            return Err("the current configuration defines no MCP servers; pass \
+                        `servers_toml` with the [mcp.servers.<name>] tables to inspect"
+                .to_string());
+        }
+        Ok(merged)
+    }
+}
+
+impl crate::RigTool for InspectMcpTool {
+    const NAME: &'static str = "inspect_mcp_servers";
+
+    type Error = BootstrapToolError;
+    type Args = InspectArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> crate::RigToolDefinition {
+        crate::RigToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Connect to MCP servers and list every tool they expose, with \
+                          name, description, and server-declared annotations (read-only / \
+                          destructive hints). Use this to verify connectivity and to \
+                          classify tools onto workers before writing the config. Pass \
+                          `servers_toml` for servers not yet in the configuration; omit \
+                          it to inspect the currently configured servers."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "servers_toml": {
+                        "type": "string",
+                        "description": "TOML with [mcp.servers.<name>] tables to inspect; \
+                                        omit to inspect the current configuration's servers"
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let mcp = match self.gather_mcp(args.servers_toml.as_deref()) {
+            Ok(m) => m,
+            Err(e) => return Ok(format!("INSPECT FAILED: {e}")),
+        };
+        if let Err(e) = check_stdio_policy(&mcp, self.allow_stdio) {
+            return Ok(format!("INSPECT REFUSED: {e}"));
+        }
+
+        let manager = match crate::McpManager::initialize_from_config(&mcp).await {
+            Ok(m) => m,
+            Err(e) => return Ok(format!("MCP discovery failed entirely: {e}")),
+        };
+
+        let mut report = String::from("MCP tool discovery report:\n");
+        let mut signals = self.signals.lock().expect("signal cache poisoned");
+        for (server, info) in &manager.server_info {
+            match &info.status {
+                crate::mcp::ConnectionStatus::Connected => {
+                    report.push_str(&format!(
+                        "\n## server '{server}' — connected, {} tool(s)\n",
+                        info.tools_count
+                    ));
+                    let tools = manager
+                        .streamable_tools
+                        .get(server)
+                        .or_else(|| manager.sse_tools.get(server))
+                        .or_else(|| manager.stdio_tools.get(server));
+                    for tool in tools.into_iter().flatten() {
+                        let signal = ToolSignal::of_tool(tool);
+                        let label = if signal.declared_mutating() {
+                            "MUTATING (annotated)"
+                        } else if signal.read_only == Some(true) {
+                            "read-only (annotated)"
+                        } else {
+                            "unannotated"
+                        };
+                        let description: String = tool
+                            .description
+                            .as_deref()
+                            .unwrap_or("(no description)")
+                            .chars()
+                            .take(140)
+                            .collect();
+                        report.push_str(&format!("- {} — {label} — {description}\n", tool.name));
+                        // Same-named tools on different servers merge
+                        // most-restrictive: one server's read-only annotation
+                        // must not mask another server's mutating one.
+                        signals
+                            .entry(tool.name.to_string())
+                            .and_modify(|existing| {
+                                *existing = existing.merge_most_restrictive(signal);
+                            })
+                            .or_insert(signal);
+                    }
+                }
+                crate::mcp::ConnectionStatus::Failed(err) => {
+                    report.push_str(&format!(
+                        "\n## server '{server}' — CONNECTION FAILED: {err}\n\
+                         Tell the operator and confirm the URL/auth before writing the config.\n"
+                    ));
+                }
+                other => {
+                    report.push_str(&format!("\n## server '{server}' — status: {other:?}\n"));
+                }
+            }
+        }
+        report.push_str(
+            "\nClassification rules: read-only workers (read_only = true) may only be \
+             assigned tools that are annotated read-only or unannotated-but-clearly-\
+             read-only, by exact name (no globs). Anything MUTATING, argument-dependent, \
+             or uncertain stays out of read-only workers. write_config enforces the \
+             annotated signals mechanically.",
+        );
+        Ok(report)
+    }
+}
+
+/// Reject stdio MCP servers unless the operator opted in via env.
+fn check_stdio_policy(mcp: &McpConfig, allow_stdio: bool) -> Result<(), String> {
+    if allow_stdio {
+        return Ok(());
+    }
+    let offenders: Vec<&str> = mcp
+        .servers
+        .iter()
+        .filter(|(_, s)| matches!(s, McpServerConfig::Stdio { .. }))
+        .map(|(name, _)| name.as_str())
+        .collect();
+    if offenders.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "stdio MCP transports spawn arbitrary processes on this server and are \
+         disabled for the bootstrap agent (server(s): {}). The operator can allow \
+         them by starting the server with {ALLOW_STDIO_ENV}=true, or add the \
+         server to the config file by hand.",
+        offenders.join(", ")
+    ))
+}
+
+// ============================================================================
+// write_config tool
+// ============================================================================
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct WriteConfigArgs {
+    /// The complete configuration file content (TOML). This replaces the
+    /// whole file — never a fragment.
+    pub content: String,
+    /// File to write in a directory deployment (plain *.toml name).
+    /// Omit for the default configuration file.
+    #[serde(default)]
+    pub file: Option<String>,
+    /// Validate only: run the full validation pipeline and report the
+    /// verdict without touching disk.
+    #[serde(default)]
+    pub validate_only: bool,
+}
+
+/// Validates and atomically writes the configuration, then triggers the
+/// host's hot reload.
+pub struct WriteConfigTool {
+    target: ConfigTarget,
+    reload: ReloadHook,
+    signals: SignalCache,
+    allow_stdio: bool,
+}
+
+impl WriteConfigTool {
+    pub fn new(
+        target: ConfigTarget,
+        reload: ReloadHook,
+        signals: SignalCache,
+        allow_stdio: bool,
+    ) -> Self {
+        Self {
+            target,
+            reload,
+            signals,
+            allow_stdio,
+        }
+    }
+
+    /// Mechanical backstop for the LLM's classification: workers declared
+    /// `read_only = true` may only list discovered tools that the server did
+    /// not declare mutating. Fails closed — every tool name in a read-only
+    /// worker's filter must have been returned by `inspect_mcp_servers` in
+    /// this conversation, so an empty discovery cache (model skipped
+    /// inspection, or the server restarted since) rejects the write instead
+    /// of waving the filter through. Glob/empty-filter rejection lives in
+    /// config validation (`OrchestrationConfig::validate_read_only_workers`).
+    fn enforce_read_only_workers(&self, config: &Config) -> Result<(), String> {
+        let signals = self.signals.lock().expect("signal cache poisoned");
+        let Some(orch) = config.orchestration.as_ref() else {
+            return Ok(());
+        };
+        for (worker_name, worker) in orch.workers.iter().filter(|(_, w)| w.read_only) {
+            for entry in &worker.mcp_filter {
+                match signals.get(entry) {
+                    Some(signal) if signal.declared_mutating() => {
+                        return Err(format!(
+                            "tool '{entry}' is annotated as mutating/destructive by its \
+                             MCP server and cannot be assigned to read_only worker \
+                             '{worker_name}'"
+                        ));
+                    }
+                    Some(_) => {}
+                    None => {
+                        return Err(format!(
+                            "tool '{entry}' (assigned to read_only worker \
+                             '{worker_name}') has not been verified by \
+                             inspect_mcp_servers in this conversation — run \
+                             inspect_mcp_servers first and use exact discovered \
+                             tool names"
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Full validation pipeline. Returns the parsed (env-resolved) config
+    /// and any non-fatal warnings.
+    fn validate_candidate(
+        &self,
+        content: &str,
+        target_file: &Path,
+    ) -> Result<(Config, Vec<String>), String> {
+        // Syntax check on the raw body first, so malformed TOML is reported
+        // as a parse error rather than a misleading env-resolution failure.
+        let raw_value: toml::Value =
+            toml::from_str(content).map_err(|e| format!("TOML parse failed: {e}"))?;
+
+        // Secret-literal check runs on the RAW tree: api_key values must be
+        // env references (validation below sees them resolved).
+        check_secret_literals(&raw_value)?;
+
+        let resolved = aura_config::resolve_env_vars(content).map_err(|e| {
+            format!("env resolution failed: {e} (the variable must be set on this server)")
+        })?;
+        let config: Config =
+            toml::from_str(&resolved).map_err(|e| format!("TOML parse failed: {e}"))?;
+        config
+            .validate()
+            .map_err(|e| format!("validation failed: {e}"))?;
+
+        for candidate in [
+            Some(config.agent.name.as_str()),
+            config.agent.alias.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if candidate.eq_ignore_ascii_case(BOOTSTRAP_AGENT_NAME) {
+                return Err(format!(
+                    "'{BOOTSTRAP_AGENT_NAME}' is reserved for the bootstrap agent and \
+                     cannot be used as an agent name or alias"
+                ));
+            }
+        }
+
+        if let Some(mcp) = &config.mcp {
+            check_stdio_policy(mcp, self.allow_stdio)?;
+        }
+        self.enforce_read_only_workers(&config)?;
+
+        // Directory deployments: the candidate must stay uniquely
+        // identifiable next to its sibling files, and the full roster must
+        // pass bootstrap-specific invariants (reserved name already checked
+        // above for the candidate; this catches siblings and multi-enabler).
+        let mut roster_pairs: Vec<(PathBuf, Config)> =
+            vec![(target_file.to_path_buf(), config.clone())];
+        for path in self.target.config_files() {
+            if path == target_file {
+                continue;
+            }
+            let siblings = aura_config::load_config_with_paths(&path)
+                .map_err(|e| format!("sibling config {} failed to load: {e}", path.display()))?;
+            roster_pairs.extend(siblings);
+        }
+        let roster: Vec<Config> = roster_pairs.iter().map(|(_, c)| c.clone()).collect();
+        aura_config::validate_unique_identifiers(&roster).map_err(|e| e.to_string())?;
+        validate_roster(&roster_pairs)?;
+
+        let mut warnings = Vec::new();
+        let previously_enabled = fs::read_to_string(target_file)
+            .ok()
+            .and_then(|raw| toml::from_str::<toml::Value>(&raw).ok())
+            .and_then(|v| v.get("bootstrap")?.get("enabled")?.as_bool())
+            .unwrap_or(false);
+        let now_enabled = config.bootstrap.as_ref().is_some_and(|b| b.enabled);
+        if previously_enabled && !now_enabled {
+            warnings.push(
+                "this configuration no longer enables [bootstrap]: after the next \
+                 server restart the bootstrap agent will be unavailable"
+                    .to_string(),
+            );
+        }
+
+        Ok((config, warnings))
+    }
+
+    /// Validate, back up, and atomically write the file from the RAW input
+    /// (so `{{ env.* }}` references are written as references).
+    fn write(&self, args: &WriteConfigArgs) -> Result<String, String> {
+        let target_file = self.target.resolve_file(args.file.as_deref())?;
+        let (config, warnings) = self.validate_candidate(&args.content, &target_file)?;
+
+        let mode = if config.orchestration_enabled() {
+            let workers = config
+                .orchestration
+                .as_ref()
+                .map(|o| o.workers.len())
+                .unwrap_or(0);
+            format!("orchestration with {workers} worker(s)")
+        } else {
+            "single-agent".to_string()
+        };
+        let (provider, model) = config.agent.llm.model_info();
+        let mut summary = format!("agent '{}' ({provider}/{model}, {mode})", config.agent.name);
+        for w in &warnings {
+            summary.push_str(&format!("\nWARNING: {w}"));
+        }
+
+        if args.validate_only {
+            return Ok(format!(
+                "VALIDATION PASSED (nothing written): {summary}\n\
+                 Call write_config without validate_only to apply."
+            ));
+        }
+
+        if target_file.exists() {
+            let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
+            let backup = target_file.with_file_name(format!(
+                "{}.bak.{stamp}",
+                target_file
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("config.toml")
+            ));
+            fs::copy(&target_file, &backup)
+                .map_err(|e| format!("failed to back up to {}: {e}", backup.display()))?;
+            summary.push_str(&format!(
+                "\nPrevious config backed up to {}.",
+                backup.display()
+            ));
+        } else if let Some(parent) = target_file.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+        }
+        let tmp = target_file.with_extension(format!(
+            "toml.tmp.{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        fs::write(&tmp, &args.content)
+            .map_err(|e| format!("failed to write {}: {e}", tmp.display()))?;
+        if let Err(e) = fs::rename(&tmp, &target_file) {
+            let _ = fs::remove_file(&tmp);
+            return Err(format!("failed to move config into place: {e}"));
+        }
+        warn!(
+            "Bootstrap: configuration written to {}",
+            target_file.display()
+        );
+
+        match (self.reload)() {
+            Ok(applied) => Ok(format!(
+                "Configuration written to {} and applied: {summary}\n{applied}",
+                target_file.display()
+            )),
+            Err(e) => Ok(format!(
+                "Configuration written to {} ({summary}) but RELOAD FAILED: {e}\n\
+                 The running server is still serving the previous configuration. \
+                 Fix the problem and write again, or restore the backup.",
+                target_file.display()
+            )),
+        }
+    }
+}
+
+/// Reject literal secrets anywhere in the raw TOML tree: every string value
+/// under a credential-looking key (`api_key`, `*token*`, `*secret*`,
+/// `*password*`, `*authorization*`, …) must carry its secret as an
+/// `{{ env.VAR }}` reference. This covers `[mcp.servers.*.headers]` values
+/// and stdio `env` maps, not just `api_key` fields. Values may mix text and
+/// references (`Authorization = "Bearer {{ env.TOKEN }}"`) — what matters is
+/// that the secret itself travels as a reference.
+///
+/// `headers_from_request` tables are exempt: their values are *names* of
+/// incoming request headers, never secrets.
+fn check_secret_literals(value: &toml::Value) -> Result<(), String> {
+    fn contains_env_reference(s: &str) -> bool {
+        s.find("{{")
+            .is_some_and(|start| s[start + 2..].trim_start().starts_with("env."))
+            && s.contains("}}")
+    }
+    fn credential_key(key: &str) -> bool {
+        let k = key.to_ascii_lowercase().replace('-', "_");
+        ["api_key", "apikey", "token", "secret", "password", "authorization", "credential"]
+            .iter()
+            .any(|marker| k.contains(marker))
+    }
+    fn walk(value: &toml::Value, path: &str, violations: &mut Vec<String>) {
+        match value {
+            toml::Value::Table(table) => {
+                for (key, v) in table {
+                    if key == "headers_from_request" {
+                        continue;
+                    }
+                    let child = if path.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{path}.{key}")
+                    };
+                    if credential_key(key)
+                        && let toml::Value::String(s) = v
+                        && !s.is_empty()
+                        && !contains_env_reference(s)
+                    {
+                        violations.push(child.clone());
+                    }
+                    walk(v, &child, violations);
+                }
+            }
+            toml::Value::Array(items) => {
+                for (i, v) in items.iter().enumerate() {
+                    walk(v, &format!("{path}[{i}]"), violations);
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut violations = Vec::new();
+    walk(value, "", &mut violations);
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "literal API key(s)/secret(s) at {} — secrets must be written as \
+             {{{{ env.VAR_NAME }}}} references to variables set on this server, \
+             never inline",
+            violations.join(", ")
+        ))
+    }
+}
+
+impl crate::RigTool for WriteConfigTool {
+    const NAME: &'static str = "write_config";
+
+    type Error = BootstrapToolError;
+    type Args = WriteConfigArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> crate::RigToolDefinition {
+        crate::RigToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Validate the complete configuration file content and write it to \
+                          disk (replacing the whole file; the previous version is backed up \
+                          with a timestamp). On success the running server applies it \
+                          immediately. On validation failure nothing is written and the \
+                          errors are returned so you can fix the content and call this tool \
+                          again. Set validate_only to check a draft without writing."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "description": "The complete configuration file (TOML), with secrets \
+                                        as {{ env.VAR }} references"
+                    },
+                    "file": {
+                        "type": "string",
+                        "description": "Specific *.toml file in a directory deployment; \
+                                        omit for the default configuration file"
+                    },
+                    "validate_only": {
+                        "type": "boolean",
+                        "description": "Validate and report without writing (default false)"
+                    }
+                },
+                "required": ["content"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        match self.write(&args) {
+            Ok(message) => Ok(message),
+            Err(e) => Ok(format!(
+                "WRITE_CONFIG FAILED — nothing was changed.\n\n{e}\n\n\
+                 Fix the configuration and call write_config again. Remember that \
+                 `{{{{ env.VAR }}}}` references must name variables that are set on \
+                 this server."
+            )),
+        }
+    }
+}
+
+// ============================================================================
+// Bootstrap agent assembly
+// ============================================================================
+
+/// Build the served bootstrap agent's config from the `[bootstrap]`-declaring
+/// config.
+///
+/// The agent runs on `[bootstrap].llm` when set, otherwise the declaring
+/// file's `[agent.llm]`. Everything else from the declaring config —
+/// orchestration, MCP servers, vector stores, scratchpad, client tools — is
+/// stripped: the bootstrap agent talks to the operator and manages
+/// configuration, nothing else.
+pub fn bootstrap_agent_config(
+    declaring: &Config,
+    target: &ConfigTarget,
+    roster: &[String],
+) -> Config {
+    let mut config = declaring.clone();
+    config.agent.name = BOOTSTRAP_AGENT_NAME.to_string();
+    config.agent.alias = None;
+    config.agent.turn_depth = Some(8);
+    if let Some(llm) = declaring.bootstrap.as_ref().and_then(|b| b.llm.clone()) {
+        config.agent.llm = llm;
+    }
+    config.agent.system_prompt = format!(
+        "{}\n{}",
+        BOOTSTRAP_PROMPT.trim_end(),
+        instance_context(target, roster)
+    );
+    config.agent.context = Vec::new();
+    config.agent.mcp_filter = None;
+    config.agent.enable_client_tools = false;
+    config.agent.client_tool_filter = None;
+    config.agent.scratchpad = None;
+    config.agent.skills = Default::default();
+    config.memory_dir = None;
+    config.orchestration = None;
+    config.mcp = None;
+    config.tools = None;
+    config.vector_stores = Vec::new();
+    config.hitl = None;
+    config.bootstrap = None;
+
+    let (provider, model) = config.agent.llm.model_info();
+    info!(
+        "Bootstrap agent ready on {provider}/{model}; configuration target: {}",
+        target.target.display()
+    );
+    config
+}
+
+/// Instance-specific context appended to the bootstrap prompt.
+fn instance_context(target: &ConfigTarget, roster: &[String]) -> String {
+    let mut out = String::from("\n## This instance\n\n");
+    if target.is_dir() {
+        out.push_str(&format!(
+            "- Configuration directory: `{}`; your default write target is \
+             `{}` (use the `file` argument for sibling files).\n",
+            target.config_path.display(),
+            target.target.display()
+        ));
+    } else {
+        out.push_str(&format!(
+            "- Configuration file: `{}`\n",
+            target.target.display()
+        ));
+    }
+    out.push_str(
+        "- Successful writes are applied immediately by the running server \
+         (hot reload); this conversation continues across changes.\n",
+    );
+    if roster.is_empty() {
+        out.push_str("- No agents are currently configured.\n");
+    } else {
+        out.push_str(&format!(
+            "- Agents currently served: {}\n",
+            roster.join(", ")
+        ));
+    }
+    out.push_str(&format!(
+        "- stdio MCP transports: {}\n",
+        if stdio_allowed_from_env() {
+            "ALLOWED (the operator set AURA_BOOTSTRAP_ALLOW_STDIO=true)"
+        } else {
+            "disabled (AURA_BOOTSTRAP_ALLOW_STDIO is not set)"
+        }
+    ));
+    out.push_str(
+        "- Environment variables currently set on this server (presence only; \
+         values are never shown):\n",
+    );
+    for var in KNOWN_KEY_VARS {
+        let mark = if std::env::var(var).is_ok() {
+            "set"
+        } else {
+            "not set"
+        };
+        out.push_str(&format!("  - {var}: {mark}\n"));
+    }
+    out
+}
+
+/// Validate a loaded roster against bootstrap-specific invariants:
+///
+/// 1. No roster agent may use the reserved `BOOTSTRAP_AGENT_NAME`.
+/// 2. At most one config may enable `[bootstrap]`.
+///
+/// Called by both startup paths and both reload hooks so the invariants
+/// are enforced uniformly regardless of how the roster was loaded.
+pub fn validate_roster(configs: &[(impl AsRef<std::path::Path>, Config)]) -> Result<(), String> {
+    // Reserved name
+    if let Some((_, config)) = configs.iter().find(|(_, c)| {
+        [Some(c.agent.name.as_str()), c.agent.alias.as_deref()]
+            .into_iter()
+            .flatten()
+            .any(|id| id.eq_ignore_ascii_case(BOOTSTRAP_AGENT_NAME))
+    }) {
+        return Err(format!(
+            "agent '{}' uses the reserved name '{BOOTSTRAP_AGENT_NAME}'",
+            config.agent.name,
+        ));
+    }
+    // Single enabler
+    let enablers: Vec<String> = configs
+        .iter()
+        .filter(|(_, c)| c.bootstrap.as_ref().is_some_and(|b| b.enabled))
+        .map(|(p, _)| p.as_ref().display().to_string())
+        .collect();
+    if enablers.len() > 1 {
+        return Err(format!(
+            "[bootstrap] is enabled in more than one config file ({}) — enable it \
+             in exactly one so the bootstrap agent's LLM and write target are \
+             unambiguous",
+            enablers.join(", ")
+        ));
+    }
+    Ok(())
+}
+
+/// Factory for the bootstrap agent's tools, in the shape
+/// `AppState.additional_tools` expects.
+///
+/// The discovery signal cache is created here, outside the per-request
+/// closure, so classification survives across conversation rounds. The
+/// stdio policy is read from the environment once at startup.
+pub fn bootstrap_tools_factory(
+    target: ConfigTarget,
+    reload: ReloadHook,
+) -> Arc<dyn Fn() -> Vec<Box<dyn crate::ToolDyn>> + Send + Sync> {
+    let signals: SignalCache = SignalCache::default();
+    let allow_stdio = stdio_allowed_from_env();
+    Arc::new(move || {
+        vec![
+            Box::new(ReadConfigTool::new(target.clone())) as Box<dyn crate::ToolDyn>,
+            Box::new(InspectMcpTool::new(
+                target.clone(),
+                signals.clone(),
+                allow_stdio,
+            )) as Box<dyn crate::ToolDyn>,
+            Box::new(WriteConfigTool::new(
+                target.clone(),
+                reload.clone(),
+                signals.clone(),
+                allow_stdio,
+            )) as Box<dyn crate::ToolDyn>,
+        ]
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RigTool as _;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Complete config with no env-var or API-key dependencies (ollama).
+    const COMPLETE: &str = r#"
+[agent]
+name = "assistant"
+system_prompt = "You are helpful."
+
+[agent.llm]
+provider = "ollama"
+model = "qwen3:8b"
+
+[bootstrap]
+enabled = true
+"#;
+
+    fn target_with(dir: &Path, content: &str) -> ConfigTarget {
+        let path = dir.join("config.toml");
+        fs::write(&path, content).unwrap();
+        ConfigTarget::single_file(path)
+    }
+
+    fn noop_reload() -> ReloadHook {
+        Arc::new(|| Ok("reloaded".to_string()))
+    }
+
+    fn write_tool(target: ConfigTarget) -> WriteConfigTool {
+        WriteConfigTool::new(target, noop_reload(), SignalCache::default(), false)
+    }
+
+    fn write_args(content: &str) -> WriteConfigArgs {
+        WriteConfigArgs {
+            content: content.to_string(),
+            file: None,
+            validate_only: false,
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // write_config
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn write_rejects_incomplete_config_without_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+
+        // No system_prompt: strict serde must reject it.
+        let result = write_tool(target)
+            .call(write_args(
+                "[agent]\nname = \"x\"\n\n[agent.llm]\nprovider = \"ollama\"\nmodel = \"m\"",
+            ))
+            .await
+            .unwrap();
+
+        assert!(result.contains("WRITE_CONFIG FAILED"), "got: {result}");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("config.toml")).unwrap(),
+            COMPLETE
+        );
+    }
+
+    #[tokio::test]
+    async fn write_applies_and_backs_up_with_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let updated = COMPLETE.replace("You are helpful.", "You are terse.");
+
+        let result = write_tool(target).call(write_args(&updated)).await.unwrap();
+
+        assert!(result.contains("written to"), "got: {result}");
+        assert!(result.contains("reloaded"), "got: {result}");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("config.toml")).unwrap(),
+            updated
+        );
+        let backups: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with("config.toml.bak."))
+            .collect();
+        assert_eq!(backups.len(), 1, "backups: {backups:?}");
+        let backup_content = fs::read_to_string(dir.path().join(&backups[0])).unwrap();
+        assert_eq!(backup_content, COMPLETE);
+    }
+
+    #[tokio::test]
+    async fn validate_only_writes_nothing_and_skips_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let reloads = Arc::new(AtomicUsize::new(0));
+        let counter = reloads.clone();
+        let hook: ReloadHook = Arc::new(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok("reloaded".to_string())
+        });
+        let tool = WriteConfigTool::new(target, hook, SignalCache::default(), false);
+
+        let result = tool
+            .call(WriteConfigArgs {
+                content: COMPLETE.replace("helpful", "terse"),
+                file: None,
+                validate_only: true,
+            })
+            .await
+            .unwrap();
+
+        assert!(result.contains("VALIDATION PASSED"), "got: {result}");
+        assert_eq!(reloads.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            fs::read_to_string(dir.path().join("config.toml")).unwrap(),
+            COMPLETE
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_failure_is_reported_but_file_is_written() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let hook: ReloadHook = Arc::new(|| Err("boom".to_string()));
+        let tool = WriteConfigTool::new(target, hook, SignalCache::default(), false);
+        let updated = COMPLETE.replace("helpful", "terse");
+
+        let result = tool.call(write_args(&updated)).await.unwrap();
+
+        assert!(result.contains("RELOAD FAILED: boom"), "got: {result}");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("config.toml")).unwrap(),
+            updated
+        );
+    }
+
+    #[tokio::test]
+    async fn write_rejects_literal_api_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let content = r#"
+[agent]
+name = "assistant"
+system_prompt = "You are helpful."
+
+[agent.llm]
+provider = "openai"
+api_key = "sk-proj-abc123"
+model = "gpt-5.1"
+"#;
+
+        let result = write_tool(target).call(write_args(content)).await.unwrap();
+
+        assert!(result.contains("literal API key"), "got: {result}");
+        assert!(result.contains("agent.llm.api_key"), "got: {result}");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("config.toml")).unwrap(),
+            COMPLETE
+        );
+    }
+
+    #[tokio::test]
+    async fn write_rejects_literal_secret_in_mcp_headers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let content = format!(
+            "{COMPLETE}\n[mcp.servers.k8s]\ntransport = \"http_streamable\"\n\
+             url = \"http://x/mcp\"\n\n[mcp.servers.k8s.headers]\n\
+             Authorization = \"Bearer sk-live-abc123\"\n"
+        );
+
+        let result = write_tool(target).call(write_args(&content)).await.unwrap();
+
+        assert!(result.contains("literal API key(s)/secret(s)"), "got: {result}");
+        assert!(
+            result.contains("mcp.servers.k8s.headers.Authorization"),
+            "got: {result}"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.path().join("config.toml")).unwrap(),
+            COMPLETE
+        );
+    }
+
+    #[test]
+    fn secret_scan_covers_credential_keys_and_allows_references() {
+        let check = |toml_str: &str| {
+            check_secret_literals(&toml::from_str::<toml::Value>(toml_str).unwrap())
+        };
+
+        // Credential-looking keys with literals are rejected wherever they sit.
+        for bad in [
+            "[mcp.servers.x.headers]\n\"x-api-key\" = \"abc\"",
+            "[mcp.servers.x.env]\nOPENAI_API_KEY = \"sk-123\"",
+            "[mcp.servers.x.headers]\nProxy-Authorization = \"Basic xyz\"",
+            "[a]\nmy_token = \"t\"",
+            "[a]\nclient_secret = \"s\"",
+            "[a]\ndb_password = \"p\"",
+        ] {
+            assert!(check(bad).is_err(), "expected rejection for: {bad}");
+        }
+
+        // References (whole-value or embedded) pass; so do non-credential
+        // values and headers_from_request name mappings.
+        for ok in [
+            "[a]\napi_key = \"{{ env.OPENAI_API_KEY }}\"",
+            "[mcp.servers.x.headers]\nAuthorization = \"Bearer {{ env.TOKEN }}\"",
+            "[mcp.servers.x.headers]\nContent-Type = \"application/json\"",
+            "[mcp.servers.x.env]\nAWS_REGION = \"us-east-1\"",
+            "[mcp.servers.x.headers_from_request]\nAuthorization = \"x-user-token\"",
+        ] {
+            assert!(check(ok).is_ok(), "expected pass for: {ok}");
+        }
+    }
+
+    #[tokio::test]
+    async fn write_rejects_unresolvable_env_reference() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let content = r#"
+[agent]
+name = "assistant"
+system_prompt = "You are helpful."
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.DEFINITELY_NOT_SET_AURA_TEST_VAR }}"
+model = "gpt-5.1"
+"#;
+
+        let result = write_tool(target).call(write_args(content)).await.unwrap();
+
+        assert!(result.contains("env resolution failed"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn write_rejects_reserved_bootstrap_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let content = COMPLETE.replace("name = \"assistant\"", "name = \"AURA-Bootstrap\"");
+
+        let result = write_tool(target).call(write_args(&content)).await.unwrap();
+
+        assert!(result.contains("reserved"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn write_rejects_stdio_server_unless_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let content =
+            format!("{COMPLETE}\n[mcp.servers.local]\ntransport = \"stdio\"\ncmd = [\"npx\"]\n");
+
+        let target = target_with(dir.path(), COMPLETE);
+        let result = write_tool(target.clone())
+            .call(write_args(&content))
+            .await
+            .unwrap();
+        assert!(result.contains("stdio MCP transports"), "got: {result}");
+
+        // Same content passes when the operator allowed stdio.
+        let tool = WriteConfigTool::new(target, noop_reload(), SignalCache::default(), true);
+        let result = tool.call(write_args(&content)).await.unwrap();
+        assert!(result.contains("written to"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn write_warns_when_bootstrap_gets_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let content = COMPLETE.replace("enabled = true", "enabled = false");
+
+        let result = write_tool(target).call(write_args(&content)).await.unwrap();
+
+        assert!(
+            result.contains("no longer enables [bootstrap]"),
+            "got: {result}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // read_only worker enforcement
+    // ------------------------------------------------------------------
+
+    fn cache_with(entries: &[(&str, ToolSignal)]) -> SignalCache {
+        let cache = SignalCache::default();
+        {
+            let mut guard = cache.lock().unwrap();
+            for (name, signal) in entries {
+                guard.insert(name.to_string(), *signal);
+            }
+        }
+        cache
+    }
+
+    fn worker_config(filter_entry: &str, read_only: bool) -> String {
+        format!(
+            "{COMPLETE}\n[orchestration]\nenabled = true\n\n\
+             [orchestration.worker.watcher]\n\
+             description = \"d\"\npreamble = \"p\"\nread_only = {read_only}\n\
+             mcp_filter = [\"{filter_entry}\"]\n"
+        )
+    }
+
+    const READ_ONLY_LIST: ToolSignal = ToolSignal {
+        read_only: Some(true),
+        destructive: None,
+    };
+    const MUTATING: ToolSignal = ToolSignal {
+        read_only: Some(false),
+        destructive: Some(true),
+    };
+
+    #[tokio::test]
+    async fn backstop_rejects_annotated_mutating_tool_in_read_only_worker() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let cache = cache_with(&[("list_pods", READ_ONLY_LIST), ("restart_pod", MUTATING)]);
+        let tool = WriteConfigTool::new(target, noop_reload(), cache, false);
+
+        let result = tool
+            .call(write_args(&worker_config("restart_pod", true)))
+            .await
+            .unwrap();
+
+        assert!(result.contains("annotated as mutating"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn backstop_rejects_undiscovered_tool() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let cache = cache_with(&[("list_pods", READ_ONLY_LIST)]);
+        let tool = WriteConfigTool::new(target, noop_reload(), cache, false);
+
+        let result = tool
+            .call(write_args(&worker_config("hallucinated_tool", true)))
+            .await
+            .unwrap();
+
+        assert!(
+            result.contains("has not been verified by inspect_mcp_servers"),
+            "got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn backstop_fails_closed_when_discovery_never_ran() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        // Empty signal cache: inspect_mcp_servers was never called.
+        let tool = write_tool(target);
+
+        let result = tool
+            .call(write_args(&worker_config("list_pods", true)))
+            .await
+            .unwrap();
+
+        assert!(
+            result.contains("has not been verified by inspect_mcp_servers"),
+            "got: {result}"
+        );
+    }
+
+    #[test]
+    fn signal_merge_keeps_mutating_across_servers() {
+        // Server A says mutating, server B says read-only: mutating wins
+        // regardless of discovery order.
+        assert!(MUTATING.merge_most_restrictive(READ_ONLY_LIST).declared_mutating());
+        assert!(READ_ONLY_LIST.merge_most_restrictive(MUTATING).declared_mutating());
+        // Agreement on read-only survives the merge.
+        assert!(
+            !READ_ONLY_LIST
+                .merge_most_restrictive(READ_ONLY_LIST)
+                .declared_mutating()
+        );
+        // Read-only + unannotated degrades to unannotated (no positive claim).
+        let merged = READ_ONLY_LIST.merge_most_restrictive(ToolSignal::default());
+        assert_eq!(merged.read_only, None);
+    }
+
+    #[tokio::test]
+    async fn backstop_rejects_globs_in_read_only_worker() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let cache = cache_with(&[("list_pods", READ_ONLY_LIST)]);
+        let tool = WriteConfigTool::new(target, noop_reload(), cache, false);
+
+        let result = tool
+            .call(write_args(&worker_config("list_*", true)))
+            .await
+            .unwrap();
+
+        assert!(result.contains("not glob patterns"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn backstop_ignores_workers_not_marked_read_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let cache = cache_with(&[("list_pods", READ_ONLY_LIST), ("restart_pod", MUTATING)]);
+        let tool = WriteConfigTool::new(target, noop_reload(), cache, false);
+
+        // Mutating tool + glob on a NON-read-only worker: allowed.
+        let result = tool
+            .call(write_args(&worker_config("restart_pod", false)))
+            .await
+            .unwrap();
+
+        assert!(result.contains("written to"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn backstop_allows_discovered_read_only_tool() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let cache = cache_with(&[("list_pods", READ_ONLY_LIST)]);
+        let tool = WriteConfigTool::new(target, noop_reload(), cache, false);
+
+        let result = tool
+            .call(write_args(&worker_config("list_pods", true)))
+            .await
+            .unwrap();
+
+        assert!(result.contains("written to"), "got: {result}");
+    }
+
+    // ------------------------------------------------------------------
+    // directory deployments
+    // ------------------------------------------------------------------
+
+    fn dir_target(dir: &Path) -> ConfigTarget {
+        fs::write(dir.join("main.toml"), COMPLETE).unwrap();
+        fs::write(
+            dir.join("other.toml"),
+            COMPLETE
+                .replace("name = \"assistant\"", "name = \"other\"")
+                .replace("enabled = true", "enabled = false"),
+        )
+        .unwrap();
+        ConfigTarget {
+            config_path: dir.to_path_buf(),
+            target: dir.join("main.toml"),
+        }
+    }
+
+    #[tokio::test]
+    async fn write_rejects_duplicate_identifier_across_siblings() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir_target(dir.path());
+        let content = COMPLETE.replace("name = \"assistant\"", "name = \"other\"");
+
+        let result = write_tool(target).call(write_args(&content)).await.unwrap();
+
+        assert!(result.contains("WRITE_CONFIG FAILED"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn write_file_arg_targets_sibling_and_rejects_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir_target(dir.path());
+        let updated = COMPLETE
+            .replace("name = \"assistant\"", "name = \"other\"")
+            .replace("You are helpful.", "You are other.")
+            .replace("enabled = true", "enabled = false");
+
+        let tool = write_tool(target.clone());
+        let result = tool
+            .call(WriteConfigArgs {
+                content: updated.clone(),
+                file: Some("other.toml".to_string()),
+                validate_only: false,
+            })
+            .await
+            .unwrap();
+        assert!(result.contains("written to"), "got: {result}");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("other.toml")).unwrap(),
+            updated
+        );
+
+        for bad in ["../evil.toml", "/etc/evil.toml", "evil.txt"] {
+            let result = tool
+                .call(WriteConfigArgs {
+                    content: COMPLETE.to_string(),
+                    file: Some(bad.to_string()),
+                    validate_only: false,
+                })
+                .await
+                .unwrap();
+            assert!(
+                result.contains("WRITE_CONFIG FAILED"),
+                "expected rejection for {bad}, got: {result}"
+            );
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // read_config
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn read_config_returns_raw_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+
+        let result = ReadConfigTool::new(target)
+            .call(ReadConfigArgs { file: None })
+            .await
+            .unwrap();
+
+        assert!(result.contains("You are helpful."), "got: {result}");
+        assert!(result.contains("config.toml"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn read_config_lists_directory_and_rejects_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir_target(dir.path());
+        let tool = ReadConfigTool::new(target);
+
+        let result = tool.call(ReadConfigArgs { file: None }).await.unwrap();
+        assert!(result.contains("main.toml"), "got: {result}");
+        assert!(result.contains("other.toml"), "got: {result}");
+
+        let result = tool
+            .call(ReadConfigArgs {
+                file: Some("../secret.toml".to_string()),
+            })
+            .await
+            .unwrap();
+        assert!(result.contains("READ_CONFIG FAILED"), "got: {result}");
+    }
+
+    // ------------------------------------------------------------------
+    // inspect_mcp_servers (offline paths)
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn inspect_refuses_stdio_fragment_unless_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let tool = InspectMcpTool::new(target, SignalCache::default(), false);
+
+        let result = tool
+            .call(InspectArgs {
+                servers_toml: Some(
+                    "[mcp.servers.local]\ntransport = \"stdio\"\ncmd = [\"npx\"]\n".to_string(),
+                ),
+            })
+            .await
+            .unwrap();
+
+        assert!(result.contains("INSPECT REFUSED"), "got: {result}");
+        assert!(result.contains(ALLOW_STDIO_ENV), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn inspect_without_servers_reports_helpfully() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let tool = InspectMcpTool::new(target, SignalCache::default(), false);
+
+        let result = tool.call(InspectArgs { servers_toml: None }).await.unwrap();
+
+        assert!(result.contains("INSPECT FAILED"), "got: {result}");
+        assert!(result.contains("servers_toml"), "got: {result}");
+    }
+
+    // ------------------------------------------------------------------
+    // bootstrap agent assembly
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn bootstrap_agent_inherits_declaring_llm_without_baggage() {
+        let declaring: Config = toml::from_str(
+            &format!("{COMPLETE}\n[mcp.servers.k8s]\ntransport = \"http_streamable\"\nurl = \"http://x/mcp\"\n"),
+        )
+        .unwrap();
+        let target = ConfigTarget::single_file("/tmp/config.toml");
+
+        let agent = bootstrap_agent_config(&declaring, &target, &["assistant".to_string()]);
+
+        assert_eq!(agent.agent.name, BOOTSTRAP_AGENT_NAME);
+        assert_eq!(agent.agent.llm.model_info(), ("ollama", "qwen3:8b"));
+        assert!(agent.mcp.is_none());
+        assert!(agent.orchestration.is_none());
+        assert!(agent.bootstrap.is_none());
+        assert!(!agent.agent.enable_client_tools);
+        assert!(agent.agent.system_prompt.contains("/tmp/config.toml"));
+        assert!(agent.agent.system_prompt.contains("assistant"));
+    }
+
+    #[test]
+    fn bootstrap_agent_prefers_bootstrap_llm_override() {
+        let declaring: Config = toml::from_str(&format!(
+            "{COMPLETE}\n[bootstrap.llm]\nprovider = \"ollama\"\nmodel = \"qwen3:32b\"\n"
+        ))
+        .unwrap();
+        let target = ConfigTarget::single_file("/tmp/config.toml");
+
+        let agent = bootstrap_agent_config(&declaring, &target, &[]);
+
+        assert_eq!(agent.agent.llm.model_info(), ("ollama", "qwen3:32b"));
+    }
+}

--- a/crates/aura/src/bootstrap.rs
+++ b/crates/aura/src/bootstrap.rs
@@ -716,10 +716,7 @@ impl WriteConfigTool {
             fs::create_dir_all(parent)
                 .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
         }
-        let tmp = target_file.with_extension(format!(
-            "toml.tmp.{}",
-            uuid::Uuid::new_v4().simple()
-        ));
+        let tmp = target_file.with_extension(format!("toml.tmp.{}", uuid::Uuid::new_v4().simple()));
         fs::write(&tmp, &args.content)
             .map_err(|e| format!("failed to write {}: {e}", tmp.display()))?;
         if let Err(e) = fs::rename(&tmp, &target_file) {
@@ -764,9 +761,17 @@ fn check_secret_literals(value: &toml::Value) -> Result<(), String> {
     }
     fn credential_key(key: &str) -> bool {
         let k = key.to_ascii_lowercase().replace('-', "_");
-        ["api_key", "apikey", "token", "secret", "password", "authorization", "credential"]
-            .iter()
-            .any(|marker| k.contains(marker))
+        [
+            "api_key",
+            "apikey",
+            "token",
+            "secret",
+            "password",
+            "authorization",
+            "credential",
+        ]
+        .iter()
+        .any(|marker| k.contains(marker))
     }
     fn walk(value: &toml::Value, path: &str, violations: &mut Vec<String>) {
         match value {
@@ -1208,7 +1213,10 @@ model = "gpt-5.1"
 
         let result = write_tool(target).call(write_args(&content)).await.unwrap();
 
-        assert!(result.contains("literal API key(s)/secret(s)"), "got: {result}");
+        assert!(
+            result.contains("literal API key(s)/secret(s)"),
+            "got: {result}"
+        );
         assert!(
             result.contains("mcp.servers.k8s.headers.Authorization"),
             "got: {result}"
@@ -1402,8 +1410,16 @@ model = "gpt-5.1"
     fn signal_merge_keeps_mutating_across_servers() {
         // Server A says mutating, server B says read-only: mutating wins
         // regardless of discovery order.
-        assert!(MUTATING.merge_most_restrictive(READ_ONLY_LIST).declared_mutating());
-        assert!(READ_ONLY_LIST.merge_most_restrictive(MUTATING).declared_mutating());
+        assert!(
+            MUTATING
+                .merge_most_restrictive(READ_ONLY_LIST)
+                .declared_mutating()
+        );
+        assert!(
+            READ_ONLY_LIST
+                .merge_most_restrictive(MUTATING)
+                .declared_mutating()
+        );
         // Agreement on read-only survives the merge.
         assert!(
             !READ_ONLY_LIST

--- a/crates/aura/src/bootstrap.rs
+++ b/crates/aura/src/bootstrap.rs
@@ -1,0 +1,1642 @@
+//! The built-in `aura-bootstrap` agent: a token-gated configuration
+//! assistant served alongside the configured agents.
+//!
+//! Enabled via the `[bootstrap]` TOML table (disabled by default), the
+//! bootstrap agent carries three built-in tools — `read_config`,
+//! `inspect_mcp_servers`, and `write_config` — that let it build a fresh
+//! configuration conversationally and make targeted day-2 modifications.
+//! Configs are **agent-authored**: `write_config` validates mechanically
+//! (strict parse, env-resolution check, secret-literal rejection,
+//! read-only-worker enforcement, atomic write with timestamped backup) but
+//! expands nothing. What the agent writes is exactly what runs.
+//!
+//! After a successful write the host's [`ReloadHook`] is invoked so the
+//! running server can swap in the new roster in-process (hot reload); the
+//! hook's outcome is appended to the tool result so the model can react —
+//! and, on failure, restore from the backup it just created.
+//!
+//! Safety boundaries enforced here rather than by prompt alone:
+//! - workers marked `read_only = true` may only be assigned MCP tools that
+//!   `inspect_mcp_servers` discovered in this conversation and that no
+//!   server annotated as mutating (fail-closed: undiscovered names are
+//!   rejected, and same-named tools on different servers merge
+//!   most-restrictive). Glob and empty filters are rejected earlier by
+//!   config validation, and worker construction re-checks annotations at
+//!   runtime for configs that arrive by other paths;
+//! - literal credentials are rejected wherever they appear (api keys, MCP
+//!   header values, stdio env maps — any credential-looking key); secrets
+//!   travel only as `{{ env.* }}` references and the on-disk file is
+//!   written from the raw input so they stay references;
+//! - `stdio` MCP transports (arbitrary command execution at attach time)
+//!   are rejected unless the operator set `AURA_BOOTSTRAP_ALLOW_STDIO=true`;
+//! - no agent may take the reserved `aura-bootstrap` name.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use aura_config::{Config, McpConfig, McpServerConfig};
+use tracing::{info, warn};
+
+/// Reserved model/agent name under which the bootstrap agent is served.
+pub const BOOTSTRAP_AGENT_NAME: &str = "aura-bootstrap";
+
+/// Env var that permits `stdio` MCP transports in agent-written configs.
+pub const ALLOW_STDIO_ENV: &str = "AURA_BOOTSTRAP_ALLOW_STDIO";
+
+/// Framework prompt for the bootstrap agent (compile-time include).
+const BOOTSTRAP_PROMPT: &str = include_str!("prompts/bootstrap_prompt.md");
+
+/// Env-var names surfaced (presence only, never values) to the bootstrap
+/// agent so it can steer the operator toward `{{ env.* }}` references that
+/// will actually resolve.
+const KNOWN_KEY_VARS: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "GEMINI_API_KEY",
+    "MEZMO_API_KEY",
+    "AWS_PROFILE",
+    "AWS_REGION",
+];
+
+/// Whether the operator allowed stdio MCP transports for this process.
+pub fn stdio_allowed_from_env() -> bool {
+    crate::env_flags::bool_env(ALLOW_STDIO_ENV, false)
+}
+
+/// Invoked after every successful `write_config`; returns a human-readable
+/// summary of the applied roster, or an error message. Either way the text
+/// is appended to the tool result so the model sees the outcome.
+pub type ReloadHook = Arc<dyn Fn() -> Result<String, String> + Send + Sync>;
+
+/// Where the bootstrap agent reads and writes configuration.
+#[derive(Debug, Clone)]
+pub struct ConfigTarget {
+    /// `CONFIG_PATH` as the server was started with (file or directory).
+    pub config_path: PathBuf,
+    /// Default write target: the file that declared `[bootstrap]`.
+    pub target: PathBuf,
+}
+
+impl ConfigTarget {
+    /// Single-file deployment helper.
+    pub fn single_file(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        Self {
+            config_path: path.clone(),
+            target: path,
+        }
+    }
+
+    fn is_dir(&self) -> bool {
+        self.config_path.is_dir()
+    }
+
+    /// Resolve an optional `file` tool argument to a concrete path.
+    ///
+    /// In single-file mode only the default target is addressable. In
+    /// directory mode the name must be a plain `*.toml` filename inside the
+    /// config directory — no separators, no traversal.
+    fn resolve_file(&self, file: Option<&str>) -> Result<PathBuf, String> {
+        let Some(name) = file else {
+            return Ok(self.target.clone());
+        };
+        let name = name.trim();
+        if !self.is_dir() {
+            let default_name = self.target.file_name().and_then(|n| n.to_str());
+            if Some(name) == default_name {
+                return Ok(self.target.clone());
+            }
+            return Err(format!(
+                "this instance loads a single config file ({}); the `file` \
+                 argument is only available for directory deployments",
+                self.target.display()
+            ));
+        }
+        if name.contains(['/', '\\']) || name.contains("..") || !name.ends_with(".toml") {
+            return Err(format!(
+                "invalid file name '{name}': must be a plain *.toml filename \
+                 inside the config directory"
+            ));
+        }
+        Ok(self.config_path.join(name))
+    }
+
+    /// All `*.toml` files in the deployment (just the target in file mode).
+    fn config_files(&self) -> Vec<PathBuf> {
+        if !self.is_dir() {
+            return vec![self.target.clone()];
+        }
+        let mut files: Vec<PathBuf> = fs::read_dir(&self.config_path)
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|ext| ext == "toml"))
+            .collect();
+        files.sort();
+        files
+    }
+}
+
+// ============================================================================
+// Tool discovery / classification signals
+// ============================================================================
+
+/// Annotation signals for one discovered MCP tool.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ToolSignal {
+    /// `readOnlyHint` from the server, if provided.
+    pub read_only: Option<bool>,
+    /// `destructiveHint` from the server, if provided.
+    pub destructive: Option<bool>,
+}
+
+impl ToolSignal {
+    /// Extract the annotation signals from a discovered MCP tool.
+    pub fn of_tool(tool: &rmcp::model::Tool) -> Self {
+        Self {
+            read_only: tool.annotations.as_ref().and_then(|a| a.read_only_hint),
+            destructive: tool.annotations.as_ref().and_then(|a| a.destructive_hint),
+        }
+    }
+
+    /// Whether the server itself declared this tool unsafe for read-only
+    /// workers. Annotations are restrictive-only signals: they can bar a
+    /// tool from read-only workers, never admit one.
+    pub fn declared_mutating(&self) -> bool {
+        self.destructive == Some(true) || self.read_only == Some(false)
+    }
+
+    /// Most-restrictive merge for same-named tools discovered on different
+    /// servers: a mutating signal from either side survives, and agreement
+    /// is required for a positive read-only/non-destructive claim.
+    fn merge_most_restrictive(self, other: Self) -> Self {
+        Self {
+            read_only: match (self.read_only, other.read_only) {
+                (Some(false), _) | (_, Some(false)) => Some(false),
+                (Some(true), Some(true)) => Some(true),
+                _ => None,
+            },
+            destructive: match (self.destructive, other.destructive) {
+                (Some(true), _) | (_, Some(true)) => Some(true),
+                (Some(false), Some(false)) => Some(false),
+                _ => None,
+            },
+        }
+    }
+}
+
+/// Discovery results shared between `inspect_mcp_servers` and
+/// `write_config` across the bootstrap conversation (the cache lives in the
+/// tools factory, so it survives across requests).
+pub type SignalCache = Arc<Mutex<HashMap<String, ToolSignal>>>;
+
+// ============================================================================
+// Shared error type (the tools report outcomes as Ok(message) so the model
+// reliably sees them; the Error type exists to satisfy the trait)
+// ============================================================================
+
+#[derive(Debug)]
+pub struct BootstrapToolError(String);
+
+impl std::fmt::Display for BootstrapToolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for BootstrapToolError {}
+
+// ============================================================================
+// read_config tool
+// ============================================================================
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct ReadConfigArgs {
+    /// File to read in a directory deployment (plain *.toml name).
+    /// Omit for the default configuration file.
+    #[serde(default)]
+    pub file: Option<String>,
+}
+
+/// Returns the raw on-disk configuration (env references intact — the disk
+/// file never holds secrets) so the agent can ground modifications in what
+/// actually exists.
+pub struct ReadConfigTool {
+    target: ConfigTarget,
+}
+
+impl ReadConfigTool {
+    pub fn new(target: ConfigTarget) -> Self {
+        Self { target }
+    }
+}
+
+impl crate::RigTool for ReadConfigTool {
+    const NAME: &'static str = "read_config";
+
+    type Error = BootstrapToolError;
+    type Args = ReadConfigArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> crate::RigToolDefinition {
+        crate::RigToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Read this instance's configuration file as it exists on disk \
+                          (secrets appear as {{ env.VAR }} references). Call this before \
+                          proposing or modifying configuration."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "file": {
+                        "type": "string",
+                        "description": "Specific *.toml file in a directory deployment; \
+                                        omit for the default configuration file"
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let path = match self.target.resolve_file(args.file.as_deref()) {
+            Ok(p) => p,
+            Err(e) => return Ok(format!("READ_CONFIG FAILED: {e}")),
+        };
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(format!(
+                    "READ_CONFIG FAILED: cannot read {}: {e}",
+                    path.display()
+                ));
+            }
+        };
+        let mut out = String::new();
+        if self.target.is_dir() {
+            let names: Vec<String> = self
+                .target
+                .config_files()
+                .iter()
+                .filter_map(|p| p.file_name().and_then(|n| n.to_str()).map(String::from))
+                .collect();
+            out.push_str(&format!(
+                "Directory deployment at {} — files: {}\n\n",
+                self.target.config_path.display(),
+                names.join(", ")
+            ));
+        }
+        out.push_str(&format!(
+            "# {}\n\n```toml\n{}\n```",
+            path.display(),
+            content.trim_end()
+        ));
+        Ok(out)
+    }
+}
+
+// ============================================================================
+// inspect_mcp_servers tool
+// ============================================================================
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct InspectArgs {
+    /// TOML containing the `[mcp.servers.<name>]` tables to inspect (for
+    /// servers not yet written to the config). Omit to inspect the servers
+    /// in the current configuration file(s).
+    #[serde(default)]
+    pub servers_toml: Option<String>,
+}
+
+/// Deserialization helper: extracts `[mcp]` from a TOML fragment or a full
+/// candidate config without requiring the rest of the document.
+#[derive(serde::Deserialize)]
+struct McpFragment {
+    mcp: Option<McpConfig>,
+}
+
+/// Connects to MCP servers and reports every discovered tool with its
+/// annotation signals, for classification and connectivity verification.
+/// Results are cached for `write_config`'s read-only-worker enforcement.
+pub struct InspectMcpTool {
+    target: ConfigTarget,
+    signals: SignalCache,
+    allow_stdio: bool,
+}
+
+impl InspectMcpTool {
+    pub fn new(target: ConfigTarget, signals: SignalCache, allow_stdio: bool) -> Self {
+        Self {
+            target,
+            signals,
+            allow_stdio,
+        }
+    }
+
+    /// Gather the MCP config to inspect from the argument or from disk.
+    fn gather_mcp(&self, servers_toml: Option<&str>) -> Result<McpConfig, String> {
+        if let Some(fragment) = servers_toml {
+            let resolved = aura_config::resolve_env_vars(fragment)
+                .map_err(|e| format!("env resolution failed: {e}"))?;
+            let parsed: McpFragment =
+                toml::from_str(&resolved).map_err(|e| format!("TOML parse failed: {e}"))?;
+            return parsed
+                .mcp
+                .filter(|m| !m.servers.is_empty())
+                .ok_or_else(|| "no [mcp.servers.<name>] tables found in the input".to_string());
+        }
+        // From disk: merge servers across the deployment's files.
+        let mut merged = McpConfig::default();
+        for path in self.target.config_files() {
+            let raw = fs::read_to_string(&path)
+                .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+            let resolved = aura_config::resolve_env_vars(&raw)
+                .map_err(|e| format!("env resolution failed for {}: {e}", path.display()))?;
+            let parsed: McpFragment = toml::from_str(&resolved)
+                .map_err(|e| format!("TOML parse failed for {}: {e}", path.display()))?;
+            if let Some(mcp) = parsed.mcp {
+                merged.sanitize_schemas = mcp.sanitize_schemas;
+                merged.servers.extend(mcp.servers);
+            }
+        }
+        if merged.servers.is_empty() {
+            return Err("the current configuration defines no MCP servers; pass \
+                        `servers_toml` with the [mcp.servers.<name>] tables to inspect"
+                .to_string());
+        }
+        Ok(merged)
+    }
+}
+
+impl crate::RigTool for InspectMcpTool {
+    const NAME: &'static str = "inspect_mcp_servers";
+
+    type Error = BootstrapToolError;
+    type Args = InspectArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> crate::RigToolDefinition {
+        crate::RigToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Connect to MCP servers and list every tool they expose, with \
+                          name, description, and server-declared annotations (read-only / \
+                          destructive hints). Use this to verify connectivity and to \
+                          classify tools onto workers before writing the config. Pass \
+                          `servers_toml` for servers not yet in the configuration; omit \
+                          it to inspect the currently configured servers."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "servers_toml": {
+                        "type": "string",
+                        "description": "TOML with [mcp.servers.<name>] tables to inspect; \
+                                        omit to inspect the current configuration's servers"
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let mcp = match self.gather_mcp(args.servers_toml.as_deref()) {
+            Ok(m) => m,
+            Err(e) => return Ok(format!("INSPECT FAILED: {e}")),
+        };
+        if let Err(e) = check_stdio_policy(&mcp, self.allow_stdio) {
+            return Ok(format!("INSPECT REFUSED: {e}"));
+        }
+
+        let manager = match crate::McpManager::initialize_from_config(&mcp).await {
+            Ok(m) => m,
+            Err(e) => return Ok(format!("MCP discovery failed entirely: {e}")),
+        };
+
+        let mut report = String::from("MCP tool discovery report:\n");
+        let mut signals = self.signals.lock().expect("signal cache poisoned");
+        for (server, info) in &manager.server_info {
+            match &info.status {
+                crate::mcp::ConnectionStatus::Connected => {
+                    report.push_str(&format!(
+                        "\n## server '{server}' — connected, {} tool(s)\n",
+                        info.tools_count
+                    ));
+                    let tools = manager
+                        .streamable_tools
+                        .get(server)
+                        .or_else(|| manager.sse_tools.get(server))
+                        .or_else(|| manager.stdio_tools.get(server));
+                    for tool in tools.into_iter().flatten() {
+                        let signal = ToolSignal::of_tool(tool);
+                        let label = if signal.declared_mutating() {
+                            "MUTATING (annotated)"
+                        } else if signal.read_only == Some(true) {
+                            "read-only (annotated)"
+                        } else {
+                            "unannotated"
+                        };
+                        let description: String = tool
+                            .description
+                            .as_deref()
+                            .unwrap_or("(no description)")
+                            .chars()
+                            .take(140)
+                            .collect();
+                        report.push_str(&format!("- {} — {label} — {description}\n", tool.name));
+                        // Same-named tools on different servers merge
+                        // most-restrictive: one server's read-only annotation
+                        // must not mask another server's mutating one.
+                        signals
+                            .entry(tool.name.to_string())
+                            .and_modify(|existing| {
+                                *existing = existing.merge_most_restrictive(signal);
+                            })
+                            .or_insert(signal);
+                    }
+                }
+                crate::mcp::ConnectionStatus::Failed(err) => {
+                    report.push_str(&format!(
+                        "\n## server '{server}' — CONNECTION FAILED: {err}\n\
+                         Tell the operator and confirm the URL/auth before writing the config.\n"
+                    ));
+                }
+                other => {
+                    report.push_str(&format!("\n## server '{server}' — status: {other:?}\n"));
+                }
+            }
+        }
+        report.push_str(
+            "\nClassification rules: read-only workers (read_only = true) may only be \
+             assigned tools that are annotated read-only or unannotated-but-clearly-\
+             read-only, by exact name (no globs). Anything MUTATING, argument-dependent, \
+             or uncertain stays out of read-only workers. write_config enforces the \
+             annotated signals mechanically.",
+        );
+        Ok(report)
+    }
+}
+
+/// Reject stdio MCP servers unless the operator opted in via env.
+fn check_stdio_policy(mcp: &McpConfig, allow_stdio: bool) -> Result<(), String> {
+    if allow_stdio {
+        return Ok(());
+    }
+    let offenders: Vec<&str> = mcp
+        .servers
+        .iter()
+        .filter(|(_, s)| matches!(s, McpServerConfig::Stdio { .. }))
+        .map(|(name, _)| name.as_str())
+        .collect();
+    if offenders.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "stdio MCP transports spawn arbitrary processes on this server and are \
+         disabled for the bootstrap agent (server(s): {}). The operator can allow \
+         them by starting the server with {ALLOW_STDIO_ENV}=true, or add the \
+         server to the config file by hand.",
+        offenders.join(", ")
+    ))
+}
+
+// ============================================================================
+// write_config tool
+// ============================================================================
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct WriteConfigArgs {
+    /// The complete configuration file content (TOML). This replaces the
+    /// whole file — never a fragment.
+    pub content: String,
+    /// File to write in a directory deployment (plain *.toml name).
+    /// Omit for the default configuration file.
+    #[serde(default)]
+    pub file: Option<String>,
+    /// Validate only: run the full validation pipeline and report the
+    /// verdict without touching disk.
+    #[serde(default)]
+    pub validate_only: bool,
+}
+
+/// Validates and atomically writes the configuration, then triggers the
+/// host's hot reload.
+pub struct WriteConfigTool {
+    target: ConfigTarget,
+    reload: ReloadHook,
+    signals: SignalCache,
+    allow_stdio: bool,
+}
+
+impl WriteConfigTool {
+    pub fn new(
+        target: ConfigTarget,
+        reload: ReloadHook,
+        signals: SignalCache,
+        allow_stdio: bool,
+    ) -> Self {
+        Self {
+            target,
+            reload,
+            signals,
+            allow_stdio,
+        }
+    }
+
+    /// Mechanical backstop for the LLM's classification: workers declared
+    /// `read_only = true` may only list discovered tools that the server did
+    /// not declare mutating. Fails closed — every tool name in a read-only
+    /// worker's filter must have been returned by `inspect_mcp_servers` in
+    /// this conversation, so an empty discovery cache (model skipped
+    /// inspection, or the server restarted since) rejects the write instead
+    /// of waving the filter through. Glob/missing-filter rejection lives in
+    /// config validation (`OrchestrationConfig::validate_read_only_workers`).
+    fn enforce_read_only_workers(&self, config: &Config) -> Result<(), String> {
+        let signals = self.signals.lock().expect("signal cache poisoned");
+        let Some(orch) = config.orchestration.as_ref() else {
+            return Ok(());
+        };
+        for (worker_name, worker) in orch.workers.iter().filter(|(_, w)| w.read_only) {
+            for entry in worker.mcp_filter.iter().flatten() {
+                match signals.get(entry) {
+                    Some(signal) if signal.declared_mutating() => {
+                        return Err(format!(
+                            "tool '{entry}' is annotated as mutating/destructive by its \
+                             MCP server and cannot be assigned to read_only worker \
+                             '{worker_name}'"
+                        ));
+                    }
+                    Some(_) => {}
+                    None => {
+                        return Err(format!(
+                            "tool '{entry}' (assigned to read_only worker \
+                             '{worker_name}') has not been verified by \
+                             inspect_mcp_servers in this conversation — run \
+                             inspect_mcp_servers first and use exact discovered \
+                             tool names"
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Full validation pipeline. Returns the parsed (env-resolved) config
+    /// and any non-fatal warnings.
+    fn validate_candidate(
+        &self,
+        content: &str,
+        target_file: &Path,
+    ) -> Result<(Config, Vec<String>), String> {
+        // Syntax check on the raw body first, so malformed TOML is reported
+        // as a parse error rather than a misleading env-resolution failure.
+        let raw_value: toml::Value =
+            toml::from_str(content).map_err(|e| format!("TOML parse failed: {e}"))?;
+
+        // Secret-literal check runs on the RAW tree: api_key values must be
+        // env references (validation below sees them resolved).
+        check_secret_literals(&raw_value)?;
+
+        let resolved = aura_config::resolve_env_vars(content).map_err(|e| {
+            format!("env resolution failed: {e} (the variable must be set on this server)")
+        })?;
+        let config: Config =
+            toml::from_str(&resolved).map_err(|e| format!("TOML parse failed: {e}"))?;
+        config
+            .validate()
+            .map_err(|e| format!("validation failed: {e}"))?;
+
+        for candidate in [
+            Some(config.agent.name.as_str()),
+            config.agent.alias.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if candidate.eq_ignore_ascii_case(BOOTSTRAP_AGENT_NAME) {
+                return Err(format!(
+                    "'{BOOTSTRAP_AGENT_NAME}' is reserved for the bootstrap agent and \
+                     cannot be used as an agent name or alias"
+                ));
+            }
+        }
+
+        if let Some(mcp) = &config.mcp {
+            check_stdio_policy(mcp, self.allow_stdio)?;
+        }
+        self.enforce_read_only_workers(&config)?;
+
+        // Directory deployments: the candidate must stay uniquely
+        // identifiable next to its sibling files, and the full roster must
+        // pass bootstrap-specific invariants (reserved name already checked
+        // above for the candidate; this catches siblings and multi-enabler).
+        let mut roster_pairs: Vec<(PathBuf, Config)> =
+            vec![(target_file.to_path_buf(), config.clone())];
+        for path in self.target.config_files() {
+            if path == target_file {
+                continue;
+            }
+            let siblings = aura_config::load_config_with_paths(&path)
+                .map_err(|e| format!("sibling config {} failed to load: {e}", path.display()))?;
+            roster_pairs.extend(siblings);
+        }
+        let roster: Vec<Config> = roster_pairs.iter().map(|(_, c)| c.clone()).collect();
+        aura_config::validate_unique_identifiers(&roster).map_err(|e| e.to_string())?;
+        validate_roster(&roster_pairs)?;
+
+        let mut warnings = Vec::new();
+        let previously_enabled = fs::read_to_string(target_file)
+            .ok()
+            .and_then(|raw| toml::from_str::<toml::Value>(&raw).ok())
+            .and_then(|v| v.get("bootstrap")?.get("enabled")?.as_bool())
+            .unwrap_or(false);
+        let now_enabled = config.bootstrap.as_ref().is_some_and(|b| b.enabled);
+        if previously_enabled && !now_enabled {
+            warnings.push(
+                "this configuration no longer enables [bootstrap]: after the next \
+                 server restart the bootstrap agent will be unavailable"
+                    .to_string(),
+            );
+        }
+
+        Ok((config, warnings))
+    }
+
+    /// Validate, back up, and atomically write the file from the RAW input
+    /// (so `{{ env.* }}` references are written as references).
+    fn write(&self, args: &WriteConfigArgs) -> Result<String, String> {
+        let target_file = self.target.resolve_file(args.file.as_deref())?;
+        let (config, warnings) = self.validate_candidate(&args.content, &target_file)?;
+
+        let mode = if config.orchestration_enabled() {
+            let workers = config
+                .orchestration
+                .as_ref()
+                .map(|o| o.workers.len())
+                .unwrap_or(0);
+            format!("orchestration with {workers} worker(s)")
+        } else {
+            "single-agent".to_string()
+        };
+        let (provider, model) = config.agent.llm.model_info();
+        let mut summary = format!("agent '{}' ({provider}/{model}, {mode})", config.agent.name);
+        for w in &warnings {
+            summary.push_str(&format!("\nWARNING: {w}"));
+        }
+
+        if args.validate_only {
+            return Ok(format!(
+                "VALIDATION PASSED (nothing written): {summary}\n\
+                 Call write_config without validate_only to apply."
+            ));
+        }
+
+        if target_file.exists() {
+            let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
+            let backup = target_file.with_file_name(format!(
+                "{}.bak.{stamp}",
+                target_file
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("config.toml")
+            ));
+            fs::copy(&target_file, &backup)
+                .map_err(|e| format!("failed to back up to {}: {e}", backup.display()))?;
+            summary.push_str(&format!(
+                "\nPrevious config backed up to {}.",
+                backup.display()
+            ));
+        } else if let Some(parent) = target_file.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+        }
+        let tmp = target_file.with_extension(format!(
+            "toml.tmp.{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        fs::write(&tmp, &args.content)
+            .map_err(|e| format!("failed to write {}: {e}", tmp.display()))?;
+        if let Err(e) = fs::rename(&tmp, &target_file) {
+            let _ = fs::remove_file(&tmp);
+            return Err(format!("failed to move config into place: {e}"));
+        }
+        warn!(
+            "Bootstrap: configuration written to {}",
+            target_file.display()
+        );
+
+        match (self.reload)() {
+            Ok(applied) => Ok(format!(
+                "Configuration written to {} and applied: {summary}\n{applied}",
+                target_file.display()
+            )),
+            Err(e) => Ok(format!(
+                "Configuration written to {} ({summary}) but RELOAD FAILED: {e}\n\
+                 The running server is still serving the previous configuration. \
+                 Fix the problem and write again, or restore the backup.",
+                target_file.display()
+            )),
+        }
+    }
+}
+
+/// Reject literal secrets anywhere in the raw TOML tree: every string value
+/// under a credential-looking key (`api_key`, `*token*`, `*secret*`,
+/// `*password*`, `*authorization*`, …) must carry its secret as an
+/// `{{ env.VAR }}` reference. This covers `[mcp.servers.*.headers]` values
+/// and stdio `env` maps, not just `api_key` fields. Values may mix text and
+/// references (`Authorization = "Bearer {{ env.TOKEN }}"`) — what matters is
+/// that the secret itself travels as a reference.
+///
+/// `headers_from_request` tables are exempt: their values are *names* of
+/// incoming request headers, never secrets.
+fn check_secret_literals(value: &toml::Value) -> Result<(), String> {
+    fn contains_env_reference(s: &str) -> bool {
+        s.find("{{")
+            .is_some_and(|start| s[start + 2..].trim_start().starts_with("env."))
+            && s.contains("}}")
+    }
+    fn credential_key(key: &str) -> bool {
+        let k = key.to_ascii_lowercase().replace('-', "_");
+        ["api_key", "apikey", "token", "secret", "password", "authorization", "credential"]
+            .iter()
+            .any(|marker| k.contains(marker))
+    }
+    fn walk(value: &toml::Value, path: &str, violations: &mut Vec<String>) {
+        match value {
+            toml::Value::Table(table) => {
+                for (key, v) in table {
+                    if key == "headers_from_request" {
+                        continue;
+                    }
+                    let child = if path.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{path}.{key}")
+                    };
+                    if credential_key(key)
+                        && let toml::Value::String(s) = v
+                        && !s.is_empty()
+                        && !contains_env_reference(s)
+                    {
+                        violations.push(child.clone());
+                    }
+                    walk(v, &child, violations);
+                }
+            }
+            toml::Value::Array(items) => {
+                for (i, v) in items.iter().enumerate() {
+                    walk(v, &format!("{path}[{i}]"), violations);
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut violations = Vec::new();
+    walk(value, "", &mut violations);
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "literal API key(s)/secret(s) at {} — secrets must be written as \
+             {{{{ env.VAR_NAME }}}} references to variables set on this server, \
+             never inline",
+            violations.join(", ")
+        ))
+    }
+}
+
+impl crate::RigTool for WriteConfigTool {
+    const NAME: &'static str = "write_config";
+
+    type Error = BootstrapToolError;
+    type Args = WriteConfigArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> crate::RigToolDefinition {
+        crate::RigToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Validate the complete configuration file content and write it to \
+                          disk (replacing the whole file; the previous version is backed up \
+                          with a timestamp). On success the running server applies it \
+                          immediately. On validation failure nothing is written and the \
+                          errors are returned so you can fix the content and call this tool \
+                          again. Set validate_only to check a draft without writing."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "description": "The complete configuration file (TOML), with secrets \
+                                        as {{ env.VAR }} references"
+                    },
+                    "file": {
+                        "type": "string",
+                        "description": "Specific *.toml file in a directory deployment; \
+                                        omit for the default configuration file"
+                    },
+                    "validate_only": {
+                        "type": "boolean",
+                        "description": "Validate and report without writing (default false)"
+                    }
+                },
+                "required": ["content"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        match self.write(&args) {
+            Ok(message) => Ok(message),
+            Err(e) => Ok(format!(
+                "WRITE_CONFIG FAILED — nothing was changed.\n\n{e}\n\n\
+                 Fix the configuration and call write_config again. Remember that \
+                 `{{{{ env.VAR }}}}` references must name variables that are set on \
+                 this server."
+            )),
+        }
+    }
+}
+
+// ============================================================================
+// Bootstrap agent assembly
+// ============================================================================
+
+/// Build the served bootstrap agent's config from the `[bootstrap]`-declaring
+/// config.
+///
+/// The agent runs on `[bootstrap].llm` when set, otherwise the declaring
+/// file's `[agent.llm]`. Everything else from the declaring config —
+/// orchestration, MCP servers, vector stores, scratchpad, client tools — is
+/// stripped: the bootstrap agent talks to the operator and manages
+/// configuration, nothing else.
+pub fn bootstrap_agent_config(
+    declaring: &Config,
+    target: &ConfigTarget,
+    roster: &[String],
+) -> Config {
+    let mut config = declaring.clone();
+    config.agent.name = BOOTSTRAP_AGENT_NAME.to_string();
+    config.agent.alias = None;
+    config.agent.turn_depth = Some(8);
+    if let Some(llm) = declaring.bootstrap.as_ref().and_then(|b| b.llm.clone()) {
+        config.agent.llm = llm;
+    }
+    config.agent.system_prompt = format!(
+        "{}\n{}",
+        BOOTSTRAP_PROMPT.trim_end(),
+        instance_context(target, roster)
+    );
+    config.agent.context = Vec::new();
+    config.agent.mcp_filter = None;
+    config.agent.enable_client_tools = false;
+    config.agent.client_tool_filter = None;
+    config.agent.scratchpad = None;
+    config.agent.skills = Default::default();
+    config.memory_dir = None;
+    config.orchestration = None;
+    config.mcp = None;
+    config.tools = None;
+    config.vector_stores = Vec::new();
+    config.hitl = None;
+    config.bootstrap = None;
+
+    let (provider, model) = config.agent.llm.model_info();
+    info!(
+        "Bootstrap agent ready on {provider}/{model}; configuration target: {}",
+        target.target.display()
+    );
+    config
+}
+
+/// Instance-specific context appended to the bootstrap prompt.
+fn instance_context(target: &ConfigTarget, roster: &[String]) -> String {
+    let mut out = String::from("\n## This instance\n\n");
+    if target.is_dir() {
+        out.push_str(&format!(
+            "- Configuration directory: `{}`; your default write target is \
+             `{}` (use the `file` argument for sibling files).\n",
+            target.config_path.display(),
+            target.target.display()
+        ));
+    } else {
+        out.push_str(&format!(
+            "- Configuration file: `{}`\n",
+            target.target.display()
+        ));
+    }
+    out.push_str(
+        "- Successful writes are applied immediately by the running server \
+         (hot reload); this conversation continues across changes.\n",
+    );
+    if roster.is_empty() {
+        out.push_str("- No agents are currently configured.\n");
+    } else {
+        out.push_str(&format!(
+            "- Agents currently served: {}\n",
+            roster.join(", ")
+        ));
+    }
+    out.push_str(&format!(
+        "- stdio MCP transports: {}\n",
+        if stdio_allowed_from_env() {
+            "ALLOWED (the operator set AURA_BOOTSTRAP_ALLOW_STDIO=true)"
+        } else {
+            "disabled (AURA_BOOTSTRAP_ALLOW_STDIO is not set)"
+        }
+    ));
+    out.push_str(
+        "- Environment variables currently set on this server (presence only; \
+         values are never shown):\n",
+    );
+    for var in KNOWN_KEY_VARS {
+        let mark = if std::env::var(var).is_ok() {
+            "set"
+        } else {
+            "not set"
+        };
+        out.push_str(&format!("  - {var}: {mark}\n"));
+    }
+    out
+}
+
+/// Validate a loaded roster against bootstrap-specific invariants:
+///
+/// 1. No roster agent may use the reserved `BOOTSTRAP_AGENT_NAME`.
+/// 2. At most one config may enable `[bootstrap]`.
+///
+/// Called by both startup paths and both reload hooks so the invariants
+/// are enforced uniformly regardless of how the roster was loaded.
+pub fn validate_roster(configs: &[(impl AsRef<std::path::Path>, Config)]) -> Result<(), String> {
+    // Reserved name
+    if let Some((_, config)) = configs.iter().find(|(_, c)| {
+        [Some(c.agent.name.as_str()), c.agent.alias.as_deref()]
+            .into_iter()
+            .flatten()
+            .any(|id| id.eq_ignore_ascii_case(BOOTSTRAP_AGENT_NAME))
+    }) {
+        return Err(format!(
+            "agent '{}' uses the reserved name '{BOOTSTRAP_AGENT_NAME}'",
+            config.agent.name,
+        ));
+    }
+    // Single enabler
+    let enablers: Vec<String> = configs
+        .iter()
+        .filter(|(_, c)| c.bootstrap.as_ref().is_some_and(|b| b.enabled))
+        .map(|(p, _)| p.as_ref().display().to_string())
+        .collect();
+    if enablers.len() > 1 {
+        return Err(format!(
+            "[bootstrap] is enabled in more than one config file ({}) — enable it \
+             in exactly one so the bootstrap agent's LLM and write target are \
+             unambiguous",
+            enablers.join(", ")
+        ));
+    }
+    Ok(())
+}
+
+/// Factory for the bootstrap agent's tools, in the shape
+/// `AppState.additional_tools` expects.
+///
+/// The discovery signal cache is created here, outside the per-request
+/// closure, so classification survives across conversation rounds. The
+/// stdio policy is read from the environment once at startup.
+pub fn bootstrap_tools_factory(
+    target: ConfigTarget,
+    reload: ReloadHook,
+) -> Arc<dyn Fn() -> Vec<Box<dyn crate::ToolDyn>> + Send + Sync> {
+    let signals: SignalCache = SignalCache::default();
+    let allow_stdio = stdio_allowed_from_env();
+    Arc::new(move || {
+        vec![
+            Box::new(ReadConfigTool::new(target.clone())) as Box<dyn crate::ToolDyn>,
+            Box::new(InspectMcpTool::new(
+                target.clone(),
+                signals.clone(),
+                allow_stdio,
+            )) as Box<dyn crate::ToolDyn>,
+            Box::new(WriteConfigTool::new(
+                target.clone(),
+                reload.clone(),
+                signals.clone(),
+                allow_stdio,
+            )) as Box<dyn crate::ToolDyn>,
+        ]
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RigTool as _;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Complete config with no env-var or API-key dependencies (ollama).
+    const COMPLETE: &str = r#"
+[agent]
+name = "assistant"
+system_prompt = "You are helpful."
+
+[agent.llm]
+provider = "ollama"
+model = "qwen3:8b"
+
+[bootstrap]
+enabled = true
+"#;
+
+    fn target_with(dir: &Path, content: &str) -> ConfigTarget {
+        let path = dir.join("config.toml");
+        fs::write(&path, content).unwrap();
+        ConfigTarget::single_file(path)
+    }
+
+    fn noop_reload() -> ReloadHook {
+        Arc::new(|| Ok("reloaded".to_string()))
+    }
+
+    fn write_tool(target: ConfigTarget) -> WriteConfigTool {
+        WriteConfigTool::new(target, noop_reload(), SignalCache::default(), false)
+    }
+
+    fn write_args(content: &str) -> WriteConfigArgs {
+        WriteConfigArgs {
+            content: content.to_string(),
+            file: None,
+            validate_only: false,
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // write_config
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn write_rejects_incomplete_config_without_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+
+        // No system_prompt: strict serde must reject it.
+        let result = write_tool(target)
+            .call(write_args(
+                "[agent]\nname = \"x\"\n\n[agent.llm]\nprovider = \"ollama\"\nmodel = \"m\"",
+            ))
+            .await
+            .unwrap();
+
+        assert!(result.contains("WRITE_CONFIG FAILED"), "got: {result}");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("config.toml")).unwrap(),
+            COMPLETE
+        );
+    }
+
+    #[tokio::test]
+    async fn write_applies_and_backs_up_with_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let updated = COMPLETE.replace("You are helpful.", "You are terse.");
+
+        let result = write_tool(target).call(write_args(&updated)).await.unwrap();
+
+        assert!(result.contains("written to"), "got: {result}");
+        assert!(result.contains("reloaded"), "got: {result}");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("config.toml")).unwrap(),
+            updated
+        );
+        let backups: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with("config.toml.bak."))
+            .collect();
+        assert_eq!(backups.len(), 1, "backups: {backups:?}");
+        let backup_content = fs::read_to_string(dir.path().join(&backups[0])).unwrap();
+        assert_eq!(backup_content, COMPLETE);
+    }
+
+    #[tokio::test]
+    async fn validate_only_writes_nothing_and_skips_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let reloads = Arc::new(AtomicUsize::new(0));
+        let counter = reloads.clone();
+        let hook: ReloadHook = Arc::new(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok("reloaded".to_string())
+        });
+        let tool = WriteConfigTool::new(target, hook, SignalCache::default(), false);
+
+        let result = tool
+            .call(WriteConfigArgs {
+                content: COMPLETE.replace("helpful", "terse"),
+                file: None,
+                validate_only: true,
+            })
+            .await
+            .unwrap();
+
+        assert!(result.contains("VALIDATION PASSED"), "got: {result}");
+        assert_eq!(reloads.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            fs::read_to_string(dir.path().join("config.toml")).unwrap(),
+            COMPLETE
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_failure_is_reported_but_file_is_written() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let hook: ReloadHook = Arc::new(|| Err("boom".to_string()));
+        let tool = WriteConfigTool::new(target, hook, SignalCache::default(), false);
+        let updated = COMPLETE.replace("helpful", "terse");
+
+        let result = tool.call(write_args(&updated)).await.unwrap();
+
+        assert!(result.contains("RELOAD FAILED: boom"), "got: {result}");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("config.toml")).unwrap(),
+            updated
+        );
+    }
+
+    #[tokio::test]
+    async fn write_rejects_literal_api_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let content = r#"
+[agent]
+name = "assistant"
+system_prompt = "You are helpful."
+
+[agent.llm]
+provider = "openai"
+api_key = "sk-proj-abc123"
+model = "gpt-5.1"
+"#;
+
+        let result = write_tool(target).call(write_args(content)).await.unwrap();
+
+        assert!(result.contains("literal API key"), "got: {result}");
+        assert!(result.contains("agent.llm.api_key"), "got: {result}");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("config.toml")).unwrap(),
+            COMPLETE
+        );
+    }
+
+    #[tokio::test]
+    async fn write_rejects_literal_secret_in_mcp_headers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let content = format!(
+            "{COMPLETE}\n[mcp.servers.k8s]\ntransport = \"http_streamable\"\n\
+             url = \"http://x/mcp\"\n\n[mcp.servers.k8s.headers]\n\
+             Authorization = \"Bearer sk-live-abc123\"\n"
+        );
+
+        let result = write_tool(target).call(write_args(&content)).await.unwrap();
+
+        assert!(result.contains("literal API key(s)/secret(s)"), "got: {result}");
+        assert!(
+            result.contains("mcp.servers.k8s.headers.Authorization"),
+            "got: {result}"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.path().join("config.toml")).unwrap(),
+            COMPLETE
+        );
+    }
+
+    #[test]
+    fn secret_scan_covers_credential_keys_and_allows_references() {
+        let check = |toml_str: &str| {
+            check_secret_literals(&toml::from_str::<toml::Value>(toml_str).unwrap())
+        };
+
+        // Credential-looking keys with literals are rejected wherever they sit.
+        for bad in [
+            "[mcp.servers.x.headers]\n\"x-api-key\" = \"abc\"",
+            "[mcp.servers.x.env]\nOPENAI_API_KEY = \"sk-123\"",
+            "[mcp.servers.x.headers]\nProxy-Authorization = \"Basic xyz\"",
+            "[a]\nmy_token = \"t\"",
+            "[a]\nclient_secret = \"s\"",
+            "[a]\ndb_password = \"p\"",
+        ] {
+            assert!(check(bad).is_err(), "expected rejection for: {bad}");
+        }
+
+        // References (whole-value or embedded) pass; so do non-credential
+        // values and headers_from_request name mappings.
+        for ok in [
+            "[a]\napi_key = \"{{ env.OPENAI_API_KEY }}\"",
+            "[mcp.servers.x.headers]\nAuthorization = \"Bearer {{ env.TOKEN }}\"",
+            "[mcp.servers.x.headers]\nContent-Type = \"application/json\"",
+            "[mcp.servers.x.env]\nAWS_REGION = \"us-east-1\"",
+            "[mcp.servers.x.headers_from_request]\nAuthorization = \"x-user-token\"",
+        ] {
+            assert!(check(ok).is_ok(), "expected pass for: {ok}");
+        }
+    }
+
+    #[tokio::test]
+    async fn write_rejects_unresolvable_env_reference() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let content = r#"
+[agent]
+name = "assistant"
+system_prompt = "You are helpful."
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.DEFINITELY_NOT_SET_AURA_TEST_VAR }}"
+model = "gpt-5.1"
+"#;
+
+        let result = write_tool(target).call(write_args(content)).await.unwrap();
+
+        assert!(result.contains("env resolution failed"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn write_rejects_reserved_bootstrap_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let content = COMPLETE.replace("name = \"assistant\"", "name = \"AURA-Bootstrap\"");
+
+        let result = write_tool(target).call(write_args(&content)).await.unwrap();
+
+        assert!(result.contains("reserved"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn write_rejects_stdio_server_unless_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let content =
+            format!("{COMPLETE}\n[mcp.servers.local]\ntransport = \"stdio\"\ncmd = [\"npx\"]\n");
+
+        let target = target_with(dir.path(), COMPLETE);
+        let result = write_tool(target.clone())
+            .call(write_args(&content))
+            .await
+            .unwrap();
+        assert!(result.contains("stdio MCP transports"), "got: {result}");
+
+        // Same content passes when the operator allowed stdio.
+        let tool = WriteConfigTool::new(target, noop_reload(), SignalCache::default(), true);
+        let result = tool.call(write_args(&content)).await.unwrap();
+        assert!(result.contains("written to"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn write_warns_when_bootstrap_gets_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let content = COMPLETE.replace("enabled = true", "enabled = false");
+
+        let result = write_tool(target).call(write_args(&content)).await.unwrap();
+
+        assert!(
+            result.contains("no longer enables [bootstrap]"),
+            "got: {result}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // read_only worker enforcement
+    // ------------------------------------------------------------------
+
+    fn cache_with(entries: &[(&str, ToolSignal)]) -> SignalCache {
+        let cache = SignalCache::default();
+        {
+            let mut guard = cache.lock().unwrap();
+            for (name, signal) in entries {
+                guard.insert(name.to_string(), *signal);
+            }
+        }
+        cache
+    }
+
+    fn worker_config(filter_entry: &str, read_only: bool) -> String {
+        format!(
+            "{COMPLETE}\n[orchestration]\nenabled = true\n\n\
+             [orchestration.worker.watcher]\n\
+             description = \"d\"\npreamble = \"p\"\nread_only = {read_only}\n\
+             mcp_filter = [\"{filter_entry}\"]\n"
+        )
+    }
+
+    const READ_ONLY_LIST: ToolSignal = ToolSignal {
+        read_only: Some(true),
+        destructive: None,
+    };
+    const MUTATING: ToolSignal = ToolSignal {
+        read_only: Some(false),
+        destructive: Some(true),
+    };
+
+    #[tokio::test]
+    async fn backstop_rejects_annotated_mutating_tool_in_read_only_worker() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let cache = cache_with(&[("list_pods", READ_ONLY_LIST), ("restart_pod", MUTATING)]);
+        let tool = WriteConfigTool::new(target, noop_reload(), cache, false);
+
+        let result = tool
+            .call(write_args(&worker_config("restart_pod", true)))
+            .await
+            .unwrap();
+
+        assert!(result.contains("annotated as mutating"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn backstop_rejects_undiscovered_tool() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let cache = cache_with(&[("list_pods", READ_ONLY_LIST)]);
+        let tool = WriteConfigTool::new(target, noop_reload(), cache, false);
+
+        let result = tool
+            .call(write_args(&worker_config("hallucinated_tool", true)))
+            .await
+            .unwrap();
+
+        assert!(
+            result.contains("has not been verified by inspect_mcp_servers"),
+            "got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn backstop_fails_closed_when_discovery_never_ran() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        // Empty signal cache: inspect_mcp_servers was never called.
+        let tool = write_tool(target);
+
+        let result = tool
+            .call(write_args(&worker_config("list_pods", true)))
+            .await
+            .unwrap();
+
+        assert!(
+            result.contains("has not been verified by inspect_mcp_servers"),
+            "got: {result}"
+        );
+    }
+
+    #[test]
+    fn signal_merge_keeps_mutating_across_servers() {
+        // Server A says mutating, server B says read-only: mutating wins
+        // regardless of discovery order.
+        assert!(MUTATING.merge_most_restrictive(READ_ONLY_LIST).declared_mutating());
+        assert!(READ_ONLY_LIST.merge_most_restrictive(MUTATING).declared_mutating());
+        // Agreement on read-only survives the merge.
+        assert!(
+            !READ_ONLY_LIST
+                .merge_most_restrictive(READ_ONLY_LIST)
+                .declared_mutating()
+        );
+        // Read-only + unannotated degrades to unannotated (no positive claim).
+        let merged = READ_ONLY_LIST.merge_most_restrictive(ToolSignal::default());
+        assert_eq!(merged.read_only, None);
+    }
+
+    #[tokio::test]
+    async fn backstop_rejects_globs_in_read_only_worker() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let cache = cache_with(&[("list_pods", READ_ONLY_LIST)]);
+        let tool = WriteConfigTool::new(target, noop_reload(), cache, false);
+
+        let result = tool
+            .call(write_args(&worker_config("list_*", true)))
+            .await
+            .unwrap();
+
+        assert!(result.contains("not glob patterns"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn backstop_ignores_workers_not_marked_read_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let cache = cache_with(&[("list_pods", READ_ONLY_LIST), ("restart_pod", MUTATING)]);
+        let tool = WriteConfigTool::new(target, noop_reload(), cache, false);
+
+        // Mutating tool + glob on a NON-read-only worker: allowed.
+        let result = tool
+            .call(write_args(&worker_config("restart_pod", false)))
+            .await
+            .unwrap();
+
+        assert!(result.contains("written to"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn backstop_allows_discovered_read_only_tool() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let cache = cache_with(&[("list_pods", READ_ONLY_LIST)]);
+        let tool = WriteConfigTool::new(target, noop_reload(), cache, false);
+
+        let result = tool
+            .call(write_args(&worker_config("list_pods", true)))
+            .await
+            .unwrap();
+
+        assert!(result.contains("written to"), "got: {result}");
+    }
+
+    // ------------------------------------------------------------------
+    // directory deployments
+    // ------------------------------------------------------------------
+
+    fn dir_target(dir: &Path) -> ConfigTarget {
+        fs::write(dir.join("main.toml"), COMPLETE).unwrap();
+        fs::write(
+            dir.join("other.toml"),
+            COMPLETE
+                .replace("name = \"assistant\"", "name = \"other\"")
+                .replace("enabled = true", "enabled = false"),
+        )
+        .unwrap();
+        ConfigTarget {
+            config_path: dir.to_path_buf(),
+            target: dir.join("main.toml"),
+        }
+    }
+
+    #[tokio::test]
+    async fn write_rejects_duplicate_identifier_across_siblings() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir_target(dir.path());
+        let content = COMPLETE.replace("name = \"assistant\"", "name = \"other\"");
+
+        let result = write_tool(target).call(write_args(&content)).await.unwrap();
+
+        assert!(result.contains("WRITE_CONFIG FAILED"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn write_file_arg_targets_sibling_and_rejects_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir_target(dir.path());
+        let updated = COMPLETE
+            .replace("name = \"assistant\"", "name = \"other\"")
+            .replace("You are helpful.", "You are other.")
+            .replace("enabled = true", "enabled = false");
+
+        let tool = write_tool(target.clone());
+        let result = tool
+            .call(WriteConfigArgs {
+                content: updated.clone(),
+                file: Some("other.toml".to_string()),
+                validate_only: false,
+            })
+            .await
+            .unwrap();
+        assert!(result.contains("written to"), "got: {result}");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("other.toml")).unwrap(),
+            updated
+        );
+
+        for bad in ["../evil.toml", "/etc/evil.toml", "evil.txt"] {
+            let result = tool
+                .call(WriteConfigArgs {
+                    content: COMPLETE.to_string(),
+                    file: Some(bad.to_string()),
+                    validate_only: false,
+                })
+                .await
+                .unwrap();
+            assert!(
+                result.contains("WRITE_CONFIG FAILED"),
+                "expected rejection for {bad}, got: {result}"
+            );
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // read_config
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn read_config_returns_raw_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+
+        let result = ReadConfigTool::new(target)
+            .call(ReadConfigArgs { file: None })
+            .await
+            .unwrap();
+
+        assert!(result.contains("You are helpful."), "got: {result}");
+        assert!(result.contains("config.toml"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn read_config_lists_directory_and_rejects_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir_target(dir.path());
+        let tool = ReadConfigTool::new(target);
+
+        let result = tool.call(ReadConfigArgs { file: None }).await.unwrap();
+        assert!(result.contains("main.toml"), "got: {result}");
+        assert!(result.contains("other.toml"), "got: {result}");
+
+        let result = tool
+            .call(ReadConfigArgs {
+                file: Some("../secret.toml".to_string()),
+            })
+            .await
+            .unwrap();
+        assert!(result.contains("READ_CONFIG FAILED"), "got: {result}");
+    }
+
+    // ------------------------------------------------------------------
+    // inspect_mcp_servers (offline paths)
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn inspect_refuses_stdio_fragment_unless_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let tool = InspectMcpTool::new(target, SignalCache::default(), false);
+
+        let result = tool
+            .call(InspectArgs {
+                servers_toml: Some(
+                    "[mcp.servers.local]\ntransport = \"stdio\"\ncmd = [\"npx\"]\n".to_string(),
+                ),
+            })
+            .await
+            .unwrap();
+
+        assert!(result.contains("INSPECT REFUSED"), "got: {result}");
+        assert!(result.contains(ALLOW_STDIO_ENV), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn inspect_without_servers_reports_helpfully() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = target_with(dir.path(), COMPLETE);
+        let tool = InspectMcpTool::new(target, SignalCache::default(), false);
+
+        let result = tool.call(InspectArgs { servers_toml: None }).await.unwrap();
+
+        assert!(result.contains("INSPECT FAILED"), "got: {result}");
+        assert!(result.contains("servers_toml"), "got: {result}");
+    }
+
+    // ------------------------------------------------------------------
+    // bootstrap agent assembly
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn bootstrap_agent_inherits_declaring_llm_without_baggage() {
+        let declaring: Config = toml::from_str(
+            &format!("{COMPLETE}\n[mcp.servers.k8s]\ntransport = \"http_streamable\"\nurl = \"http://x/mcp\"\n"),
+        )
+        .unwrap();
+        let target = ConfigTarget::single_file("/tmp/config.toml");
+
+        let agent = bootstrap_agent_config(&declaring, &target, &["assistant".to_string()]);
+
+        assert_eq!(agent.agent.name, BOOTSTRAP_AGENT_NAME);
+        assert_eq!(agent.agent.llm.model_info(), ("ollama", "qwen3:8b"));
+        assert!(agent.mcp.is_none());
+        assert!(agent.orchestration.is_none());
+        assert!(agent.bootstrap.is_none());
+        assert!(!agent.agent.enable_client_tools);
+        assert!(agent.agent.system_prompt.contains("/tmp/config.toml"));
+        assert!(agent.agent.system_prompt.contains("assistant"));
+    }
+
+    #[test]
+    fn bootstrap_agent_prefers_bootstrap_llm_override() {
+        let declaring: Config = toml::from_str(&format!(
+            "{COMPLETE}\n[bootstrap.llm]\nprovider = \"ollama\"\nmodel = \"qwen3:32b\"\n"
+        ))
+        .unwrap();
+        let target = ConfigTarget::single_file("/tmp/config.toml");
+
+        let agent = bootstrap_agent_config(&declaring, &target, &[]);
+
+        assert_eq!(agent.agent.llm.model_info(), ("ollama", "qwen3:32b"));
+    }
+}

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod approval_event_broker;
 pub mod bedrock_embedding;
+pub mod bootstrap;
 pub mod builder;
 pub mod config;
 pub mod env_flags;

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod approval_event_broker;
 pub mod approver_headers;
 pub mod bedrock_embedding;
+pub mod bootstrap;
 pub mod builder;
 pub mod config;
 pub mod env_flags;

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -4486,6 +4486,7 @@ mod tests {
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
         workers.insert(
@@ -4499,6 +4500,7 @@ mod tests {
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
 
@@ -4564,6 +4566,7 @@ mod tests {
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
 
@@ -4579,6 +4582,7 @@ mod tests {
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
 
@@ -4594,6 +4598,7 @@ mod tests {
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
 
@@ -4728,6 +4733,7 @@ mod tests {
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
 

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -4636,6 +4636,7 @@ mod tests {
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
         workers.insert(
@@ -4649,6 +4650,7 @@ mod tests {
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
 
@@ -4714,6 +4716,7 @@ mod tests {
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
 
@@ -4729,6 +4732,7 @@ mod tests {
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
 
@@ -4744,6 +4748,7 @@ mod tests {
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
 
@@ -4878,6 +4883,7 @@ mod tests {
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
 

--- a/crates/aura/src/orchestration/templates.rs
+++ b/crates/aura/src/orchestration/templates.rs
@@ -386,6 +386,7 @@ Always verify your calculations before reporting results."
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
         workers.insert(
@@ -412,6 +413,7 @@ TOOL USAGE:
                 llm: None,
                 scratchpad: None,
                 skills: None,
+                read_only: false,
             },
         );
 

--- a/crates/aura/src/prompts/bootstrap_prompt.md
+++ b/crates/aura/src/prompts/bootstrap_prompt.md
@@ -1,0 +1,246 @@
+# AURA Configuration Assistant
+
+You are `aura-bootstrap`, the built-in configuration assistant for this
+AURA instance. Your job is to build a sane configuration for the operator
+and to make good suggestions — for first-time setup and for later changes
+alike. You read, validate, and write this instance's configuration file
+using your tools; successful writes are applied immediately by the running
+server (hot reload), so this conversation continues across changes.
+
+Start every conversation by calling `read_config` so you know what
+currently exists. If the configuration is a fresh starter config from
+`aura init`, run first-time setup (below). Otherwise treat the
+request as a targeted modification of what is already there.
+
+When the conversation starts, briefly orient the operator: say what you
+can help with (build a new agent, connect MCP tool servers, add workers,
+adjust prompts, switch models) so they know the scope. Keep it to 2–3
+lines, not a menu. You are here to help them get a working agent — lead
+with that.
+
+## You are here to protect the operator's systems
+
+State this plainly when you propose a setup, and act on it throughout:
+
+- **Read-only by default.** Workers you create get `read_only = true`
+  unless the operator explicitly asks for an agent that executes changes.
+  A read-only worker missing a tool is an inconvenience; a read-only
+  worker with a mutating tool is an incident.
+- **You never allowlist mutating tools onto read-only workers** — and the
+  `write_config` tool enforces this mechanically, so you could not do it
+  even by mistake. Say so when you present tool assignments.
+- Agents that mutate infrastructure (restarts, scaling, deletes, applies)
+  are created only on an explicit operator request, and you confirm the
+  blast radius with them before writing.
+
+## First-time setup
+
+Lead with a suggestion, not an interrogation. Propose a complete setup up
+front — a single agent with a clear system prompt you draft from the
+operator's stated purpose, read-only posture, no tools until servers are
+known — then ask what to adjust. Be brief: at most 2–3 questions per
+turn, each with a default the operator can accept by just saying "yes".
+
+Gather, in this order (skip anything already decided):
+
+1. **Purpose** — what is this agent for, and how should it behave? You
+   write the system prompt yourself from the answer; show it and let the
+   operator edit. Do not ask the operator to author prompts. Give the
+   agent a short, descriptive name derived from its purpose (e.g.
+   "k8s-sre", "log-analyst", "incident-responder") — never leave it as
+   the placeholder "assistant". The name is the model ID that clients
+   use to address this agent.
+2. **MCP servers** — the tool servers to connect: name, URL, transport,
+   and auth headers (as `{{ env.VAR }}` references). If the operator
+   doesn't have MCP servers yet, that's fine — say so honestly. An agent
+   is useful without tools (it can reason, investigate, and advise), and
+   you can wire MCP servers later. Don't make it feel like a dead end.
+3. **Workers** (only when the job benefits from specialists or the
+   operator asks): draft `description` and `preamble` yourself, mark them
+   `read_only = true` by default, and assign tools via classification
+   (below).
+4. **Mutating capability** — ask whether the agent may execute changes.
+   Default is NO: agents diagnose and recommend; a human executes.
+
+Then: classify tools, summarize the configuration in plain language (see
+"Pre-write confirmation" below), get an explicit confirmation, and call
+`write_config`.
+
+## Pre-write confirmation
+
+Before calling `write_config`, show a **plain-language summary** — not
+the raw TOML. Users don't read TOML; they need to understand what the
+agent will do. Include:
+
+- What the agent does (one sentence from the system prompt)
+- Which provider/model it runs on
+- If orchestration: the workers, what each one does, and which are
+  read-only vs. have mutation capability
+- Which MCP servers are connected and what tools they provide
+- The file path where the config will be written
+
+Then ask for confirmation. If the operator wants to see or edit the
+system prompt you drafted, offer to show it — but don't dump it
+unprompted.
+
+Do **not** echo the full TOML unless the operator asks for it.
+
+## After a successful write
+
+Don't go silent. After `write_config` succeeds, end with a **call to
+action** — tell the operator what they can do next:
+
+- **Try the new agent**: "Switch to your agent with `/model <name>` and
+  start chatting." (Or if they're on the web server: send requests with
+  `model: "<name>"`.)
+- **Keep building**: "You can add MCP tool servers, add workers, or
+  adjust the system prompt — just tell me what to change."
+- **Come back later**: "This bootstrap agent stays available as
+  `aura-bootstrap`. You can return anytime to make changes."
+
+Don't print a receipt and go quiet. The operator should never wonder
+"now what?"
+
+## Day-2 changes
+
+For requests like "add this MCP server", "tighten the allowlist", or
+"rename the agent": `read_config`, make the smallest change that
+satisfies the request, show the operator what will change (quote the
+affected sections before/after), confirm, then write the **full**
+updated file — `write_config` replaces the whole file, never a fragment.
+Every write creates a timestamped backup alongside the file, so mistakes
+are recoverable; mention this when relevant.
+
+## Tool classification
+
+After MCP servers are settled — and before proposing tool assignments —
+call `inspect_mcp_servers`. It connects to each server (verifying the
+operator's URLs and auth actually work) and lists every tool with its
+description and server-declared annotations (read-only / destructive
+hints).
+
+Assign tools to workers via explicit `mcp_filter` lists. For workers
+marked `read_only = true`, list exact tool names — glob patterns are
+rejected for them.
+
+Risk rules, in priority order:
+
+1. Server annotations are authoritative restrictions: a tool annotated
+   MUTATING can never go to a read-only worker. `write_config` enforces
+   this mechanically — you cannot override it.
+2. A tool whose effect depends on its arguments (exec, run-query,
+   raw-request style tools) counts as mutating, even if it can be used
+   read-only.
+3. When uncertain, classify as mutating.
+
+Show the operator the proposed assignment — worker → tool list, plus the
+tools you deliberately left out of read-only workers and why — and
+repeat that no mutating tools were allowlisted. Note that tools a server
+adds later will NOT be picked up by explicit lists until the config is
+edited again; that is intentional (fail-closed).
+
+If a server is unreachable, tell the operator and confirm the URL/auth
+before writing. Only proceed without classification if the operator
+explicitly insists; warn that tool scoping is then unverified.
+
+## Hard rules
+
+- **Never inline secrets.** API keys and tokens are written only as
+  `{{ env.VAR_NAME }}` references. If the operator pastes a raw secret
+  into the chat, do not echo it back and do not write it into the config
+  — ask them to export it as an environment variable on this server and
+  reference it by name. The variable must be set in **this server
+  process's** environment; the "This instance" section below lists which
+  well-known variables are set. `write_config` rejects literal keys.
+- Only call `write_config` with content the operator has confirmed
+  (`validate_only = true` lets you check a draft without writing).
+- If `write_config` reports a validation error, fix the TOML yourself
+  and call it again. Do not ask the operator to debug TOML syntax.
+- Do not invent MCP server URLs or env var names — ask.
+- Never name an agent `aura-bootstrap` (reserved; rejected mechanically).
+- **This assistant is controlled by the `[bootstrap]` section.** When it
+  is enabled, anyone with the token can rewrite the entire config — it is
+  a standing admin surface. Changes to `[bootstrap]` (enabling/disabling,
+  its LLM) take effect on the next server restart, not immediately.
+  Warn the operator before writing a config that disables it: after the
+  next restart, configuration changes will require editing TOML by hand.
+
+## Configuration reference
+
+A complete minimal configuration:
+
+```toml
+[agent]
+name = "my-agent"
+system_prompt = """
+(the prompt you drafted)
+"""
+
+[agent.llm]
+provider = "openai"                       # openai | anthropic | bedrock | gemini | ollama | openrouter
+api_key = "{{ env.OPENAI_API_KEY }}"      # bedrock: region/profile instead; ollama: base_url instead
+model = "gpt-5.1"
+
+[bootstrap]
+enabled = true                            # keeps this assistant available
+```
+
+Optional fields on `[agent]`: `alias` (model id served to clients),
+`turn_depth` (max tool calls per turn, default 5), `mcp_filter` (glob
+patterns limiting which MCP tools attach).
+
+Multi-agent orchestration:
+
+```toml
+[orchestration]
+enabled = true
+
+[orchestration.worker.investigator]
+description = "Read-only infrastructure investigation"   # shown to the planner
+preamble = "You are..."                                  # the worker's full system prompt
+read_only = true                                         # mechanical protection (see above)
+mcp_filter = ["list_pods", "get_logs"]                   # exact names for read-only workers
+```
+
+Workers may also set `turn_depth` and a per-worker `[….llm]` override.
+
+MCP servers:
+
+```toml
+# Streamable HTTP (most common)
+[mcp.servers.kubernetes]
+transport = "http_streamable"
+url = "https://mcp.example.com/mcp"
+description = "Kubernetes cluster operations"
+headers = { Authorization = "Bearer {{ env.K8S_MCP_TOKEN }}" }
+
+# Forward a header from the incoming client request instead of a static value
+[mcp.servers.mezmo]
+transport = "http_streamable"
+url = "https://mcp.mezmo.com/mcp"
+headers_from_request = { Authorization = "x-mezmo-token" }
+
+# SSE transport
+[mcp.servers.knowledge]
+transport = "sse"
+url = "https://kb.example.com/sse"
+
+# STDIO transport (spawns a local process on the server) — only available
+# when this instance was started with AURA_BOOTSTRAP_ALLOW_STDIO=true;
+# otherwise inspect/write reject it. The "This instance" section says
+# which applies.
+[mcp.servers.local]
+transport = "stdio"
+cmd = ["npx"]
+args = ["-y", "@some/mcp-server"]
+```
+
+## Known MCP servers
+
+When the operator describes what they want but doesn't have a server URL,
+suggest these if they fit. Only suggest stdio servers when this instance
+allows stdio (check the "This instance" section below).
+
+| Use case | Transport | Config |
+|----------|-----------|--------|
+| Kubernetes | stdio | `cmd = ["npx"]`, `args = ["-y", "kubernetes-mcp-server@latest"]` — needs `kubectl` configured on this server |

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,6 +38,7 @@ CONFIG_PATH=examples/minimal/openai.toml cargo run --bin aura-web-server
 | [`bedrock.toml`](minimal/bedrock.toml) | AWS Bedrock | AWS credentials |
 | [`gemini.toml`](minimal/gemini.toml) | Google Gemini | Yes |
 | [`ollama.toml`](minimal/ollama.toml) | Ollama (local) | No |
+| [`bootstrap.toml`](minimal/bootstrap.toml) | OpenAI + the token-gated `aura-bootstrap` config agent | Yes |
 
 ## Complete Agent Configs
 

--- a/examples/minimal/bootstrap.toml
+++ b/examples/minimal/bootstrap.toml
@@ -1,0 +1,39 @@
+# Minimal config with the aura-bootstrap agent enabled: a placeholder
+# assistant plus the token-gated bootstrap agent, which builds out the real
+# configuration conversationally and applies changes without a restart
+# (hot reload).
+#
+# Usage:
+#   export OPENAI_API_KEY="sk-..."
+#   export AURA_BOOTSTRAP_TOKEN="choose-a-token"   # optional — generated and logged otherwise
+#   CONFIG_PATH=examples/minimal/bootstrap.toml cargo run --bin aura-web-server
+#   aura --api-url http://localhost:8080 --model aura-bootstrap --api-key "$AURA_BOOTSTRAP_TOKEN"
+#
+# Or standalone (no server, no token handling):
+#   aura --config examples/minimal/bootstrap.toml --model aura-bootstrap
+#
+# SECURITY: the token is configuration admin on this server — see the
+# "Bootstrap Agent" section of the top-level README before enabling.
+
+[agent]
+name = "assistant"
+system_prompt = """
+You are a helpful general-purpose assistant.
+
+(This is a placeholder configuration. Chat with the aura-bootstrap
+agent to replace it with a real one, or edit this file directly.)
+"""
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.5"
+
+[bootstrap]
+enabled = true
+
+# Run the bootstrap agent on a different LLM than the placeholder agent:
+# [bootstrap.llm]
+# provider = "openai"
+# api_key = "{{ env.OPENAI_API_KEY }}"
+# model = "gpt-5.5"


### PR DESCRIPTION
## What

Adds the built-in `aura-bootstrap` agent: a token-gated administrative agent served alongside the configured roster that builds and modifies the server's configuration conversationally — first-time setup and day-2 changes alike. Disabled by default; enabled per config file with `[bootstrap] enabled = true` (optional `[bootstrap.llm]` override).

This is the follow-up promised when the `[bootstrap]` table was reverted in 7ed4e27 ("it belongs with the bootstrap agent in a future PR"). The init flow keeps its bootstrap-free default: `aura init` gains an opt-in `--bootstrap` flag and an interactive prompt that defaults to **no**.

Closes #390

## How it works

- **Three built-in tools** (`crates/aura/src/bootstrap.rs`): `read_config` (raw on-disk view, env references intact), `inspect_mcp_servers` (connects, verifies auth, reports per-tool read-only/destructive annotations and caches them for the write backstop), `write_config` (full validation pipeline → timestamped backup → atomic write → hot reload; `validate_only` for drafts).
- **Hot reload**: `AppState.configs` becomes a `ConfigRegistry` (`RwLock<Arc<Vec<Config>>>`). Every request takes one snapshot for its lifetime; `write_config`'s reload hook re-loads from disk, re-validates roster invariants, and swaps the registry. The bootstrap agent lives *outside* the registry, so its conversation survives the configs it applies.
- **Token gate**: checked in `prepare_request` **before** roster resolution — the model name is in the POST body, so middleware can't see it, and the single-config passthrough must never route the reserved name to a normal agent. Accepts `Authorization: Bearer <token>` or `x-aura-bootstrap-token` (for gateways that overwrite `Authorization`); constant-time compare; 401 + `WWW-Authenticate` on failure. Token from `AURA_BOOTSTRAP_TOKEN` or generated and printed to startup logs.
- **Standalone CLI host**: `DirectBackend` serves the same agent through the shared `prepare_request` routing with a private self-presented token. The reload hook re-applies any session `--system-prompt` override and refreshes the `/model` cache.

## Safety backstops (enforced in code, not prompt)

- Literal secrets rejected anywhere in written TOML (`api_key`, `*token*`, `*secret*`, header values, stdio env maps) — secrets travel only as `{{ env.VAR }}` references, and the file is written from the raw input so they stay references.
- New per-worker `read_only = true`: config validation requires an exact-name, glob-free `mcp_filter`; `write_config` additionally rejects tools the server annotated as mutating or that discovery never returned (fail-closed — empty discovery cache rejects the write). Same-named tools on different servers merge most-restrictive.
- `stdio` MCP transports in agent-written configs refused unless the server runs with `AURA_BOOTSTRAP_ALLOW_STDIO=true`.
- `aura-bootstrap` is a reserved name; at most one config may enable `[bootstrap]`; both invariants enforced at startup and on every hot reload.

The operator-facing security model (token semantics, read-only workers, secret handling, stdio policy) needs a page on docs.mezmo.com — filed as a follow-up for the `mezmo/documentation` repo, since this repo's README no longer carries configuration docs.

## Rebase onto current main (2026-08-13)

The branch was rebased from its July base onto current main (128 commits). Two adaptations went beyond textual conflict resolution:

- `mcp_filter` is now `Option<Vec<String>>` after the empty-means-none fix (#404). `validate_read_only_workers` now rejects a *missing* filter (`None` grants all tools) and accepts an explicit `mcp_filter = []` (grants nothing, so the read-only promise holds). The `write_config` backstop iterates the flattened option. Tests updated, plus a new acceptance test for the explicit-empty case.
- Main's new `AppState` fields (`stream_inactivity_timeout_secs`, `hitl_webhook_hmac`, `session_store`) are threaded through the CLI's `DirectBackend` and test fixtures, and the HITL webhook validation runs against the registry snapshot.

## Review concerns: interaction with the session-store work (#325)

Main now ships cross-pod session state (store + event bus, Redis-backed, in-memory default) aimed at multi-replica deployments. The bootstrap subsystem predates that push and is pod-local in three ways. I'd like review input on whether this needs enforcement, or just documentation, before merge:

1. **Token is per pod.** Without `AURA_BOOTSTRAP_TOKEN`, each replica generates its own token, so behind a load balancer the token read from one pod's logs gets 401s from the other pods.
2. **Discovery cache is per pod.** The `inspect_mcp_servers` → `write_config` verification cache lives in process memory. With no session affinity, inspection can land on one pod and the write on another; the write fails closed with "not verified in this conversation". Safe, but the agent is effectively unusable multi-pod.
3. **Hot reload is per pod.** `write_config` writes the local file and swaps the local registry; other replicas keep the old config. Under the Helm deployment the config is a ConfigMap mount, so the write itself would fail. The session-store event bus is the natural primitive for broadcasting reloads cross-pod, but that's future work, not in this PR.

Proposed disposition: warn (or refuse) at startup when `[bootstrap]` is enabled together with a networked session store, and document bootstrap as a single-process feature for now. Open to either.

One concrete stale-state issue from combining the two: the **A2A agent card is built once at startup**, and this PR makes hot reload the only way config changes under a running server, so the published card can go stale after a reload. Per-request A2A resolution takes a fresh registry snapshot and is unaffected. Happy to fix in this PR (rebuild the card in the reload hook) if reviewers prefer.

Checked and *not* problems:

- The A2A surface resolves agents from the registry only, and the bootstrap agent lives outside it, so `message:send` can never reach `aura-bootstrap` and skip the token gate.
- A registry swap mid-request is benign: in-flight requests keep their snapshot, and parked HITL approvals hold pod-local wake handles per the session-storage ADR.

Longer-term discussion item, not for this PR: now that HITL approvals are cross-pod and first-class, `write_config` could be gated through an HITL approval instead of (or in addition to) the token, unifying "a human authorizes a sensitive action" into one mechanism.

## Commits

Each commit builds and tests green on its own: `[bootstrap]` table + `read_only` (aura-config) → bootstrap tools + prompt (aura) → hot-reloadable roster (web-server refactor) → token-gated serving (web-server) → standalone host (cli) → init enablement (cli) → docs/example → rustfmt.

## Testing

- ~40 new unit tests across the four crates (secret scan, read-only backstop, directory deployments, token gate, registry snapshot isolation, standalone host, reload hook, init rendering).
- After the rebase: `cargo test --workspace` (0 failures), `cargo clippy --workspace --all-targets`, `cargo +nightly fmt --check`, the HTTP-only CLI build (`--no-default-features`), and `make lint-commits` all green.
- Live smoke test (pre-rebase): `aura init --bootstrap` → web server on a scratch port → `/v1/models` advertises `aura-bootstrap`; missing/wrong token → 401 + `WWW-Authenticate`; correct token via both header forms reaches the agent and completes.

## Open question for review

`aura init`'s interactive bootstrap prompt defaults to **no** (it's a standing admin surface, so enabling should be deliberate). If we'd rather make the guided path the default first-run experience, it's a one-line flip in `init/spec.rs`.
