### PR TITLE
feat(cli): add slash command tab completion

### DIFF
--- a/crates/aura-cli/README.md
+++ b/crates/aura-cli/README.md
@@ -132,7 +132,7 @@ cargo build -p aura-cli --no-default-features
 - **Local tool execution** — the model can read files, search code, list directories, run shell commands, and edit files on your behalf
 - **Standalone mode** (default) — run agents directly from TOML config without a web server
 - **Conversation persistence** — pick up where you left off with `--resume` or `/resume`
-- **Tab completion** — cycle through matching models and conversations with `Tab` / `Shift+Tab`
+- **Tab completion** — cycle through slash commands, models, and conversations with `Tab` / `Shift+Tab`
 - **Model selection** — browse and select models from the server (or loaded configs in standalone mode)
 - **Permission system** — control which local tools are allowed, denied, or prompted before execution
 - **SSE streaming** — real-time token-by-token output with a toggleable event panel
@@ -286,7 +286,7 @@ Once inside the REPL, the slash commands below are available. All slash commands
 | `Enter`                 | Submit input                                                         |
 | `Ctrl+C`                | Cancel the current streaming request, or exit if idle                |
 | `Ctrl+L`                | Clear the current input line; if the line is empty, clear the screen |
-| `Tab`                   | Cycle forward through matches (in `/model` and `/resume`)            |
+| `Tab`                   | Cycle forward through slash-command and argument matches             |
 | `Shift+Tab`             | Cycle backward through matches                                       |
 | `Esc`                   | Cancel tab-completion selection, or exit stream panel focus          |
 | `Up` / `Down`           | Navigate input history                                               |

--- a/crates/aura-cli/src/repl/input_reader.rs
+++ b/crates/aura-cli/src/repl/input_reader.rs
@@ -11,6 +11,7 @@ use std::borrow::Cow;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use crate::repl::registry::{lookup, matching_commands};
 use crate::ui::prompt::{
     at_stream_top, check_resize, clear_screen_preserve_frame, commit_cursor_row,
     enter_stream_focus, exit_stream_focus, handle_resize_frame, is_stream_panel_focused,
@@ -270,7 +271,7 @@ impl ConditionalEventHandler for PageUpHandler {
     }
 }
 
-/// Tab: cycle through model/conversation matches with visual highlighting.
+/// Tab: cycle through slash commands or command-specific matches.
 struct TabHandler;
 
 impl ConditionalEventHandler for TabHandler {
@@ -282,7 +283,10 @@ impl ConditionalEventHandler for TabHandler {
         ctx: &EventContext,
     ) -> Option<Cmd> {
         let line = ctx.line();
-        let match_count = if line == "/model" || line.starts_with("/model ") {
+        let command_match_count = matching_commands(line).len();
+        let match_count = if lookup(line).is_none() && command_match_count > 0 {
+            command_match_count
+        } else if line == "/model" || line.starts_with("/model ") {
             get_model_matches().len()
         } else if line == "/resume" || line.starts_with("/resume ") {
             RESUME_MATCHES.lock().map(|g| g.len()).unwrap_or(0)
@@ -306,7 +310,7 @@ impl ConditionalEventHandler for TabHandler {
     }
 }
 
-/// Shift+Tab: cycle backward through model/conversation matches.
+/// Shift+Tab: cycle backward through slash commands or command-specific matches.
 struct ShiftTabHandler;
 
 impl ConditionalEventHandler for ShiftTabHandler {
@@ -318,7 +322,10 @@ impl ConditionalEventHandler for ShiftTabHandler {
         ctx: &EventContext,
     ) -> Option<Cmd> {
         let line = ctx.line();
-        let match_count = if line == "/model" || line.starts_with("/model ") {
+        let command_match_count = matching_commands(line).len();
+        let match_count = if lookup(line).is_none() && command_match_count > 0 {
+            command_match_count
+        } else if line == "/model" || line.starts_with("/model ") {
             get_model_matches().len()
         } else if line == "/resume" || line.starts_with("/resume ") {
             RESUME_MATCHES.lock().map(|g| g.len()).unwrap_or(0)
@@ -437,7 +444,7 @@ pub(crate) fn create_input_reader() -> rustyline::Result<Editor<AuraHelper, Defa
         KeyEvent(KeyCode::PageUp, Modifiers::NONE),
         EventHandler::Conditional(Box::new(PageUpHandler)),
     );
-    // Tab: cycle through model/conversation matches
+    // Tab: cycle through command and argument matches
     input_reader.bind_sequence(
         KeyEvent(KeyCode::Tab, Modifiers::NONE),
         EventHandler::Conditional(Box::new(TabHandler)),

--- a/crates/aura-cli/src/repl/registry.rs
+++ b/crates/aura-cli/src/repl/registry.rs
@@ -15,7 +15,9 @@ use super::history::ConversationHistory;
 use super::input_reader::AuraHelper;
 use crate::backend::Backend;
 use crate::ui::prompt::{is_expanded_output, with_event_log};
-use crate::ui::state::{MODEL_MATCHES, RESUME_MATCHES, STYLE_MATCHES, get_tab_select_index};
+use crate::ui::state::{
+    MODEL_MATCHES, RESUME_MATCHES, STYLE_MATCHES, get_tab_select_index, set_tab_select_index,
+};
 
 /// Mutable per-session state passed to each command handler.
 pub(crate) struct CommandContext<'a> {
@@ -198,6 +200,18 @@ pub(crate) fn lookup(name: &str) -> Option<&'static Command> {
     COMMANDS.iter().find(|c| c.name == name)
 }
 
+/// Return commands whose names start with a slash-command prefix.
+pub(crate) fn matching_commands(prefix: &str) -> Vec<&'static Command> {
+    if !prefix.starts_with('/') || prefix.chars().any(char::is_whitespace) {
+        return Vec::new();
+    }
+
+    COMMANDS
+        .iter()
+        .filter(|command| command.name.starts_with(prefix))
+        .collect()
+}
+
 /// Split a resolved command line into its command word (the leading
 /// whitespace-delimited token) and the trimmed argument remainder.
 pub(crate) fn split_command(resolved: &str) -> (&str, &str) {
@@ -210,7 +224,14 @@ pub(crate) fn split_command(resolved: &str) -> (&str, &str) {
 /// the line names no known command.
 pub(crate) fn dispatch(line: &str, ctx: &mut CommandContext) -> Option<CommandOutcome> {
     let (word, args) = split_command(line);
-    Some((lookup(word)?.handler)(ctx, args))
+    let command = lookup(word).or_else(|| {
+        let command = matching_commands(word)
+            .get(get_tab_select_index()?)
+            .copied();
+        set_tab_select_index(None);
+        command
+    })?;
+    Some((command.handler)(ctx, args))
 }
 
 fn cmd_exit(ctx: &mut CommandContext, _args: &str) -> CommandOutcome {
@@ -348,6 +369,18 @@ mod tests {
     fn lookup_is_exact() {
         assert!(lookup("/he").is_none());
         assert!(lookup("/nope").is_none());
+    }
+
+    #[test]
+    fn command_completion_matches_prefixes_and_rejects_arguments() {
+        let matches: Vec<&str> = matching_commands("/m")
+            .iter()
+            .map(|command| command.name)
+            .collect();
+        assert_eq!(matches, vec!["/model", "/mcp"]);
+        assert_eq!(matching_commands("/mc")[0].name, "/mcp");
+        assert!(matching_commands("m").is_empty());
+        assert!(matching_commands("/model gpt").is_empty());
     }
 
     #[test]

--- a/crates/aura-cli/src/ui/input_hint.rs
+++ b/crates/aura-cli/src/ui/input_hint.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use crossterm::style::Stylize;
 
 use crate::repl::conversations::ConversationStore;
-use crate::repl::registry::{COMMANDS, Command, lookup, split_command};
+use crate::repl::registry::{lookup, matching_commands, split_command};
 
 use super::input_frame::resize_status_area;
 use super::state::{
@@ -354,37 +354,26 @@ pub fn update_input_hint(line: &str) {
             let entries: Vec<String> = filtered.iter().map(|n| mark(n)).collect();
             build_columnar_hints(&entries, tab_idx)
         }
-    } else if let Some(prefix) = line.strip_prefix('/') {
+    } else if line.starts_with('/') {
         if let Ok(mut guard) = RESUME_MATCHES.lock() {
             guard.clear();
         }
-        let matching: Vec<&Command> = COMMANDS
-            .iter()
-            .filter(|c| {
-                c.name
-                    .strip_prefix('/')
-                    .unwrap_or(c.name)
-                    .starts_with(prefix)
-            })
-            .collect();
+        let matching = matching_commands(line);
+        let tab_idx = get_tab_select_index();
         if matching.is_empty() {
             vec![]
-        } else if matching.len() == 1 {
+        } else if matching.len() == 1 && tab_idx.is_none() {
             vec![format!(
                 "{}",
                 format!("{} — {}", matching[0].name, matching[0].description)
                     .themed(AuraStyle::Muted)
             )]
         } else {
-            vec![format!(
-                "{}",
-                matching
-                    .iter()
-                    .map(|c| c.name)
-                    .collect::<Vec<_>>()
-                    .join("  ")
-                    .themed(AuraStyle::Muted)
-            )]
+            let entries: Vec<String> = matching
+                .iter()
+                .map(|command| command.name.to_owned())
+                .collect();
+            build_columnar_hints(&entries, tab_idx)
         }
     } else {
         if let Ok(mut guard) = RESUME_MATCHES.lock() {


### PR DESCRIPTION
## Summary

- add Tab and Shift+Tab cycling for matching slash commands
- preserve the typed prefix while cycling so additional input refines the matches
- visibly highlight the selected command, including when only one match remains

## Validation

- `make fmt-check`
- `cargo test -p aura-cli`
- `cargo test --workspace`
- `make lint`

Closes #415
