### PR TITLE
feat: guided mcp server install flow (/mcp)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",
+ "toml_edit 0.22.27",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 toml = "0.8"
+toml_edit = { version = "0.22", features = ["serde"] }
 
 # Async runtime
 tokio = { version = "1.45", features = ["full", "test-util"] }

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ For a fuller multi-worker example, see [configs/example-math-orchestration.toml]
 |-------|------|---------|-------------|
 | `description` | string | *required* | Short description shown to coordinator during planning |
 | `preamble` | string | *required* | System prompt for this worker |
-| `mcp_filter` | list | `[]` | Glob patterns selecting which MCP tools this worker can use |
+| `mcp_filter` | list | — | Glob patterns selecting which MCP tools this worker can use; omitted = all tools, `[]` = none |
 | `vector_stores` | list | `[]` | Named vector stores this worker has access to |
 | `turn_depth` | int | — | Per-worker tool-call depth limit (overrides `[agent].turn_depth`) |
 | `llm` | table | inherits `[agent.llm]` | Optional per-worker LLM override — different model (and other `[agent.llm]` fields) while reusing provider credentials |

--- a/crates/aura-cli/Cargo.toml
+++ b/crates/aura-cli/Cargo.toml
@@ -25,9 +25,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 # Format-preserving TOML editor for in-place [telemetry] cli.toml edits.
-# Pinned to the 0.22 line that `toml` 0.8 already builds on, so it adds
-# no new transitive tree.
-toml_edit = "0.22"
+toml_edit = { workspace = true }
 anyhow = { workspace = true }
 uuid = { workspace = true }
 regex = { workspace = true }

--- a/crates/aura-cli/README.md
+++ b/crates/aura-cli/README.md
@@ -274,6 +274,7 @@ Once inside the REPL, the slash commands below are available. All slash commands
 | `/rename <name>`   | Rename the current conversation                                     |
 | `/model <filter>`  | Browse and select a model (see [Model Selection](#model-selection)) |
 | `/style [name]`    | Switch visual style: `normal`, `high-contrast`, `no-colors`         |
+| `/mcp [add]`       | List the agent's MCP servers, or install one via a guided flow      |
 | `/quit` or `/exit` | Exit the REPL                                                       |
 
 ---

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -119,11 +119,9 @@ impl DirectBackend {
         })
     }
 
-    /// Path the agent configs were loaded from, as given at startup.
-    ///
-    /// `load_config` accepts both a single TOML file and a directory of
-    /// them, so callers that want to *write* config (e.g. `/mcp add`) must
-    /// check `is_file()` before treating this as an editable target.
+    /// Path the agent configs were loaded from, as given at startup. May
+    /// be a directory (`load_config` accepts both) — writers must check
+    /// `is_file()` first.
     pub fn config_path(&self) -> &Path {
         &self.config_path
     }

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -7,6 +7,7 @@
 //! identical behavior whether the CLI connects via HTTP or runs standalone.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::Duration;
@@ -50,6 +51,8 @@ fn additional_tools_factory() -> Arc<dyn Fn() -> Vec<Box<dyn aura::ToolDyn>> + S
 pub struct DirectBackend {
     app_state: Arc<AppState>,
     extra_headers: HashMap<String, String>,
+    /// Filesystem source of the loaded configs (file or directory).
+    config_path: PathBuf,
 }
 
 impl DirectBackend {
@@ -112,7 +115,17 @@ impl DirectBackend {
         Ok(Self {
             app_state,
             extra_headers: headers_map,
+            config_path: PathBuf::from(config_path),
         })
+    }
+
+    /// Path the agent configs were loaded from, as given at startup.
+    ///
+    /// `load_config` accepts both a single TOML file and a directory of
+    /// them, so callers that want to *write* config (e.g. `/mcp add`) must
+    /// check `is_file()` before treating this as an editable target.
+    pub fn config_path(&self) -> &Path {
+        &self.config_path
     }
 
     /// Return `true` if any loaded config enables client-side tools.
@@ -459,6 +472,9 @@ mod tests {
         DirectBackend {
             app_state,
             extra_headers: HashMap::new(),
+            // Synthetic: these configs were built in memory, not loaded
+            // from disk, so point at a path that cannot exist.
+            config_path: PathBuf::from("/nonexistent/in-memory-test-config.toml"),
         }
     }
 

--- a/crates/aura-cli/src/init.rs
+++ b/crates/aura-cli/src/init.rs
@@ -39,6 +39,7 @@ mod provider;
 mod ranking;
 mod render;
 mod spec;
+
 #[cfg(test)]
 mod test_support;
 
@@ -50,7 +51,8 @@ use std::io::IsTerminal;
 use model_list::HttpModelLister;
 use prompt::Prompter;
 use provider::Provider;
-use render::{merge_env, next_steps, render_config, render_env};
+pub(crate) use render::{merge_env, render_env};
+use render::{next_steps, render_config};
 use spec::{ApiKeySource, resolve_spec};
 
 #[derive(Debug, clap::Args)]

--- a/crates/aura-cli/src/init/config_template.toml
+++ b/crates/aura-cli/src/init/config_template.toml
@@ -114,7 +114,8 @@ per_call_timeout_secs = 120
 
 # ─── Workers ────────────────────────────────────────────────────
 # Each worker specializes in a domain. Add mcp_filter to restrict
-# which MCP tools a worker can see — without it, workers see all.
+# which MCP tools a worker can see — without it, workers see all;
+# mcp_filter = [] gives a worker no MCP tools.
 
 [orchestration.worker.incident-responder]
 description = "Incident triage: fetch incident details, parse alerts, check oncall schedules, and escalation policies"

--- a/crates/aura-cli/src/repl/mcp.rs
+++ b/crates/aura-cli/src/repl/mcp.rs
@@ -1,0 +1,141 @@
+//! `/mcp` — inspect the MCP servers available to the active agent.
+//!
+//! Reads the same credential-free [`AgentInfo::mcp_servers`] view the
+//! startup call-to-action uses, so it works identically against a local
+//! standalone agent and a remote aura-web-server.
+
+use aura_events::{AgentInfo, McpServerOverview};
+
+use crate::backend::Backend;
+use crate::theme::{AuraStyle, Themed};
+use crate::ui::prompt::redraw_input_frame;
+
+pub(crate) fn handle_mcp(args: &str, rt: &tokio::runtime::Runtime, backend: &Backend) {
+    let body = match args.trim() {
+        "" => {
+            let agent = rt.block_on(backend.startup_agent_overview());
+            format_server_list(agent.as_ref())
+        }
+        other => format!("Unknown /mcp subcommand: {other}\nRun /mcp to list configured servers."),
+    };
+    println!("{body}");
+    redraw_input_frame();
+}
+
+/// A known-empty server set gets the setup nudge, mirroring the startup CTA;
+/// `None` means the connected server predates the `mcp_servers` info field.
+fn format_server_list(agent: Option<&AgentInfo>) -> String {
+    let Some(agent) = agent else {
+        return "No agent information available.".to_string();
+    };
+    let Some(servers) = agent.mcp_servers.as_ref() else {
+        return "The connected server does not report MCP configuration.".to_string();
+    };
+    if servers.is_empty() {
+        return format!(
+            "No MCP servers configured for {}.\nSet up an MCP server to connect AURA to your tools.",
+            agent.id
+        );
+    }
+
+    let mut lines = vec![format!(
+        "{} {}",
+        "MCP servers".themed(AuraStyle::Heading),
+        format!("({})", agent.id).themed(AuraStyle::Muted),
+    )];
+    for (name, server) in servers {
+        let (transport, target, description): (&str, &str, Option<&str>) = match server {
+            McpServerOverview::Stdio {
+                command,
+                description,
+            } => ("stdio", command, description.as_deref()),
+            McpServerOverview::HttpStreamable { url, description } => {
+                ("http_streamable", url, description.as_deref())
+            }
+            McpServerOverview::Sse { url, description } => ("sse", url, description.as_deref()),
+            // `McpServerOverview` is #[non_exhaustive]; a newer wire peer
+            // may send a transport this build doesn't know.
+            _ => ("unknown transport", "", None),
+        };
+        lines.push(format!(
+            "  {} {} {} {} {}",
+            "•".themed(AuraStyle::Muted),
+            name.as_str().themed(AuraStyle::Heading),
+            "—".themed(AuraStyle::Muted),
+            transport.themed(AuraStyle::Muted),
+            target.themed(AuraStyle::Identifier),
+        ));
+        if let Some(desc) = description {
+            lines.push(format!("      {}", desc.themed(AuraStyle::Muted)));
+        }
+    }
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// Strip SGR sequences (`ESC[…m`) so assertions are theme-independent.
+    fn strip_sgr(s: &str) -> String {
+        let mut out = String::new();
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\u{1b}' {
+                for c2 in chars.by_ref() {
+                    if c2 == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn lists_servers_with_transport_and_target() {
+        let mut agent = crate::test_fixtures::agent("sre", vec![]);
+        agent.mcp_servers = Some(BTreeMap::from([
+            (
+                "mezmo".to_string(),
+                McpServerOverview::HttpStreamable {
+                    url: "https://mcp.mezmo.com".to_string(),
+                    description: Some("Log analysis".to_string()),
+                },
+            ),
+            (
+                "k8s".to_string(),
+                McpServerOverview::Stdio {
+                    command: "kubernetes-mcp-server".to_string(),
+                    description: None,
+                },
+            ),
+        ]));
+        let text = strip_sgr(&format_server_list(Some(&agent)));
+        assert!(text.contains("MCP servers (sre)"), "{text}");
+        assert!(
+            text.contains("mezmo — http_streamable https://mcp.mezmo.com"),
+            "{text}"
+        );
+        assert!(text.contains("Log analysis"), "{text}");
+        assert!(text.contains("k8s — stdio kubernetes-mcp-server"), "{text}");
+    }
+
+    #[test]
+    fn empty_set_nudges_setup() {
+        let mut agent = crate::test_fixtures::agent("sre", vec![]);
+        agent.mcp_servers = Some(BTreeMap::new());
+        let text = format_server_list(Some(&agent));
+        assert!(text.contains("No MCP servers configured for sre"), "{text}");
+    }
+
+    #[test]
+    fn absent_field_reports_older_server() {
+        let agent = crate::test_fixtures::agent("sre", vec![]);
+        let text = format_server_list(Some(&agent));
+        assert!(text.contains("does not report MCP configuration"), "{text}");
+    }
+}

--- a/crates/aura-cli/src/repl/mcp/catalog.rs
+++ b/crates/aura-cli/src/repl/mcp/catalog.rs
@@ -1,10 +1,6 @@
-//! Curated MCP servers `/mcp add` can install without hand-authoring TOML.
-//!
-//! Each entry carries everything the guided flow needs: the config shape to
-//! write, the credentials to collect (as `{{ env.VAR }}` placeholders so
-//! secrets land in `.env`, never in the TOML), the prerequisites to show
-//! before asking for anything, and a starter prompt that exercises the
-//! integration once connected.
+//! Curated MCP servers `/mcp add` can install: the config shape to write,
+//! the credentials to collect (as `{{ env.VAR }}` placeholders), the
+//! prerequisites to show first, and a starter prompt.
 
 /// A blessed MCP server the wizard can install.
 pub(crate) struct CatalogEntry {

--- a/crates/aura-cli/src/repl/mcp/catalog.rs
+++ b/crates/aura-cli/src/repl/mcp/catalog.rs
@@ -38,10 +38,9 @@ pub(crate) struct HeaderTemplate {
     /// Literal header value written to the config, e.g.
     /// `"Bearer {{ env.MEZMO_API_KEY }}"`.
     pub value_template: &'static str,
-    /// The env var the placeholder references; its value is collected
-    /// with masked input and written to `.env`.
+    /// The env var the placeholder references.
     pub env_var: &'static str,
-    /// Masked-input prompt shown when collecting the secret.
+    /// Masked-input prompt for this credential.
     pub secret_prompt: &'static str,
 }
 
@@ -106,10 +105,11 @@ pub(crate) const CATALOG: &[CatalogEntry] = &[
         key: "kubernetes",
         description: "Kubernetes cluster inspection via kubernetes-mcp-server",
         prerequisites: "Requires Node.js (npx) and a working kubeconfig context.\n\
-                        AURA will access your cluster with your kubeconfig's permissions.",
+                        AURA gets read-only access to your cluster through your kubeconfig \
+                        (the server runs with --read-only; edit the config to allow writes).",
         template: Template::Stdio {
             cmd: &["npx"],
-            args: &["-y", "kubernetes-mcp-server@latest"],
+            args: &["-y", "kubernetes-mcp-server@latest", "--read-only"],
         },
         starter_prompt: "What pods are running in my cluster, and are any of them unhealthy?",
     },

--- a/crates/aura-cli/src/repl/mcp/catalog.rs
+++ b/crates/aura-cli/src/repl/mcp/catalog.rs
@@ -1,0 +1,116 @@
+//! Curated MCP servers `/mcp add` can install without hand-authoring TOML.
+//!
+//! Each entry carries everything the guided flow needs: the config shape to
+//! write, the credentials to collect (as `{{ env.VAR }}` placeholders so
+//! secrets land in `.env`, never in the TOML), the prerequisites to show
+//! before asking for anything, and a starter prompt that exercises the
+//! integration once connected.
+
+/// A blessed MCP server the wizard can install.
+pub(crate) struct CatalogEntry {
+    /// Default `[mcp.servers.<key>]` name; also the display name.
+    pub key: &'static str,
+    /// One-line description written into the config.
+    pub description: &'static str,
+    /// What the user must have ready, and the access AURA will get.
+    pub prerequisites: &'static str,
+    pub template: Template,
+    /// First prompt to try once the server is connected.
+    pub starter_prompt: &'static str,
+}
+
+pub(crate) enum Template {
+    /// `transport = "http_streamable"` with static auth headers.
+    Http {
+        url: &'static str,
+        headers: &'static [HeaderTemplate],
+    },
+    /// `transport = "stdio"` (no credential collection).
+    Stdio {
+        cmd: &'static [&'static str],
+        args: &'static [&'static str],
+    },
+}
+
+/// One static header whose value holds a `{{ env.VAR }}` placeholder.
+pub(crate) struct HeaderTemplate {
+    pub header: &'static str,
+    /// Literal header value written to the config, e.g.
+    /// `"Bearer {{ env.MEZMO_API_KEY }}"`.
+    pub value_template: &'static str,
+    /// The env var the placeholder references; its value is collected
+    /// with masked input and written to `.env`.
+    pub env_var: &'static str,
+    /// Masked-input prompt shown when collecting the secret.
+    pub secret_prompt: &'static str,
+}
+
+pub(crate) const CATALOG: &[CatalogEntry] = &[
+    CatalogEntry {
+        key: "mezmo",
+        description: "Mezmo log analysis, export, and pipeline monitoring",
+        prerequisites: "Requires a Mezmo service API key (Mezmo UI: Settings > API Keys).\n\
+                        AURA will be able to query logs, exports, and pipeline state on your account.",
+        template: Template::Http {
+            url: "https://mcp.mezmo.com/mcp",
+            headers: &[HeaderTemplate {
+                header: "Authorization",
+                value_template: "Bearer {{ env.MEZMO_API_KEY }}",
+                env_var: "MEZMO_API_KEY",
+                secret_prompt: "Mezmo service API key",
+            }],
+        },
+        starter_prompt: "What are the most common errors in my logs from the last hour?",
+    },
+    CatalogEntry {
+        key: "pagerduty",
+        description: "PagerDuty incident management, on-call schedules, and escalation",
+        prerequisites: "Requires a PagerDuty API token (User Settings > API Access).\n\
+                        AURA will be able to read incidents, on-call schedules, and escalation policies.",
+        template: Template::Http {
+            url: "https://mcp.pagerduty.com/mcp",
+            headers: &[HeaderTemplate {
+                header: "Authorization",
+                value_template: "Token {{ env.PAGERDUTY_API_TOKEN }}",
+                env_var: "PAGERDUTY_API_TOKEN",
+                secret_prompt: "PagerDuty API token",
+            }],
+        },
+        starter_prompt: "Who is on call right now, and are there any open incidents?",
+    },
+    CatalogEntry {
+        key: "datadog",
+        description: "Datadog metrics, monitors, dashboards, and APM traces",
+        prerequisites: "Requires a Datadog API key and application key (Organization Settings).\n\
+                        AURA will be able to read metrics, monitors, dashboards, and traces.",
+        template: Template::Http {
+            url: "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp",
+            headers: &[
+                HeaderTemplate {
+                    header: "DD-API-KEY",
+                    value_template: "{{ env.DD_API_KEY }}",
+                    env_var: "DD_API_KEY",
+                    secret_prompt: "Datadog API key",
+                },
+                HeaderTemplate {
+                    header: "DD-APPLICATION-KEY",
+                    value_template: "{{ env.DD_APPLICATION_KEY }}",
+                    env_var: "DD_APPLICATION_KEY",
+                    secret_prompt: "Datadog application key",
+                },
+            ],
+        },
+        starter_prompt: "Which Datadog monitors are currently alerting?",
+    },
+    CatalogEntry {
+        key: "kubernetes",
+        description: "Kubernetes cluster inspection via kubernetes-mcp-server",
+        prerequisites: "Requires Node.js (npx) and a working kubeconfig context.\n\
+                        AURA will access your cluster with your kubeconfig's permissions.",
+        template: Template::Stdio {
+            cmd: &["npx"],
+            args: &["-y", "kubernetes-mcp-server@latest"],
+        },
+        starter_prompt: "What pods are running in my cluster, and are any of them unhealthy?",
+    },
+];

--- a/crates/aura-cli/src/repl/mcp/mod.rs
+++ b/crates/aura-cli/src/repl/mcp/mod.rs
@@ -1,8 +1,6 @@
-//! `/mcp` — inspect the MCP servers available to the active agent.
-//!
-//! Reads the same credential-free [`AgentInfo::mcp_servers`] view the
-//! startup call-to-action uses, so it works identically against a local
-//! standalone agent and a remote aura-web-server.
+//! `/mcp` — inspect and install MCP servers for the active agent. Listing
+//! reads the credential-free [`AgentInfo::mcp_servers`] view, identical in
+//! standalone and HTTP modes.
 
 #[cfg(feature = "standalone-cli")]
 mod catalog;

--- a/crates/aura-cli/src/repl/mcp/mod.rs
+++ b/crates/aura-cli/src/repl/mcp/mod.rs
@@ -4,21 +4,37 @@
 //! startup call-to-action uses, so it works identically against a local
 //! standalone agent and a remote aura-web-server.
 
+#[cfg(feature = "standalone-cli")]
+mod catalog;
+#[cfg(feature = "standalone-cli")]
+mod wizard;
+
 use aura_events::{AgentInfo, McpServerOverview};
 
-use crate::backend::Backend;
+use super::registry::CommandContext;
 use crate::theme::{AuraStyle, Themed};
 use crate::ui::prompt::redraw_input_frame;
 
-pub(crate) fn handle_mcp(args: &str, rt: &tokio::runtime::Runtime, backend: &Backend) {
-    let body = match args.trim() {
+pub(crate) fn handle_mcp(ctx: &mut CommandContext, args: &str) {
+    match args.trim() {
         "" => {
-            let agent = rt.block_on(backend.startup_agent_overview());
-            format_server_list(agent.as_ref())
+            let agent = ctx.rt.block_on(ctx.backend.startup_agent_overview());
+            println!("{}", format_server_list(agent.as_ref()));
         }
-        other => format!("Unknown /mcp subcommand: {other}\nRun /mcp to list configured servers."),
-    };
-    println!("{body}");
+        "add" => {
+            #[cfg(feature = "standalone-cli")]
+            wizard::run(ctx);
+            #[cfg(not(feature = "standalone-cli"))]
+            println!(
+                "/mcp add edits a local agent config and needs a build with the \
+                 standalone-cli feature; this build is HTTP-only."
+            );
+        }
+        other => println!(
+            "Unknown /mcp subcommand: {other}\n\
+             Run /mcp to list configured servers, or /mcp add to set one up."
+        ),
+    }
     redraw_input_frame();
 }
 

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -149,7 +149,7 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
             vars.join(", ")
         );
     }
-    let existing_vars: Vec<&str> = collected
+    let mut existing_vars: Vec<&str> = collected
         .secrets
         .iter()
         .filter_map(|source| match source {
@@ -157,6 +157,7 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
             CredentialSource::New { .. } => None,
         })
         .collect();
+    existing_vars.dedup();
     if !existing_vars.is_empty() {
         println!(
             "References environment variable(s) you already manage ({}) — nothing is written for them.",
@@ -186,12 +187,13 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
         println!("Saved secrets to {}.", env_path.display());
     }
 
-    let unresolved: Vec<&str> = collected
+    let mut unresolved: Vec<&str> = collected
         .secrets
         .iter()
         .filter(|source| source.known_value().is_none())
         .map(CredentialSource::env_var)
         .collect();
+    unresolved.dedup();
     if !unresolved.is_empty() {
         println!(
             "\nSkipping the connection check — {} not set in this session.",
@@ -243,7 +245,14 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
             print_allowlist_hint(config_path, &collected.name);
             false
         }
-        Ok((aura::mcp::ConnectionStatus::NotAttempted, _)) => false,
+        Ok((aura::mcp::ConnectionStatus::NotAttempted, _)) => {
+            println!(
+                "{} The connection was not attempted.",
+                "!".themed(AuraStyle::Warning)
+            );
+            print_allowlist_hint(config_path, &collected.name);
+            false
+        }
         Err(reason) => {
             println!(
                 "{} Could not verify the connection: {reason}",
@@ -348,10 +357,10 @@ fn verify_server(
 /// Offer to expose a freshly verified server's tools to orchestration
 /// workers.
 ///
-/// Worker `mcp_filter` globs match *tool names*, and an empty filter grants
-/// every MCP tool — so workers without a filter already see the new server
-/// (that's stated, not asked), and only allowlisted workers are offered an
-/// update. Grants go through the format-preserving
+/// Workers without an `mcp_filter` already see the new server (empty
+/// filter = every MCP tool; see `resolve_worker_tools` in the
+/// orchestrator), so that's stated rather than asked; only allowlisted
+/// workers are offered an update, via the format-preserving
 /// `append_worker_mcp_filter` writer.
 fn offer_worker_access(
     ctx: &mut CommandContext,
@@ -461,8 +470,20 @@ fn orchestrated_workers(config_path: &Path) -> Vec<(String, Vec<String>)> {
     result
 }
 
-/// Filter entries granting exactly the given tools: a `{prefix}*` glob when
-/// every tool shares a meaningful prefix (≥4 chars), else the exact names.
+/// Tool-name stems too generic to anchor a glob.
+const GENERIC_STEMS: [&str; 10] = [
+    "get", "list", "read", "set", "create", "delete", "update", "query", "fetch", "describe",
+];
+
+/// Filter entries granting the given tools: a `{prefix}*` glob when every
+/// tool shares a namespacing prefix, else the exact names.
+///
+/// Globs are matched against the tool names of *every* configured server,
+/// so a glob is only used when the shared prefix looks like a namespace
+/// rather than a verb: it must end at a `_`/`-` separator, be at least 5
+/// chars, and its stem must not be a [`GENERIC_STEMS`] verb — `mezmo_*`
+/// qualifies, but `get_issue`/`get_pr` fall back to exact names because
+/// `get_*` would also grant `get_logs` from an unrelated server.
 fn filter_entries(tool_names: &[String]) -> Vec<String> {
     if tool_names.len() > 1 {
         let first = &tool_names[0];
@@ -478,8 +499,12 @@ fn filter_entries(tool_names: &[String]) -> Vec<String> {
         while len > 0 && !first.is_char_boundary(len) {
             len -= 1;
         }
-        if len >= 4 {
-            return vec![format!("{}*", &first[..len])];
+        if let Some(sep) = first[..len].rfind(['_', '-']) {
+            let prefix = &first[..=sep];
+            let stem = first[..sep].to_ascii_lowercase();
+            if prefix.len() >= 5 && !GENERIC_STEMS.contains(&stem.as_str()) {
+                return vec![format!("{prefix}*")];
+            }
         }
     }
     tool_names.to_vec()
@@ -550,6 +575,16 @@ fn collect_credential(
         match answer.as_str() {
             "1" => {
                 let value = ask_secret(&format!("{secret_prompt}: "))?;
+                // At startup the shell's export wins over .env (dotenvy
+                // never overwrites existing env), so a value entered here
+                // is dead weight while the export exists.
+                if set_env_value(default_env_var).is_some() {
+                    println!(
+                        "note: {default_env_var} is exported in your shell, and exported \
+                         values override .env at startup — unset or update the export \
+                         for this value to take effect."
+                    );
+                }
                 return Some(CredentialSource::New {
                     env_var: default_env_var.to_string(),
                     value,
@@ -1139,13 +1174,26 @@ mod tests {
     }
 
     #[test]
-    fn filter_entries_prefer_common_prefix_glob() {
+    fn filter_entries_prefer_namespace_prefix_glob() {
         let tools = vec![
             "mezmo_logs".to_string(),
             "mezmo_pipelines".to_string(),
             "mezmo_export".to_string(),
         ];
         assert_eq!(filter_entries(&tools), ["mezmo_*"]);
+
+        // A generic verb stem must not become a glob: `get_*` would also
+        // match other servers' tools.
+        let generic = vec![
+            "get_issue".to_string(),
+            "get_pr".to_string(),
+            "get_file".to_string(),
+        ];
+        assert_eq!(filter_entries(&generic), generic);
+
+        // Too-short namespace falls back to exact names.
+        let short = vec!["dd_metrics".to_string(), "dd_monitors".to_string()];
+        assert_eq!(filter_entries(&short), short);
 
         let mixed = vec!["ListKnowledgeBases".to_string(), "QueryBases".to_string()];
         assert_eq!(filter_entries(&mixed), mixed);

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -125,15 +125,6 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
         return WizardEnd::Aborted;
     };
 
-    // Preview exactly what will be appended before touching the file.
-    match aura_config::writer::upsert_mcp_server_in_str("", &collected.name, &collected.server) {
-        Ok(preview) => println!("\nThis will be added to the config:\n\n{preview}"),
-        Err(e) => {
-            return WizardEnd::Failed(format!(
-                "could not render the server config: {e}\nNothing was written."
-            ));
-        }
-    }
     let new_secrets: Vec<(String, String)> = collected
         .secrets
         .iter()
@@ -142,13 +133,6 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
             CredentialSource::Existing { .. } => None,
         })
         .collect();
-    if !new_secrets.is_empty() {
-        let vars: Vec<&str> = new_secrets.iter().map(|(var, _)| var.as_str()).collect();
-        println!(
-            "Secrets are stored in `.env` next to the config ({}), not in the TOML.",
-            vars.join(", ")
-        );
-    }
     let mut existing_vars: Vec<&str> = collected
         .secrets
         .iter()
@@ -158,13 +142,105 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
         })
         .collect();
     existing_vars.dedup();
+    let mut unresolved: Vec<&str> = collected
+        .secrets
+        .iter()
+        .filter(|source| source.known_value().is_none())
+        .map(CredentialSource::env_var)
+        .collect();
+    unresolved.dedup();
+    let known_values: Vec<(String, String)> = collected
+        .secrets
+        .iter()
+        .filter_map(|source| {
+            source
+                .known_value()
+                .map(|value| (source.env_var().to_string(), value.to_string()))
+        })
+        .collect();
+
+    // Verify BEFORE asking to write, so consent to the config change is
+    // informed by a live connection result and the discovered tools — and
+    // a failing credential never lands on disk unless explicitly chosen.
+    // The check runs against an in-memory copy; nothing is written yet.
+    let mut verified = false;
+    let mut tool_names: Vec<String> = Vec::new();
+    if !unresolved.is_empty() {
+        println!(
+            "\nSkipping the connection check — {} not set in this session.",
+            unresolved.join(", ")
+        );
+    } else {
+        println!(
+            "\nVerifying connection to `{}` (up to {}s)...",
+            collected.name,
+            VERIFY_TIMEOUT.as_secs()
+        );
+        match verify_server(
+            ctx.rt,
+            &collected.name,
+            inline_secrets(&collected.server, &known_values),
+        ) {
+            Ok((aura::mcp::ConnectionStatus::Connected, names)) => {
+                println!(
+                    "{} Connected — {} tool(s) discovered.",
+                    "✓".themed(AuraStyle::Success),
+                    names.len()
+                );
+                if !names.is_empty() {
+                    println!("  {}", entries_summary(&names).themed(AuraStyle::Muted));
+                }
+                verified = true;
+                tool_names = names;
+            }
+            Ok((aura::mcp::ConnectionStatus::Failed(reason), _)) => println!(
+                "{} Connection failed: {reason}",
+                "✗".themed(AuraStyle::Error)
+            ),
+            Ok((aura::mcp::ConnectionStatus::NotAttempted, _)) => println!(
+                "{} The connection was not attempted.",
+                "!".themed(AuraStyle::Warning)
+            ),
+            Err(reason) => println!(
+                "{} Could not verify the connection: {reason}",
+                "!".themed(AuraStyle::Warning)
+            ),
+        }
+    }
+
+    // Preview exactly what will be appended before touching the file.
+    match aura_config::writer::upsert_mcp_server_in_str("", &collected.name, &collected.server) {
+        Ok(preview) => println!("\nThis will be added to the config:\n\n{preview}"),
+        Err(e) => {
+            return WizardEnd::Failed(format!(
+                "could not render the server config: {e}\nNothing was written."
+            ));
+        }
+    }
+    if !new_secrets.is_empty() {
+        let vars: Vec<&str> = new_secrets.iter().map(|(var, _)| var.as_str()).collect();
+        println!(
+            "Secrets are stored in `.env` next to the config ({}), not in the TOML.",
+            vars.join(", ")
+        );
+    }
     if !existing_vars.is_empty() {
         println!(
             "References environment variable(s) you already manage ({}) — nothing is written for them.",
             existing_vars.join(", ")
         );
     }
-    if !confirm(ctx, &format!("Write to {}? [Y/n] ", config_path.display())) {
+    // A verified (or knowingly unverifiable) server defaults to yes; a
+    // server that just failed its check defaults to no.
+    let write_prompt = if verified || !unresolved.is_empty() {
+        format!("Write to {}? [Y/n] ", config_path.display())
+    } else {
+        format!(
+            "The connection could not be verified — write to {} anyway? [y/N] ",
+            config_path.display()
+        )
+    };
+    if !confirm(ctx, &write_prompt) {
         return WizardEnd::Aborted;
     }
 
@@ -187,81 +263,11 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
         println!("Saved secrets to {}.", env_path.display());
     }
 
-    let mut unresolved: Vec<&str> = collected
-        .secrets
-        .iter()
-        .filter(|source| source.known_value().is_none())
-        .map(CredentialSource::env_var)
-        .collect();
-    unresolved.dedup();
-    if !unresolved.is_empty() {
-        println!(
-            "\nSkipping the connection check — {} not set in this session.",
-            unresolved.join(", ")
-        );
+    if verified {
+        offer_worker_access(ctx, config_path, &collected.name, &tool_names);
+    } else {
         print_allowlist_hint(config_path, &collected.name);
-        return WizardEnd::Written {
-            name: collected.name,
-            starter_prompt: collected.starter_prompt,
-            verified: false,
-        };
     }
-    let known_values: Vec<(String, String)> = collected
-        .secrets
-        .iter()
-        .filter_map(|source| {
-            source
-                .known_value()
-                .map(|value| (source.env_var().to_string(), value.to_string()))
-        })
-        .collect();
-
-    println!(
-        "\nVerifying connection to `{}` (up to {}s)...",
-        collected.name,
-        VERIFY_TIMEOUT.as_secs()
-    );
-    let verified = match verify_server(
-        ctx.rt,
-        &collected.name,
-        inline_secrets(&collected.server, &known_values),
-    ) {
-        Ok((aura::mcp::ConnectionStatus::Connected, tool_names)) => {
-            println!(
-                "{} Connected — {} tool(s) discovered.",
-                "✓".themed(AuraStyle::Success),
-                tool_names.len()
-            );
-            offer_worker_access(ctx, config_path, &collected.name, &tool_names);
-            true
-        }
-        Ok((aura::mcp::ConnectionStatus::Failed(reason), _)) => {
-            println!(
-                "{} Connection failed: {reason}\n\
-                 The config entry was kept. Fix the credentials in .env (or the \
-                 server settings) and run /mcp add again to overwrite it.",
-                "✗".themed(AuraStyle::Error)
-            );
-            print_allowlist_hint(config_path, &collected.name);
-            false
-        }
-        Ok((aura::mcp::ConnectionStatus::NotAttempted, _)) => {
-            println!(
-                "{} The connection was not attempted.",
-                "!".themed(AuraStyle::Warning)
-            );
-            print_allowlist_hint(config_path, &collected.name);
-            false
-        }
-        Err(reason) => {
-            println!(
-                "{} Could not verify the connection: {reason}",
-                "!".themed(AuraStyle::Warning)
-            );
-            print_allowlist_hint(config_path, &collected.name);
-            false
-        }
-    };
 
     WizardEnd::Written {
         name: collected.name,

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -8,6 +8,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use std::time::Duration;
 
 use aura_config::config::McpServerConfig;
 
@@ -16,17 +17,22 @@ use crate::backend::Backend;
 use crate::repl::registry::CommandContext;
 use crate::theme::{AuraStyle, Themed};
 
-/// The wizard's terminal states, folded into a user-facing message by [`run`].
+/// How the wizard ended.
 enum WizardEnd {
     Written {
         name: String,
         starter_prompt: Option<&'static str>,
+        verified: bool,
     },
     Aborted,
     Failed(String),
 }
 
 pub(super) fn run(ctx: &mut CommandContext) {
+    // The REPL loop hides the cursor before dispatching a command and only
+    // re-shows it on the next prompt; this handler reads input, so bring
+    // the cursor back for its prompts.
+    let _ = crossterm::execute!(std::io::stdout(), crossterm::cursor::Show);
     let Backend::Direct(direct) = ctx.backend else {
         println!(
             "/mcp add edits the local agent config, so it is only available in \
@@ -49,26 +55,32 @@ pub(super) fn run(ctx: &mut CommandContext) {
         WizardEnd::Written {
             name,
             starter_prompt,
+            verified,
         } => {
-            println!(
-                "\n{} `{name}` added to {}.",
-                "✓".themed(AuraStyle::Success),
-                config_path.display()
-            );
-            println!("Restart aura to activate the new server.");
-            if let Some(prompt) = starter_prompt {
+            if verified {
                 println!(
-                    "\nTry this once it's live:\n  {}",
-                    prompt.themed(AuraStyle::Emphasis)
+                    "\n{} `{name}` added to {} and verified.",
+                    "✓".themed(AuraStyle::Success),
+                    config_path.display()
                 );
+                println!("Restart aura to activate the new server.");
+                if let Some(prompt) = starter_prompt {
+                    println!(
+                        "\nTry this once it's live:\n  {}",
+                        prompt.themed(AuraStyle::Emphasis)
+                    );
+                }
+            } else {
+                println!(
+                    "\n`{name}` added to {} (connection not verified).",
+                    config_path.display()
+                );
+                println!("Restart aura to activate the new server once it's reachable.");
             }
         }
         WizardEnd::Aborted => println!("\n/mcp add aborted — nothing was written."),
         WizardEnd::Failed(reason) => {
-            println!(
-                "\n{} {reason}\nNothing was partially applied to the config.",
-                "error:".themed(AuraStyle::Error)
-            );
+            println!("\n{} {reason}", "error:".themed(AuraStyle::Error));
         }
     }
 }
@@ -116,7 +128,11 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
     // Preview exactly what will be appended before touching the file.
     match aura_config::writer::upsert_mcp_server_in_str("", &collected.name, &collected.server) {
         Ok(preview) => println!("\nThis will be added to the config:\n\n{preview}"),
-        Err(e) => return WizardEnd::Failed(format!("could not render the server config: {e}")),
+        Err(e) => {
+            return WizardEnd::Failed(format!(
+                "could not render the server config: {e}\nNothing was written."
+            ));
+        }
     }
     if !collected.secrets.is_empty() {
         let vars: Vec<&str> = collected
@@ -136,7 +152,9 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
     if let Err(e) =
         aura_config::writer::upsert_mcp_server(config_path, &collected.name, &collected.server)
     {
-        return WizardEnd::Failed(format!("failed to update the config: {e}"));
+        return WizardEnd::Failed(format!(
+            "failed to update the config: {e}\nThe config file was left unchanged."
+        ));
     }
     if !collected.secrets.is_empty() {
         let env_path = config_path.parent().unwrap_or(Path::new(".")).join(".env");
@@ -150,31 +168,46 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
         println!("Saved secrets to {}.", env_path.display());
     }
 
-    println!("\nVerifying connection to `{}`...", collected.name);
-    match verify_server(
+    println!(
+        "\nVerifying connection to `{}` (up to {}s)...",
+        collected.name,
+        VERIFY_TIMEOUT.as_secs()
+    );
+    let verified = match verify_server(
         ctx.rt,
         &collected.name,
         inline_secrets(&collected.server, &collected.secrets),
     ) {
-        Ok((aura::mcp::ConnectionStatus::Connected, tools_count)) => println!(
-            "{} Connected — {tools_count} tool(s) discovered.",
-            "✓".themed(AuraStyle::Success)
-        ),
-        Ok((aura::mcp::ConnectionStatus::Failed(reason), _)) => println!(
-            "{} Connection failed: {reason}\n\
-             The config entry was kept. Fix the credentials in .env (or the \
-             server settings) and run /mcp add again to overwrite it.",
-            "✗".themed(AuraStyle::Error)
-        ),
-        Ok((aura::mcp::ConnectionStatus::NotAttempted, _)) | Err(_) => println!(
-            "{} Could not verify the connection; check the server after restarting.",
-            "!".themed(AuraStyle::Warning)
-        ),
-    }
+        Ok((aura::mcp::ConnectionStatus::Connected, tools_count)) => {
+            println!(
+                "{} Connected — {tools_count} tool(s) discovered.",
+                "✓".themed(AuraStyle::Success)
+            );
+            true
+        }
+        Ok((aura::mcp::ConnectionStatus::Failed(reason), _)) => {
+            println!(
+                "{} Connection failed: {reason}\n\
+                 The config entry was kept. Fix the credentials in .env (or the \
+                 server settings) and run /mcp add again to overwrite it.",
+                "✗".themed(AuraStyle::Error)
+            );
+            false
+        }
+        Ok((aura::mcp::ConnectionStatus::NotAttempted, _)) => false,
+        Err(reason) => {
+            println!(
+                "{} Could not verify the connection: {reason}",
+                "!".themed(AuraStyle::Warning)
+            );
+            false
+        }
+    };
 
     WizardEnd::Written {
         name: collected.name,
         starter_prompt: collected.starter_prompt,
+        verified,
     }
 }
 
@@ -208,6 +241,12 @@ fn inline_secrets(server: &McpServerConfig, secrets: &[(String, String)]) -> Mcp
 /// agent — the new server only joins the real roster on restart), reads the
 /// resulting status and tool count, and closes every client — including any
 /// spawned stdio child process — before returning.
+/// Bounds the whole connect + tool-discovery attempt: the underlying HTTP
+/// client has no timeout of its own, so a blackholed endpoint (or npx
+/// downloading a stdio server on first run) would otherwise hang the REPL
+/// with no Ctrl-C escape.
+const VERIFY_TIMEOUT: Duration = Duration::from_secs(30);
+
 fn verify_server(
     rt: &tokio::runtime::Runtime,
     name: &str,
@@ -218,9 +257,21 @@ fn verify_server(
         sanitize_schemas: true,
     };
     rt.block_on(async {
-        let manager = aura::mcp::McpManager::initialize_from_config(&mcp_config)
-            .await
-            .map_err(|e| e.to_string())?;
+        let manager = match tokio::time::timeout(
+            VERIFY_TIMEOUT,
+            aura::mcp::McpManager::initialize_from_config(&mcp_config),
+        )
+        .await
+        {
+            Err(_) => {
+                return Err(format!(
+                    "timed out after {}s; check the server after restarting",
+                    VERIFY_TIMEOUT.as_secs()
+                ));
+            }
+            Ok(Err(e)) => return Err(e.to_string()),
+            Ok(Ok(manager)) => manager,
+        };
         let result = manager
             .server_info
             .get(name)
@@ -237,7 +288,7 @@ fn verify_server(
 struct CollectedServer {
     name: String,
     server: McpServerConfig,
-    /// `(env var, secret value)` pairs destined for `.env`.
+    /// `(env var, secret value)` pairs.
     secrets: Vec<(String, String)>,
     starter_prompt: Option<&'static str>,
 }
@@ -425,7 +476,10 @@ fn config_has_server(config_path: &Path, name: &str) -> bool {
 
 /// Merge `(env var, value)` pairs into the `.env` file, creating it (with
 /// the do-not-commit header and `0o600` on unix) when absent. Values of
-/// existing keys are replaced; unrelated lines are preserved.
+/// existing keys are replaced; unrelated lines are preserved. Values are
+/// quoted as needed so dotenvy can parse them back — an unquoted space or
+/// `#` doesn't just corrupt that entry, it aborts dotenvy's parse and
+/// silently drops every line after it.
 fn write_env_secrets(env_path: &Path, secrets: &[(String, String)]) -> std::io::Result<()> {
     let mut content = match fs::read_to_string(env_path) {
         Ok(content) => content,
@@ -434,19 +488,49 @@ fn write_env_secrets(env_path: &Path, secrets: &[(String, String)]) -> std::io::
     };
     let creating = content.is_empty();
     for (var, value) in secrets {
+        let value = quote_env_value(value);
         if content.is_empty() {
-            content = crate::init::render_env(var, value);
+            content = crate::init::render_env(var, &value);
         } else {
-            content = crate::init::merge_env(&content, var, value);
+            content = crate::init::merge_env(&content, var, &value);
         }
     }
-    fs::write(env_path, content)?;
+    // On unix, apply 0600 at creation rather than after the write so the
+    // secrets are never on disk in a umask-default readable file.
     #[cfg(unix)]
-    if creating {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(env_path, fs::Permissions::from_mode(0o600))?;
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+        if creating {
+            options.mode(0o600);
+        }
+        options.open(env_path)?.write_all(content.as_bytes())?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = creating;
+        fs::write(env_path, content)?;
     }
     Ok(())
+}
+
+/// Quote a dotenv value when it contains characters dotenvy would misparse
+/// unquoted (whitespace, `#`, quotes, backslash). Plain token-like values
+/// stay unquoted; single quotes are preferred because dotenvy treats their
+/// contents as fully literal.
+fn quote_env_value(value: &str) -> String {
+    let plain = value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || "_@%+=:,./-".contains(c));
+    if plain {
+        value.to_string()
+    } else if !value.contains('\'') {
+        format!("'{value}'")
+    } else {
+        format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+    }
 }
 
 /// `GRAFANA` + `Authorization` → `GRAFANA_AUTHORIZATION`: uppercase, with
@@ -513,11 +597,33 @@ fn confirm(ctx: &mut CommandContext, prompt: &str) -> bool {
 }
 
 /// Masked credential input straight from the tty (never echoed, never in
-/// rustyline history). `None` on error or empty input — treat as abort.
+/// rustyline history). Empty input gets one re-prompt (rpassword runs in
+/// cooked mode where Ctrl-C doesn't interrupt, so Enter-on-empty is the
+/// documented escape); `None` aborts the wizard.
+///
+/// Clears [`SIGINT_RECEIVED`](crate::ui::state::SIGINT_RECEIVED) before
+/// returning: a Ctrl-C pressed during the masked read only sets the flag,
+/// and left set it would count as a phantom first quit-press on the next
+/// streaming turn.
 fn ask_secret(prompt: &str) -> Option<String> {
-    let value = rpassword::prompt_password(prompt).ok()?;
-    let value = value.trim().to_string();
-    if value.is_empty() { None } else { Some(value) }
+    let mut result = None;
+    for attempt in 0..2 {
+        match rpassword::prompt_password(prompt).ok() {
+            None => break,
+            Some(value) => {
+                let value = value.trim().to_string();
+                if !value.is_empty() {
+                    result = Some(value);
+                    break;
+                }
+                if attempt == 0 {
+                    println!("Empty input — enter the value, or press Enter again to abort.");
+                }
+            }
+        }
+    }
+    crate::ui::state::SIGINT_RECEIVED.store(false, std::sync::atomic::Ordering::Relaxed);
+    result
 }
 
 #[cfg(test)]
@@ -632,6 +738,43 @@ mod tests {
             let mode = fs::metadata(&env_path).unwrap().permissions().mode();
             assert_eq!(mode & 0o777, 0o600);
         }
+    }
+
+    #[test]
+    fn env_values_with_spaces_survive_dotenv_parsing() {
+        let dir = tempfile::tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        write_env_secrets(
+            &env_path,
+            &[
+                ("AUTH_HEADER".to_string(), "Bearer abc def#ghi".to_string()),
+                ("PLAIN_KEY".to_string(), "sk-plain-123".to_string()),
+            ],
+        )
+        .unwrap();
+        // An unquoted space would abort dotenvy's parse here and drop every
+        // later line, so parse the whole file back and check both keys.
+        let parsed: HashMap<String, String> = dotenvy::from_path_iter(&env_path)
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            parsed.get("AUTH_HEADER").map(String::as_str),
+            Some("Bearer abc def#ghi")
+        );
+        assert_eq!(
+            parsed.get("PLAIN_KEY").map(String::as_str),
+            Some("sk-plain-123")
+        );
+    }
+
+    #[test]
+    fn quotes_env_values_only_when_needed() {
+        assert_eq!(quote_env_value("sk-plain_123"), "sk-plain_123");
+        assert_eq!(quote_env_value("Bearer abc"), "'Bearer abc'");
+        assert_eq!(quote_env_value("with#hash"), "'with#hash'");
+        assert_eq!(quote_env_value("it's"), "\"it's\"");
+        assert_eq!(quote_env_value("a\"b"), "'a\"b'");
     }
 
     #[test]

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -150,10 +150,87 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
         println!("Saved secrets to {}.", env_path.display());
     }
 
+    println!("\nVerifying connection to `{}`...", collected.name);
+    match verify_server(
+        ctx.rt,
+        &collected.name,
+        inline_secrets(&collected.server, &collected.secrets),
+    ) {
+        Ok((aura::mcp::ConnectionStatus::Connected, tools_count)) => println!(
+            "{} Connected — {tools_count} tool(s) discovered.",
+            "✓".themed(AuraStyle::Success)
+        ),
+        Ok((aura::mcp::ConnectionStatus::Failed(reason), _)) => println!(
+            "{} Connection failed: {reason}\n\
+             The config entry was kept. Fix the credentials in .env (or the \
+             server settings) and run /mcp add again to overwrite it.",
+            "✗".themed(AuraStyle::Error)
+        ),
+        Ok((aura::mcp::ConnectionStatus::NotAttempted, _)) | Err(_) => println!(
+            "{} Could not verify the connection; check the server after restarting.",
+            "!".themed(AuraStyle::Warning)
+        ),
+    }
+
     WizardEnd::Written {
         name: collected.name,
         starter_prompt: collected.starter_prompt,
     }
+}
+
+/// Replace each `{{ env.VAR }}` placeholder with its collected secret value.
+///
+/// The connectivity check needs real credentials, but the freshly written
+/// `.env` is only read at process startup (dotenvy), so the placeholders
+/// can't resolve through the normal loader this session. The inlined copy
+/// exists only in memory for the duration of the check.
+fn inline_secrets(server: &McpServerConfig, secrets: &[(String, String)]) -> McpServerConfig {
+    let mut server = server.clone();
+    let inline = |values: &mut HashMap<String, String>| {
+        for value in values.values_mut() {
+            for (var, secret) in secrets {
+                *value = value.replace(&format!("{{{{ env.{var} }}}}"), secret);
+            }
+        }
+    };
+    match &mut server {
+        McpServerConfig::HttpStreamable { headers, .. } | McpServerConfig::Sse { headers, .. } => {
+            inline(headers);
+        }
+        McpServerConfig::Stdio { env, .. } => inline(env),
+    }
+    server
+}
+
+/// Throwaway connection + tool-discovery check against just the new server.
+///
+/// Builds a single-server `McpManager` (entirely separate from the running
+/// agent — the new server only joins the real roster on restart), reads the
+/// resulting status and tool count, and closes every client — including any
+/// spawned stdio child process — before returning.
+fn verify_server(
+    rt: &tokio::runtime::Runtime,
+    name: &str,
+    server: McpServerConfig,
+) -> Result<(aura::mcp::ConnectionStatus, usize), String> {
+    let mcp_config = aura_config::config::McpConfig {
+        servers: HashMap::from([(name.to_string(), server)]),
+        sanitize_schemas: true,
+    };
+    rt.block_on(async {
+        let manager = aura::mcp::McpManager::initialize_from_config(&mcp_config)
+            .await
+            .map_err(|e| e.to_string())?;
+        let result = manager
+            .server_info
+            .get(name)
+            .map(|info| (info.status.clone(), info.tools_count))
+            .ok_or_else(|| format!("`{name}` missing from the connection status snapshot"));
+        manager
+            .cancel_and_close_all("mcp-add-verify", "verification complete")
+            .await;
+        result
+    })
 }
 
 /// Everything the interactive steps produce for the write phase.
@@ -555,6 +632,37 @@ mod tests {
             let mode = fs::metadata(&env_path).unwrap().permissions().mode();
             assert_eq!(mode & 0o777, 0o600);
         }
+    }
+
+    #[test]
+    fn inlines_secrets_for_verification_without_touching_original() {
+        let server = http_streamable(
+            "https://mcp.mezmo.com/mcp".to_string(),
+            HashMap::from([(
+                "Authorization".to_string(),
+                "Bearer {{ env.MEZMO_API_KEY }}".to_string(),
+            )]),
+            "",
+        );
+        let inlined = inline_secrets(
+            &server,
+            &[("MEZMO_API_KEY".to_string(), "sk-live-123".to_string())],
+        );
+        let McpServerConfig::HttpStreamable { headers, .. } = &inlined else {
+            panic!("transport changed");
+        };
+        assert_eq!(
+            headers.get("Authorization").map(String::as_str),
+            Some("Bearer sk-live-123")
+        );
+        // The original (destined for the config file) keeps the placeholder.
+        let McpServerConfig::HttpStreamable { headers, .. } = &server else {
+            panic!("transport changed");
+        };
+        assert_eq!(
+            headers.get("Authorization").map(String::as_str),
+            Some("Bearer {{ env.MEZMO_API_KEY }}")
+        );
     }
 
     #[test]

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -1,0 +1,576 @@
+//! Guided `/mcp add` flow: pick a catalog server (or define a custom one),
+//! collect credentials with masked input, and write the result to the
+//! standalone config via `aura_config::writer` plus `.env` for secrets.
+//!
+//! Standalone mode only — HTTP mode's config lives on the remote server.
+//! The flow is deliberately deterministic: no LLM ever sees a credential.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use aura_config::config::McpServerConfig;
+
+use super::catalog::{CATALOG, CatalogEntry, Template};
+use crate::backend::Backend;
+use crate::repl::registry::CommandContext;
+use crate::theme::{AuraStyle, Themed};
+
+/// The wizard's terminal states, folded into a user-facing message by [`run`].
+enum WizardEnd {
+    Written {
+        name: String,
+        starter_prompt: Option<&'static str>,
+    },
+    Aborted,
+    Failed(String),
+}
+
+pub(super) fn run(ctx: &mut CommandContext) {
+    let Backend::Direct(direct) = ctx.backend else {
+        println!(
+            "/mcp add edits the local agent config, so it is only available in \
+             standalone mode (run without --api-url)."
+        );
+        return;
+    };
+    let config_path = direct.config_path().to_path_buf();
+    if !config_path.is_file() {
+        println!(
+            "The agent config was loaded from `{}`, which is not a single file. \
+             /mcp add can only edit a single-file config; add the server to one \
+             of the TOML files in that directory manually.",
+            config_path.display()
+        );
+        return;
+    }
+
+    match drive(ctx, &config_path) {
+        WizardEnd::Written {
+            name,
+            starter_prompt,
+        } => {
+            println!(
+                "\n{} `{name}` added to {}.",
+                "✓".themed(AuraStyle::Success),
+                config_path.display()
+            );
+            println!("Restart aura to activate the new server.");
+            if let Some(prompt) = starter_prompt {
+                println!(
+                    "\nTry this once it's live:\n  {}",
+                    prompt.themed(AuraStyle::Emphasis)
+                );
+            }
+        }
+        WizardEnd::Aborted => println!("\n/mcp add aborted — nothing was written."),
+        WizardEnd::Failed(reason) => {
+            println!(
+                "\n{} {reason}\nNothing was partially applied to the config.",
+                "error:".themed(AuraStyle::Error)
+            );
+        }
+    }
+}
+
+/// Interactive body. Every early `return` before the config write means no
+/// file was touched; `.env` is only written after the config upsert succeeds.
+fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
+    println!("{}", "Add an MCP server".themed(AuraStyle::Heading));
+    for (i, entry) in CATALOG.iter().enumerate() {
+        println!(
+            "  {} {} {} {}",
+            format!("{}.", i + 1).themed(AuraStyle::Muted),
+            entry.key.themed(AuraStyle::Heading),
+            "—".themed(AuraStyle::Muted),
+            entry.description.themed(AuraStyle::Muted),
+        );
+    }
+    println!(
+        "  {} {} {} {}",
+        format!("{}.", CATALOG.len() + 1).themed(AuraStyle::Muted),
+        "custom".themed(AuraStyle::Heading),
+        "—".themed(AuraStyle::Muted),
+        "define transport, URL/command, and auth yourself".themed(AuraStyle::Muted),
+    );
+
+    let entry = loop {
+        let Some(answer) = ask(ctx, &format!("Server to add [1-{}]: ", CATALOG.len() + 1)) else {
+            return WizardEnd::Aborted;
+        };
+        match answer.parse::<usize>() {
+            Ok(n) if (1..=CATALOG.len()).contains(&n) => break Some(&CATALOG[n - 1]),
+            Ok(n) if n == CATALOG.len() + 1 => break None,
+            _ => println!("Enter a number between 1 and {}.", CATALOG.len() + 1),
+        }
+    };
+
+    let collected = match entry {
+        Some(entry) => collect_catalog(ctx, entry, config_path),
+        None => collect_custom(ctx, config_path),
+    };
+    let Some(collected) = collected else {
+        return WizardEnd::Aborted;
+    };
+
+    // Preview exactly what will be appended before touching the file.
+    match aura_config::writer::upsert_mcp_server_in_str("", &collected.name, &collected.server) {
+        Ok(preview) => println!("\nThis will be added to the config:\n\n{preview}"),
+        Err(e) => return WizardEnd::Failed(format!("could not render the server config: {e}")),
+    }
+    if !collected.secrets.is_empty() {
+        let vars: Vec<&str> = collected
+            .secrets
+            .iter()
+            .map(|(var, _)| var.as_str())
+            .collect();
+        println!(
+            "Secrets are stored in `.env` next to the config ({}), not in the TOML.",
+            vars.join(", ")
+        );
+    }
+    if !confirm(ctx, &format!("Write to {}? [Y/n] ", config_path.display())) {
+        return WizardEnd::Aborted;
+    }
+
+    if let Err(e) =
+        aura_config::writer::upsert_mcp_server(config_path, &collected.name, &collected.server)
+    {
+        return WizardEnd::Failed(format!("failed to update the config: {e}"));
+    }
+    if !collected.secrets.is_empty() {
+        let env_path = config_path.parent().unwrap_or(Path::new(".")).join(".env");
+        if let Err(e) = write_env_secrets(&env_path, &collected.secrets) {
+            return WizardEnd::Failed(format!(
+                "the server was written to the config, but saving secrets to {} failed: {e}\n\
+                 Add the variable(s) to that file manually.",
+                env_path.display()
+            ));
+        }
+        println!("Saved secrets to {}.", env_path.display());
+    }
+
+    WizardEnd::Written {
+        name: collected.name,
+        starter_prompt: collected.starter_prompt,
+    }
+}
+
+/// Everything the interactive steps produce for the write phase.
+struct CollectedServer {
+    name: String,
+    server: McpServerConfig,
+    /// `(env var, secret value)` pairs destined for `.env`.
+    secrets: Vec<(String, String)>,
+    starter_prompt: Option<&'static str>,
+}
+
+fn collect_catalog(
+    ctx: &mut CommandContext,
+    entry: &'static CatalogEntry,
+    config_path: &Path,
+) -> Option<CollectedServer> {
+    println!("\n{}", entry.prerequisites.themed(AuraStyle::Muted));
+    if !confirm(ctx, "Continue? [Y/n] ") {
+        return None;
+    }
+
+    let name = ask_server_name(ctx, Some(entry.key), config_path)?;
+
+    let (server, secrets) = match &entry.template {
+        Template::Http { url, headers } => {
+            let mut header_map = HashMap::new();
+            let mut secrets = Vec::new();
+            for template in *headers {
+                let value = ask_secret(&format!("{}: ", template.secret_prompt))?;
+                header_map.insert(
+                    template.header.to_string(),
+                    template.value_template.to_string(),
+                );
+                secrets.push((template.env_var.to_string(), value));
+            }
+            (
+                http_streamable(url.to_string(), header_map, entry.description),
+                secrets,
+            )
+        }
+        Template::Stdio { cmd, args } => (
+            McpServerConfig::Stdio {
+                cmd: cmd.iter().map(|s| s.to_string()).collect(),
+                args: args.iter().map(|s| s.to_string()).collect(),
+                env: HashMap::new(),
+                description: Some(entry.description.to_string()),
+                scratchpad: HashMap::new(),
+            },
+            Vec::new(),
+        ),
+    };
+
+    Some(CollectedServer {
+        name,
+        server,
+        secrets,
+        starter_prompt: Some(entry.starter_prompt),
+    })
+}
+
+fn collect_custom(ctx: &mut CommandContext, config_path: &Path) -> Option<CollectedServer> {
+    let name = ask_server_name(ctx, None, config_path)?;
+
+    println!("Transport:");
+    println!("  1. http_streamable (HTTP endpoint)");
+    println!("  2. sse (Server-Sent Events endpoint)");
+    println!("  3. stdio (local command)");
+    let transport = loop {
+        let answer = ask(ctx, "Transport [1-3]: ")?;
+        match answer.as_str() {
+            "1" | "2" | "3" => break answer,
+            _ => println!("Enter 1, 2, or 3."),
+        }
+    };
+
+    let (server, secrets) = if transport == "3" {
+        let (cmd, args) = loop {
+            let line = ask(ctx, "Command to run (e.g. npx -y some-mcp-server): ")?;
+            match parse_command_line(&line) {
+                Some(parsed) => break parsed,
+                None => println!("Enter a non-empty command."),
+            }
+        };
+        (
+            McpServerConfig::Stdio {
+                cmd,
+                args,
+                env: HashMap::new(),
+                description: None,
+                scratchpad: HashMap::new(),
+            },
+            Vec::new(),
+        )
+    } else {
+        let url = loop {
+            let url = ask(ctx, "Server URL: ")?;
+            if url.starts_with("http://") || url.starts_with("https://") {
+                break url;
+            }
+            println!("Enter an http:// or https:// URL.");
+        };
+        let mut headers = HashMap::new();
+        let mut secrets = Vec::new();
+        if confirm(ctx, "Does the server need an auth header? [y/N] ")
+            && let Some(header) = ask_with_default(ctx, "Header name", "Authorization")
+        {
+            let env_var = derive_env_var(&name, &header);
+            let value = ask_secret(&format!(
+                "Value for `{header}` (full value, e.g. `Bearer <token>`): "
+            ))?;
+            headers.insert(header, format!("{{{{ env.{env_var} }}}}"));
+            secrets.push((env_var, value));
+        }
+        let server = if transport == "1" {
+            http_streamable(url, headers, "")
+        } else {
+            McpServerConfig::Sse {
+                url,
+                headers,
+                description: None,
+                headers_from_request: HashMap::new(),
+                scratchpad: HashMap::new(),
+            }
+        };
+        (server, secrets)
+    };
+
+    Some(CollectedServer {
+        name,
+        server,
+        secrets,
+        starter_prompt: None,
+    })
+}
+
+fn http_streamable(
+    url: String,
+    headers: HashMap<String, String>,
+    description: &str,
+) -> McpServerConfig {
+    McpServerConfig::HttpStreamable {
+        url,
+        headers,
+        description: (!description.is_empty()).then(|| description.to_string()),
+        headers_from_request: HashMap::new(),
+        scratchpad: HashMap::new(),
+    }
+}
+
+/// Ask for (or default) the server name, rejecting invalid names and
+/// confirming before an existing `[mcp.servers.<name>]` is overwritten.
+fn ask_server_name(
+    ctx: &mut CommandContext,
+    default: Option<&str>,
+    config_path: &Path,
+) -> Option<String> {
+    let name = loop {
+        let name = match default {
+            Some(default) => ask_with_default(ctx, "Server name", default)?,
+            None => ask(ctx, "Server name: ")?,
+        };
+        if is_valid_server_name(&name) {
+            break name;
+        }
+        println!("Server names may contain letters, digits, `-`, and `_` only.");
+    };
+    if config_has_server(config_path, &name)
+        && !confirm(
+            ctx,
+            &format!("`{name}` is already configured. Overwrite? [y/N] "),
+        )
+    {
+        return None;
+    }
+    Some(name)
+}
+
+/// Best-effort check whether `[mcp.servers.<name>]` already exists; a
+/// malformed config reads as "absent" here and fails properly at write time.
+fn config_has_server(config_path: &Path, name: &str) -> bool {
+    let Ok(content) = fs::read_to_string(config_path) else {
+        return false;
+    };
+    let Ok(doc) = content.parse::<toml_edit::DocumentMut>() else {
+        return false;
+    };
+    doc.get("mcp")
+        .and_then(|mcp| mcp.get("servers"))
+        .and_then(|servers| servers.get(name))
+        .is_some()
+}
+
+/// Merge `(env var, value)` pairs into the `.env` file, creating it (with
+/// the do-not-commit header and `0o600` on unix) when absent. Values of
+/// existing keys are replaced; unrelated lines are preserved.
+fn write_env_secrets(env_path: &Path, secrets: &[(String, String)]) -> std::io::Result<()> {
+    let mut content = match fs::read_to_string(env_path) {
+        Ok(content) => content,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e),
+    };
+    let creating = content.is_empty();
+    for (var, value) in secrets {
+        if content.is_empty() {
+            content = crate::init::render_env(var, value);
+        } else {
+            content = crate::init::merge_env(&content, var, value);
+        }
+    }
+    fs::write(env_path, content)?;
+    #[cfg(unix)]
+    if creating {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(env_path, fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+/// `GRAFANA` + `Authorization` → `GRAFANA_AUTHORIZATION`: uppercase, with
+/// every non-alphanumeric run collapsed to a single `_`.
+fn derive_env_var(server: &str, header: &str) -> String {
+    let mut out = String::new();
+    for part in [server, header] {
+        for c in part.chars() {
+            if c.is_ascii_alphanumeric() {
+                out.push(c.to_ascii_uppercase());
+            } else if !out.ends_with('_') && !out.is_empty() {
+                out.push('_');
+            }
+        }
+        if !out.ends_with('_') {
+            out.push('_');
+        }
+    }
+    out.trim_end_matches('_').to_string()
+}
+
+fn is_valid_server_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Whitespace-split a command line into `cmd = [first]` + `args = rest`.
+/// No shell quoting — the wizard says so in the prompt example.
+fn parse_command_line(line: &str) -> Option<(Vec<String>, Vec<String>)> {
+    let mut tokens = line.split_whitespace().map(str::to_string);
+    let first = tokens.next()?;
+    Some((vec![first], tokens.collect()))
+}
+
+/// One line of wizard input via the REPL's rustyline editor (which owns the
+/// terminal between dispatches). `None` on Ctrl-C/Ctrl-D — treat as abort.
+fn ask(ctx: &mut CommandContext, prompt: &str) -> Option<String> {
+    ctx.input_reader
+        .readline(prompt)
+        .ok()
+        .map(|line| line.trim().to_string())
+}
+
+fn ask_with_default(ctx: &mut CommandContext, prompt: &str, default: &str) -> Option<String> {
+    let answer = ask(ctx, &format!("{prompt} [{default}]: "))?;
+    Some(if answer.is_empty() {
+        default.to_string()
+    } else {
+        answer
+    })
+}
+
+/// Y/n confirmation; the capitalized letter in the caller's prompt is the
+/// default taken on plain Enter.
+fn confirm(ctx: &mut CommandContext, prompt: &str) -> bool {
+    let default_yes = prompt.contains("[Y/n]");
+    match ask(ctx, prompt) {
+        Some(answer) if answer.is_empty() => default_yes,
+        Some(answer) => matches!(answer.to_ascii_lowercase().as_str(), "y" | "yes"),
+        None => false,
+    }
+}
+
+/// Masked credential input straight from the tty (never echoed, never in
+/// rustyline history). `None` on error or empty input — treat as abort.
+fn ask_secret(prompt: &str) -> Option<String> {
+    let value = rpassword::prompt_password(prompt).ok()?;
+    let value = value.trim().to_string();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_env_var_names() {
+        assert_eq!(
+            derive_env_var("grafana", "Authorization"),
+            "GRAFANA_AUTHORIZATION"
+        );
+        assert_eq!(
+            derive_env_var("my-server", "X-Api-Key"),
+            "MY_SERVER_X_API_KEY"
+        );
+    }
+
+    #[test]
+    fn validates_server_names() {
+        assert!(is_valid_server_name("mezmo"));
+        assert!(is_valid_server_name("my_server-2"));
+        assert!(!is_valid_server_name(""));
+        assert!(!is_valid_server_name("has space"));
+        assert!(!is_valid_server_name("dotted.name"));
+    }
+
+    #[test]
+    fn splits_command_lines() {
+        assert_eq!(
+            parse_command_line("npx -y some-mcp"),
+            Some((
+                vec!["npx".to_string()],
+                vec!["-y".to_string(), "some-mcp".to_string()]
+            ))
+        );
+        assert_eq!(parse_command_line("   "), None);
+    }
+
+    #[test]
+    fn catalog_templates_render_and_reload() {
+        for entry in CATALOG {
+            let (server, _secrets) = match &entry.template {
+                Template::Http { url, headers } => {
+                    let header_map = headers
+                        .iter()
+                        .map(|t| (t.header.to_string(), t.value_template.to_string()))
+                        .collect();
+                    (
+                        http_streamable(url.to_string(), header_map, entry.description),
+                        (),
+                    )
+                }
+                Template::Stdio { cmd, args } => (
+                    McpServerConfig::Stdio {
+                        cmd: cmd.iter().map(|s| s.to_string()).collect(),
+                        args: args.iter().map(|s| s.to_string()).collect(),
+                        env: HashMap::new(),
+                        description: Some(entry.description.to_string()),
+                        scratchpad: HashMap::new(),
+                    },
+                    (),
+                ),
+            };
+            let rendered =
+                aura_config::writer::upsert_mcp_server_in_str("", entry.key, &server).unwrap();
+            assert!(
+                rendered.contains(&format!("[mcp.servers.{}]", entry.key)),
+                "{rendered}"
+            );
+            // Placeholders must land verbatim so secrets stay in .env.
+            if let Template::Http { headers, .. } = &entry.template {
+                for template in *headers {
+                    assert!(
+                        rendered.contains(&format!("{{{{ env.{} }}}}", template.env_var)),
+                        "missing placeholder for {} in:\n{rendered}",
+                        template.env_var
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn env_secrets_create_and_merge() {
+        let dir = tempfile::tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        write_env_secrets(
+            &env_path,
+            &[("MEZMO_API_KEY".to_string(), "secret1".to_string())],
+        )
+        .unwrap();
+        let first = fs::read_to_string(&env_path).unwrap();
+        assert!(first.contains("MEZMO_API_KEY=secret1"), "{first}");
+
+        write_env_secrets(
+            &env_path,
+            &[
+                ("MEZMO_API_KEY".to_string(), "rotated".to_string()),
+                ("DD_API_KEY".to_string(), "secret2".to_string()),
+            ],
+        )
+        .unwrap();
+        let merged = fs::read_to_string(&env_path).unwrap();
+        assert!(merged.contains("MEZMO_API_KEY=rotated"), "{merged}");
+        assert!(!merged.contains("secret1"), "{merged}");
+        assert!(merged.contains("DD_API_KEY=secret2"), "{merged}");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&env_path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+    }
+
+    #[test]
+    fn detects_existing_server_in_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            "[agent]\nname = \"a\"\n\n[mcp.servers.mezmo]\ntransport = \"sse\"\nurl = \"https://x\"\n",
+        )
+        .unwrap();
+        assert!(config_has_server(&path, "mezmo"));
+        assert!(!config_has_server(&path, "datadog"));
+        assert!(!config_has_server(
+            &dir.path().join("missing.toml"),
+            "mezmo"
+        ));
+    }
+}

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -751,12 +751,43 @@ fn collect_custom(ctx: &mut CommandContext, config_path: &Path) -> Option<Collec
         if confirm(ctx, "Does the server need an auth header? [y/N] ")
             && let Some(header) = ask_with_default(ctx, "Header name", "Authorization")
         {
-            let source = collect_credential(
-                ctx,
-                &derive_env_var(&name, &header),
-                &format!("`{header}` header value (full value, e.g. `Bearer <token>`)"),
-            )?;
-            headers.insert(header, format!("{{{{ env.{} }}}}", source.env_var()));
+            println!("How is the `{header}` value formed?");
+            println!("  1. Bearer <secret>");
+            println!("  2. Token <secret>");
+            println!("  3. <secret> only (no prefix)");
+            println!("  4. Custom prefix");
+            let prefix = loop {
+                let answer = ask(ctx, "Choice [1-4]: ")?;
+                match answer.as_str() {
+                    "1" => break "Bearer ".to_string(),
+                    "2" => break "Token ".to_string(),
+                    "3" => break String::new(),
+                    "4" => {
+                        // `ask` trims, so a separating space can't be typed —
+                        // add it for any non-empty prefix.
+                        let custom = ask(ctx, "Prefix: ")?;
+                        break if custom.is_empty() {
+                            custom
+                        } else {
+                            format!("{custom} ")
+                        };
+                    }
+                    _ => println!("Enter a number between 1 and 4."),
+                }
+            };
+            let secret_prompt = if prefix.is_empty() {
+                format!("`{header}` secret")
+            } else {
+                format!(
+                    "`{header}` secret (without the `{}` prefix)",
+                    prefix.trim_end()
+                )
+            };
+            let source = collect_credential(ctx, &derive_env_var(&name, &header), &secret_prompt)?;
+            headers.insert(
+                header,
+                format!("{prefix}{{{{ env.{} }}}}", source.env_var()),
+            );
             secrets.push(source);
         }
         let server = if transport == "1" {

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -1,9 +1,8 @@
-//! Guided `/mcp add` flow: pick a catalog server (or define a custom one),
-//! collect credentials with masked input, and write the result to the
-//! standalone config via `aura_config::writer` plus `.env` for secrets.
+//! Guided `/mcp add` flow: pick a catalog or custom server, collect
+//! credentials with masked input, write the config + `.env`.
 //!
-//! Standalone mode only — HTTP mode's config lives on the remote server.
-//! The flow is deliberately deterministic: no LLM ever sees a credential.
+//! Standalone mode only, and deliberately deterministic: no LLM ever
+//! sees a credential.
 
 use std::collections::HashMap;
 use std::fs;
@@ -29,9 +28,8 @@ enum WizardEnd {
 }
 
 pub(super) fn run(ctx: &mut CommandContext) {
-    // The REPL loop hides the cursor before dispatching a command and only
-    // re-shows it on the next prompt; this handler reads input, so bring
-    // the cursor back for its prompts.
+    // The REPL loop hides the cursor around dispatch; this handler reads
+    // input, so bring it back.
     let _ = crossterm::execute!(std::io::stdout(), crossterm::cursor::Show);
     let Backend::Direct(direct) = ctx.backend else {
         println!(
@@ -159,10 +157,9 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
         })
         .collect();
 
-    // Verify BEFORE asking to write, so consent to the config change is
-    // informed by a live connection result and the discovered tools — and
-    // a failing credential never lands on disk unless explicitly chosen.
-    // The check runs against an in-memory copy; nothing is written yet.
+    // Verify before asking to write (in memory — nothing on disk yet):
+    // consent is informed by the live result, and a failing credential
+    // never lands in the config unless explicitly chosen.
     let mut verified = false;
     let mut tool_names: Vec<String> = Vec::new();
     if !unresolved.is_empty() {
@@ -230,8 +227,7 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
             existing_vars.join(", ")
         );
     }
-    // A verified (or knowingly unverifiable) server defaults to yes; a
-    // server that just failed its check defaults to no.
+    // A failed check flips the default to no.
     let write_prompt = if verified || !unresolved.is_empty() {
         format!("Write to {}? [Y/n] ", config_path.display())
     } else {
@@ -276,12 +272,9 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
     }
 }
 
-/// Replace each `{{ env.VAR }}` placeholder with its collected secret value.
-///
-/// The connectivity check needs real credentials, but the freshly written
-/// `.env` is only read at process startup (dotenvy), so the placeholders
-/// can't resolve through the normal loader this session. The inlined copy
-/// exists only in memory for the duration of the check.
+/// Replace `{{ env.VAR }}` placeholders with the collected values, in
+/// memory only — `.env` isn't re-read until restart, so the connection
+/// check can't resolve placeholders through the normal loader.
 fn inline_secrets(server: &McpServerConfig, secrets: &[(String, String)]) -> McpServerConfig {
     let mut server = server.clone();
     let inline = |values: &mut HashMap<String, String>| {
@@ -300,16 +293,11 @@ fn inline_secrets(server: &McpServerConfig, secrets: &[(String, String)]) -> Mcp
     server
 }
 
-/// Throwaway connection + tool-discovery check against just the new server.
-///
-/// Builds a single-server `McpManager` (entirely separate from the running
-/// agent — the new server only joins the real roster on restart), reads the
-/// resulting status and tool count, and closes every client — including any
-/// spawned stdio child process — before returning.
-/// Bounds the whole connect + tool-discovery attempt: the underlying HTTP
-/// client has no timeout of its own, so a blackholed endpoint (or npx
-/// downloading a stdio server on first run) would otherwise hang the REPL
-/// with no Ctrl-C escape.
+/// Throwaway single-server connection + tool-discovery check, entirely
+/// separate from the running agent. Closes every client — including
+/// spawned stdio children — before returning.
+/// Bounds the connect + tool-discovery attempt — the underlying HTTP
+/// client has no timeout, and Ctrl-C can't interrupt the blocking check.
 const VERIFY_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn verify_server(
@@ -360,19 +348,9 @@ fn verify_server(
     })
 }
 
-/// Offer to expose (or scope) a freshly verified server's tools per
-/// orchestration worker.
-///
-/// Two cases, both via the format-preserving `append_worker_mcp_filter`
-/// writer:
-/// - Workers *without* an `mcp_filter` already see the new server (an
-///   omitted filter = every MCP tool; see `resolve_worker_tools` in the
-///   orchestrator). They're offered a lockdown choice: scope to this
-///   server's tools, assign no MCP tools (`mcp_filter = []`), or keep
-///   all-tools access (the default).
-/// - Workers with a filter (including the explicit no-tools `[]`) don't
-///   see the new server; they're offered a grant appending to their
-///   filter.
+/// Offer per-worker access to a freshly verified server: workers without
+/// an `mcp_filter` already see it (omitted = every tool) and get a
+/// lockdown choice; workers with one don't and get an append-style grant.
 fn offer_worker_access(
     ctx: &mut CommandContext,
     config_path: &Path,
@@ -464,9 +442,8 @@ fn append_filter_and_report(config_path: &Path, worker: &str, entries: &[String]
     }
 }
 
-/// When the new server couldn't be verified (so its tool names are
-/// unknown), workers with an mcp_filter still won't see it — say so
-/// instead of leaving them silently blind to the new server.
+/// Unverified server → tool names unknown; name the filtered workers that
+/// won't see it rather than leaving them silently blind.
 fn print_allowlist_hint(config_path: &Path, server: &str) {
     let filtered: Vec<String> = orchestrated_workers(config_path)
         .into_iter()
@@ -482,11 +459,9 @@ fn print_allowlist_hint(config_path: &Path, server: &str) {
     }
 }
 
-/// Read `(worker name, mcp_filter)` pairs from the config file when
-/// orchestration is enabled; empty when it isn't (or on any parse problem —
-/// this is an optional convenience step, not a gate). `None` = the worker
-/// has no `mcp_filter` key (all tools); `Some` mirrors the written array,
-/// where empty is the explicit no-tools assignment.
+/// `(worker, mcp_filter)` pairs from the config file; empty unless
+/// orchestration is enabled (or on any parse problem — a convenience
+/// step, not a gate). `None` = no `mcp_filter` key.
 fn orchestrated_workers(config_path: &Path) -> Vec<(String, Option<Vec<String>>)> {
     let Ok(content) = fs::read_to_string(config_path) else {
         return Vec::new();
@@ -534,15 +509,11 @@ const GENERIC_STEMS: [&str; 10] = [
     "get", "list", "read", "set", "create", "delete", "update", "query", "fetch", "describe",
 ];
 
-/// Filter entries granting the given tools: a `{prefix}*` glob when every
-/// tool shares a namespacing prefix, else the exact names.
-///
-/// Globs are matched against the tool names of *every* configured server,
-/// so a glob is only used when the shared prefix looks like a namespace
-/// rather than a verb: it must end at a `_`/`-` separator, be at least 5
-/// chars, and its stem must not be a [`GENERIC_STEMS`] verb — `mezmo_*`
-/// qualifies, but `get_issue`/`get_pr` fall back to exact names because
-/// `get_*` would also grant `get_logs` from an unrelated server.
+/// A `{prefix}*` glob when every tool shares a namespacing prefix, else
+/// the exact names. Globs match against *every* server's tools, so the
+/// prefix must end at a `_`/`-` separator, be ≥5 chars, and not stem from
+/// a [`GENERIC_STEMS`] verb (`get_*` would grant another server's
+/// `get_logs`).
 fn filter_entries(tool_names: &[String]) -> Vec<String> {
     if tool_names.len() > 1 {
         let first = &tool_names[0];
@@ -597,8 +568,7 @@ impl CredentialSource {
         }
     }
 
-    /// The value as known this session (always known for `New`; for
-    /// `Existing` only when the var is actually set).
+    /// The value as known this session, if any.
     fn known_value(&self) -> Option<&str> {
         match self {
             CredentialSource::New { value, .. } => Some(value),
@@ -607,9 +577,9 @@ impl CredentialSource {
     }
 }
 
-/// Collect one credential: prefer an env var the user already exports
-/// (auto-offered when the conventional var is set) over entering the value
-/// now, which is the only path that writes to `.env`.
+/// Collect one credential: an already-exported env var (auto-offered when
+/// the conventional var is set) or a value entered now — only the latter
+/// writes to `.env`.
 fn collect_credential(
     ctx: &mut CommandContext,
     default_env_var: &str,
@@ -634,9 +604,8 @@ fn collect_credential(
         match answer.as_str() {
             "1" => {
                 let value = ask_secret(&format!("{secret_prompt}: "))?;
-                // At startup the shell's export wins over .env (dotenvy
-                // never overwrites existing env), so a value entered here
-                // is dead weight while the export exists.
+                // Shell exports override .env at startup (dotenvy never
+                // overwrites), so warn when one shadows this value.
                 if set_env_value(default_env_var).is_some() {
                     println!(
                         "note: {default_env_var} is exported in your shell, and exported \
@@ -894,12 +863,9 @@ fn config_has_server(config_path: &Path, name: &str) -> bool {
         .is_some()
 }
 
-/// Merge `(env var, value)` pairs into the `.env` file, creating it (with
-/// the do-not-commit header and `0o600` on unix) when absent. Values of
-/// existing keys are replaced; unrelated lines are preserved. Values are
-/// quoted as needed so dotenvy can parse them back — an unquoted space or
-/// `#` doesn't just corrupt that entry, it aborts dotenvy's parse and
-/// silently drops every line after it.
+/// Merge `(env var, value)` pairs into `.env`, creating it (0600 on unix)
+/// when absent. Values are quoted as needed — an unquoted space or `#`
+/// aborts dotenvy's parse and silently drops every later line.
 fn write_env_secrets(env_path: &Path, secrets: &[(String, String)]) -> std::io::Result<()> {
     let mut content = match fs::read_to_string(env_path) {
         Ok(content) => content,
@@ -936,10 +902,8 @@ fn write_env_secrets(env_path: &Path, secrets: &[(String, String)]) -> std::io::
     Ok(())
 }
 
-/// Quote a dotenv value when it contains characters dotenvy would misparse
-/// unquoted (whitespace, `#`, quotes, backslash). Plain token-like values
-/// stay unquoted; single quotes are preferred because dotenvy treats their
-/// contents as fully literal.
+/// Quote a dotenv value when dotenvy would misparse it unquoted; single
+/// quotes preferred (fully literal in dotenvy).
 fn quote_env_value(value: &str) -> String {
     let plain = value
         .chars()
@@ -993,8 +957,8 @@ fn parse_command_line(line: &str) -> Option<(Vec<String>, Vec<String>)> {
     Some((vec![first], tokens.collect()))
 }
 
-/// One line of wizard input via the REPL's rustyline editor (which owns the
-/// terminal between dispatches). `None` on Ctrl-C/Ctrl-D — treat as abort.
+/// One wizard line via the REPL's rustyline editor (idle between
+/// dispatches). `None` on Ctrl-C/Ctrl-D — treat as abort.
 fn ask(ctx: &mut CommandContext, prompt: &str) -> Option<String> {
     ctx.input_reader
         .readline(prompt)
@@ -1022,15 +986,11 @@ fn confirm(ctx: &mut CommandContext, prompt: &str) -> bool {
     }
 }
 
-/// Masked credential input straight from the tty (never echoed, never in
-/// rustyline history). Empty input gets one re-prompt (rpassword runs in
-/// cooked mode where Ctrl-C doesn't interrupt, so Enter-on-empty is the
-/// documented escape); `None` aborts the wizard.
-///
-/// Clears [`SIGINT_RECEIVED`](crate::ui::state::SIGINT_RECEIVED) before
-/// returning: a Ctrl-C pressed during the masked read only sets the flag,
-/// and left set it would count as a phantom first quit-press on the next
-/// streaming turn.
+/// Masked tty input — never echoed, never in rustyline history. Empty
+/// input gets one re-prompt (Ctrl-C can't interrupt rpassword's cooked-mode
+/// read; Enter-on-empty is the escape); `None` aborts. Clears
+/// [`SIGINT_RECEIVED`](crate::ui::state::SIGINT_RECEIVED) so a Ctrl-C
+/// during the read doesn't become a phantom quit-press later.
 fn ask_secret(prompt: &str) -> Option<String> {
     let mut result = None;
     for attempt in 0..2 {

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -359,13 +359,14 @@ fn verify_server(
 ///
 /// Two cases, both via the format-preserving `append_worker_mcp_filter`
 /// writer:
-/// - Workers *without* an `mcp_filter` already see the new server (empty
-///   filter = every MCP tool; see `resolve_worker_tools` in the
-///   orchestrator). They're offered *scoping*: writing their first filter
-///   entries narrows them from all tools to exactly the listed ones, so
-///   that tradeoff is stated and defaults to no.
-/// - Allowlisted workers don't see the new server; they're offered a grant
-///   appending to their existing filter.
+/// - Workers *without* an `mcp_filter` already see the new server (an
+///   omitted filter = every MCP tool; see `resolve_worker_tools` in the
+///   orchestrator). They're offered a lockdown choice: scope to this
+///   server's tools, assign no MCP tools (`mcp_filter = []`), or keep
+///   all-tools access (the default).
+/// - Workers with a filter (including the explicit no-tools `[]`) don't
+///   see the new server; they're offered a grant appending to their
+///   filter.
 fn offer_worker_access(
     ctx: &mut CommandContext,
     config_path: &Path,
@@ -377,9 +378,9 @@ fn offer_worker_access(
         return;
     }
     let entries = filter_entries(tool_names);
-    let (open, allowlisted): (Vec<_>, Vec<_>) = workers
+    let (open, filtered): (Vec<_>, Vec<_>) = workers
         .into_iter()
-        .partition(|(_, filter)| filter.is_empty());
+        .partition(|(_, filter)| filter.is_none());
 
     if !open.is_empty() {
         let names: Vec<&str> = open.iter().map(|(name, _)| name.as_str()).collect();
@@ -389,25 +390,42 @@ fn offer_worker_access(
             names.join(", ")
         );
         println!(
-            "You can scope them to `{server}` now (adds {} as the worker's \
-             mcp_filter). Scoping limits a worker to exactly the listed tools — \
-             extend its filter as you add more servers:",
-            entries_summary(&entries)
+            "You can lock each one down now — a written mcp_filter limits the \
+             worker to exactly the listed tools:"
         );
         for (worker, _) in open {
-            if confirm(ctx, &format!("  Scope `{worker}` to `{server}`? [y/N] ")) {
-                append_filter_and_report(config_path, &worker, &entries);
+            println!("  `{worker}`:");
+            println!(
+                "    1. Scope to `{server}`'s tools ({})",
+                entries_summary(&entries)
+            );
+            println!("    2. No MCP tools at all (mcp_filter = [])");
+            println!("    3. Keep access to every tool");
+            loop {
+                let Some(answer) = ask(ctx, "    Choice [1-3, default 3]: ") else {
+                    return;
+                };
+                match answer.as_str() {
+                    "1" => append_filter_and_report(config_path, &worker, &entries),
+                    "2" => append_filter_and_report(config_path, &worker, &[]),
+                    "3" | "" => {}
+                    _ => {
+                        println!("    Enter 1, 2, or 3.");
+                        continue;
+                    }
+                }
+                break;
             }
         }
     }
 
-    if !allowlisted.is_empty() {
+    if !filtered.is_empty() {
         println!(
-            "\nWorkers with tool allowlists don't see `{server}` yet. \
+            "\nWorkers with an mcp_filter don't see `{server}` yet. \
              Grant access per worker (adds {} to their mcp_filter):",
             entries_summary(&entries)
         );
-        for (worker, _) in allowlisted {
+        for (worker, _) in filtered {
             if confirm(ctx, &format!("  Grant `{worker}` access? [y/N] ")) {
                 append_filter_and_report(config_path, &worker, &entries);
             }
@@ -441,27 +459,29 @@ fn append_filter_and_report(config_path: &Path, worker: &str, entries: &[String]
 }
 
 /// When the new server couldn't be verified (so its tool names are
-/// unknown), allowlisted workers still won't see it — say so instead of
-/// leaving them silently blind to the new server.
+/// unknown), workers with an mcp_filter still won't see it — say so
+/// instead of leaving them silently blind to the new server.
 fn print_allowlist_hint(config_path: &Path, server: &str) {
-    let allowlisted: Vec<String> = orchestrated_workers(config_path)
+    let filtered: Vec<String> = orchestrated_workers(config_path)
         .into_iter()
-        .filter(|(_, filter)| !filter.is_empty())
+        .filter(|(_, filter)| filter.is_some())
         .map(|(name, _)| name)
         .collect();
-    if !allowlisted.is_empty() {
+    if !filtered.is_empty() {
         println!(
-            "Workers with mcp_filter allowlists ({}) won't see `{server}`'s tools \
+            "Workers with an mcp_filter ({}) won't see `{server}`'s tools \
              until matching patterns are added to their filters.",
-            allowlisted.join(", ")
+            filtered.join(", ")
         );
     }
 }
 
 /// Read `(worker name, mcp_filter)` pairs from the config file when
 /// orchestration is enabled; empty when it isn't (or on any parse problem —
-/// this is an optional convenience step, not a gate).
-fn orchestrated_workers(config_path: &Path) -> Vec<(String, Vec<String>)> {
+/// this is an optional convenience step, not a gate). `None` = the worker
+/// has no `mcp_filter` key (all tools); `Some` mirrors the written array,
+/// where empty is the explicit no-tools assignment.
+fn orchestrated_workers(config_path: &Path) -> Vec<(String, Option<Vec<String>>)> {
     let Ok(content) = fs::read_to_string(config_path) else {
         return Vec::new();
     };
@@ -484,7 +504,7 @@ fn orchestrated_workers(config_path: &Path) -> Vec<(String, Vec<String>)> {
     else {
         return Vec::new();
     };
-    let mut result: Vec<(String, Vec<String>)> = workers
+    let mut result: Vec<(String, Option<Vec<String>>)> = workers
         .iter()
         .map(|(name, worker)| {
             let filter = worker
@@ -495,8 +515,7 @@ fn orchestrated_workers(config_path: &Path) -> Vec<(String, Vec<String>)> {
                         .iter()
                         .filter_map(|v| v.as_str().map(str::to_owned))
                         .collect()
-                })
-                .unwrap_or_default();
+                });
             (name.to_string(), filter)
         })
         .collect();
@@ -1292,8 +1311,8 @@ mod tests {
         assert_eq!(
             workers,
             [
-                ("ops".to_string(), vec!["logs_*".to_string()]),
-                ("writer".to_string(), vec![]),
+                ("ops".to_string(), Some(vec!["logs_*".to_string()])),
+                ("writer".to_string(), None),
             ]
         );
 

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -134,15 +134,33 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
             ));
         }
     }
-    if !collected.secrets.is_empty() {
-        let vars: Vec<&str> = collected
-            .secrets
-            .iter()
-            .map(|(var, _)| var.as_str())
-            .collect();
+    let new_secrets: Vec<(String, String)> = collected
+        .secrets
+        .iter()
+        .filter_map(|source| match source {
+            CredentialSource::New { env_var, value } => Some((env_var.clone(), value.clone())),
+            CredentialSource::Existing { .. } => None,
+        })
+        .collect();
+    if !new_secrets.is_empty() {
+        let vars: Vec<&str> = new_secrets.iter().map(|(var, _)| var.as_str()).collect();
         println!(
             "Secrets are stored in `.env` next to the config ({}), not in the TOML.",
             vars.join(", ")
+        );
+    }
+    let existing_vars: Vec<&str> = collected
+        .secrets
+        .iter()
+        .filter_map(|source| match source {
+            CredentialSource::Existing { env_var, .. } => Some(env_var.as_str()),
+            CredentialSource::New { .. } => None,
+        })
+        .collect();
+    if !existing_vars.is_empty() {
+        println!(
+            "References environment variable(s) you already manage ({}) — nothing is written for them.",
+            existing_vars.join(", ")
         );
     }
     if !confirm(ctx, &format!("Write to {}? [Y/n] ", config_path.display())) {
@@ -156,9 +174,9 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
             "failed to update the config: {e}\nThe config file was left unchanged."
         ));
     }
-    if !collected.secrets.is_empty() {
+    if !new_secrets.is_empty() {
         let env_path = config_path.parent().unwrap_or(Path::new(".")).join(".env");
-        if let Err(e) = write_env_secrets(&env_path, &collected.secrets) {
+        if let Err(e) = write_env_secrets(&env_path, &new_secrets) {
             return WizardEnd::Failed(format!(
                 "the server was written to the config, but saving secrets to {} failed: {e}\n\
                  Add the variable(s) to that file manually.",
@@ -168,6 +186,33 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
         println!("Saved secrets to {}.", env_path.display());
     }
 
+    let unresolved: Vec<&str> = collected
+        .secrets
+        .iter()
+        .filter(|source| source.known_value().is_none())
+        .map(CredentialSource::env_var)
+        .collect();
+    if !unresolved.is_empty() {
+        println!(
+            "\nSkipping the connection check — {} not set in this session.",
+            unresolved.join(", ")
+        );
+        return WizardEnd::Written {
+            name: collected.name,
+            starter_prompt: collected.starter_prompt,
+            verified: false,
+        };
+    }
+    let known_values: Vec<(String, String)> = collected
+        .secrets
+        .iter()
+        .filter_map(|source| {
+            source
+                .known_value()
+                .map(|value| (source.env_var().to_string(), value.to_string()))
+        })
+        .collect();
+
     println!(
         "\nVerifying connection to `{}` (up to {}s)...",
         collected.name,
@@ -176,7 +221,7 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
     let verified = match verify_server(
         ctx.rt,
         &collected.name,
-        inline_secrets(&collected.server, &collected.secrets),
+        inline_secrets(&collected.server, &known_values),
     ) {
         Ok((aura::mcp::ConnectionStatus::Connected, tools_count)) => {
             println!(
@@ -288,9 +333,99 @@ fn verify_server(
 struct CollectedServer {
     name: String,
     server: McpServerConfig,
-    /// `(env var, secret value)` pairs.
-    secrets: Vec<(String, String)>,
+    secrets: Vec<CredentialSource>,
     starter_prompt: Option<&'static str>,
+}
+
+/// Where a credential's value comes from.
+enum CredentialSource {
+    /// Entered during the wizard.
+    New { env_var: String, value: String },
+    /// An env var the user already exports.
+    Existing {
+        env_var: String,
+        value: Option<String>,
+    },
+}
+
+impl CredentialSource {
+    fn env_var(&self) -> &str {
+        match self {
+            CredentialSource::New { env_var, .. } | CredentialSource::Existing { env_var, .. } => {
+                env_var
+            }
+        }
+    }
+
+    /// The value as known this session (always known for `New`; for
+    /// `Existing` only when the var is actually set).
+    fn known_value(&self) -> Option<&str> {
+        match self {
+            CredentialSource::New { value, .. } => Some(value),
+            CredentialSource::Existing { value, .. } => value.as_deref(),
+        }
+    }
+}
+
+/// Collect one credential: prefer an env var the user already exports
+/// (auto-offered when the conventional var is set) over entering the value
+/// now, which is the only path that writes to `.env`.
+fn collect_credential(
+    ctx: &mut CommandContext,
+    default_env_var: &str,
+    secret_prompt: &str,
+) -> Option<CredentialSource> {
+    if let Some(value) = set_env_value(default_env_var)
+        && confirm(
+            ctx,
+            &format!("{default_env_var} is already set in your environment — use it? [Y/n] "),
+        )
+    {
+        return Some(CredentialSource::Existing {
+            env_var: default_env_var.to_string(),
+            value: Some(value),
+        });
+    }
+    println!("How do you want to provide the {secret_prompt}?");
+    println!("  1. Enter it now (saved to .env next to the config)");
+    println!("  2. Reference an environment variable you already export");
+    loop {
+        let answer = ask(ctx, "Choice [1-2]: ")?;
+        match answer.as_str() {
+            "1" => {
+                let value = ask_secret(&format!("{secret_prompt}: "))?;
+                return Some(CredentialSource::New {
+                    env_var: default_env_var.to_string(),
+                    value,
+                });
+            }
+            "2" => {
+                let env_var = loop {
+                    let name = ask_with_default(ctx, "Environment variable", default_env_var)?;
+                    if is_valid_env_var(&name) {
+                        break name;
+                    }
+                    println!(
+                        "Variable names contain letters, digits, and `_`, and don't \
+                         start with a digit."
+                    );
+                };
+                let value = set_env_value(&env_var);
+                if value.is_none() {
+                    println!(
+                        "note: {env_var} is not set in this session, so the connection \
+                         check will be skipped."
+                    );
+                }
+                return Some(CredentialSource::Existing { env_var, value });
+            }
+            _ => println!("Enter 1 or 2."),
+        }
+    }
+}
+
+fn set_env_value(var: &str) -> Option<String> {
+    std::env::var(var).ok().filter(|v| !v.trim().is_empty())
 }
 
 fn collect_catalog(
@@ -310,12 +445,15 @@ fn collect_catalog(
             let mut header_map = HashMap::new();
             let mut secrets = Vec::new();
             for template in *headers {
-                let value = ask_secret(&format!("{}: ", template.secret_prompt))?;
-                header_map.insert(
-                    template.header.to_string(),
-                    template.value_template.to_string(),
+                let source = collect_credential(ctx, template.env_var, template.secret_prompt)?;
+                // The template names the conventional var; rewrite its
+                // placeholder when the user picked a different one.
+                let value = template.value_template.replace(
+                    &format!("{{{{ env.{} }}}}", template.env_var),
+                    &format!("{{{{ env.{} }}}}", source.env_var()),
                 );
-                secrets.push((template.env_var.to_string(), value));
+                header_map.insert(template.header.to_string(), value);
+                secrets.push(source);
             }
             (
                 http_streamable(url.to_string(), header_map, entry.description),
@@ -388,12 +526,13 @@ fn collect_custom(ctx: &mut CommandContext, config_path: &Path) -> Option<Collec
         if confirm(ctx, "Does the server need an auth header? [y/N] ")
             && let Some(header) = ask_with_default(ctx, "Header name", "Authorization")
         {
-            let env_var = derive_env_var(&name, &header);
-            let value = ask_secret(&format!(
-                "Value for `{header}` (full value, e.g. `Bearer <token>`): "
-            ))?;
-            headers.insert(header, format!("{{{{ env.{env_var} }}}}"));
-            secrets.push((env_var, value));
+            let source = collect_credential(
+                ctx,
+                &derive_env_var(&name, &header),
+                &format!("`{header}` header value (full value, e.g. `Bearer <token>`)"),
+            )?;
+            headers.insert(header, format!("{{{{ env.{} }}}}", source.env_var()));
+            secrets.push(source);
         }
         let server = if transport == "1" {
             http_streamable(url, headers, "")
@@ -559,6 +698,12 @@ fn is_valid_server_name(name: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
+fn is_valid_env_var(name: &str) -> bool {
+    !name.is_empty()
+        && !name.starts_with(|c: char| c.is_ascii_digit())
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 /// Whitespace-split a command line into `cmd = [first]` + `args = rest`.
 /// No shell quoting — the wizard says so in the prompt example.
 fn parse_command_line(line: &str) -> Option<(Vec<String>, Vec<String>)> {
@@ -640,6 +785,35 @@ mod tests {
             derive_env_var("my-server", "X-Api-Key"),
             "MY_SERVER_X_API_KEY"
         );
+    }
+
+    #[test]
+    fn validates_env_var_names() {
+        assert!(is_valid_env_var("MEZMO_API_KEY"));
+        assert!(is_valid_env_var("_PRIVATE"));
+        assert!(!is_valid_env_var(""));
+        assert!(!is_valid_env_var("1BAD"));
+        assert!(!is_valid_env_var("HAS-DASH"));
+    }
+
+    #[test]
+    fn credential_source_reports_env_var_and_value() {
+        let new = CredentialSource::New {
+            env_var: "A".to_string(),
+            value: "v".to_string(),
+        };
+        assert_eq!(new.env_var(), "A");
+        assert_eq!(new.known_value(), Some("v"));
+        let set = CredentialSource::Existing {
+            env_var: "B".to_string(),
+            value: Some("w".to_string()),
+        };
+        assert_eq!(set.known_value(), Some("w"));
+        let unset = CredentialSource::Existing {
+            env_var: "C".to_string(),
+            value: None,
+        };
+        assert_eq!(unset.known_value(), None);
     }
 
     #[test]

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -1304,14 +1304,19 @@ mod tests {
         let base = "[agent]\nname = \"a\"\n\n[orchestration]\nenabled = %E%\n\n\
                     [orchestration.worker.ops]\ndescription = \"d\"\npreamble = \"p\"\n\
                     mcp_filter = [\"logs_*\"]\n\n\
+                    [orchestration.worker.silent]\ndescription = \"d\"\npreamble = \"p\"\n\
+                    mcp_filter = []\n\n\
                     [orchestration.worker.writer]\ndescription = \"d\"\npreamble = \"p\"\n";
 
         fs::write(&path, base.replace("%E%", "true")).unwrap();
         let workers = orchestrated_workers(&path);
+        // `mcp_filter = []` must stay distinct from an omitted filter — the
+        // lockdown/grant partition hinges on it.
         assert_eq!(
             workers,
             [
                 ("ops".to_string(), Some(vec!["logs_*".to_string()])),
+                ("silent".to_string(), Some(vec![])),
                 ("writer".to_string(), None),
             ]
         );

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -354,14 +354,18 @@ fn verify_server(
     })
 }
 
-/// Offer to expose a freshly verified server's tools to orchestration
-/// workers.
+/// Offer to expose (or scope) a freshly verified server's tools per
+/// orchestration worker.
 ///
-/// Workers without an `mcp_filter` already see the new server (empty
-/// filter = every MCP tool; see `resolve_worker_tools` in the
-/// orchestrator), so that's stated rather than asked; only allowlisted
-/// workers are offered an update, via the format-preserving
-/// `append_worker_mcp_filter` writer.
+/// Two cases, both via the format-preserving `append_worker_mcp_filter`
+/// writer:
+/// - Workers *without* an `mcp_filter` already see the new server (empty
+///   filter = every MCP tool; see `resolve_worker_tools` in the
+///   orchestrator). They're offered *scoping*: writing their first filter
+///   entries narrows them from all tools to exactly the listed ones, so
+///   that tradeoff is stated and defaults to no.
+/// - Allowlisted workers don't see the new server; they're offered a grant
+///   appending to their existing filter.
 fn offer_worker_access(
     ctx: &mut CommandContext,
     config_path: &Path,
@@ -372,37 +376,67 @@ fn offer_worker_access(
     if workers.is_empty() || tool_names.is_empty() {
         return;
     }
+    let entries = filter_entries(tool_names);
     let (open, allowlisted): (Vec<_>, Vec<_>) = workers
         .into_iter()
         .partition(|(_, filter)| filter.is_empty());
+
     if !open.is_empty() {
         let names: Vec<&str> = open.iter().map(|(name, _)| name.as_str()).collect();
         println!(
-            "\nWorkers without an mcp_filter receive every MCP tool, including \
-             `{server}`: {}.",
+            "\nWorkers without an mcp_filter receive every MCP tool, so `{server}` \
+             is already visible to: {}.",
             names.join(", ")
         );
+        println!(
+            "You can scope them to `{server}` now (adds {} as the worker's \
+             mcp_filter). Scoping limits a worker to exactly the listed tools — \
+             extend its filter as you add more servers:",
+            entries_summary(&entries)
+        );
+        for (worker, _) in open {
+            if confirm(ctx, &format!("  Scope `{worker}` to `{server}`? [y/N] ")) {
+                append_filter_and_report(config_path, &worker, &entries);
+            }
+        }
     }
-    if allowlisted.is_empty() {
-        return;
+
+    if !allowlisted.is_empty() {
+        println!(
+            "\nWorkers with tool allowlists don't see `{server}` yet. \
+             Grant access per worker (adds {} to their mcp_filter):",
+            entries_summary(&entries)
+        );
+        for (worker, _) in allowlisted {
+            if confirm(ctx, &format!("  Grant `{worker}` access? [y/N] ")) {
+                append_filter_and_report(config_path, &worker, &entries);
+            }
+        }
     }
-    let entries = filter_entries(tool_names);
-    println!(
-        "\nWorkers with tool allowlists don't see `{server}` yet. \
-         Grant access per worker (adds {} to their mcp_filter):",
+}
+
+/// Compact display form of filter entries for prompts; the full list is
+/// always what gets written.
+fn entries_summary(entries: &[String]) -> String {
+    const SHOW: usize = 5;
+    if entries.len() <= SHOW {
         entries.join(", ")
-    );
-    for (worker, _) in allowlisted {
-        if !confirm(ctx, &format!("  Grant `{worker}` access? [y/N] ")) {
-            continue;
-        }
-        match aura_config::writer::append_worker_mcp_filter(config_path, &worker, &entries) {
-            Ok(()) => println!("  {} updated `{worker}`", "✓".themed(AuraStyle::Success)),
-            Err(e) => println!(
-                "  {} failed to update `{worker}`: {e}",
-                "error:".themed(AuraStyle::Error)
-            ),
-        }
+    } else {
+        format!(
+            "{}, ... ({} tools)",
+            entries[..SHOW].join(", "),
+            entries.len()
+        )
+    }
+}
+
+fn append_filter_and_report(config_path: &Path, worker: &str, entries: &[String]) {
+    match aura_config::writer::append_worker_mcp_filter(config_path, worker, entries) {
+        Ok(()) => println!("  {} updated `{worker}`", "✓".themed(AuraStyle::Success)),
+        Err(e) => println!(
+            "  {} failed to update `{worker}`: {e}",
+            "error:".themed(AuraStyle::Error)
+        ),
     }
 }
 
@@ -1200,6 +1234,17 @@ mod tests {
 
         let single = vec!["only_tool".to_string()];
         assert_eq!(filter_entries(&single), single);
+    }
+
+    #[test]
+    fn entries_summary_truncates_long_lists() {
+        let short: Vec<String> = ["a", "b"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(entries_summary(&short), "a, b");
+        let long: Vec<String> = (0..8).map(|i| format!("tool_{i}")).collect();
+        assert_eq!(
+            entries_summary(&long),
+            "tool_0, tool_1, tool_2, tool_3, tool_4, ... (8 tools)"
+        );
     }
 
     #[test]

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -197,6 +197,7 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
             "\nSkipping the connection check — {} not set in this session.",
             unresolved.join(", ")
         );
+        print_allowlist_hint(config_path, &collected.name);
         return WizardEnd::Written {
             name: collected.name,
             starter_prompt: collected.starter_prompt,
@@ -223,11 +224,13 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
         &collected.name,
         inline_secrets(&collected.server, &known_values),
     ) {
-        Ok((aura::mcp::ConnectionStatus::Connected, tools_count)) => {
+        Ok((aura::mcp::ConnectionStatus::Connected, tool_names)) => {
             println!(
-                "{} Connected — {tools_count} tool(s) discovered.",
-                "✓".themed(AuraStyle::Success)
+                "{} Connected — {} tool(s) discovered.",
+                "✓".themed(AuraStyle::Success),
+                tool_names.len()
             );
+            offer_worker_access(ctx, config_path, &collected.name, &tool_names);
             true
         }
         Ok((aura::mcp::ConnectionStatus::Failed(reason), _)) => {
@@ -237,6 +240,7 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
                  server settings) and run /mcp add again to overwrite it.",
                 "✗".themed(AuraStyle::Error)
             );
+            print_allowlist_hint(config_path, &collected.name);
             false
         }
         Ok((aura::mcp::ConnectionStatus::NotAttempted, _)) => false,
@@ -245,6 +249,7 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
                 "{} Could not verify the connection: {reason}",
                 "!".themed(AuraStyle::Warning)
             );
+            print_allowlist_hint(config_path, &collected.name);
             false
         }
     };
@@ -296,7 +301,7 @@ fn verify_server(
     rt: &tokio::runtime::Runtime,
     name: &str,
     server: McpServerConfig,
-) -> Result<(aura::mcp::ConnectionStatus, usize), String> {
+) -> Result<(aura::mcp::ConnectionStatus, Vec<String>), String> {
     let mcp_config = aura_config::config::McpConfig {
         servers: HashMap::from([(name.to_string(), server)]),
         sanitize_schemas: true,
@@ -320,13 +325,164 @@ fn verify_server(
         let result = manager
             .server_info
             .get(name)
-            .map(|info| (info.status.clone(), info.tools_count))
+            .map(|info| {
+                let tools: Vec<String> = manager
+                    .streamable_tools
+                    .get(name)
+                    .into_iter()
+                    .chain(manager.sse_tools.get(name))
+                    .chain(manager.stdio_tools.get(name))
+                    .flatten()
+                    .map(|tool| tool.name.to_string())
+                    .collect();
+                (info.status.clone(), tools)
+            })
             .ok_or_else(|| format!("`{name}` missing from the connection status snapshot"));
         manager
             .cancel_and_close_all("mcp-add-verify", "verification complete")
             .await;
         result
     })
+}
+
+/// Offer to expose a freshly verified server's tools to orchestration
+/// workers.
+///
+/// Worker `mcp_filter` globs match *tool names*, and an empty filter grants
+/// every MCP tool — so workers without a filter already see the new server
+/// (that's stated, not asked), and only allowlisted workers are offered an
+/// update. Grants go through the format-preserving
+/// `append_worker_mcp_filter` writer.
+fn offer_worker_access(
+    ctx: &mut CommandContext,
+    config_path: &Path,
+    server: &str,
+    tool_names: &[String],
+) {
+    let workers = orchestrated_workers(config_path);
+    if workers.is_empty() || tool_names.is_empty() {
+        return;
+    }
+    let (open, allowlisted): (Vec<_>, Vec<_>) = workers
+        .into_iter()
+        .partition(|(_, filter)| filter.is_empty());
+    if !open.is_empty() {
+        let names: Vec<&str> = open.iter().map(|(name, _)| name.as_str()).collect();
+        println!(
+            "\nWorkers without an mcp_filter receive every MCP tool, including \
+             `{server}`: {}.",
+            names.join(", ")
+        );
+    }
+    if allowlisted.is_empty() {
+        return;
+    }
+    let entries = filter_entries(tool_names);
+    println!(
+        "\nWorkers with tool allowlists don't see `{server}` yet. \
+         Grant access per worker (adds {} to their mcp_filter):",
+        entries.join(", ")
+    );
+    for (worker, _) in allowlisted {
+        if !confirm(ctx, &format!("  Grant `{worker}` access? [y/N] ")) {
+            continue;
+        }
+        match aura_config::writer::append_worker_mcp_filter(config_path, &worker, &entries) {
+            Ok(()) => println!("  {} updated `{worker}`", "✓".themed(AuraStyle::Success)),
+            Err(e) => println!(
+                "  {} failed to update `{worker}`: {e}",
+                "error:".themed(AuraStyle::Error)
+            ),
+        }
+    }
+}
+
+/// When the new server couldn't be verified (so its tool names are
+/// unknown), allowlisted workers still won't see it — say so instead of
+/// leaving them silently blind to the new server.
+fn print_allowlist_hint(config_path: &Path, server: &str) {
+    let allowlisted: Vec<String> = orchestrated_workers(config_path)
+        .into_iter()
+        .filter(|(_, filter)| !filter.is_empty())
+        .map(|(name, _)| name)
+        .collect();
+    if !allowlisted.is_empty() {
+        println!(
+            "Workers with mcp_filter allowlists ({}) won't see `{server}`'s tools \
+             until matching patterns are added to their filters.",
+            allowlisted.join(", ")
+        );
+    }
+}
+
+/// Read `(worker name, mcp_filter)` pairs from the config file when
+/// orchestration is enabled; empty when it isn't (or on any parse problem —
+/// this is an optional convenience step, not a gate).
+fn orchestrated_workers(config_path: &Path) -> Vec<(String, Vec<String>)> {
+    let Ok(content) = fs::read_to_string(config_path) else {
+        return Vec::new();
+    };
+    let Ok(doc) = content.parse::<toml_edit::DocumentMut>() else {
+        return Vec::new();
+    };
+    let Some(orchestration) = doc.get("orchestration") else {
+        return Vec::new();
+    };
+    if !orchestration
+        .get("enabled")
+        .and_then(toml_edit::Item::as_bool)
+        .unwrap_or(false)
+    {
+        return Vec::new();
+    }
+    let Some(workers) = orchestration
+        .get("worker")
+        .and_then(toml_edit::Item::as_table_like)
+    else {
+        return Vec::new();
+    };
+    let mut result: Vec<(String, Vec<String>)> = workers
+        .iter()
+        .map(|(name, worker)| {
+            let filter = worker
+                .get("mcp_filter")
+                .and_then(toml_edit::Item::as_array)
+                .map(|array| {
+                    array
+                        .iter()
+                        .filter_map(|v| v.as_str().map(str::to_owned))
+                        .collect()
+                })
+                .unwrap_or_default();
+            (name.to_string(), filter)
+        })
+        .collect();
+    result.sort_by(|a, b| a.0.cmp(&b.0));
+    result
+}
+
+/// Filter entries granting exactly the given tools: a `{prefix}*` glob when
+/// every tool shares a meaningful prefix (≥4 chars), else the exact names.
+fn filter_entries(tool_names: &[String]) -> Vec<String> {
+    if tool_names.len() > 1 {
+        let first = &tool_names[0];
+        let mut len = first.len();
+        for name in &tool_names[1..] {
+            let common = first
+                .bytes()
+                .zip(name.bytes())
+                .take_while(|(a, b)| a == b)
+                .count();
+            len = len.min(common);
+        }
+        while len > 0 && !first.is_char_boundary(len) {
+            len -= 1;
+        }
+        if len >= 4 {
+            return vec![format!("{}*", &first[..len])];
+        }
+    }
+    tool_names.to_vec()
 }
 
 /// Everything the interactive steps produce for the write phase.
@@ -980,6 +1136,45 @@ mod tests {
             headers.get("Authorization").map(String::as_str),
             Some("Bearer {{ env.MEZMO_API_KEY }}")
         );
+    }
+
+    #[test]
+    fn filter_entries_prefer_common_prefix_glob() {
+        let tools = vec![
+            "mezmo_logs".to_string(),
+            "mezmo_pipelines".to_string(),
+            "mezmo_export".to_string(),
+        ];
+        assert_eq!(filter_entries(&tools), ["mezmo_*"]);
+
+        let mixed = vec!["ListKnowledgeBases".to_string(), "QueryBases".to_string()];
+        assert_eq!(filter_entries(&mixed), mixed);
+
+        let single = vec!["only_tool".to_string()];
+        assert_eq!(filter_entries(&single), single);
+    }
+
+    #[test]
+    fn reads_orchestrated_workers_only_when_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let base = "[agent]\nname = \"a\"\n\n[orchestration]\nenabled = %E%\n\n\
+                    [orchestration.worker.ops]\ndescription = \"d\"\npreamble = \"p\"\n\
+                    mcp_filter = [\"logs_*\"]\n\n\
+                    [orchestration.worker.writer]\ndescription = \"d\"\npreamble = \"p\"\n";
+
+        fs::write(&path, base.replace("%E%", "true")).unwrap();
+        let workers = orchestrated_workers(&path);
+        assert_eq!(
+            workers,
+            [
+                ("ops".to_string(), vec!["logs_*".to_string()]),
+                ("writer".to_string(), vec![]),
+            ]
+        );
+
+        fs::write(&path, base.replace("%E%", "false")).unwrap();
+        assert!(orchestrated_workers(&path).is_empty());
     }
 
     #[test]

--- a/crates/aura-cli/src/repl/mod.rs
+++ b/crates/aura-cli/src/repl/mod.rs
@@ -3,5 +3,6 @@ pub mod conversations;
 pub mod history;
 pub mod input_reader;
 pub mod r#loop;
+pub mod mcp;
 pub mod registry;
 pub mod telemetry_notice;

--- a/crates/aura-cli/src/repl/registry.rs
+++ b/crates/aura-cli/src/repl/registry.rs
@@ -177,8 +177,8 @@ pub(crate) const COMMANDS: &[Command] = &[
     },
     Command {
         name: "/mcp",
-        description: "List the MCP servers available to the agent",
-        usage_hint: None,
+        description: "List MCP servers, or set one up with `add`",
+        usage_hint: Some("[add]"),
         handler: cmd_mcp,
         validate: None,
         mid_stream: MidStream::Defer,
@@ -283,7 +283,7 @@ fn cmd_style(_ctx: &mut CommandContext, args: &str) -> CommandOutcome {
 }
 
 fn cmd_mcp(ctx: &mut CommandContext, args: &str) -> CommandOutcome {
-    super::mcp::handle_mcp(args, ctx.rt, ctx.backend);
+    super::mcp::handle_mcp(ctx, args);
     CommandOutcome::Handled
 }
 

--- a/crates/aura-cli/src/repl/registry.rs
+++ b/crates/aura-cli/src/repl/registry.rs
@@ -176,6 +176,14 @@ pub(crate) const COMMANDS: &[Command] = &[
         mid_stream: MidStream::Live(crate::ui::mid_stream::live_style),
     },
     Command {
+        name: "/mcp",
+        description: "List the MCP servers available to the agent",
+        usage_hint: None,
+        handler: cmd_mcp,
+        validate: None,
+        mid_stream: MidStream::Defer,
+    },
+    Command {
         name: "/telemetry",
         description: "Inspect or disable anonymous usage telemetry",
         usage_hint: Some("status|recent|disable"),
@@ -271,6 +279,11 @@ fn cmd_model(ctx: &mut CommandContext, args: &str) -> CommandOutcome {
 
 fn cmd_style(_ctx: &mut CommandContext, args: &str) -> CommandOutcome {
     commands::handle_style(args);
+    CommandOutcome::Handled
+}
+
+fn cmd_mcp(ctx: &mut CommandContext, args: &str) -> CommandOutcome {
+    super::mcp::handle_mcp(args, ctx.rt, ctx.backend);
     CommandOutcome::Handled
 }
 

--- a/crates/aura-config/Cargo.toml
+++ b/crates/aura-config/Cargo.toml
@@ -9,6 +9,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 
 # Configuration / CLI
 clap = { workspace = true }

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -832,7 +832,8 @@ pub struct AgentSettings {
     /// Glob patterns for filtering which MCP tools to include.
     /// When set, only tools matching at least one pattern are added.
     /// Supports glob syntax: `*` (any chars), `?` (single char).
-    /// Empty or None means all tools are included.
+    /// None (omitted) means all tools are included; an empty list
+    /// (`mcp_filter = []`) includes none.
     /// Can be set via `[agent].mcp_filter` in TOML for single-agent configs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_filter: Option<Vec<String>>,

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -1985,7 +1985,7 @@ max_extraction_tokens = 4000
         let worker = WorkerConfig {
             description: "d".to_string(),
             preamble: "p".to_string(),
-            mcp_filter: Vec::new(),
+            mcp_filter: None,
             vector_stores: Vec::new(),
             turn_depth: None,
             llm: None,

--- a/crates/aura-config/src/error.rs
+++ b/crates/aura-config/src/error.rs
@@ -8,6 +8,12 @@ pub enum ConfigError {
     #[error("TOML parse error: {0}")]
     TomlParse(#[from] toml::de::Error),
 
+    #[error("TOML edit error: {0}")]
+    TomlEdit(#[from] toml_edit::TomlError),
+
+    #[error("TOML serialize error: {0}")]
+    TomlSerialize(#[from] toml_edit::ser::Error),
+
     #[error("Environment variable error: {0}")]
     EnvVar(String),
 

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -8,6 +8,7 @@ pub mod orchestration;
 pub mod scratchpad;
 pub mod session_store;
 pub mod skills;
+pub mod writer;
 
 #[cfg(test)]
 mod config_test;
@@ -25,6 +26,7 @@ pub use orchestration::{
 pub use scratchpad::{ScratchpadConfig, ScratchpadToolEntry};
 pub use session_store::{RedisSessionStoreConfig, SessionStoreBackend, SessionStoreConfig};
 pub use skills::SkillName;
+pub use writer::upsert_mcp_server;
 
 use std::collections::HashSet;
 use std::fs;

--- a/crates/aura-config/src/orchestration.rs
+++ b/crates/aura-config/src/orchestration.rs
@@ -66,13 +66,14 @@ pub struct WorkerConfig {
     /// Glob patterns for which MCP tools this worker gets access to.
     ///
     /// Examples:
+    /// - omitted - all tools (default)
     /// - `["mezmo_*"]` - all tools starting with "mezmo_"
     /// - `["ListKnowledgeBases", "QueryKnowledgeBases"]` - specific tools
-    /// - `["*"]` or empty - all tools (default)
+    /// - `[]` - no MCP tools
     ///
     /// Patterns are matched using glob syntax (supports `*`, `**`, `?`, `[abc]`).
     #[serde(default)]
-    pub mcp_filter: Vec<String>,
+    pub mcp_filter: Option<Vec<String>>,
 
     /// Vector stores this worker has access to.
     ///
@@ -678,18 +679,29 @@ mod tests {
         let config: WorkerConfig = toml::from_str(toml).unwrap();
         assert_eq!(config.description, "For operations");
         assert_eq!(config.preamble, "You are an Operations Specialist.");
-        assert_eq!(config.mcp_filter, vec!["mezmo_*"]);
+        assert_eq!(config.mcp_filter, Some(vec!["mezmo_*".to_string()]));
     }
 
     #[test]
-    fn test_worker_config_empty_filter() {
+    fn test_worker_config_omitted_filter_is_none() {
         let toml = r#"
             description = "Generic tasks"
             preamble = "Generic worker."
         "#;
         let config: WorkerConfig = toml::from_str(toml).unwrap();
         assert_eq!(config.preamble, "Generic worker.");
-        assert!(config.mcp_filter.is_empty());
+        assert_eq!(config.mcp_filter, None);
+    }
+
+    #[test]
+    fn test_worker_config_empty_filter_is_explicit() {
+        let toml = r#"
+            description = "No tools"
+            preamble = "Tool-free worker."
+            mcp_filter = []
+        "#;
+        let config: WorkerConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.mcp_filter, Some(vec![]));
     }
 
     #[test]
@@ -700,17 +712,10 @@ mod tests {
             mcp_filter = ["ListKnowledgeBases", "QueryKnowledgeBases"]
         "#;
         let config: WorkerConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.mcp_filter.len(), 2);
-        assert!(
-            config
-                .mcp_filter
-                .contains(&"ListKnowledgeBases".to_string())
-        );
-        assert!(
-            config
-                .mcp_filter
-                .contains(&"QueryKnowledgeBases".to_string())
-        );
+        let filter = config.mcp_filter.expect("filter present");
+        assert_eq!(filter.len(), 2);
+        assert!(filter.contains(&"ListKnowledgeBases".to_string()));
+        assert!(filter.contains(&"QueryKnowledgeBases".to_string()));
     }
 
     #[test]
@@ -737,12 +742,12 @@ mod tests {
         let ops = config.get_worker("operations").unwrap();
         assert_eq!(ops.description, "For logs and pipelines");
         assert_eq!(ops.preamble, "Operations specialist.");
-        assert_eq!(ops.mcp_filter, vec!["mezmo_*"]);
+        assert_eq!(ops.mcp_filter, Some(vec!["mezmo_*".to_string()]));
 
         let kb = config.get_worker("knowledge").unwrap();
         assert_eq!(kb.description, "For documentation");
         assert_eq!(kb.preamble, "Knowledge specialist.");
-        assert_eq!(kb.mcp_filter.len(), 2);
+        assert_eq!(kb.mcp_filter.as_ref().map(Vec::len), Some(2));
     }
 
     #[test]

--- a/crates/aura-config/src/writer.rs
+++ b/crates/aura-config/src/writer.rs
@@ -50,9 +50,10 @@ pub fn append_worker_mcp_filter(
 /// The worker table must already exist — this never creates workers.
 /// Entries already present are skipped; a missing `mcp_filter` array is
 /// created. Callers should mind the filter's semantics when creating it:
-/// an empty or absent `mcp_filter` grants a worker every MCP tool, so
-/// adding the first entries *narrows* that worker's access to just the
-/// listed patterns.
+/// an *absent* `mcp_filter` grants a worker every MCP tool while a
+/// written one limits the worker to its entries, so creating the array
+/// narrows the worker — and calling with empty `entries` writes the
+/// explicit no-tools assignment (`mcp_filter = []`).
 pub fn append_worker_mcp_filter_in_str(
     content: &str,
     worker: &str,
@@ -550,6 +551,17 @@ preamble = "You write"
                 .mcp_filter
                 .as_deref(),
             Some(["k8s_*".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn empty_entries_write_the_no_tools_assignment() {
+        let updated = append_worker_mcp_filter_in_str(ORCHESTRATED_CONFIG, "writer", &[]).unwrap();
+        assert!(updated.contains("mcp_filter = []"), "{updated}");
+        let config = load_config_from_str(&updated).expect("config must parse");
+        assert_eq!(
+            config.orchestration.expect("orchestration table").workers["writer"].mcp_filter,
+            Some(vec![])
         );
     }
 

--- a/crates/aura-config/src/writer.rs
+++ b/crates/aura-config/src/writer.rs
@@ -15,22 +15,97 @@ use crate::error::ConfigError;
 /// Map-valued fields of an MCP server table.
 const MAP_FIELDS: [&str; 4] = ["env", "headers", "headers_from_request", "scratchpad"];
 
-/// Insert or replace `[mcp.servers.<name>]` in the config file at `path`.
+/// Insert or replace `[mcp.servers.<name>]` in the config file at `path`,
+/// atomically (see [`rewrite_file`]).
 ///
-/// The file is rewritten atomically (temp file + rename in the same
-/// directory), carrying the original file's permissions over — agent
-/// configs hold credentials, so a `chmod 600` must survive the rewrite.
 /// A missing file is an error rather than an implicit create: a config
 /// that holds only an MCP table is not runnable, so the caller is
-/// expected to target an existing config. On any error the original
-/// file is left untouched and the temp file removed.
+/// expected to target an existing config.
 pub fn upsert_mcp_server(
     path: &Path,
     name: &str,
     server: &McpServerConfig,
 ) -> Result<(), ConfigError> {
+    rewrite_file(path, |existing| {
+        upsert_mcp_server_in_str(existing, name, server)
+    })
+}
+
+/// Append `entries` to `[orchestration.worker.<worker>].mcp_filter` in the
+/// config file at `path`, with the same atomic-write guarantees as
+/// [`upsert_mcp_server`].
+pub fn append_worker_mcp_filter(
+    path: &Path,
+    worker: &str,
+    entries: &[String],
+) -> Result<(), ConfigError> {
+    rewrite_file(path, |existing| {
+        append_worker_mcp_filter_in_str(existing, worker, entries)
+    })
+}
+
+/// String-level core of [`append_worker_mcp_filter`]: returns the updated
+/// TOML text.
+///
+/// The worker table must already exist — this never creates workers.
+/// Entries already present are skipped; a missing `mcp_filter` array is
+/// created. Callers should mind the filter's semantics when creating it:
+/// an empty or absent `mcp_filter` grants a worker every MCP tool, so
+/// adding the first entries *narrows* that worker's access to just the
+/// listed patterns.
+pub fn append_worker_mcp_filter_in_str(
+    content: &str,
+    worker: &str,
+    entries: &[String],
+) -> Result<String, ConfigError> {
+    let mut doc: toml_edit::DocumentMut = content.parse()?;
+    let worker_table = doc
+        .get_mut("orchestration")
+        .and_then(|o| o.get_mut("worker"))
+        .and_then(|w| w.get_mut(worker))
+        .and_then(toml_edit::Item::as_table_like_mut)
+        .ok_or_else(|| {
+            ConfigError::Validation(format!(
+                "no [orchestration.worker.{worker}] table in the config"
+            ))
+        })?;
+    if worker_table.get("mcp_filter").is_none() {
+        worker_table.insert(
+            "mcp_filter",
+            toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new())),
+        );
+    }
+    let filter = worker_table
+        .get_mut("mcp_filter")
+        .and_then(toml_edit::Item::as_array_mut)
+        .ok_or_else(|| {
+            ConfigError::Validation(format!(
+                "`mcp_filter` for worker `{worker}` is not a TOML array"
+            ))
+        })?;
+    let existing: Vec<String> = filter
+        .iter()
+        .filter_map(|v| v.as_str().map(str::to_owned))
+        .collect();
+    for entry in entries {
+        if !existing.contains(entry) {
+            filter.push(entry.as_str());
+        }
+    }
+    Ok(doc.to_string())
+}
+
+/// Apply a text transformation to the file at `path` and write the result
+/// atomically (temp file + rename in the same directory), carrying the
+/// original file's permissions over — agent configs hold credentials, so a
+/// `chmod 600` must survive the rewrite. On any error the original file is
+/// left untouched and the temp file removed.
+fn rewrite_file(
+    path: &Path,
+    transform: impl FnOnce(&str) -> Result<String, ConfigError>,
+) -> Result<(), ConfigError> {
     let existing = fs::read_to_string(path)?;
-    let updated = upsert_mcp_server_in_str(&existing, name, server)?;
+    let updated = transform(&existing)?;
     let permissions = fs::metadata(path)?.permissions();
     let tmp = path.with_extension(format!("toml.tmp.{}", std::process::id()));
     let written = fs::write(&tmp, updated)
@@ -418,6 +493,77 @@ url = "https://old.example.com/mcp"
         let content = format!("mcp = 3\n{BASE_CONFIG}");
         let err = upsert_mcp_server_in_str(&content, "srv", &stdio_server()).unwrap_err();
         assert!(matches!(err, ConfigError::Validation(_)), "{err:?}");
+    }
+
+    const ORCHESTRATED_CONFIG: &str = r#"[agent]
+name = "Coordinator"
+system_prompt = "Coordinate"
+
+[agent.llm]
+provider = "anthropic"
+api_key = "test_key"
+model = "claude-3-sonnet-20240229"
+
+[orchestration]
+enabled = true
+
+# Ops worker comment
+[orchestration.worker.operations]
+description = "ops"
+preamble = "You are ops"
+mcp_filter = ["logs_*"] # trailing comment
+
+[orchestration.worker.writer]
+description = "writes summaries"
+preamble = "You write"
+"#;
+
+    #[test]
+    fn appends_filter_entries_and_dedupes() {
+        let updated = append_worker_mcp_filter_in_str(
+            ORCHESTRATED_CONFIG,
+            "operations",
+            &["mezmo_*".to_string(), "logs_*".to_string()],
+        )
+        .unwrap();
+        assert!(
+            updated.contains(r#"mcp_filter = ["logs_*", "mezmo_*"]"#),
+            "existing entry deduped, new one appended:\n{updated}"
+        );
+        assert!(updated.contains("# Ops worker comment"), "{updated}");
+        let config = load_config_from_str(&updated).expect("config must parse");
+        let orch = config.orchestration.expect("orchestration table");
+        assert_eq!(orch.workers["operations"].mcp_filter, ["logs_*", "mezmo_*"]);
+    }
+
+    #[test]
+    fn creates_missing_filter_array() {
+        let updated =
+            append_worker_mcp_filter_in_str(ORCHESTRATED_CONFIG, "writer", &["k8s_*".to_string()])
+                .unwrap();
+        let config = load_config_from_str(&updated).expect("config must parse");
+        assert_eq!(
+            config.orchestration.expect("orchestration table").workers["writer"].mcp_filter,
+            ["k8s_*"]
+        );
+    }
+
+    #[test]
+    fn errors_on_unknown_worker() {
+        let err =
+            append_worker_mcp_filter_in_str(ORCHESTRATED_CONFIG, "nope", &["k8s_*".to_string()])
+                .unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)), "{err:?}");
+    }
+
+    #[test]
+    fn file_append_worker_filter_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, ORCHESTRATED_CONFIG).unwrap();
+        append_worker_mcp_filter(&path, "operations", &["mezmo_*".to_string()]).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains(r#"["logs_*", "mezmo_*"]"#), "{written}");
     }
 
     #[test]

--- a/crates/aura-config/src/writer.rs
+++ b/crates/aura-config/src/writer.rs
@@ -533,7 +533,10 @@ preamble = "You write"
         assert!(updated.contains("# Ops worker comment"), "{updated}");
         let config = load_config_from_str(&updated).expect("config must parse");
         let orch = config.orchestration.expect("orchestration table");
-        assert_eq!(orch.workers["operations"].mcp_filter, ["logs_*", "mezmo_*"]);
+        assert_eq!(
+            orch.workers["operations"].mcp_filter.as_deref(),
+            Some(["logs_*".to_string(), "mezmo_*".to_string()].as_slice())
+        );
     }
 
     #[test]
@@ -543,8 +546,10 @@ preamble = "You write"
                 .unwrap();
         let config = load_config_from_str(&updated).expect("config must parse");
         assert_eq!(
-            config.orchestration.expect("orchestration table").workers["writer"].mcp_filter,
-            ["k8s_*"]
+            config.orchestration.expect("orchestration table").workers["writer"]
+                .mcp_filter
+                .as_deref(),
+            Some(["k8s_*".to_string()].as_slice())
         );
     }
 

--- a/crates/aura-config/src/writer.rs
+++ b/crates/aura-config/src/writer.rs
@@ -1,10 +1,8 @@
 //! Format-preserving writes to an agent config file.
 //!
-//! The MCP install helper (and any other tooling that mutates a user's
-//! `config.toml`) must not destroy unrelated settings, comments, or
-//! `{{ env.VAR }}` placeholders. This module edits the raw TOML text via
-//! `toml_edit` instead of round-tripping through [`crate::Config`], so
-//! everything outside the touched `[mcp]` tables survives byte-for-byte.
+//! Edits raw TOML text via `toml_edit` (no round-trip through
+//! [`crate::Config`]), so unrelated settings, comments, and
+//! `{{ env.VAR }}` placeholders survive untouched.
 
 use std::fs;
 use std::path::Path;
@@ -16,11 +14,8 @@ use crate::error::ConfigError;
 const MAP_FIELDS: [&str; 4] = ["env", "headers", "headers_from_request", "scratchpad"];
 
 /// Insert or replace `[mcp.servers.<name>]` in the config file at `path`,
-/// atomically (see [`rewrite_file`]).
-///
-/// A missing file is an error rather than an implicit create: a config
-/// that holds only an MCP table is not runnable, so the caller is
-/// expected to target an existing config.
+/// atomically (see [`rewrite_file`]). A missing file is an error, not an
+/// implicit create — the caller targets an existing config.
 pub fn upsert_mcp_server(
     path: &Path,
     name: &str,
@@ -47,13 +42,10 @@ pub fn append_worker_mcp_filter(
 /// String-level core of [`append_worker_mcp_filter`]: returns the updated
 /// TOML text.
 ///
-/// The worker table must already exist — this never creates workers.
-/// Entries already present are skipped; a missing `mcp_filter` array is
-/// created. Callers should mind the filter's semantics when creating it:
-/// an *absent* `mcp_filter` grants a worker every MCP tool while a
-/// written one limits the worker to its entries, so creating the array
-/// narrows the worker — and calling with empty `entries` writes the
-/// explicit no-tools assignment (`mcp_filter = []`).
+/// Never creates workers; dedupes entries; creates a missing `mcp_filter`
+/// array. Note the semantics: writing the array narrows an absent-filter
+/// (all-tools) worker, and empty `entries` writes the explicit no-tools
+/// `mcp_filter = []`.
 pub fn append_worker_mcp_filter_in_str(
     content: &str,
     worker: &str,
@@ -96,11 +88,10 @@ pub fn append_worker_mcp_filter_in_str(
     Ok(doc.to_string())
 }
 
-/// Apply a text transformation to the file at `path` and write the result
-/// atomically (temp file + rename in the same directory), carrying the
-/// original file's permissions over — agent configs hold credentials, so a
-/// `chmod 600` must survive the rewrite. On any error the original file is
-/// left untouched and the temp file removed.
+/// Apply a text transformation to `path` and write the result atomically
+/// (temp + rename), preserving the file's permissions (configs holding
+/// credentials may be chmod 600). On error the original is untouched and
+/// the temp file removed.
 fn rewrite_file(
     path: &Path,
     transform: impl FnOnce(&str) -> Result<String, ConfigError>,
@@ -120,14 +111,10 @@ fn rewrite_file(
 
 /// String-level core of [`upsert_mcp_server`]: returns the updated TOML text.
 ///
-/// `[mcp]` and `[mcp.servers]` are created as implicit tables when absent,
-/// so a fresh insert emits only the `[mcp.servers.<name>]` header; when one
-/// of them exists as an *inline* table (`mcp = { ... }`), it is restyled to
-/// a header table so the new server can nest under it. Replacing an existing
-/// server keeps the comments directly above its header (they live in the
-/// table's decor) but drops comments inside the replaced table. Errors
-/// (rather than clobbering) when `content` is not valid TOML or when an
-/// existing `mcp`/`servers` key holds something other than a table.
+/// `[mcp]`/`[mcp.servers]` are created implicitly when absent (and restyled
+/// from inline tables); replacing a server keeps the comments above its
+/// header but drops those inside it. Errors (rather than clobbering) on
+/// invalid TOML or a non-table `mcp`/`servers` key.
 pub fn upsert_mcp_server_in_str(
     content: &str,
     name: &str,
@@ -150,12 +137,9 @@ pub fn upsert_mcp_server_in_str(
 }
 
 /// Serialize a server config into an explicit-header `toml_edit` table.
-///
-/// Serde emits the `transport` tag first and struct fields in declaration
-/// order, which is already deterministic. Two cleanups on top of that keep
-/// the written config tidy and stable: empty optional collections (`args`
-/// plus the [`MAP_FIELDS`]) are omitted entirely, and map-valued fields are
-/// key-sorted so `HashMap` iteration order never leaks into the file.
+/// Empty optional collections (`args` plus the [`MAP_FIELDS`]) are omitted
+/// and map-valued fields key-sorted, so `HashMap` iteration order never
+/// leaks into the file.
 fn server_to_table(server: &McpServerConfig) -> Result<toml_edit::Table, ConfigError> {
     let mut doc = toml_edit::ser::to_document(server)?;
     let mut table = std::mem::take(doc.as_table_mut());
@@ -186,13 +170,10 @@ fn item_is_empty_collection(item: Option<&toml_edit::Item>) -> bool {
     }
 }
 
-/// Get `parent[key]` as a mutable table, creating it as an *implicit* table
-/// when absent (implicit tables render no header of their own, so creating
-/// `[mcp]`/`[mcp.servers]` here adds no visible lines to the file). An
-/// existing inline table is converted to a header table in place — inline
-/// tables can't be extended with `[header]`-style children, and the loader
-/// accepts both spellings, so the data is equivalent. Errors when an
-/// existing `key` holds a non-table value (including `[[array]]` tables).
+/// Get `parent[key]` as a mutable table, creating it implicitly (no header
+/// line of its own) when absent, and converting an existing inline table in
+/// place — inline tables can't take `[header]`-style children. Errors when
+/// `key` holds anything else (including `[[array]]` tables).
 fn ensure_table<'a>(
     parent: &'a mut toml_edit::Table,
     key: &str,

--- a/crates/aura-config/src/writer.rs
+++ b/crates/aura-config/src/writer.rs
@@ -1,0 +1,475 @@
+//! Format-preserving writes to an agent config file.
+//!
+//! The MCP install helper (and any other tooling that mutates a user's
+//! `config.toml`) must not destroy unrelated settings, comments, or
+//! `{{ env.VAR }}` placeholders. This module edits the raw TOML text via
+//! `toml_edit` instead of round-tripping through [`crate::Config`], so
+//! everything outside the touched `[mcp]` tables survives byte-for-byte.
+
+use std::fs;
+use std::path::Path;
+
+use crate::config::McpServerConfig;
+use crate::error::ConfigError;
+
+/// Map-valued fields of an MCP server table.
+const MAP_FIELDS: [&str; 4] = ["env", "headers", "headers_from_request", "scratchpad"];
+
+/// Insert or replace `[mcp.servers.<name>]` in the config file at `path`.
+///
+/// The file is rewritten atomically (temp file + rename in the same
+/// directory), carrying the original file's permissions over — agent
+/// configs hold credentials, so a `chmod 600` must survive the rewrite.
+/// A missing file is an error rather than an implicit create: a config
+/// that holds only an MCP table is not runnable, so the caller is
+/// expected to target an existing config. On any error the original
+/// file is left untouched and the temp file removed.
+pub fn upsert_mcp_server(
+    path: &Path,
+    name: &str,
+    server: &McpServerConfig,
+) -> Result<(), ConfigError> {
+    let existing = fs::read_to_string(path)?;
+    let updated = upsert_mcp_server_in_str(&existing, name, server)?;
+    let permissions = fs::metadata(path)?.permissions();
+    let tmp = path.with_extension(format!("toml.tmp.{}", std::process::id()));
+    let written = fs::write(&tmp, updated)
+        .and_then(|()| fs::set_permissions(&tmp, permissions))
+        .and_then(|()| fs::rename(&tmp, path));
+    if written.is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+    Ok(written?)
+}
+
+/// String-level core of [`upsert_mcp_server`]: returns the updated TOML text.
+///
+/// `[mcp]` and `[mcp.servers]` are created as implicit tables when absent,
+/// so a fresh insert emits only the `[mcp.servers.<name>]` header; when one
+/// of them exists as an *inline* table (`mcp = { ... }`), it is restyled to
+/// a header table so the new server can nest under it. Replacing an existing
+/// server keeps the comments directly above its header (they live in the
+/// table's decor) but drops comments inside the replaced table. Errors
+/// (rather than clobbering) when `content` is not valid TOML or when an
+/// existing `mcp`/`servers` key holds something other than a table.
+pub fn upsert_mcp_server_in_str(
+    content: &str,
+    name: &str,
+    server: &McpServerConfig,
+) -> Result<String, ConfigError> {
+    if name.trim().is_empty() {
+        return Err(ConfigError::Validation(
+            "MCP server name must be non-empty".to_string(),
+        ));
+    }
+    let mut doc: toml_edit::DocumentMut = content.parse()?;
+    let mut table = server_to_table(server)?;
+    let mcp = ensure_table(doc.as_table_mut(), "mcp")?;
+    let servers = ensure_table(mcp, "servers")?;
+    if let Some(toml_edit::Item::Table(old)) = servers.get(name) {
+        *table.decor_mut() = old.decor().clone();
+    }
+    servers.insert(name, toml_edit::Item::Table(table));
+    Ok(doc.to_string())
+}
+
+/// Serialize a server config into an explicit-header `toml_edit` table.
+///
+/// Serde emits the `transport` tag first and struct fields in declaration
+/// order, which is already deterministic. Two cleanups on top of that keep
+/// the written config tidy and stable: empty optional collections (`args`
+/// plus the [`MAP_FIELDS`]) are omitted entirely, and map-valued fields are
+/// key-sorted so `HashMap` iteration order never leaks into the file.
+fn server_to_table(server: &McpServerConfig) -> Result<toml_edit::Table, ConfigError> {
+    let mut doc = toml_edit::ser::to_document(server)?;
+    let mut table = std::mem::take(doc.as_table_mut());
+
+    for key in MAP_FIELDS.iter().chain(std::iter::once(&"args")) {
+        if item_is_empty_collection(table.get(key)) {
+            table.remove(key);
+        }
+    }
+    for key in MAP_FIELDS {
+        match table.get_mut(key) {
+            Some(toml_edit::Item::Table(t)) => t.sort_values(),
+            Some(toml_edit::Item::Value(toml_edit::Value::InlineTable(t))) => t.sort_values(),
+            _ => {}
+        }
+    }
+
+    table.set_implicit(false);
+    Ok(table)
+}
+
+fn item_is_empty_collection(item: Option<&toml_edit::Item>) -> bool {
+    match item {
+        Some(toml_edit::Item::Table(t)) => t.is_empty(),
+        Some(toml_edit::Item::Value(toml_edit::Value::InlineTable(t))) => t.is_empty(),
+        Some(toml_edit::Item::Value(toml_edit::Value::Array(a))) => a.is_empty(),
+        _ => false,
+    }
+}
+
+/// Get `parent[key]` as a mutable table, creating it as an *implicit* table
+/// when absent (implicit tables render no header of their own, so creating
+/// `[mcp]`/`[mcp.servers]` here adds no visible lines to the file). An
+/// existing inline table is converted to a header table in place — inline
+/// tables can't be extended with `[header]`-style children, and the loader
+/// accepts both spellings, so the data is equivalent. Errors when an
+/// existing `key` holds a non-table value (including `[[array]]` tables).
+fn ensure_table<'a>(
+    parent: &'a mut toml_edit::Table,
+    key: &str,
+) -> Result<&'a mut toml_edit::Table, ConfigError> {
+    match parent.get_mut(key) {
+        None => {
+            let mut table = toml_edit::Table::new();
+            table.set_implicit(true);
+            parent.insert(key, toml_edit::Item::Table(table));
+        }
+        Some(item) => {
+            if let toml_edit::Item::Value(toml_edit::Value::InlineTable(_)) = item {
+                let toml_edit::Item::Value(toml_edit::Value::InlineTable(inline)) =
+                    std::mem::replace(item, toml_edit::Item::None)
+                else {
+                    unreachable!("matched an inline table above");
+                };
+                *item = toml_edit::Item::Table(inline.into_table());
+            }
+        }
+    }
+    parent
+        .get_mut(key)
+        .and_then(toml_edit::Item::as_table_mut)
+        .ok_or_else(|| {
+            ConfigError::Validation(format!(
+                "cannot add MCP server: existing `{key}` entry is not a TOML table"
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::McpServerConfig;
+    use crate::load_config_from_str;
+    use std::collections::HashMap;
+
+    const BASE_CONFIG: &str = r#"# My aura config
+[agent]
+name = "Minimal Agent"
+system_prompt = "Basic prompt"
+
+[agent.llm]
+provider = "anthropic"
+api_key = "test_key"
+model = "claude-3-sonnet-20240229"
+"#;
+
+    fn stdio_server() -> McpServerConfig {
+        McpServerConfig::Stdio {
+            cmd: vec!["npx".to_owned(), "-y".to_owned(), "some-mcp".to_owned()],
+            args: vec![],
+            env: HashMap::new(),
+            description: None,
+            scratchpad: HashMap::new(),
+        }
+    }
+
+    fn http_server(headers: HashMap<String, String>) -> McpServerConfig {
+        McpServerConfig::HttpStreamable {
+            url: "https://mcp.example.com/mcp".to_owned(),
+            headers,
+            description: Some("Example server".to_owned()),
+            headers_from_request: HashMap::new(),
+            scratchpad: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn insert_preserves_original_and_creates_implicit_tables() {
+        let updated = upsert_mcp_server_in_str(BASE_CONFIG, "k8s", &stdio_server()).unwrap();
+        assert!(
+            updated.starts_with(BASE_CONFIG),
+            "original content must survive verbatim as a prefix:\n{updated}"
+        );
+        assert!(updated.contains("[mcp.servers.k8s]"), "{updated}");
+        assert!(
+            !updated.contains("\n[mcp]\n") && !updated.contains("\n[mcp.servers]\n"),
+            "intermediate tables must stay implicit (no bare headers):\n{updated}"
+        );
+    }
+
+    #[test]
+    fn round_trips_through_loader_for_all_transports() {
+        let servers: [(&str, McpServerConfig); 3] = [
+            ("stdio_srv", stdio_server()),
+            ("http_srv", http_server(HashMap::new())),
+            (
+                "sse_srv",
+                McpServerConfig::Sse {
+                    url: "https://sse.example.com/mcp".to_owned(),
+                    headers: HashMap::new(),
+                    description: None,
+                    headers_from_request: HashMap::new(),
+                    scratchpad: HashMap::new(),
+                },
+            ),
+        ];
+        let mut content = BASE_CONFIG.to_owned();
+        for (name, server) in &servers {
+            content = upsert_mcp_server_in_str(&content, name, server).unwrap();
+        }
+        let config = load_config_from_str(&content).expect("written config must parse");
+        let parsed = config.mcp.expect("mcp table present").servers;
+        assert_eq!(parsed.len(), 3);
+        match &parsed["stdio_srv"] {
+            McpServerConfig::Stdio { cmd, .. } => {
+                assert_eq!(cmd, &["npx", "-y", "some-mcp"]);
+            }
+            other => panic!("expected stdio, got {other:?}"),
+        }
+        match &parsed["http_srv"] {
+            McpServerConfig::HttpStreamable {
+                url, description, ..
+            } => {
+                assert_eq!(url, "https://mcp.example.com/mcp");
+                assert_eq!(description.as_deref(), Some("Example server"));
+            }
+            other => panic!("expected http_streamable, got {other:?}"),
+        }
+        match &parsed["sse_srv"] {
+            McpServerConfig::Sse { url, .. } => assert_eq!(url, "https://sse.example.com/mcp"),
+            other => panic!("expected sse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn overwrite_replaces_server_and_preserves_siblings() {
+        let mut content = BASE_CONFIG.to_owned();
+        content.push_str(
+            r#"
+# Keep me: sibling server comment
+[mcp.servers.keeper]
+transport = "stdio"
+cmd = ["keeper-mcp"]
+
+[mcp.servers.target]
+transport = "http_streamable"
+url = "https://old.example.com/mcp"
+"#,
+        );
+        let updated =
+            upsert_mcp_server_in_str(&content, "target", &http_server(HashMap::new())).unwrap();
+        assert!(
+            updated.contains("# Keep me: sibling server comment"),
+            "{updated}"
+        );
+        assert!(updated.contains("cmd = [\"keeper-mcp\"]"), "{updated}");
+        assert!(updated.contains("https://mcp.example.com/mcp"), "{updated}");
+        assert!(
+            !updated.contains("https://old.example.com/mcp"),
+            "{updated}"
+        );
+    }
+
+    #[test]
+    fn preserves_env_placeholders_verbatim() {
+        let headers = HashMap::from([(
+            "Authorization".to_owned(),
+            "Bearer {{ env.MEZMO_API_KEY }}".to_owned(),
+        )]);
+        let updated =
+            upsert_mcp_server_in_str(BASE_CONFIG, "mezmo", &http_server(headers)).unwrap();
+        assert!(
+            updated.contains("Bearer {{ env.MEZMO_API_KEY }}"),
+            "placeholder must land in the file unresolved:\n{updated}"
+        );
+    }
+
+    #[test]
+    fn omits_empty_optional_collections() {
+        let updated = upsert_mcp_server_in_str(BASE_CONFIG, "k8s", &stdio_server()).unwrap();
+        let server_section = updated.split("[mcp.servers.k8s]").nth(1).unwrap();
+        for absent in ["args", "env", "scratchpad", "description"] {
+            assert!(
+                !server_section.contains(absent),
+                "`{absent}` should be omitted when empty/None:\n{server_section}"
+            );
+        }
+    }
+
+    #[test]
+    fn map_output_is_key_sorted_and_deterministic() {
+        let headers = HashMap::from([
+            ("b-header".to_owned(), "2".to_owned()),
+            ("a-header".to_owned(), "1".to_owned()),
+            ("c-header".to_owned(), "3".to_owned()),
+        ]);
+        let first =
+            upsert_mcp_server_in_str(BASE_CONFIG, "srv", &http_server(headers.clone())).unwrap();
+        let second = upsert_mcp_server_in_str(BASE_CONFIG, "srv", &http_server(headers)).unwrap();
+        assert_eq!(first, second);
+        let a = first.find("a-header").unwrap();
+        let b = first.find("b-header").unwrap();
+        let c = first.find("c-header").unwrap();
+        assert!(a < b && b < c, "headers must be key-sorted:\n{first}");
+    }
+
+    #[test]
+    fn preserves_comment_above_replaced_server_header() {
+        let content = format!(
+            "{BASE_CONFIG}\n# IMPORTANT: do not remove\n[mcp.servers.target]\ntransport = \"stdio\"\ncmd = [\"old\"]\n"
+        );
+        let updated =
+            upsert_mcp_server_in_str(&content, "target", &http_server(HashMap::new())).unwrap();
+        assert!(
+            updated.contains("# IMPORTANT: do not remove"),
+            "comment above the replaced header must survive:\n{updated}"
+        );
+        assert!(!updated.contains("cmd = [\"old\"]"), "{updated}");
+    }
+
+    #[test]
+    fn converts_inline_servers_table_to_header_table() {
+        let content = format!(
+            "{BASE_CONFIG}\n[mcp]\nservers = {{ target = {{ transport = \"stdio\", cmd = [\"old\"] }} }}\n"
+        );
+        let updated =
+            upsert_mcp_server_in_str(&content, "target", &http_server(HashMap::new())).unwrap();
+        let config = load_config_from_str(&updated).expect("restyled config must parse");
+        let parsed = config.mcp.expect("mcp table present").servers;
+        match &parsed["target"] {
+            McpServerConfig::HttpStreamable { url, .. } => {
+                assert_eq!(url, "https://mcp.example.com/mcp");
+            }
+            other => panic!("expected http_streamable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn upserts_next_to_dotted_key_server() {
+        let content = format!(
+            "{BASE_CONFIG}\n[mcp]\nservers.dotted.transport = \"stdio\"\nservers.dotted.cmd = [\"dotted-mcp\"]\n"
+        );
+        let updated =
+            upsert_mcp_server_in_str(&content, "added", &http_server(HashMap::new())).unwrap();
+        let config = load_config_from_str(&updated).expect("config must parse");
+        let parsed = config.mcp.expect("mcp table present").servers;
+        assert_eq!(parsed.len(), 2);
+        assert!(
+            matches!(&parsed["dotted"], McpServerConfig::Stdio { cmd, .. } if cmd == &["dotted-mcp"])
+        );
+    }
+
+    #[test]
+    fn round_trips_nonempty_maps_through_loader() {
+        let server = McpServerConfig::HttpStreamable {
+            url: "https://mcp.example.com/mcp".to_owned(),
+            headers: HashMap::from([("X-Static".to_owned(), "s".to_owned())]),
+            description: None,
+            headers_from_request: HashMap::from([(
+                "Authorization".to_owned(),
+                "authorization".to_owned(),
+            )]),
+            scratchpad: HashMap::new(),
+        };
+        let updated = upsert_mcp_server_in_str(BASE_CONFIG, "srv", &server).unwrap();
+        let config = load_config_from_str(&updated).expect("config must parse");
+        match &config.mcp.expect("mcp table present").servers["srv"] {
+            McpServerConfig::HttpStreamable {
+                headers,
+                headers_from_request,
+                ..
+            } => {
+                assert_eq!(headers.get("X-Static").map(String::as_str), Some("s"));
+                assert_eq!(
+                    headers_from_request
+                        .get("Authorization")
+                        .map(String::as_str),
+                    Some("authorization")
+                );
+            }
+            other => panic!("expected http_streamable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_array_of_tables_servers() {
+        let content = format!("{BASE_CONFIG}\n[[mcp.servers]]\ntransport = \"stdio\"\n");
+        let err = upsert_mcp_server_in_str(&content, "srv", &stdio_server()).unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)), "{err:?}");
+    }
+
+    #[test]
+    fn errors_on_malformed_toml() {
+        let err = upsert_mcp_server_in_str("not = [valid", "srv", &stdio_server()).unwrap_err();
+        assert!(matches!(err, ConfigError::TomlEdit(_)), "{err:?}");
+    }
+
+    #[test]
+    fn errors_on_empty_name() {
+        let err = upsert_mcp_server_in_str(BASE_CONFIG, "  ", &stdio_server()).unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)), "{err:?}");
+    }
+
+    #[test]
+    fn errors_when_mcp_is_not_a_table() {
+        let content = format!("mcp = 3\n{BASE_CONFIG}");
+        let err = upsert_mcp_server_in_str(&content, "srv", &stdio_server()).unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)), "{err:?}");
+    }
+
+    #[test]
+    fn file_upsert_is_atomic_and_leaves_no_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, BASE_CONFIG).unwrap();
+
+        upsert_mcp_server(&path, "k8s", &stdio_server()).unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("[mcp.servers.k8s]"));
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .filter(|n| n != "config.toml")
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "temp files left behind: {leftovers:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_upsert_preserves_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, BASE_CONFIG).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        upsert_mcp_server(&path, "k8s", &stdio_server()).unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "permissions must survive the rewrite");
+    }
+
+    #[test]
+    fn file_upsert_missing_file_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let err =
+            upsert_mcp_server(&dir.path().join("nope.toml"), "srv", &stdio_server()).unwrap_err();
+        assert!(matches!(err, ConfigError::Io(_)), "{err:?}");
+    }
+
+    #[test]
+    fn file_upsert_leaves_file_untouched_on_malformed_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "not = [valid").unwrap();
+        upsert_mcp_server(&path, "srv", &stdio_server()).unwrap_err();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "not = [valid");
+    }
+}

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -187,8 +187,7 @@ impl Agent {
         let filter = config
             .mcp_filter
             .as_deref()
-            .or(config.agent.mcp_filter.as_deref())
-            .unwrap_or(&[]);
+            .or(config.agent.mcp_filter.as_deref());
         if !scratchpad::has_accessible_scratchpad_tool(
             &accessible_tools,
             filter,

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -248,8 +248,10 @@ impl AgentRuntimeConfig {
     ///
     /// Returns true if:
     /// - No filter is set (None) - all tools pass
-    /// - Filter is empty - all tools pass
     /// - Tool name matches at least one pattern
+    ///
+    /// An empty filter (`mcp_filter = []`) matches nothing — it is the
+    /// explicit "no MCP tools" assignment, distinct from omitting the field.
     ///
     /// Checks the extension field (`self.mcp_filter`, set by orchestrator) first,
     /// then falls back to the TOML-parseable field (`self.agent.mcp_filter`).
@@ -261,7 +263,6 @@ impl AgentRuntimeConfig {
         let effective = self.mcp_filter.as_ref().or(self.agent.mcp_filter.as_ref());
         match effective {
             None => true,
-            Some(patterns) if patterns.is_empty() => true,
             Some(patterns) => patterns.iter().any(|p| glob_match(p, tool_name)),
         }
     }
@@ -306,12 +307,12 @@ mod tests {
     }
 
     #[test]
-    fn test_tool_matches_filter_empty() {
+    fn test_tool_matches_filter_empty_denies_all() {
         let config = AgentRuntimeConfig {
             mcp_filter: Some(vec![]),
             ..Default::default()
         };
-        assert!(config.tool_matches_filter("any_tool"));
+        assert!(!config.tool_matches_filter("any_tool"));
     }
 
     #[test]

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -106,9 +106,8 @@ pub struct AgentRuntimeConfig {
     pub preamble_override: Option<String>,
 
     /// Glob patterns for filtering which MCP tools to include.
-    /// When set, only tools matching at least one pattern are added.
-    /// Supports glob syntax: `*` (any chars), `?` (single char).
-    /// Empty or None means all tools are included.
+    /// When set, only tools matching at least one pattern are added
+    /// (`None` = all tools, empty = none). Glob syntax: `*`, `?`.
     pub mcp_filter: Option<Vec<String>>,
 
     /// Shared persistence for injecting `read_artifact` tool into workers.
@@ -244,21 +243,13 @@ impl AgentRuntimeConfig {
             .or_else(|| self.orchestration.as_ref().and_then(|o| o.memory_dir()))
     }
 
-    /// Check if a tool name matches the mcp_filter patterns.
+    /// Check if a tool name matches the mcp_filter patterns (glob syntax:
+    /// `*` any chars, `?` one char). No filter (`None`) passes everything;
+    /// an empty filter (`mcp_filter = []`) is the explicit no-tools
+    /// assignment and matches nothing.
     ///
-    /// Returns true if:
-    /// - No filter is set (None) - all tools pass
-    /// - Tool name matches at least one pattern
-    ///
-    /// An empty filter (`mcp_filter = []`) matches nothing — it is the
-    /// explicit "no MCP tools" assignment, distinct from omitting the field.
-    ///
-    /// Checks the extension field (`self.mcp_filter`, set by orchestrator) first,
-    /// then falls back to the TOML-parseable field (`self.agent.mcp_filter`).
-    ///
-    /// Supports simple glob patterns:
-    /// - `*` matches any sequence of characters
-    /// - `?` matches any single character
+    /// Checks the extension field (`self.mcp_filter`, set by orchestrator)
+    /// first, then falls back to `self.agent.mcp_filter`.
     pub fn tool_matches_filter(&self, tool_name: &str) -> bool {
         let effective = self.mcp_filter.as_ref().or(self.agent.mcp_filter.as_ref());
         match effective {

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -1964,9 +1964,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
         let mut worker_tools = std::collections::HashMap::new();
 
         for (worker_name, worker_config) in &self.config.workers {
-            // Match MCP tools via mcp_filter: an omitted filter grants every
-            // MCP tool (backwards compatibility); `mcp_filter = []` is the
-            // explicit no-tools assignment and matches nothing.
+            // Omitted filter = every MCP tool (backwards compatibility);
+            // `mcp_filter = []` = none.
             let mut matching_tools: Vec<String> = match &worker_config.mcp_filter {
                 None => all_tools.clone(),
                 Some(filter) => all_tools

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -614,10 +614,18 @@ impl Orchestrator {
             );
 
             if !has_matching_tool {
-                tracing::warn!(
-                    "Worker {}: scratchpad enabled but no MCP tool matches a scratchpad threshold; skipping",
-                    task_id
-                );
+                if worker_filter.is_some_and(<[String]>::is_empty) {
+                    // The deliberate no-tools assignment — nothing to intercept.
+                    tracing::info!(
+                        "Worker {}: mcp_filter = [] (no MCP tools); scratchpad not needed",
+                        task_id
+                    );
+                } else {
+                    tracing::warn!(
+                        "Worker {}: scratchpad enabled but no MCP tool matches a scratchpad threshold; skipping",
+                        task_id
+                    );
+                }
             } else {
                 // Validation enforces these upstream; re-check here so runtime
                 // misconfiguration fails loudly instead of silently degrading.

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -601,7 +601,7 @@ impl Orchestrator {
                 .unwrap_or_default();
             let scratchpad_tool_map =
                 scratchpad::scratchpad_tool_map(self.agent_config.mcp.as_ref(), &tools_per_server);
-            let worker_filter = worker_cfg.map(|w| w.mcp_filter.as_slice()).unwrap_or(&[]);
+            let worker_filter = worker_cfg.and_then(|w| w.mcp_filter.as_deref());
             let accessible_tools = self
                 .mcp_manager
                 .as_ref()
@@ -782,8 +782,8 @@ impl Orchestrator {
             let full_preamble = super::config::WORKER_PREAMBLE_TEMPLATE
                 .replace("{{worker_system_prompt}}", &worker.preamble);
             worker_config.preamble_override = Some(full_preamble);
-            if !worker.mcp_filter.is_empty() {
-                worker_config.mcp_filter = Some(worker.mcp_filter.clone());
+            if let Some(filter) = &worker.mcp_filter {
+                worker_config.mcp_filter = Some(filter.clone());
             }
 
             // Filter vector stores: worker only gets stores explicitly assigned to it
@@ -1956,20 +1956,20 @@ Assign tasks to the worker whose tools best match the required operations."#,
         let mut worker_tools = std::collections::HashMap::new();
 
         for (worker_name, worker_config) in &self.config.workers {
-            // Match MCP tools via mcp_filter (empty = all MCP tools for backwards compatibility)
-            let mut matching_tools: Vec<String> = if worker_config.mcp_filter.is_empty() {
-                all_tools.clone()
-            } else {
-                all_tools
+            // Match MCP tools via mcp_filter: an omitted filter grants every
+            // MCP tool (backwards compatibility); `mcp_filter = []` is the
+            // explicit no-tools assignment and matches nothing.
+            let mut matching_tools: Vec<String> = match &worker_config.mcp_filter {
+                None => all_tools.clone(),
+                Some(filter) => all_tools
                     .iter()
                     .filter(|tool_name| {
-                        worker_config
-                            .mcp_filter
+                        filter
                             .iter()
                             .any(|pattern| crate::config::glob_match(pattern, tool_name))
                     })
                     .cloned()
-                    .collect()
+                    .collect(),
             };
 
             // Add vector store tools based on explicit vector_stores assignment
@@ -4501,7 +4501,7 @@ mod tests {
             WorkerConfig {
                 description: "For logs and pipelines".to_string(),
                 preamble: "Operations specialist.".to_string(),
-                mcp_filter: vec!["mezmo_*".to_string()],
+                mcp_filter: Some(vec!["mezmo_*".to_string()]),
                 vector_stores: vec![], // No RAG for operations
                 turn_depth: None,
                 llm: None,
@@ -4514,7 +4514,7 @@ mod tests {
             WorkerConfig {
                 description: "For documentation".to_string(),
                 preamble: "Knowledge specialist.".to_string(),
-                mcp_filter: vec![],                            // No MCP tools
+                mcp_filter: Some(vec![]), // No MCP tools
                 vector_stores: vec!["mezmo_docs".to_string()], // RAG access
                 turn_depth: None,
                 llm: None,
@@ -4579,7 +4579,7 @@ mod tests {
             WorkerConfig {
                 description: "For documentation queries".to_string(),
                 preamble: "Documentation specialist.".to_string(),
-                mcp_filter: vec![],
+                mcp_filter: Some(vec![]),
                 vector_stores: vec!["docs".to_string()],
                 turn_depth: None,
                 llm: None,
@@ -4594,7 +4594,7 @@ mod tests {
             WorkerConfig {
                 description: "For knowledge base queries".to_string(),
                 preamble: "Knowledge specialist.".to_string(),
-                mcp_filter: vec![],
+                mcp_filter: Some(vec![]),
                 vector_stores: vec!["kb".to_string(), "runbooks".to_string()],
                 turn_depth: None,
                 llm: None,
@@ -4609,7 +4609,7 @@ mod tests {
             WorkerConfig {
                 description: "For operational tasks".to_string(),
                 preamble: "Operations specialist.".to_string(),
-                mcp_filter: vec!["mezmo_*".to_string()],
+                mcp_filter: Some(vec!["mezmo_*".to_string()]),
                 vector_stores: vec![], // Explicitly no RAG access
                 turn_depth: None,
                 llm: None,
@@ -4743,7 +4743,7 @@ mod tests {
             WorkerConfig {
                 description: "Test".to_string(),
                 preamble: "Test".to_string(),
-                mcp_filter: vec![],
+                mcp_filter: Some(vec![]),
                 vector_stores: vec!["worker_store".to_string()],
                 turn_depth: None,
                 llm: None,

--- a/crates/aura/src/orchestration/templates.rs
+++ b/crates/aura/src/orchestration/templates.rs
@@ -380,7 +380,7 @@ TOOL USAGE:
 
 Always verify your calculations before reporting results."
                     .to_string(),
-                mcp_filter: vec!["mock_tool".to_string()],
+                mcp_filter: Some(vec!["mock_tool".to_string()]),
                 vector_stores: vec![],
                 turn_depth: None,
                 llm: None,
@@ -406,7 +406,7 @@ TOOL USAGE:
 - Use chain_tool for multi-step processing sequences
 - Always report what you found"
                     .to_string(),
-                mcp_filter: vec!["list_files".to_string(), "chain_tool".to_string()],
+                mcp_filter: Some(vec!["list_files".to_string(), "chain_tool".to_string()]),
                 vector_stores: vec![],
                 turn_depth: None,
                 llm: None,

--- a/crates/aura/src/scratchpad/mod.rs
+++ b/crates/aura/src/scratchpad/mod.rs
@@ -123,20 +123,24 @@ pub fn scratchpad_tool_map(
 
 /// True when at least one tool reachable through `mcp_filter` is keyed in
 /// the resolved scratchpad map — i.e. there's something for the wrapper to
-/// intercept. Empty `mcp_filter` means "all tools are reachable".
+/// intercept. `None` means "all tools are reachable"; an empty `Some`
+/// filter is the explicit no-tools assignment, so nothing is reachable.
 ///
 /// Now an exact lookup since `scratchpad_tool_map` is keyed by tool name
 /// (not pattern) — no glob iteration on the hot path.
 pub fn has_accessible_scratchpad_tool(
     tool_names: &[String],
-    mcp_filter: &[String],
+    mcp_filter: Option<&[String]>,
     scratchpad_tool_map: &HashMap<String, usize>,
 ) -> bool {
     if scratchpad_tool_map.is_empty() {
         return false;
     }
     tool_names.iter().any(|name| {
-        let reachable = mcp_filter.is_empty() || mcp_filter.iter().any(|p| glob_match(p, name));
+        let reachable = match mcp_filter {
+            None => true,
+            Some(filter) => filter.iter().any(|p| glob_match(p, name)),
+        };
         reachable && scratchpad_tool_map.contains_key(name)
     })
 }
@@ -400,7 +404,7 @@ mod tests {
     fn has_accessible_returns_false_when_map_is_empty() {
         assert!(!has_accessible_scratchpad_tool(
             &["foo".to_string()],
-            &[],
+            None,
             &HashMap::new(),
         ));
     }
@@ -410,7 +414,7 @@ mod tests {
         let map = HashMap::from([("foo".to_string(), 256)]);
         assert!(has_accessible_scratchpad_tool(
             &["foo".to_string(), "bar".to_string()],
-            &[],
+            None,
             &map,
         ));
     }
@@ -422,7 +426,7 @@ mod tests {
         // though it's in the map.
         assert!(!has_accessible_scratchpad_tool(
             &["foo".to_string()],
-            &["bar_*".to_string()],
+            Some(&["bar_*".to_string()]),
             &map,
         ));
     }
@@ -432,7 +436,7 @@ mod tests {
         let map = HashMap::from([("foo_get".to_string(), 256)]);
         assert!(has_accessible_scratchpad_tool(
             &["foo_get".to_string()],
-            &["foo_*".to_string()],
+            Some(&["foo_*".to_string()]),
             &map,
         ));
     }

--- a/crates/aura/src/scratchpad/mod.rs
+++ b/crates/aura/src/scratchpad/mod.rs
@@ -121,13 +121,10 @@ pub fn scratchpad_tool_map(
     resolved
 }
 
-/// True when at least one tool reachable through `mcp_filter` is keyed in
-/// the resolved scratchpad map — i.e. there's something for the wrapper to
-/// intercept. `None` means "all tools are reachable"; an empty `Some`
-/// filter is the explicit no-tools assignment, so nothing is reachable.
-///
-/// Now an exact lookup since `scratchpad_tool_map` is keyed by tool name
-/// (not pattern) — no glob iteration on the hot path.
+/// True when at least one tool reachable through `mcp_filter` (`None` =
+/// all reachable, empty `Some` = none) is keyed in the resolved scratchpad
+/// map — i.e. there's something for the wrapper to intercept. An exact
+/// lookup: `scratchpad_tool_map` is keyed by tool name, not pattern.
 pub fn has_accessible_scratchpad_tool(
     tool_names: &[String],
     mcp_filter: Option<&[String]>,

--- a/crates/aura/src/scratchpad/setup.rs
+++ b/crates/aura/src/scratchpad/setup.rs
@@ -110,7 +110,8 @@ pub fn estimate_scratchpad_overhead(
 }
 
 /// BPE-count the JSON-Schema bodies of every MCP tool the agent will see,
-/// optionally filtered by glob patterns (empty filter = include all).
+/// optionally filtered by glob patterns (`None` = include all; an empty
+/// `Some` filter is the explicit no-tools assignment and includes none).
 ///
 /// Each tool is serialized as `{name, description, input_schema}` — the same
 /// shape the LLM sees in its tool list. Per-provider serialization differs
@@ -121,12 +122,13 @@ pub fn estimate_scratchpad_overhead(
 pub fn count_mcp_tool_schema_tokens<'a>(
     counter: &dyn TokenCounter,
     tools: impl IntoIterator<Item = &'a rmcp::model::Tool>,
-    mcp_filter: &[String],
+    mcp_filter: Option<&[String]>,
 ) -> usize {
     tools
         .into_iter()
-        .filter(|t| {
-            mcp_filter.is_empty() || mcp_filter.iter().any(|p| glob_match(p, t.name.as_ref()))
+        .filter(|t| match mcp_filter {
+            None => true,
+            Some(filter) => filter.iter().any(|p| glob_match(p, t.name.as_ref())),
         })
         .map(|t| {
             let json = serde_json::json!({
@@ -227,7 +229,7 @@ mod tests {
                 "required": ["pattern"]
             }),
         );
-        let actual = count_mcp_tool_schema_tokens(&*c, std::iter::once(&tool), &[]);
+        let actual = count_mcp_tool_schema_tokens(&*c, std::iter::once(&tool), None);
         let expected_json = serde_json::json!({
             "name": tool.name,
             "description": tool.description,
@@ -253,9 +255,9 @@ mod tests {
             serde_json::json!({"type": "object"}),
         );
         let filter: Vec<String> = vec!["alpha_*".into()];
-        let all = count_mcp_tool_schema_tokens(&*c, [&alpha, &beta], &[]);
-        let filtered = count_mcp_tool_schema_tokens(&*c, [&alpha, &beta], &filter);
-        let alpha_only = count_mcp_tool_schema_tokens(&*c, std::iter::once(&alpha), &[]);
+        let all = count_mcp_tool_schema_tokens(&*c, [&alpha, &beta], None);
+        let filtered = count_mcp_tool_schema_tokens(&*c, [&alpha, &beta], Some(&filter));
+        let alpha_only = count_mcp_tool_schema_tokens(&*c, std::iter::once(&alpha), None);
         assert_eq!(filtered, alpha_only);
         assert!(all > filtered, "unfiltered must exceed filtered");
     }

--- a/crates/aura/src/scratchpad/setup.rs
+++ b/crates/aura/src/scratchpad/setup.rs
@@ -110,8 +110,7 @@ pub fn estimate_scratchpad_overhead(
 }
 
 /// BPE-count the JSON-Schema bodies of every MCP tool the agent will see,
-/// optionally filtered by glob patterns (`None` = include all; an empty
-/// `Some` filter is the explicit no-tools assignment and includes none).
+/// optionally filtered by glob patterns (`None` = include all).
 ///
 /// Each tool is serialized as `{name, description, input_schema}` — the same
 /// shape the LLM sees in its tool list. Per-provider serialization differs

--- a/docs/breaking-changes/20260723-empty-mcp-filter.md
+++ b/docs/breaking-changes/20260723-empty-mcp-filter.md
@@ -1,0 +1,45 @@
+# 23 July 2026
+
+# !!BREAKING CHANGES!!
+
+## Summary
+
+An **empty** `mcp_filter` (`mcp_filter = []`) now grants **no MCP tools**
+instead of every MCP tool. This applies to orchestration workers
+(`[orchestration.worker.<name>].mcp_filter`) and to the single-agent
+`[agent].mcp_filter`.
+
+An *omitted* `mcp_filter` still grants every MCP tool, so existing configs
+that don't write the field are unaffected.
+
+## Why
+
+Previously `mcp_filter = []` and an omitted filter both meant "all tools",
+which made two things impossible or dangerous:
+
+- **"No MCP tools" was unexpressible.** Tool-free workers (like a writer
+  that only synthesizes text) had to resort to a non-matching dummy pattern
+  such as `["__none__"]`.
+- **Removing the last allowlist entry silently widened access.** Editing
+  `mcp_filter = ["logs_*"]` down to `mcp_filter = []` expanded the worker
+  from one tool family to *every* tool — the opposite of the intent.
+
+See issue [#378](https://github.com/mezmo/aura/issues/378).
+
+## The new rule
+
+| Config                        | Tools granted             |
+| ----------------------------- | ------------------------- |
+| `mcp_filter` omitted          | every MCP tool            |
+| `mcp_filter = []`             | none                      |
+| `mcp_filter = ["mezmo_*"]`    | matching tools only       |
+
+## Migration
+
+- If a config has `mcp_filter = []` **and relied on receiving all tools**:
+  delete the line (omit the field).
+- If a config used a non-matching dummy pattern (e.g. `["__none__"]`) to
+  keep a worker tool-free: replace it with `mcp_filter = []`.
+
+`client_tool_filter` is unchanged: an empty client-tool filter still means
+all client tools.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -131,7 +131,7 @@ url = "http://host.docker.internal:9000/mcp"
 
 Use `host.docker.internal` to reach services running on your host machine.
 
-Then scope the tools per worker: set `mcp_filter` on each worker that should use them (see [Customize orchestration](#customize-orchestration)). A worker with no `mcp_filter` receives **all** MCP tools, so set it explicitly on every tool-using worker and keep tool-free workers (like the default `writer`) on a non-matching pattern.
+Then scope the tools per worker: set `mcp_filter` on each worker that should use them (see [Customize orchestration](#customize-orchestration)). A worker with no `mcp_filter` receives **all** MCP tools, so set it explicitly on every tool-using worker and give tool-free workers (like the default `writer`) an explicit empty filter (`mcp_filter = []`).
 
 ### Add vector search
 
@@ -217,12 +217,12 @@ preamble = """
 You are a knowledge specialist completing one assigned task.
 Search available documentation to answer the question.
 """
-mcp_filter = ["__none__"]      # non-matching pattern: no MCP tools, vector search only
+mcp_filter = []                # no MCP tools: vector search only
 vector_stores = ["docs"]
 turn_depth = 5
 ```
 
-> **Note:** a worker whose `mcp_filter` is omitted or empty (`[]`) is granted **every** MCP tool, not none. Set an explicit `mcp_filter` on each worker once an MCP server is configured, and use a non-matching pattern (e.g. `["__none__"]`) for any worker you want to keep tool-free.
+> **Note:** a worker whose `mcp_filter` is *omitted* is granted **every** MCP tool. Set an explicit `mcp_filter` on each worker once an MCP server is configured; `mcp_filter = []` keeps a worker tool-free.
 
 Each worker inherits the agent's LLM by default. To run a worker on a different model, add a complete `[orchestration.worker.<name>.llm]` block — see the [orchestration config reference](../README.md#orchestration) for all fields.
 

--- a/quickstart.toml
+++ b/quickstart.toml
@@ -79,10 +79,10 @@ preamble = """
 You are a Writing Specialist. Take the coordinator's goal and any research
 findings and produce a concise, well-structured response.
 """
-# The writer synthesizes text and needs no tools. This non-matching pattern
-# keeps it tool-free even after you enable an MCP server (an omitted/empty
-# filter would otherwise grant it every tool). Leave it as-is.
-mcp_filter = ["__none__"]
+# The writer synthesizes text and needs no tools. The explicit empty
+# filter keeps it tool-free even after you enable an MCP server (an
+# omitted filter would grant it every tool). Leave it as-is.
+mcp_filter = []
 
 # ── MCP Tool Servers (optional) ─────────────────────────────────────
 # To give your workers external tools:


### PR DESCRIPTION
## What

The first slice of the MCP install helper epic (#310): a guided `/mcp` flow in the CLI that takes a user from "AURA is installed" to "AURA can use tools against my data" without hand-authoring TOML — plus the config-writer foundation it stands on and the `mcp_filter` semantics fix that makes worker scoping expressible.

Closes #402
Closes #403
Closes #378

## The flow

`/mcp` lists the active agent's MCP servers (name, transport, target, description) from the credential-free `AgentInfo.mcp_servers` overview, so it behaves identically in standalone and HTTP modes.

`/mcp add` (standalone mode) is a deterministic wizard — no LLM ever sees a credential:

1. Pick from a curated catalog (Mezmo, PagerDuty, Datadog, Kubernetes with `--read-only`) or define a custom server (transport, URL/command, auth header with scheme prefix, e.g. `Authorization = "Bearer {{ env.MEZMO_API_KEY }}"`). Prerequisites and the access AURA will get are shown before any input.
2. Credentials come from an env var you already export (auto-offered when the conventional var is set, or name your own) or masked entry — only entered values are saved, to `.env` (0600 on create, values quoted for dotenvy), never to the TOML.
3. The server is verified **before** the config-write prompt: a bounded (30s) in-memory connection + tool-discovery check. Consent is informed by the live result; a failed check flips the prompt to write-anyway-defaulting-to-no.
4. Config updates go through a new format-preserving `toml_edit` writer (`aura_config::writer`): atomic temp+rename, file permissions carried over, comments and unrelated settings preserved, `{{ env.VAR }}` placeholders untouched.
5. For orchestrated configs, a per-worker access step uses the discovered tool names: filterless workers get a lockdown choice (scope to this server / no MCP tools / keep all), allowlisted workers get an append-style grant (namespace glob like `mezmo_*` when safe, exact names otherwise — never a generic-verb glob that would match other servers' tools).
6. On success, a starter prompt that exercises the new integration.

## Breaking change

`mcp_filter = []` now grants **no** MCP tools instead of every tool (an omitted filter still grants all). This applies to worker filters and the single-agent `[agent].mcp_filter`, makes "no tools" expressible (the wizard's lockdown option writes it), and closes the trap where deleting the last allowlist entry silently widened access to everything. No shipped config regresses; the `["__none__"]` workaround in quickstart is replaced. Migration notes: `docs/breaking-changes/20260723-empty-mcp-filter.md`. `client_tool_filter` is unchanged.

## Not in scope

- HTTP-mode `/mcp add` (server-side config mutation needs an auth + persistence story; the bootstrap agent in #391 is the likely path)
- Hot-reload — the wizard says "restart aura to activate"; `/mcp` list reflects the running roster until then
- Config-directory setups and `/mcp remove`

## Testing

- 39 workspace test suites green; clippy and fmt clean in default and `--no-default-features` (HTTP-only) builds
- New unit coverage: writer round-trips for all three transports (format/comment/permission preservation, inline-table conversion, atomicity), `.env` quoting round-tripped through dotenvy parsing, catalog templates render-and-reload with placeholders intact, secret inlining, worker filter parsing (`[]` vs omitted), glob-safety rules
- Manually exercised end to end against a local config (catalog + custom flows, worker scoping) and a local aura-web-server deployment (`/mcp` list via `/aura/info`, `add` correctly refusing in HTTP mode)
