### PR TITLE
fix(ci): fail the coverage lane when the compile fails

### DIFF
--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -23,11 +23,12 @@ build-rust: $(DOCKER_ENV) ## Build all rust targets
 .PHONY:coverage
 coverage: $(DOCKER_ENV) $(REPORT_DIR) $(GRCOV_BIN) ## Run the local test suite with code coverage
 	-$(MAKE) debug-PROJECT_ROOT
-	-export RUSTFLAGS="--allow=warnings -Cinstrument-coverage"; \
+	@# Terminate the shell on a failed compile: make only sees the last status.
+	export RUSTFLAGS="--allow=warnings -Cinstrument-coverage"; \
 		export LLVM_PROFILE_FILE=$(PROJECT_ROOT)/$(COVERAGE_DIR)/build-%p-%m.profraw; \
-		cargo build --all-targets --workspace --frozen; \
+		cargo build --all-targets --workspace --frozen || exit 1; \
 		export LLVM_PROFILE_FILE=$(PROJECT_ROOT)/$(COVERAGE_DIR)/profile-%p-%m.profraw; \
-		$(MAKE) nextest|| touch $(TARGET_DIR)/.nextest-failed
+		$(MAKE) nextest || touch $(TARGET_DIR)/.nextest-failed
 	$(RUN) grcov $(COVERAGE_DIR) . \
 		--binary-path $(TARGET_DIR)/debug \
 		--ignore-not-existing \


### PR DESCRIPTION
The `coverage` recipe joins the compile and the test run into one shell command with `;` separators, and prefixed the whole recipe line with `-`, so make ignored the line's status and took it from `$(MAKE) nextest || touch ...`, which is always 0; a failed `cargo build --frozen` scrolled past while the lane stayed green, since nextest runs without `--frozen` and quietly rebuilt over the network. The `-` was written to keep a *test* failure from aborting the recipe before grcov ran, and silently widened to cover the compile when that step was grafted onto the same line in cb233a55. This drops the `-` and terminates the shell explicitly on a failed compile; test failures stay on the existing marker-check path, so grcov still runs and reports. Verified all four paths (build-fail exits non-zero with grcov skipped, tests-fail runs grcov then fails, all-pass exits 0) and confirmed `cargo build --all-targets --workspace --frozen` now succeeds offline under `--network none` in the `cook-debug` image, so this does not red the lane.

Fixes #140