### PR TITLE
feat(cli): recommend latest chatgpt and opus models in init

### DIFF
--- a/crates/aura-cli/src/init/provider.rs
+++ b/crates/aura-cli/src/init/provider.rs
@@ -78,8 +78,10 @@ pub(crate) fn default_key_env(provider: Provider) -> Option<&'static str> {
 /// editorial choice — keep them current as providers ship new flagships.
 pub(crate) fn family_roots(provider: Provider) -> &'static [&'static str] {
     match provider {
-        Provider::OpenAI => &["gpt-5.5"],
-        Provider::Anthropic => &["claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5"],
+        // GPT-5.6 ships as three flavors; `terra` (balanced) is the default —
+        // `sol` is the pricier frontier tier, `luna` the cheapest.
+        Provider::OpenAI => &["gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.6-luna"],
+        Provider::Anthropic => &["claude-opus-5", "claude-sonnet-4-6", "claude-haiku-4-5"],
         Provider::Gemini => &["gemini-3.5-flash", "gemini-3.1-pro"],
         // Uncurated providers (and bedrock, which has no list endpoint).
         Provider::OpenRouter | Provider::Ollama | Provider::Bedrock => &[],

--- a/crates/aura-cli/src/init/ranking.rs
+++ b/crates/aura-cli/src/init/ranking.rs
@@ -230,20 +230,27 @@ mod tests {
             "o3",
             "o4-mini",
             "gpt-4.1",
-            "gpt-5.4",
             "gpt-5.5",
-            "gpt-5.5-2025-11-01", // dated snapshot of a recommended id
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-terra-2026-07-09", // dated snapshot of a recommended id
+            "gpt-5.6-luna",
             "text-embedding-3-small",
         ]
         .iter()
         .map(|s| s.to_string())
         .collect();
 
-        // Only the recommended gpt-5.5 is shown, and the clean id wins over its
-        // dated snapshot. gpt-5.4 / o-series / 4o / 3.5 are dropped.
+        // Only the recommended gpt-5.6 flavors are shown, best-first per
+        // `family_roots` (terra default), and the clean id wins over its dated
+        // snapshot. gpt-5.5 / o-series / 4o / 3.5 are dropped.
         assert_eq!(
             rank_shortlist(Provider::OpenAI, &models),
-            vec!["gpt-5.5".to_string()]
+            vec![
+                "gpt-5.6-terra".to_string(),
+                "gpt-5.6-sol".to_string(),
+                "gpt-5.6-luna".to_string(),
+            ]
         );
     }
 
@@ -264,17 +271,17 @@ mod tests {
         let models: Vec<String> = [
             "claude-sonnet-4-6-20251001",
             "claude-sonnet-4-6-20251115", // newer sonnet snapshot
-            "claude-opus-4-8-20251101",
+            "claude-opus-5-20260724",
         ]
         .iter()
         .map(|s| s.to_string())
         .collect();
-        // Sonnet is the default (first); the newest dated id wins per family.
+        // Opus is the default (first); the newest dated id wins per family.
         assert_eq!(
             rank_shortlist(Provider::Anthropic, &models),
             vec![
+                "claude-opus-5-20260724".to_string(),
                 "claude-sonnet-4-6-20251115".to_string(),
-                "claude-opus-4-8-20251101".to_string(),
             ]
         );
     }

--- a/crates/aura-cli/src/init/spec.rs
+++ b/crates/aura-cli/src/init/spec.rs
@@ -493,7 +493,7 @@ mod tests {
         a.offline = false;
         let only_openai = |var: &str| var == "OPENAI_API_KEY";
         let detected = |var: &str| (var == "OPENAI_API_KEY").then(|| "sk-detected".to_string());
-        let lister = FixedLister(vec!["gpt-5.4", "gpt-5.5", "text-embedding-3-small"]);
+        let lister = FixedLister(vec!["gpt-5.5", "gpt-5.6-terra", "text-embedding-3-small"]);
         // provider(enter) -> accept key(enter=yes) -> model(enter=suggested)
         let spec = resolve_spec(
             &a,
@@ -504,7 +504,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(spec.provider, Provider::OpenAI);
-        assert_eq!(spec.model, "gpt-5.5");
+        assert_eq!(spec.model, "gpt-5.6-terra");
         assert_eq!(
             spec.api_key,
             Some(ApiKeySource::EnvVar("OPENAI_API_KEY".to_string()))


### PR DESCRIPTION
Updates the `aura init` model recommendations so the suggested defaults are the latest flagships. OpenAI is bumped from `gpt-5.5` to `gpt-5.6`, and the Anthropic list is reordered so `claude-opus-4-8` is the suggested default ahead of Sonnet. Anthropic Fable is intentionally left out of the recommendation list. Recommendations live in `family_roots`, and the affected `ranking`/`spec` tests are updated to match.

Resolves #463.