### PR TITLE
feat(cli): point empty-mcp hint at /mcp add command

### DIFF
--- a/crates/aura-cli/src/repl/mcp/mod.rs
+++ b/crates/aura-cli/src/repl/mcp/mod.rs
@@ -47,7 +47,7 @@ fn format_server_list(agent: Option<&AgentInfo>) -> String {
     };
     if servers.is_empty() {
         return format!(
-            "No MCP servers configured for {}.\nSet up an MCP server to connect AURA to your tools.",
+            "No MCP servers configured for {}.\nRun /mcp add to connect AURA to your tools.",
             agent.id
         );
     }

--- a/crates/aura-cli/src/ui/agent_overview.rs
+++ b/crates/aura-cli/src/ui/agent_overview.rs
@@ -105,7 +105,7 @@ fn worker_block_lines(workers: &[WorkerOverview], width: usize) -> Vec<String> {
 fn startup_cta_lines(agent: &AgentInfo, width: usize) -> Vec<String> {
     let text = match agent.mcp_servers.as_ref() {
         Some(servers) if servers.is_empty() => {
-            "Set up an MCP server to connect AURA to your tools."
+            "Run /mcp add to connect AURA to your tools."
         }
         _ => "What should we work on?",
     };
@@ -267,7 +267,7 @@ mod tests {
         let lines = plain(&startup_cta_lines(&agent, 80));
         assert_eq!(
             lines.join(" "),
-            "Set up an MCP server to connect AURA to your tools."
+            "Run /mcp add to connect AURA to your tools."
         );
     }
 

--- a/crates/aura-cli/src/ui/agent_overview.rs
+++ b/crates/aura-cli/src/ui/agent_overview.rs
@@ -104,9 +104,7 @@ fn worker_block_lines(workers: &[WorkerOverview], width: usize) -> Vec<String> {
 /// back to the generic prompt.
 fn startup_cta_lines(agent: &AgentInfo, width: usize) -> Vec<String> {
     let text = match agent.mcp_servers.as_ref() {
-        Some(servers) if servers.is_empty() => {
-            "Run /mcp add to connect AURA to your tools."
-        }
+        Some(servers) if servers.is_empty() => "Run /mcp add to connect AURA to your tools.",
         _ => "What should we work on?",
     };
     wrap_words(text, width)


### PR DESCRIPTION
The hint shown when no MCP servers are configured told users to "set up an MCP server" without saying how. This points it at the recently-added `/mcp add` command that installs one, updating both the startup CTA and the `/mcp` listing output (plus the matching test).