### PR TITLE
fix: enable sccache in mac ci build

### DIFF
--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -160,7 +160,10 @@ build-binary-darwin-amd64: $(DIST_DIR) $(DOCKER_ENV) ## Build binaries for darwi
 		$(call require_host,Darwin,) \
 		rustup target add x86_64-apple-darwin 2>/dev/null; \
 		cargo build $(CARGO_PROFILE_FLAG) --target x86_64-apple-darwin --bin aura-web-server && \
-		cargo build $(CARGO_PROFILE_FLAG) --target x86_64-apple-darwin -p aura-cli --bin aura"
+		cargo build $(CARGO_PROFILE_FLAG) --target x86_64-apple-darwin -p aura-cli --bin aura; \
+		rc=\$$?; \
+		if [ -n \"\$$RUSTC_WRAPPER\" ]; then sccache --show-stats || true; fi; \
+		exit \$$rc"
 	cp target/x86_64-apple-darwin/$(PROFILE)/aura-web-server $(DIST_DIR)/aura-web-server-darwin-amd64
 	cp target/x86_64-apple-darwin/$(PROFILE)/aura $(DIST_DIR)/aura-darwin-amd64
 
@@ -170,7 +173,10 @@ build-binary-darwin-arm64: $(DIST_DIR) $(DOCKER_ENV) ## Build binaries for darwi
 		$(call require_host,Darwin,) \
 		rustup target add aarch64-apple-darwin 2>/dev/null; \
 		cargo build $(CARGO_PROFILE_FLAG) --target aarch64-apple-darwin --bin aura-web-server && \
-		cargo build $(CARGO_PROFILE_FLAG) --target aarch64-apple-darwin -p aura-cli --bin aura"
+		cargo build $(CARGO_PROFILE_FLAG) --target aarch64-apple-darwin -p aura-cli --bin aura; \
+		rc=\$$?; \
+		if [ -n \"\$$RUSTC_WRAPPER\" ]; then sccache --show-stats || true; fi; \
+		exit \$$rc"
 	cp target/aarch64-apple-darwin/$(PROFILE)/aura-web-server $(DIST_DIR)/aura-web-server-darwin-arm64
 	cp target/aarch64-apple-darwin/$(PROFILE)/aura $(DIST_DIR)/aura-darwin-arm64
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -476,11 +476,31 @@ pipeline {
 
               environment {
                 ENABLE_DOCKER = 'false'
+                SCCACHE_BUCKET = "${BUILD_CACHE_BUCKET}"
+                SCCACHE_REGION = "${BUILD_CACHE_REGION}"
+                SCCACHE_S3_KEY_PREFIX = 'aura/sccache/'
               }
 
               steps {
                 sh './scripts/set-version.sh "$NEXT_RELEASE_VERSION"'
-                sh 'make build-binaries-darwin'
+                script {
+                  withCredentials([
+                    aws(
+                      credentialsId: 'oss-aws-build-cache',
+                      accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                      secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                    )
+                  ]) {
+                    // sccache reaches its S3 cache with the credentials bound
+                    // above, so enable the wrapper only inside this block.
+                    // Stage-wide it would route the credential-free
+                    // set-version step through sccache and time out on the
+                    // IMDS credential fallback.
+                    withEnv(['AURA_RUSTC_WRAPPER=sccache']) {
+                      sh 'make build-binaries-darwin'
+                    }
+                  }
+                }
 
                 stash(
                   name: 'darwin-release-artifacts',

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,15 @@ RUNNER_TOOLCHAIN_ENV := -e CARGO_HOME=/home/aura/.cargo -e RUSTUP_HOME=/home/aur
 # Compiler-cache passthrough, gated on the CI toggle so local $(RUN) is
 # unchanged. Bare -e copies AWS values from the host environment.
 SCCACHE_RUN_ENV = $(if $(AURA_RUSTC_WRAPPER),-e RUSTC_WRAPPER=$(AURA_RUSTC_WRAPPER) -e SCCACHE_BUCKET -e SCCACHE_REGION -e SCCACHE_S3_KEY_PREFIX -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY,)
+# Native (non-Docker) builds run cargo directly in this process's environment,
+# so translate the AURA_RUSTC_WRAPPER toggle into the RUSTC_WRAPPER cargo reads.
+# The SCCACHE_* and AWS values are inherited from the host env alongside it.
+# Docker builds inject the wrapper into the container via SCCACHE_RUN_ENV.
+ifneq ($(filter true, $(ENABLE_DOCKER)),true)
+ifneq ($(AURA_RUSTC_WRAPPER),)
+RUSTC_WRAPPER := $(AURA_RUSTC_WRAPPER)
+endif
+endif
 RUNNER_CMD = $(DOCKER_RUN) --env-file=$(DOCKER_ENV) $(RUNNER_TOOLCHAIN_ENV) $(SCCACHE_RUN_ENV) $(if $(filter true, $(IS_CI)), ,-t) -v $(PWD):/home/aura $(AURA_RUNNER_IMAGE)
 RUNNER_NO_ENV_CMD = $(DOCKER_RUN) $(if $(filter true, $(IS_CI)),,-t) -v $(PWD):/home/aura $(AURA_RUNNER_IMAGE)
 DOCKER_RUN_BUILD_ENV := $(RUNNER_CMD)


### PR DESCRIPTION
Catches up the mac ci builds with all the speedup improvements done for the linux side.