### PR TITLE
fix(agent): apply turn-limit nudges to scratchpad read tool output

### DIFF
--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -364,6 +364,7 @@ impl Agent {
                 max_depth,
             )
         };
+        config_owned.turn_nudge = turn_nudge.clone();
         if let Some(ref state) = turn_nudge {
             // First in the vec → transform_output runs last, on the text the
             // LLM actually sees (after any scratchpad pointer rewrite).
@@ -982,20 +983,46 @@ impl Agent {
                 GetInTool, GrepTool, HeadTool, ItemSchemaTool, IterateOverTool, ReadTool,
                 SchemaTool, SliceTool,
             };
+            use crate::turn_nudge::NudgedTool;
             tracing::info!(
                 "Adding scratchpad tools (head, slice, grep, schema, item_schema, get_in, iterate_over, read)"
             );
             let s = &scratchpad.storage;
             let b = &scratchpad.budget;
+            let n = &config.turn_nudge;
             builder_state = builder_state
-                .add_tool(HeadTool::new(s.clone(), b.clone()))
-                .add_tool(SliceTool::new(s.clone(), b.clone()))
-                .add_tool(GrepTool::new(s.clone(), b.clone()))
-                .add_tool(SchemaTool::new(s.clone(), b.clone()))
-                .add_tool(ItemSchemaTool::new(s.clone(), b.clone()))
-                .add_tool(GetInTool::new(s.clone(), b.clone()))
-                .add_tool(IterateOverTool::new(s.clone(), b.clone()))
-                .add_tool(ReadTool::new(s.clone(), b.clone()));
+                .add_tool(NudgedTool::new(
+                    HeadTool::new(s.clone(), b.clone()),
+                    n.clone(),
+                ))
+                .add_tool(NudgedTool::new(
+                    SliceTool::new(s.clone(), b.clone()),
+                    n.clone(),
+                ))
+                .add_tool(NudgedTool::new(
+                    GrepTool::new(s.clone(), b.clone()),
+                    n.clone(),
+                ))
+                .add_tool(NudgedTool::new(
+                    SchemaTool::new(s.clone(), b.clone()),
+                    n.clone(),
+                ))
+                .add_tool(NudgedTool::new(
+                    ItemSchemaTool::new(s.clone(), b.clone()),
+                    n.clone(),
+                ))
+                .add_tool(NudgedTool::new(
+                    GetInTool::new(s.clone(), b.clone()),
+                    n.clone(),
+                ))
+                .add_tool(NudgedTool::new(
+                    IterateOverTool::new(s.clone(), b.clone()),
+                    n.clone(),
+                ))
+                .add_tool(NudgedTool::new(
+                    ReadTool::new(s.clone(), b.clone()),
+                    n.clone(),
+                ));
         }
 
         // Add read_artifact tool when orchestration persistence is available.

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -124,6 +124,9 @@ pub struct AgentRuntimeConfig {
     /// `Some` when scratchpad is wired up for this agent or worker.
     pub scratchpad_tools_config: Option<ScratchpadToolsConfig>,
 
+    /// Shared turn-limit nudge state for this agent's tool calls.
+    pub turn_nudge: Option<Arc<crate::turn_nudge::TurnNudgeState>>,
+
     /// Shared decision state for worker `submit_result` tool.
     /// When set, workers get the `submit_result` tool for structured output.
     pub orchestration_submit_result: Option<crate::orchestration::SubmitResultDecision>,
@@ -167,6 +170,7 @@ impl Clone for AgentRuntimeConfig {
             orchestration_persistence: self.orchestration_persistence.clone(),
             session_id: self.session_id.clone(),
             scratchpad_tools_config: self.scratchpad_tools_config.clone(),
+            turn_nudge: self.turn_nudge.clone(),
             orchestration_submit_result: self.orchestration_submit_result.clone(),
             hitl: self.hitl.clone(),
             request_id: self.request_id.clone(),
@@ -203,6 +207,7 @@ impl std::fmt::Debug for AgentRuntimeConfig {
                     .map(|_| "<persistence>"),
             )
             .field("session_id", &self.session_id)
+            .field("turn_nudge", &self.turn_nudge.as_ref().map(|_| "<state>"))
             .field(
                 "orchestration_submit_result",
                 &self

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -847,6 +847,7 @@ impl Orchestrator {
 
         // Orchestrator owns tool wrapping decision
         worker_config.tool_wrapper = Some(wrapper);
+        worker_config.turn_nudge = turn_nudge.clone();
 
         // Give workers access to result artifacts
         worker_config.orchestration_persistence = Some(self.persistence.clone());

--- a/crates/aura/src/turn_nudge.rs
+++ b/crates/aura/src/turn_nudge.rs
@@ -3,9 +3,10 @@
 //! `MaxDepthError`.
 //!
 //! `Agent::count_turns` tracks the turn number (one `StreamItem::TurnUsage`
-//! per rig turn); [`TurnNudgeWrapper`] appends a notice to MCP tool output,
-//! which rig feeds back as the next turn's prompt. Enabled via
-//! `[agent].nudge_last_turn` and `[agent].nudge_turns_remaining`.
+//! per rig turn); [`TurnNudgeWrapper`] appends a notice to MCP tool output
+//! and [`NudgedTool`] to scratchpad read tool output, which rig feeds back
+//! as the next turn's prompt. Enabled via `[agent].nudge_last_turn` and
+//! `[agent].nudge_turns_remaining`.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -179,6 +180,50 @@ impl ToolWrapper for TurnNudgeWrapper {
     }
 }
 
+/// Adapter that appends turn-limit nudges to a built-in tool's output —
+/// the counterpart of [`TurnNudgeWrapper`] for tools (scratchpad reads)
+/// whose typed args/errors don't fit `WrappedTool`.
+#[derive(Clone)]
+pub struct NudgedTool<T> {
+    inner: T,
+    state: Option<Arc<TurnNudgeState>>,
+}
+
+impl<T> NudgedTool<T> {
+    pub fn new(inner: T, state: Option<Arc<TurnNudgeState>>) -> Self {
+        Self { inner, state }
+    }
+}
+
+impl<T> rig::tool::Tool for NudgedTool<T>
+where
+    T: rig::tool::Tool<Output = String>,
+{
+    const NAME: &'static str = T::NAME;
+    type Error = T::Error;
+    type Args = T::Args;
+    type Output = String;
+
+    fn name(&self) -> String {
+        self.inner.name()
+    }
+
+    async fn definition(&self, prompt: String) -> rig::completion::ToolDefinition {
+        self.inner.definition(prompt).await
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let output = self.inner.call(args).await?;
+        match self.state.as_ref().and_then(|s| s.nudge_message()) {
+            Some(nudge) => {
+                tracing::debug!(tool = %self.inner.name(), "appending turn-limit nudge to tool output");
+                Ok(format!("{output}{nudge}"))
+            }
+            None => Ok(output),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -284,5 +329,59 @@ mod tests {
         state.reset();
         // Back in turn 1 (remaining 2): no nudge.
         assert!(state.nudge_message().is_none());
+    }
+
+    #[derive(Clone)]
+    struct EchoTool;
+
+    impl rig::tool::Tool for EchoTool {
+        const NAME: &'static str = "echo";
+        type Error = std::io::Error;
+        type Args = String;
+        type Output = String;
+
+        async fn definition(&self, _prompt: String) -> rig::completion::ToolDefinition {
+            rig::completion::ToolDefinition {
+                name: Self::NAME.to_string(),
+                description: String::new(),
+                parameters: serde_json::json!({}),
+            }
+        }
+
+        async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+            Ok(args)
+        }
+    }
+
+    #[tokio::test]
+    async fn nudged_tool_appends_nudge_near_limit() {
+        use rig::tool::Tool;
+
+        let state = TurnNudgeState::new(true, None, 1).unwrap(); // 3 turns total
+        let tool = NudgedTool::new(EchoTool, Some(state.clone()));
+
+        // Turn 1 (remaining 2): output passes through untouched.
+        let out = tool.call("hello".to_string()).await.unwrap();
+        assert_eq!(out, "hello");
+
+        // Turn 2 (remaining 1): final-turn nudge appended.
+        state.record_turn_completed();
+        let out = tool.call("hello".to_string()).await.unwrap();
+        assert!(out.starts_with("hello"));
+        assert!(out.contains("FINAL TURN"));
+
+        // Second call in the same turn: shared state dedupes the nudge.
+        let out = tool.call("hello".to_string()).await.unwrap();
+        assert_eq!(out, "hello");
+    }
+
+    #[tokio::test]
+    async fn nudged_tool_without_state_is_passthrough() {
+        use rig::tool::Tool;
+
+        let tool = NudgedTool::new(EchoTool, None);
+        assert_eq!(tool.name(), "echo");
+        let out = tool.call("hello".to_string()).await.unwrap();
+        assert_eq!(out, "hello");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #452. Turn-limit nudging (#379) only fired on MCP tool output because it rides the `ToolWrapper` chain, and the scratchpad read tools bypass that chain. An agent paging through a large tool output with `head`/`grep`/`slice` got no warning before `MaxDepthError` wiped its work, and those exploration loops are where turns actually go.

## Changes

- New `NudgedTool<T>` adapter in `turn_nudge.rs`: wraps any built-in `Tool<Output = String>`, delegates unchanged, and appends the nudge to successful output. The read tools have typed args and their own error type, so they can't reuse `WrappedTool`.
- `AgentRuntimeConfig` gains a `turn_nudge` field to carry the shared `TurnNudgeState` from where it's created to tool registration.
- The single-agent build path and orchestration `create_worker` both set the field; the eight scratchpad read tools are registered wrapped.
- The state is the same one the MCP `TurnNudgeWrapper` uses, so at most one nudge is issued per turn even when a turn mixes MCP and scratchpad calls. Worker nudges keep the `submit_result` wording, and nudge timing already accounts for `turn_depth_bonus` since the state is built from the resolved max depth.

Not covered: `read_artifact` returns a typed struct rather than a string, so it would need a different adapter. Left out to keep this focused.

## Testing

- Two new unit tests: nudge appended at the final-turn boundary and deduped within a turn; passthrough when nudging is disabled.
- `cargo test --workspace`, clippy, and fmt all clean.