### PR TITLE
docs: add roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
     <a href="#quick-start"><strong>Quick Start</strong></a> ·
     <a href="#integrations"><strong>Integrations</strong></a> ·
     <a href="http://docs.mezmo.com/aura"><strong>Documentation</strong></a> ·
+    <a href="https://github.com/mezmo/aura/issues/views/4715"><strong>Roadmap</strong></a> ·
     <a href="#explore-aura"><strong>Explore</strong></a> ·
     <a href="https://mezmo.com/r/slack-aura"><strong>Community</strong></a>
   </p>


### PR DESCRIPTION
## Summary

- Add a Roadmap link to the README navigation that opens the GitHub Initiatives view.
- Make the project roadmap easier to discover for README visitors.

## Validation

- `git diff --check origin/main...HEAD`