### PR TITLE
fix(bedrock): force profile credentials for vector store aws clients

### DIFF
--- a/crates/aura/src/vector_store.rs
+++ b/crates/aura/src/vector_store.rs
@@ -116,15 +116,20 @@ impl VectorStoreManager {
         Ok(BedrockEmbeddingModel::new(aws_client, model, None))
     }
 
-    /// Load AWS SDK config with optional region and profile
+    /// Load AWS SDK config with optional region and profile. A named profile
+    /// forces its credentials even when env credentials are present.
     async fn load_aws_config(region: &str, profile: Option<&str>) -> aws_config::SdkConfig {
         use aws_config::{BehaviorVersion, Region};
 
         if let Some(profile_name) = profile {
             info!("Loading AWS config with profile '{}'", profile_name);
+            let credentials = aws_config::profile::ProfileFileCredentialsProvider::builder()
+                .profile_name(profile_name)
+                .build();
             aws_config::defaults(BehaviorVersion::latest())
                 .region(Region::new(region.to_string()))
                 .profile_name(profile_name)
+                .credentials_provider(credentials)
                 .load()
                 .await
         } else {


### PR DESCRIPTION
## Summary

`load_aws_config` passed `profile_name` to the AWS SDK default credential chain, which resolves environment credentials before profile ones. With `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` set (as in our production deployment, where static keys back the Bedrock LLM calls), a vector store's configured `profile` was silently ignored — so a profile defining a cross-account role via `role_arn` + `web_identity_token_file` (IRSA) was never consulted, and the KB client authenticated as the static IAM principal, getting AccessDenied in the external account.

This change resolves credentials with `ProfileFileCredentialsProvider` when a profile is explicitly named, pinning the client to that profile regardless of env credentials. Stores without a `profile` keep the default chain, so existing deployments are unaffected.

Verified against aws-config 1.8.16 source: the default chain order is Environment → Profile → WebIdentityToken → ECS → IMDS, and the profile provider supports `role_arn` + `web_identity_token_file` profiles (AssumeRoleWithWebIdentity).

## Motivation

First consumer is cross-account access to a customer's Bedrock Knowledge Base: the pod's IRSA-annotated service account provides a web identity token that a named profile exchanges for the customer's role, while the pod's static credentials continue to serve everything else.

## Testing

- `cargo clippy -p aura` clean
- `cargo test -p aura --lib` — 887 passed
- Cross-account IRSA path (annotation → AssumeRoleWithWebIdentity → `bedrock-agent-runtime retrieve`) validated end-to-end in-cluster with an aws-cli pod on the annotated service account

Fixes: #470