### PR TITLE
doc(scripts): document install.sh switches and fix checksum portability

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,86 @@
+# scripts/
+
+Release and install helpers.
+
+| Script | Purpose |
+| --- | --- |
+| [`install.sh`](install.sh) | Install AURA binaries from GitHub Releases |
+| [`bump-homebrew-tap.sh`](bump-homebrew-tap.sh) | Bump `mezmo/homebrew-tap` formulae to a released version |
+| [`set-version.sh`](set-version.sh) | Set the workspace and crate versions in `Cargo.toml` |
+
+## `install.sh`
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mezmo/aura/main/scripts/install.sh | bash
+```
+
+Installs `aura` (CLI) and `aura-web-server` for `linux`/`darwin` on `amd64`/`arm64`.
+
+The script takes no command-line arguments. Every switch is an environment
+variable, so it works unchanged when piped into `bash`:
+
+```bash
+curl -fsSL .../install.sh | AURA_COMPONENT=cli AURA_VERSION=0.1.3 bash
+```
+
+### Switches
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `AURA_VERSION` | `latest` | Release tag to install. A leading `v` is optional (`0.1.3` and `v0.1.3` both work). `latest` is resolved by following the `releases/latest` redirect. |
+| `AURA_INSTALL` | `~/.local/bin` | Install directory. Created if missing. |
+| `AURA_COMPONENT` | `all` | Which binaries to install: `all`, `server` (`aura-web-server` only), or `cli` (`aura` only). Any other value is an error. |
+| `AURA_REQUIRE_CHECKSUM` | `0` | `1` makes a missing `checksums.txt`, or a missing entry for an asset, a fatal error instead of a warning. A checksum *mismatch* is always fatal. |
+| `AURA_CHECKSUMS` | unset | Path to a local `checksums.txt` to verify against, instead of downloading one from the release. |
+| `AURA_NO_BREW` | `0` | `1` skips Homebrew on macOS and downloads the release assets directly. |
+
+### Homebrew on macOS
+
+On macOS the script installs from the `mezmo/tap/aura` tap instead of
+downloading assets, but only when all of these hold:
+
+- `brew` is on `PATH`
+- `AURA_NO_BREW` is not `1`
+- `AURA_VERSION` is `latest` (the tap cannot pin versions)
+- `AURA_COMPONENT` is `all`
+
+Otherwise it prints why and falls back to a direct download. `AURA_INSTALL` does
+not apply to the Homebrew path.
+
+The `mezmo/tap/aura` formula provides the `aura` CLI only, so this path does not
+install `aura-web-server`. Set `AURA_NO_BREW=1` to get both binaries on macOS.
+
+### Requirements
+
+- `curl` or `wget` for downloads
+- `sha256sum` or `shasum` for checksum verification. If neither is installed,
+  verification is skipped with a warning, or fails when
+  `AURA_REQUIRE_CHECKSUM=1`.
+
+## `bump-homebrew-tap.sh`
+
+```
+bump-homebrew-tap.sh [--dry-run] <version>
+```
+
+Rewrites the `version` and `sha256` fields in each `Formula/*.rb` of
+`mezmo/homebrew-tap` and pushes to `main`.
+
+| Switch | Default | Effect |
+| --- | --- | --- |
+| `--dry-run` / `DRY_RUN=1` | off | Print the proposed commit and test the push with `git push --dry-run` without updating any refs. Tolerates a missing checksums file, validating the version bump only. |
+| `CHECKSUMS_FILE` | `dist/checksums.txt` | Release checksums to source each `sha256` from. |
+| `GH_TOKEN` / `GITHUB_TOKEN` | unset | Token used to clone and push the tap. Required unless `--dry-run`. |
+
+Exits 0 without committing when the formulae already sit at the target version.
+
+## `set-version.sh`
+
+```
+set-version.sh <version>
+```
+
+Sets `version` in the workspace `Cargo.toml` and in each `crates/*/Cargo.toml`
+that carries its own version, then runs `make update-lockfile`. Stands in for
+`cargo set-version`, which does not build against this workspace's edition 2024
+requirements.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,7 @@
 #   AURA_INSTALL          - Install directory (default: ~/.local/bin)
 #   AURA_COMPONENT        - Which binary: "all", "server", "cli" (default: all)
 #   AURA_REQUIRE_CHECKSUM - Fail (1) instead of warn (0) when a checksum is missing (default: 0)
+#   AURA_CHECKSUMS        - Verify against this local checksums.txt instead of downloading one
 #   AURA_NO_BREW          - Skip Homebrew and download directly on macOS (default: 0)
 
 set -euo pipefail

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -173,6 +173,15 @@ download() {
     fi
 }
 
+sha256_of() {
+    local file="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "${file}" | cut -d' ' -f1
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "${file}" | cut -d' ' -f1
+    fi
+}
+
 verify_checksum() {
     local file="$1" asset_name="$2" checksums="$3"
     if [[ ! -s "${checksums}" ]]; then
@@ -194,7 +203,15 @@ verify_checksum() {
         return 0
     fi
     local actual
-    actual=$(sha256sum "${file}" | cut -d' ' -f1)
+    actual=$(sha256_of "${file}")
+    if [[ -z "${actual}" ]]; then
+        if [[ "${REQUIRE_CHECKSUM}" == 1 ]]; then
+            echo "Error: need sha256sum or shasum to verify checksums and AURA_REQUIRE_CHECKSUM is set."
+            exit 1
+        fi
+        echo "  Warning: no sha256sum or shasum found, skipping verification"
+        return 0
+    fi
     if [[ "${actual}" != "${expected}" ]]; then
         echo "Error: checksum mismatch for ${asset_name}"
         echo "  expected: ${expected}"


### PR DESCRIPTION
`scripts/install.sh` is configured entirely through environment variables, but only some of them were written down and none outside the script itself. This adds `scripts/README.md` documenting all six switches, the conditions under which macOS installs from the Homebrew tap instead of downloading release assets, and the requirements; it also adds the previously undocumented `AURA_CHECKSUMS` to the script's own usage header.

While documenting it, I found that checksum verification called `sha256sum` unconditionally, which macOS did not ship until recently, so a direct download on macOS aborted under `set -e` with a command-not-found error and installed nothing. The Homebrew path masked this for the default macOS install, but `AURA_NO_BREW=1`, a pinned `AURA_VERSION`, or a non-`all` `AURA_COMPONENT` all route macOS to the direct download. Verification now prefers `sha256sum` and falls back to `shasum -a 256`, and when neither is present it warns and continues, or exits 1 under `AURA_REQUIRE_CHECKSUM=1`.

Verified by running the script end to end against the real v0.1.6 release with a curated `PATH`: reproduced the exit-127 failure on the pre-fix script, then confirmed the fixed script verifies and installs via `shasum` alone, via `sha256sum` alone, warns-and-installs with neither, exits 1 with neither under `AURA_REQUIRE_CHECKSUM=1`, and still treats a tampered checksum as fatal.