### PR TITLE
Add none and xhigh reasoning_effort values for gpt-5.x models

### DIFF
--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -33,19 +33,24 @@ pub struct Config {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ReasoningEffort {
+    #[serde(rename = "none")]
+    Disabled,
     Minimal,
     Low,
     Medium,
     High,
+    Xhigh,
 }
 
 impl fmt::Display for ReasoningEffort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
+            ReasoningEffort::Disabled => "none",
             ReasoningEffort::Minimal => "minimal",
             ReasoningEffort::Low => "low",
             ReasoningEffort::Medium => "medium",
             ReasoningEffort::High => "high",
+            ReasoningEffort::Xhigh => "xhigh",
         };
         write!(f, "{s}")
     }

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -232,6 +232,62 @@ budget_tokens = 8000
         );
     }
 
+    fn parse_reasoning_effort(value: &str) -> Option<ReasoningEffort> {
+        let toml = format!(
+            r#"
+[agent]
+name = "t"
+system_prompt = "p"
+
+[agent.llm]
+provider = "openai"
+api_key = "k"
+model = "gpt-5.6-sol"
+reasoning_effort = "{value}"
+"#
+        );
+        let config = load_config_from_str(&toml).expect("config should parse");
+        let crate::config::LlmConfig::OpenAI {
+            reasoning_effort, ..
+        } = config.agent.llm
+        else {
+            panic!("test config should parse as OpenAI");
+        };
+        reasoning_effort
+    }
+
+    #[test]
+    fn reasoning_effort_all_variants_parse() {
+        assert_eq!(
+            parse_reasoning_effort("none"),
+            Some(ReasoningEffort::Disabled)
+        );
+        assert_eq!(
+            parse_reasoning_effort("minimal"),
+            Some(ReasoningEffort::Minimal)
+        );
+        assert_eq!(parse_reasoning_effort("low"), Some(ReasoningEffort::Low));
+        assert_eq!(
+            parse_reasoning_effort("medium"),
+            Some(ReasoningEffort::Medium)
+        );
+        assert_eq!(parse_reasoning_effort("high"), Some(ReasoningEffort::High));
+        assert_eq!(
+            parse_reasoning_effort("xhigh"),
+            Some(ReasoningEffort::Xhigh)
+        );
+    }
+
+    #[test]
+    fn reasoning_effort_display_matches_openai_wire_values() {
+        assert_eq!(ReasoningEffort::Disabled.to_string(), "none");
+        assert_eq!(ReasoningEffort::Minimal.to_string(), "minimal");
+        assert_eq!(ReasoningEffort::Low.to_string(), "low");
+        assert_eq!(ReasoningEffort::Medium.to_string(), "medium");
+        assert_eq!(ReasoningEffort::High.to_string(), "high");
+        assert_eq!(ReasoningEffort::Xhigh.to_string(), "xhigh");
+    }
+
     #[test]
     fn test_minimal_config() {
         println!("\n=== TEST_MINIMAL_CONFIG ===");

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -190,7 +190,7 @@ provider = "openai"
 api_key = "{{ env.OPENAI_API_KEY }}"
 model = "gpt-5.2"
 # temperature = 0.7
-# reasoning_effort = "medium"  # minimal, low, medium, high (provider support varies)
+# reasoning_effort = "medium"  # none, minimal, low, medium, high, xhigh (provider/model support varies)
 # max_tokens = 8192
 # base_url = "https://api.openai.com/v1"  # custom endpoint
 # Context window size in tokens. Used for usage percentage reporting


### PR DESCRIPTION
Adds `None` and `Xhigh` to the `ReasoningEffort` enum so the `none` and `xhigh` values the OpenAI Chat Completions API accepts across the gpt-5.x family can be set from TOML. `Minimal` stays: the original gpt-5/gpt-5-mini/gpt-5-nano still accept it, so dropping it would break those configs. Additive only; no existing config or behavior changes.

Verified against the live API across 22 gpt-5.x chat models (matrix in #466): `none` from gpt-5.1 on, `xhigh` from gpt-5.2 on, `minimal` only by the original gpt-5 family. End-to-end through `aura-cli --standalone`: `gpt-5` + `minimal` resolves, `gpt-5.6-sol` + `none`/`xhigh` resolve. `cargo test -p aura-config`, `cargo fmt --check`, and `cargo clippy --workspace --all-targets -- -D warnings` all pass.

The separate issue that a 400 (e.g. `minimal` against a newer model) is wrapped as assistant text and surfaces as exit-0 stdout is left for a follow-up; it's broader than this enum and tracked in #466.

Fixes: #466
