### PR TITLE
fix(bedrock): wire region into profile credentials provider

### DIFF
--- a/crates/aura/src/vector_store.rs
+++ b/crates/aura/src/vector_store.rs
@@ -123,7 +123,11 @@ impl VectorStoreManager {
 
         if let Some(profile_name) = profile {
             info!("Loading AWS config with profile '{}'", profile_name);
+            // the provider's inner STS client needs the region wired explicitly
+            let provider_config = aws_config::provider_config::ProviderConfig::without_region()
+                .with_region(Some(Region::new(region.to_string())));
             let credentials = aws_config::profile::ProfileFileCredentialsProvider::builder()
+                .configure(&provider_config)
                 .profile_name(profile_name)
                 .build();
             aws_config::defaults(BehaviorVersion::latest())


### PR DESCRIPTION
## Summary

Follow-up to #471: with a `profile` set on a vector store, credential resolution failed with `Invalid Configuration: Missing Region` — the standalone `ProfileFileCredentialsProvider` resolves region from neither the environment nor the profile file (both verified empirically against aws-config 1.8.16), so its inner STS client could never dispatch `AssumeRoleWithWebIdentity`. Wire the store's region through a `ProviderConfig` at provider construction.

## Testing

- `cargo clippy -p aura` clean, `cargo test -p aura --lib` — 887 passed
- Probe matrix against aws-config 1.8.16: `region` in profile → still Missing Region; `AWS_REGION` env → still Missing Region; `ProviderConfig` wiring → request dispatches
- Full end-to-end with a live IRSA token and dummy static env credentials present: profile credentials win, cross-account `AssumeRoleWithWebIdentity` succeeds, Bedrock KB `retrieve` returns results

Fixes: #482