### PR TITLE
Retry transient provider failures in orchestration

### DIFF
--- a/crates/aura-config/src/orchestration.rs
+++ b/crates/aura-config/src/orchestration.rs
@@ -157,9 +157,7 @@ impl Default for TimeoutsConfig {
 /// Retry configuration for the orchestration planning loop.
 ///
 /// The schedule is local to aura-config: it does not reuse rig's
-/// `ExponentialBackoff` (aura-config stays free of rig-core) and is
-/// independent of `RetryHint`, which governs MCP tool-error retries for a
-/// different consumer.
+/// `ExponentialBackoff` (aura-config stays free of rig-core).
 ///
 /// # Example
 ///
@@ -199,10 +197,7 @@ impl RetryConfig {
     ///
     /// Retry 1 uses the base delay; each subsequent retry doubles the
     /// previous delay, capped at `max_delay_ms`. Saturating arithmetic — a
-    /// huge `retry_num` returns the cap without panicking. Each retry is a
-    /// fresh `per_call_timeout_secs` budget, so one coordinator planning call
-    /// is bounded by `(max_retries + 1) × per_call_timeout_secs` plus the
-    /// cumulative backoff.
+    /// huge `retry_num` returns the cap without panicking.
     pub fn delay_for_retry(&self, retry_num: usize) -> std::time::Duration {
         // Multiplier is 2^(retry_num - 1): retry 1 -> base, each subsequent doubles.
         let exponent = retry_num.saturating_sub(1).min(128);

--- a/crates/aura-config/src/orchestration.rs
+++ b/crates/aura-config/src/orchestration.rs
@@ -151,6 +151,70 @@ impl Default for TimeoutsConfig {
 }
 
 // ============================================================================
+// Retry Sub-Config
+// ============================================================================
+
+/// Retry configuration for the orchestration planning loop.
+///
+/// The schedule is local to aura-config: it does not reuse rig's
+/// `ExponentialBackoff` (aura-config stays free of rig-core) and is
+/// independent of `RetryHint`, which governs MCP tool-error retries for a
+/// different consumer.
+///
+/// # Example
+///
+/// ```toml
+/// [orchestration.retry]
+/// base_delay_ms = 500
+/// max_delay_ms = 5000
+/// max_retries = 3
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetryConfig {
+    /// Base delay (milliseconds). Default: 500.
+    #[serde(default = "default_base_delay_ms")]
+    pub base_delay_ms: u64,
+
+    /// Maximum delay (milliseconds). Default: 5000.
+    #[serde(default = "default_max_delay_ms")]
+    pub max_delay_ms: u64,
+
+    /// Maximum transient retries after the initial planning call. Default: 3.
+    #[serde(default = "default_max_retries")]
+    pub max_retries: usize,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            base_delay_ms: default_base_delay_ms(),
+            max_delay_ms: default_max_delay_ms(),
+            max_retries: default_max_retries(),
+        }
+    }
+}
+
+impl RetryConfig {
+    /// Delay before transient planning retry `retry_num` (1-based).
+    ///
+    /// Retry 1 uses the base delay; each subsequent retry doubles the
+    /// previous delay, capped at `max_delay_ms`. Saturating arithmetic — a
+    /// huge `retry_num` returns the cap without panicking. Each retry is a
+    /// fresh `per_call_timeout_secs` budget, so one coordinator planning call
+    /// is bounded by `(max_retries + 1) × per_call_timeout_secs` plus the
+    /// cumulative backoff.
+    pub fn delay_for_retry(&self, retry_num: usize) -> std::time::Duration {
+        // Multiplier is 2^(retry_num - 1): retry 1 -> base, each subsequent doubles.
+        let exponent = retry_num.saturating_sub(1).min(128);
+        let multiplier = 1u128.checked_shl(exponent as u32).unwrap_or(u128::MAX);
+        let delay_ms = (self.base_delay_ms as u128)
+            .saturating_mul(multiplier)
+            .min(self.max_delay_ms as u128);
+        std::time::Duration::from_millis(u64::try_from(delay_ms).expect("capped u128 fits u64"))
+    }
+}
+
+// ============================================================================
 // Artifacts Sub-Config
 // ============================================================================
 
@@ -301,6 +365,9 @@ pub struct OrchestrationConfig {
     /// Timeout settings for LLM calls.
     pub timeouts: TimeoutsConfig,
 
+    /// Retry settings for the planning loop.
+    pub retry: RetryConfig,
+
     /// Artifact and persistence settings.
     pub artifacts: ArtifactsConfig,
 }
@@ -321,6 +388,7 @@ impl Default for OrchestrationConfig {
             duplicate_call_nudge_threshold: default_duplicate_call_nudge_threshold(),
             duplicate_call_block_threshold: default_duplicate_call_block_threshold(),
             timeouts: TimeoutsConfig::default(),
+            retry: RetryConfig::default(),
             artifacts: ArtifactsConfig::default(),
         }
     }
@@ -504,6 +572,8 @@ struct RawOrchestrationConfig {
     #[serde(default)]
     timeouts: Option<TimeoutsConfig>,
     #[serde(default)]
+    retry: Option<RetryConfig>,
+    #[serde(default)]
     artifacts: Option<ArtifactsConfig>,
     // Flat artifact fields (backward compat)
     #[serde(default, alias = "memory_path")]
@@ -530,6 +600,7 @@ impl<'de> Deserialize<'de> for OrchestrationConfig {
         let raw = RawOrchestrationConfig::deserialize(deserializer)?;
 
         let timeouts = raw.timeouts.unwrap_or_default();
+        let retry = raw.retry.unwrap_or_default();
 
         // Build artifacts: flat fields override sub-table defaults
         let mut artifacts = raw.artifacts.unwrap_or_default();
@@ -569,6 +640,7 @@ impl<'de> Deserialize<'de> for OrchestrationConfig {
             duplicate_call_nudge_threshold: raw.duplicate_call_nudge_threshold,
             duplicate_call_block_threshold: raw.duplicate_call_block_threshold,
             timeouts,
+            retry,
             artifacts,
         })
     }
@@ -588,6 +660,18 @@ fn default_max_tools_per_worker() -> usize {
 
 fn default_per_call_timeout_secs() -> u64 {
     0
+}
+
+fn default_base_delay_ms() -> u64 {
+    500
+}
+
+fn default_max_delay_ms() -> u64 {
+    5000
+}
+
+fn default_max_retries() -> usize {
+    3
 }
 
 fn default_stream_inactivity_timeout_secs() -> u64 {
@@ -1060,5 +1144,96 @@ mod tests {
         let config: OrchestrationConfig = toml::from_str(toml).unwrap();
         assert_eq!(config.tool_output_artifact_threshold(), 100);
         assert_eq!(config.tool_output_duration_threshold_ms(), 2000);
+    }
+
+    #[test]
+    fn test_retry_defaults_when_absent() {
+        let toml = r#"
+            enabled = true
+        "#;
+        let config: OrchestrationConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.retry.base_delay_ms, 500);
+        assert_eq!(config.retry.max_delay_ms, 5000);
+        assert_eq!(config.retry.max_retries, 3);
+    }
+
+    #[test]
+    fn test_retry_full_custom_round_trips() {
+        let toml = r#"
+            enabled = true
+
+            [retry]
+            base_delay_ms = 250
+            max_delay_ms = 8000
+            max_retries = 5
+        "#;
+        let config: OrchestrationConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.retry.base_delay_ms, 250);
+        assert_eq!(config.retry.max_delay_ms, 8000);
+        assert_eq!(config.retry.max_retries, 5);
+    }
+
+    #[test]
+    fn test_retry_partial_uses_defaults_for_unset() {
+        let toml = r#"
+            enabled = true
+
+            [retry]
+            max_retries = 5
+        "#;
+        let config: OrchestrationConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.retry.base_delay_ms, 500);
+        assert_eq!(config.retry.max_delay_ms, 5000);
+        assert_eq!(config.retry.max_retries, 5);
+    }
+
+    #[test]
+    fn test_delay_for_retry_schedule() {
+        use std::time::Duration;
+        let config = RetryConfig::default();
+        assert_eq!(config.delay_for_retry(1), Duration::from_millis(500));
+        assert_eq!(config.delay_for_retry(2), Duration::from_millis(1000));
+        assert_eq!(config.delay_for_retry(3), Duration::from_millis(2000));
+        assert_eq!(config.delay_for_retry(4), Duration::from_millis(4000));
+        // Capped at max (5000).
+        assert_eq!(config.delay_for_retry(5), Duration::from_millis(5000));
+        // Huge retry_num does not panic and returns the cap.
+        assert_eq!(config.delay_for_retry(1000), Duration::from_millis(5000));
+    }
+
+    #[test]
+    fn test_retry_max_retries_zero_round_trips() {
+        let toml = r#"
+            enabled = true
+
+            [retry]
+            max_retries = 0
+        "#;
+        let config: OrchestrationConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.retry.max_retries, 0);
+    }
+
+    #[test]
+    fn test_delay_for_retry_base_zero_returns_zero() {
+        use std::time::Duration;
+        let config = RetryConfig {
+            base_delay_ms: 0,
+            max_delay_ms: 5000,
+            max_retries: 3,
+        };
+        assert_eq!(config.delay_for_retry(1), Duration::from_millis(0));
+        assert_eq!(config.delay_for_retry(10), Duration::from_millis(0));
+    }
+
+    #[test]
+    fn test_delay_for_retry_max_below_base_caps_at_max() {
+        use std::time::Duration;
+        let config = RetryConfig {
+            base_delay_ms: 500,
+            max_delay_ms: 200,
+            max_retries: 3,
+        };
+        // The cap wins even on the first retry.
+        assert_eq!(config.delay_for_retry(1), Duration::from_millis(200));
     }
 }

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -3749,6 +3749,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
             || lower.contains("internal server error")
             || lower.contains("504")
             || lower.contains("gateway timeout")
+            || lower.contains("invalid status code 408")
+            || lower.contains("408 request timeout")
             || lower.contains("connection refused")
             || lower.contains("connection reset")
             || lower.contains("reset by peer")
@@ -6060,6 +6062,64 @@ mod tests {
     }
 
     #[test]
+    fn test_categorize_request_timeout_as_provider_overloaded() {
+        // rig retries 408 at stream-open and only surfaces it once its budget
+        // is spent, so the exhausted error is a provider condition, not a
+        // replannable agent mistake.
+        // Verbatim shape observed in the #454 harness (runs/t408-exhausted).
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "Worker failed task 0 after 1 attempts: CompletionError: ProviderError: Invalid status code 408 Request Timeout with message: {\"error\":\"throttled\"}"
+            ),
+            FailureCategory::ProviderOverloaded
+        );
+        // Bare reason-phrase form, for a provider that omits rig's prefix.
+        assert_eq!(
+            Orchestrator::categorize_failure_error("408 Request Timeout"),
+            FailureCategory::ProviderOverloaded
+        );
+    }
+
+    #[test]
+    fn test_408_match_does_not_swallow_other_provider_categories() {
+        // Both 408 patterns are anchored so a stray "408" in another status's
+        // body cannot pull it onto the overloaded arm, which runs first.
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "CompletionError: ProviderError: Invalid status code 404 Not Found with message: model 'foo-408' not found"
+            ),
+            FailureCategory::ProviderNotFound
+        );
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "CompletionError: ProviderError: Invalid status code 401 Unauthorized with message: key ending 408 is revoked"
+            ),
+            FailureCategory::ProviderAuthError
+        );
+    }
+
+    #[test]
+    fn test_own_streaming_timeout_is_not_a_provider_error() {
+        // streaming_request_hook.rs emits this noun-form message for aura's
+        // own deadline. It carries no status code, so it must not reach the
+        // provider arm. Pinned to the exact category it lands in today, so a
+        // future arm cannot quietly capture it.
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "Request timeout (30s) exceeded during planning - cancelling"
+            ),
+            FailureCategory::AgentError
+        );
+    }
+
+    #[test]
+    fn test_request_timeout_is_transient_for_the_planning_loop() {
+        assert!(is_transient_planning_error(
+            "CompletionError: ProviderError: Invalid status code 408 Request Timeout with message: upstream took too long"
+        ));
+    }
+
+    #[test]
     fn test_categorize_provider_not_found() {
         // Gemini 404 — rig formats as "Invalid status code 404 Not Found with message: ..."
         assert_eq!(
@@ -6221,6 +6281,10 @@ mod tests {
         );
         assert_eq!(
             Orchestrator::categorize_failure_error("planning timed out after 503s"),
+            FailureCategory::AgentTimeout
+        );
+        assert_eq!(
+            Orchestrator::categorize_failure_error("planning timed out after 408s"),
             FailureCategory::AgentTimeout
         );
         // Non-colliding budget stays AgentTimeout too.

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -476,6 +476,16 @@ impl TurnTally {
     }
 }
 
+/// Outcome of a failed planning call after the transient-retry loop.
+enum PlanningCallError {
+    /// Transient provider error; the retry budget is exhausted.
+    TransientExhausted { source: StreamError, retries: usize },
+    /// Context-window overflow; the caller adds the remediation suggestion.
+    ContextOverflow,
+    /// Non-transient failure; never retried.
+    Fatal(StreamError),
+}
+
 struct ForwardedRun {
     response: crate::provider_agent::CompletionResponse,
     /// Provider-reported usage of the loop's last turn — context-window
@@ -1552,6 +1562,99 @@ impl Orchestrator {
         format!("Current time: {timestamp}\n\n{base}")
     }
 
+    /// Stream a planning call with transient-provider retry and backoff.
+    ///
+    /// Clears the routing decision before each call so the decision-ready
+    /// early-exit cannot observe a decision set by a failed stream. Transient
+    /// provider errors are resent the same prompt after an exponential backoff
+    /// governed by `[orchestration.retry]`; the conversation is never touched
+    /// here because the resent prompt is identical to the failed one.
+    async fn planning_stream_with_transient_retry(
+        &self,
+        agent: &Agent,
+        params: &StreamCallParams<'_>,
+        routing_decision: &super::tools::RoutingDecision,
+    ) -> Result<crate::provider_agent::CompletionResponse, PlanningCallError> {
+        let max_retries = self.config.retry.max_retries;
+        let mut transient_retries = 0usize;
+        let attempt_start = Instant::now();
+
+        loop {
+            // Clear any routing decision left by a prior call so the
+            // decision-ready check starts false for this stream.
+            {
+                let mut guard = routing_decision.lock().await;
+                *guard = None;
+            }
+
+            let call_start = Instant::now();
+            let rd = routing_decision.clone();
+            let result = self
+                .stream_and_collect(
+                    agent,
+                    StreamCallParams {
+                        prompt: params.prompt,
+                        history: params.history.clone(),
+                        phase: params.phase,
+                        event_tx: params.event_tx,
+                    },
+                    || {
+                        let rd = rd.clone();
+                        Box::pin(async move { rd.lock().await.is_some() })
+                    },
+                )
+                .await;
+
+            let response = match result {
+                Ok(r) => r,
+                Err(e) if is_context_overflow_error(e.as_ref()) => {
+                    return Err(PlanningCallError::ContextOverflow);
+                }
+                Err(e) => {
+                    let err_str = e.to_string();
+                    if is_transient_planning_error(&err_str) {
+                        // Resend the same prompt after backoff. The provider
+                        // never produced a response, so the routing-tool
+                        // correction (meant for a response that skipped the
+                        // tool) does not apply. The failed prompt is not
+                        // appended to the conversation because it is about
+                        // to be resent verbatim — pushing it would leave an
+                        // unpaired/duplicated user message.
+                        if transient_retries >= max_retries {
+                            tracing::warn!(
+                                "Planning transient retries exhausted ({}/{}) after {:.1}s: {}",
+                                transient_retries,
+                                max_retries,
+                                attempt_start.elapsed().as_secs_f64(),
+                                err_str,
+                            );
+                            return Err(PlanningCallError::TransientExhausted {
+                                source: e,
+                                retries: transient_retries,
+                            });
+                        }
+                        transient_retries += 1;
+                        let delay = self.config.retry.delay_for_retry(transient_retries);
+                        tracing::warn!(
+                            "Planning transient error, retry {}/{} after {:.1}s, \
+                             sleeping {:.1}s before resend: {}",
+                            transient_retries,
+                            max_retries,
+                            call_start.elapsed().as_secs_f64(),
+                            delay.as_secs_f64(),
+                            err_str,
+                        );
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    return Err(PlanningCallError::Fatal(e));
+                }
+            };
+
+            return Ok(response);
+        }
+    }
+
     /// Plan with routing tool support via persistent conversation.
     ///
     /// Uses the coordinator from `CoordinatorState` (created once at
@@ -1606,21 +1709,12 @@ impl Orchestrator {
             crate::logging::set_llm_invocation_parameters(&tracing::Span::current(), &params);
         }
 
-        for attempt in 1..=max_correction_attempts {
-            // Clear any stale routing decision
-            {
-                let mut guard = coordinator_state.routing_decision.lock().await;
-                *guard = None;
-            }
+        // Prompt sent to the coordinator on each attempt.
+        let mut current_prompt = planning_prompt.clone();
 
+        for attempt in 1..=max_correction_attempts {
             let attempt_start = Instant::now();
-            // First attempt sends the planning/continuation prompt; subsequent
-            // attempts send a correction message within the same conversation.
-            let prompt = if attempt == 1 {
-                planning_prompt.clone()
-            } else {
-                super::prompt_constants::corrections::ROUTING_TOOL_REQUIRED.to_string()
-            };
+            let prompt = current_prompt.clone();
 
             tracing::info!(
                 "Planning attempt {}/{} (per_call_timeout={}s, conversation_len={})",
@@ -1643,44 +1737,38 @@ impl Orchestrator {
                 &prompt,
             );
 
-            let rd = coordinator_state.routing_decision.clone();
             let response = match self
-                .stream_and_collect(
+                .planning_stream_with_transient_retry(
                     &coordinator_state.agent,
-                    StreamCallParams {
+                    &StreamCallParams {
                         prompt: &prompt,
                         history: full_history,
                         phase: "Planning",
                         event_tx,
                     },
-                    || {
-                        let rd = rd.clone();
-                        Box::pin(async move { rd.lock().await.is_some() })
-                    },
+                    &coordinator_state.routing_decision,
                 )
                 .await
             {
                 Ok(r) => r,
-                Err(e) if is_context_overflow_error(e.as_ref()) => {
+                Err(PlanningCallError::ContextOverflow) => {
                     let suggestion = context_overflow_suggestion("planning");
                     return Err(
                         format!("Context limit exceeded during planning. {}", suggestion).into(),
                     );
                 }
-                Err(e) => {
+                Err(PlanningCallError::TransientExhausted { source, retries }) => {
+                    return Err(format!(
+                        "Planning failed after {} transient provider retries: {}",
+                        retries, source
+                    )
+                    .into());
+                }
+                Err(PlanningCallError::Fatal(e)) => {
                     let err_str = e.to_string();
                     coordinator_state
                         .conversation
                         .push(rig::completion::Message::user(&prompt));
-                    if is_transient_planning_error(&err_str) {
-                        tracing::warn!(
-                            "Planning attempt {} transient error after {:.1}s, retrying: {}",
-                            attempt,
-                            attempt_start.elapsed().as_secs_f64(),
-                            err_str,
-                        );
-                        continue;
-                    }
                     tracing::warn!(
                         "Planning attempt {} failed after {:.1}s: {}",
                         attempt,
@@ -1776,6 +1864,11 @@ impl Orchestrator {
 
             final_prompt = Some(prompt);
             final_response = Some(response_text);
+
+            // Next attempt sends the routing-tool correction: the coordinator
+            // responded without calling a routing tool.
+            current_prompt =
+                super::prompt_constants::corrections::ROUTING_TOOL_REQUIRED.to_string();
         }
 
         // All correction attempts exhausted

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -3704,8 +3704,12 @@ Assign tasks to the worker whose tools best match the required operations."#,
     /// Revisit if/when we replace rig.
     ///
     /// Arm ordering is load-bearing. The context arm precedes the provider arms
-    /// because context-overflow bodies embed large token counts (e.g. "135000
-    /// tokens") that collide with bare status-code substrings like "500". An
+    /// because context-overflow bodies embed large token counts (e.g. "14290
+    /// tokens") that collide with bare status-code substrings like "429". The
+    /// "500" match is anchored to rig's "invalid status code" prefixes because
+    /// bare "500" also collides with durations and byte sizes in permanent
+    /// errors (a 404 body mentioning "500" must not read as transient); its
+    /// unanchored textual companion is "internal server error". An
     /// own-timeout guard precedes the provider arms because "timed out after"
     /// is this orchestrator's timeout-format signature; its "invalid status
     /// code" exclusion keeps a rig-flattened provider error whose body mentions
@@ -3745,11 +3749,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
             || lower.contains("service unavailable")
             || lower.contains("overloaded")
             || lower.contains("529")
-            || lower.contains("500")
+            || lower.contains("invalid status code 500")
+            || lower.contains("invalid status code: 500")
             || lower.contains("internal server error")
             || lower.contains("504")
             || lower.contains("gateway timeout")
             || lower.contains("invalid status code 408")
+            || lower.contains("invalid status code: 408")
             || lower.contains("408 request timeout")
             || lower.contains("connection refused")
             || lower.contains("connection reset")
@@ -6095,6 +6101,26 @@ mod tests {
                 "CompletionError: ProviderError: Invalid status code 401 Unauthorized with message: key ending 408 is revoked"
             ),
             FailureCategory::ProviderAuthError
+        );
+    }
+
+    #[test]
+    fn test_500_match_does_not_swallow_other_provider_categories() {
+        // Both 500 patterns are anchored to rig's "invalid status code"
+        // prefixes so a stray "500" in another status's body (durations,
+        // byte sizes, ids) cannot pull a permanent error onto the overloaded
+        // arm, which runs first.
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "CompletionError: ProviderError: Invalid status code 404 Not Found with message: model 'foo-500' not found"
+            ),
+            FailureCategory::ProviderNotFound
+        );
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "CompletionError: ProviderError: Invalid status code 500 Internal Server Error with message: upstream crashed"
+            ),
+            FailureCategory::ProviderOverloaded
         );
     }
 

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -476,13 +476,10 @@ impl TurnTally {
     }
 }
 
-/// Outcome of a failed planning call after the transient-retry loop.
+/// Failure outcome of [`Orchestrator::planning_stream_with_transient_retry`].
 enum PlanningCallError {
-    /// Transient provider error; the retry budget is exhausted.
     TransientExhausted { source: StreamError, retries: usize },
-    /// Context-window overflow; the caller adds the remediation suggestion.
     ContextOverflow,
-    /// Non-transient failure; never retried.
     Fatal(StreamError),
 }
 
@@ -1568,7 +1565,11 @@ impl Orchestrator {
     /// early-exit cannot observe a decision set by a failed stream. Transient
     /// provider errors are resent the same prompt after an exponential backoff
     /// governed by `[orchestration.retry]`; the conversation is never touched
-    /// here because the resent prompt is identical to the failed one.
+    /// here because the resent prompt is identical to the failed one. Each
+    /// attempt gets a fresh `per_call_timeout_secs` budget; when that timeout
+    /// is nonzero, one coordinator planning call is bounded by
+    /// `(max_retries + 1) × per_call_timeout_secs` plus the cumulative
+    /// backoff.
     async fn planning_stream_with_transient_retry(
         &self,
         agent: &Agent,

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -3697,7 +3697,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
     /// Classify a task failure error string into a structured category.
     ///
     /// These are deterministic string matches against error messages produced by
-    /// our rig fork (mezmo/rig @ d7e9d92) and our own orchestrator code — never
+    /// our rig fork (mezmo/rig @ 5b0238a) and our own orchestrator code — never
     /// against non-deterministic model output. Rig's `CompletionError::ProviderError(String)`
     /// flattens HTTP status codes into the error string, so string matching is
     /// the only classification path available without forking rig's error types.

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -3609,13 +3609,22 @@ Assign tasks to the worker whose tools best match the required operations."#,
     /// flattens HTTP status codes into the error string, so string matching is
     /// the only classification path available without forking rig's error types.
     /// Revisit if/when we replace rig.
+    ///
+    /// Arm ordering is load-bearing. The context arm precedes the provider arms
+    /// because context-overflow bodies embed large token counts (e.g. "135000
+    /// tokens") that collide with bare status-code substrings like "500". An
+    /// own-timeout guard precedes the provider arms because "timed out after"
+    /// is this orchestrator's timeout-format signature; its "invalid status
+    /// code" exclusion keeps a rig-flattened provider error whose body mentions
+    /// a timeout (e.g. "request timed out after 30s") on the provider arm,
+    /// since rig's "Invalid status code …" prefix proves provider origin. The
+    /// generic "timed out" arm follows the provider arms as the fallback for
+    /// other timeout phrasings (e.g. reqwest "operation timed out").
     fn categorize_failure_error(error: &str) -> FailureCategory {
         let lower = error.to_lowercase();
         if lower.contains(STALL_MESSAGE) {
             // Inactivity stall carries its own sentinel so it cannot collide
             // with provider errors that merely mention a timeout.
-            FailureCategory::AgentTimeout
-        } else if lower.contains("timed out") {
             FailureCategory::AgentTimeout
         } else if (lower.contains("context")
             && (lower.contains("limit")
@@ -3633,18 +3642,24 @@ Assign tasks to the worker whose tools best match the required operations."#,
             || lower.contains("input is too long")
         {
             FailureCategory::ContextOverflow
-        } else if lower.contains("maxdeptherror") || lower.contains("reached limit") {
-            FailureCategory::DepthExhausted
-        } else if lower.contains("duplicate call loop") {
-            FailureCategory::LoopDetected
-        } else if lower.contains("did not call submit_result") {
-            FailureCategory::SoftFailure
+        } else if lower.contains("timed out after") && !lower.contains("invalid status code") {
+            FailureCategory::AgentTimeout
         } else if lower.contains("rate limit")
             || lower.contains("429")
             || lower.contains("too many requests")
             || lower.contains("503")
             || lower.contains("502")
             || lower.contains("service unavailable")
+            || lower.contains("overloaded")
+            || lower.contains("529")
+            || lower.contains("500")
+            || lower.contains("internal server error")
+            || lower.contains("504")
+            || lower.contains("gateway timeout")
+            || lower.contains("connection refused")
+            || lower.contains("connection reset")
+            || lower.contains("reset by peer")
+            || lower.contains("dns error")
         {
             FailureCategory::ProviderOverloaded
         } else if lower.contains("authentication")
@@ -3659,6 +3674,14 @@ Assign tasks to the worker whose tools best match the required operations."#,
             || lower.contains("is not found for api version")
         {
             FailureCategory::ProviderNotFound
+        } else if lower.contains("timed out") {
+            FailureCategory::AgentTimeout
+        } else if lower.contains("maxdeptherror") || lower.contains("reached limit") {
+            FailureCategory::DepthExhausted
+        } else if lower.contains("duplicate call loop") {
+            FailureCategory::LoopDetected
+        } else if lower.contains("did not call submit_result") {
+            FailureCategory::SoftFailure
         } else {
             FailureCategory::AgentError
         }
@@ -5893,6 +5916,17 @@ mod tests {
     }
 
     #[test]
+    fn test_should_short_circuit_connection_failures() {
+        let failures = vec![
+            make_failure("Http client error: connection refused"),
+            make_failure("Invalid status code: 500 Internal Server Error"),
+        ];
+        assert!(Orchestrator::should_short_circuit_provider_errors(
+            &failures, 0
+        ));
+    }
+
+    #[test]
     fn test_categorize_failure_loop_detected() {
         assert_eq!(
             Orchestrator::categorize_failure_error("Worker blocked by duplicate call loop"),
@@ -6034,10 +6068,73 @@ mod tests {
     }
 
     #[test]
-    fn test_categorize_failure_precedence_timeout_before_provider() {
-        // "timed out" should match AgentTimeout even if message also contains "503"
+    fn test_categorize_failure_precedence_provider_before_timeout() {
+        // Rig-flattened 503 whose body mentions a timeout: provider origin wins.
         assert_eq!(
-            Orchestrator::categorize_failure_error("Request timed out after 503 retries"),
+            Orchestrator::categorize_failure_error(
+                "Invalid status code 503 Service Unavailable with message: request timed out after 30s"
+            ),
+            FailureCategory::ProviderOverloaded
+        );
+    }
+
+    #[test]
+    fn test_categorize_failure_provider_unavailable_patterns() {
+        // Anthropic 529 (overloaded_error), rig-flattened.
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "Invalid status code 529 with message: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}"
+            ),
+            FailureCategory::ProviderOverloaded
+        );
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "Invalid status code: 500 Internal Server Error"
+            ),
+            FailureCategory::ProviderOverloaded
+        );
+        assert_eq!(
+            Orchestrator::categorize_failure_error("Invalid status code: 504 Gateway Timeout"),
+            FailureCategory::ProviderOverloaded
+        );
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "Http client error: error sending request for url (https://api.anthropic.com/v1/messages): error trying to connect: tcp connect error: Connection refused (os error 61)"
+            ),
+            FailureCategory::ProviderOverloaded
+        );
+        assert_eq!(
+            Orchestrator::categorize_failure_error("Http client error: connection reset by peer"),
+            FailureCategory::ProviderOverloaded
+        );
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "Http client error: error trying to connect: dns error: failed to lookup address information: nodename nor servname provided"
+            ),
+            FailureCategory::ProviderOverloaded
+        );
+    }
+
+    #[test]
+    fn test_categorize_failure_own_timeout_stays_agent_timeout() {
+        // Regression guard: the orchestrator's own timeout strings stay
+        // AgentTimeout even when the budget's digits collide with a status
+        // substring (500s, 503s).
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "worker timed out after 500s — the LLM provider did not respond in time"
+            ),
+            FailureCategory::AgentTimeout
+        );
+        assert_eq!(
+            Orchestrator::categorize_failure_error("planning timed out after 503s"),
+            FailureCategory::AgentTimeout
+        );
+        // Non-colliding budget stays AgentTimeout too.
+        assert_eq!(
+            Orchestrator::categorize_failure_error(
+                "worker timed out after 300s — the LLM provider did not respond in time"
+            ),
             FailureCategory::AgentTimeout
         );
     }

--- a/crates/aura/src/orchestration/types.rs
+++ b/crates/aura/src/orchestration/types.rs
@@ -495,7 +495,7 @@ pub enum FailureCategory {
     DepthExhausted,
     /// Duplicate call guard fired — worker stuck in a loop.
     LoopDetected,
-    /// LLM temporarily unavailable (429/503).
+    /// LLM provider temporarily unavailable or unreachable.
     ProviderOverloaded,
     /// LLM credentials or auth failed (401/403).
     ProviderAuthError,


### PR DESCRIPTION
## Why

Orchestrated workers and coordinator planning calls die on the first transient provider failure. One 429 at SSE stream-open kills a worker task (#454). This PR is staged in three commits; the first two are AURA-only and integration-green on the current rig pin.

## Commits

1. **`fix(orchestration): classify provider 5xx and connection failures`** — failure classification fix so transient provider errors are recognized as retryable.
2. **`feat(orchestration): back off transient planning retries`** — `[orchestration.retry]` config (`base_delay_ms`/`max_delay_ms`/`max_retries`); the coordinator resends a transiently failed planning call with exponential backoff, budget adjudicated per coordinator call.
3. **(not yet in this PR) rig pin bump** — picks up mezmo/rig#9, which retries retryable status codes at SSE stream-open below the agent loop. Commit 3 lands here after the rig PR merges to `mezmo`; reverting it ships commits 1-2 AURA-only on the old pin. That is why this PR is a draft.

## Interaction note (measured)

Once commit 3 lands, the rig's bounded stream-open retry (~31s worst case: 1+2+4+8+16s) runs BEFORE aura's planning backoff ever sees the error. Hard-down provider worst case per coordinator call: 4 aura attempts x ~31s rig + 3.5s aura = ~127s, vs ~3.5s today. Measured with a mock provider (`m-new-planning-nest`): 6 rig POSTs on a clean exponential, then aura retries take over.

## Verification

- Commits 1-2: `cargo test --workspace` green; Docker orchestration integration suite 95/0 on the old pin; rebased onto 0.1.8 with `cargo test -p aura --lib` (890) and `cargo test -p aura-config --lib` (195) green.
- Stage-3 behavior (rig side, not in this diff): full mocked-failure matrix (429/500/502/503/504/529 x hint/no-hint, HTTP-date hint treated as absent, exhaustion bound at exactly max_retries+1 POSTs, 400 fast-fail parity with the old pin), real-OpenAI smoke, and the nesting measurement above.

Fixes: #454