### PR TITLE
ci(release): build and publish deb/rpm packages

### DIFF
--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -190,8 +190,18 @@ build-binaries-darwin: ## Build binaries for darwin (amd64 + arm64, PROFILE=rele
 	$(MAKE) build-binary-darwin-amd64 build-binary-darwin-arm64
 
 .PHONY: build-checksums
-build-checksums: ## Write sha256 checksums for the binaries in dist
-	cd $(DIST_DIR) && sha256sum aura-* > checksums.txt
+build-checksums: ## Write sha256 checksums for the release artifacts (binaries + any packages) in dist
+	@# The *.deb/*.rpm globs overlap aura-* (nfpm's rpm and web-server package
+	@# names also start with "aura-"), so sort -u is load-bearing: it collapses
+	@# the duplicate matches before hashing.
+	@cd $(DIST_DIR) && \
+		files=$$(ls aura-* *.deb *.rpm 2>/dev/null | sort -u); \
+		[ -n "$$files" ] || { echo "error: no release artifacts found in $(DIST_DIR)" >&2; exit 1; }; \
+		printf '%s\n' "$$files" | xargs sha256sum > checksums.txt
+
+.PHONY: build-packages
+build-packages: $(DIST_DIR) $(DOCKER_ENV) ## Build .deb/.rpm packages from the linux binaries in dist (PACKAGE_VERSION overrides the version)
+	$(RUN) ./scripts/build-packages.sh $(PACKAGE_VERSION)
 
 # Every binary a complete release must contain, across all platforms.
 EXPECTED_BINARIES := \
@@ -201,16 +211,14 @@ EXPECTED_BINARIES := \
 	aura-darwin-arm64 aura-web-server-darwin-arm64
 
 .PHONY: verify-binaries
-verify-binaries: build-checksums $(DOCKER_ENV) ## Verify every expected binary is present and checksummed correctly
+verify-binaries: $(DOCKER_ENV) ## Verify every expected binary is present, then smoke-test the runnable pair
 	@cd $(DIST_DIR) && \
 	for f in $(EXPECTED_BINARIES); do \
 		[ -f "$$f" ] || { echo "error: missing binary: $$f" >&2; exit 1; }; \
-		grep -q " $$f\$$" checksums.txt || { echo "error: $$f absent from checksums.txt" >&2; exit 1; }; \
 	done
-	cd $(DIST_DIR) && sha256sum -c checksums.txt
 	@# Execution smoke for the pair the runner container can actually run;
-	@# cross-arch artifacts are covered by presence + checksum only. The
-	@# chmod restores the executable bit, which stash/unstash can drop.
+	@# cross-arch artifacts are covered by presence only. The chmod restores
+	@# the executable bit, which stash/unstash can drop.
 	@if [ "$(ENABLE_DOCKER)" = "true" ]; then \
 		chmod +x $(DIST_DIR)/aura-linux-amd64 $(DIST_DIR)/aura-web-server-linux-amd64 && \
 		$(RUN) ./dist/aura-linux-amd64 --version && \
@@ -218,6 +226,12 @@ verify-binaries: build-checksums $(DOCKER_ENV) ## Verify every expected binary i
 	else \
 		echo "skipping execution smoke: runner container disabled"; \
 	fi
+
+.PHONY: release-artifacts
+release-artifacts: ## Assemble a complete release in dist/: verify binaries, build packages, write checksums
+	$(MAKE) verify-binaries
+	$(MAKE) build-packages
+	$(MAKE) build-checksums
 
 clean:: clean-dist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@
 ARG SCCACHE_VERSION=0.16.0
 ARG SCCACHE_SHA256=aec995a83ad3dff3d14b6314e08858b7b73d35ca85a5bcf3d3a9ec07dee35588
 
+# nfpm builds the .deb/.rpm release packages from the cross-compiled binaries.
+ARG NFPM_VERSION=2.47.0
+ARG NFPM_SHA256=0660ca602b2d2d2ae4781a06c692b3eeb9d437ffea05b831d76e41f4a3188783
+
 ### 000 Chef
 FROM lukemathwalker/cargo-chef:latest-rust-1.95@sha256:00c3c07c51d092325df88f0df2d626cd4302e12933f179ba154509cc314d6c2a AS chef
 
@@ -85,6 +89,19 @@ EOR
 # Pinned STDIO integration fixture.
 RUN npm install -g @modelcontextprotocol/server-everything@2026.1.26 \
   && command -v mcp-server-everything
+
+# nfpm packages release binaries into .deb/.rpm without dpkg/rpmbuild or root.
+ARG NFPM_VERSION
+ARG NFPM_SHA256
+RUN <<EOR
+  set -e
+  curl -fsSL -o /tmp/nfpm.tar.gz "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz"
+  printf '%s  /tmp/nfpm.tar.gz\n' "${NFPM_SHA256}" > /tmp/nfpm.tar.gz.sha256
+  sha256sum -c /tmp/nfpm.tar.gz.sha256
+  tar -xzf /tmp/nfpm.tar.gz -C /usr/local/bin nfpm
+  rm /tmp/nfpm.tar.gz /tmp/nfpm.tar.gz.sha256
+  nfpm --version
+EOR
 
 COPY --from=sccache-dl /usr/local/bin/sccache /usr/local/bin/sccache
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -530,7 +530,7 @@ pipeline {
             unstash 'linux-release-artifacts'
             unstash 'darwin-release-artifacts'
 
-            sh 'make verify-binaries'
+            sh 'make release-artifacts PACKAGE_VERSION="$NEXT_RELEASE_VERSION"'
 
             script {
               docker.withRegistry(

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Build Debian (.deb) and RPM (.rpm) packages from the release binaries in dist/.
+#
+# Consumes the Linux binaries produced by `make build-binaries-linux`
+# (dist/<binary>-linux-<arch>) and emits one package per binary, per arch, per
+# format into DIST_DIR. Uses nfpm, so no dpkg/rpmbuild toolchain or root
+# privilege is required.
+#
+# Usage: build-packages.sh [version]
+#   version    - package version (default: workspace version from Cargo.toml)
+#
+# Environment:
+#   DIST_DIR   - directory holding the binaries and receiving packages (default: dist)
+#   PACKAGERS  - space-separated formats to build (default: "deb rpm")
+#   ARCHS      - space-separated architectures to build (default: "amd64 arm64")
+#   NFPM       - nfpm executable to use (default: nfpm on PATH)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+DIST_DIR="${DIST_DIR:-${PROJECT_ROOT}/dist}"
+PACKAGERS="${PACKAGERS:-deb rpm}"
+ARCHS="${ARCHS:-amd64 arm64}"
+NFPM="${NFPM:-nfpm}"
+
+MAINTAINER="Mezmo <support@mezmo.com>"
+LICENSE="Apache-2.0"
+HOMEPAGE="https://github.com/mezmo/aura"
+
+# Each entry: "<package name>|<binary basename>|<description>". The binary
+# basename combines with the platform suffix to locate the source file
+# (dist/<basename>-linux-<arch>) and names the installed executable
+# (/usr/bin/<basename>).
+PACKAGES=(
+    "aura|aura|AURA interactive terminal client for chat completions with tool execution"
+    "aura-web-server|aura-web-server|AURA OpenAI-compatible web server for composing Rig.rs AI agents with MCP tools and RAG pipelines"
+)
+
+resolve_version() {
+    local version="${1:-}"
+    if [ -z "${version}" ]; then
+        version="$(awk '
+            /^\[workspace\.package\]/ { in_section = 1; next }
+            /^\[/ { in_section = 0 }
+            in_section && /^version[[:space:]]*=/ { print $2; exit }
+        ' FS='"' "${PROJECT_ROOT}/Cargo.toml")"
+    fi
+    version="${version#v}"
+    if [ -z "${version}" ]; then
+        echo "error: could not determine version" >&2
+        exit 1
+    fi
+    printf '%s' "${version}"
+}
+
+require_nfpm() {
+    if ! command -v "${NFPM}" >/dev/null 2>&1; then
+        echo "error: nfpm not found (set NFPM or install from https://nfpm.goreleaser.com)" >&2
+        exit 1
+    fi
+}
+
+# Write an nfpm config for one package/arch pair to stdout.
+write_config() {
+    local name="$1" binary="$2" description="$3" arch="$4" version="$5" src="$6"
+    cat <<EOF
+name: "${name}"
+arch: "${arch}"
+version: "${version}"
+version_schema: none
+maintainer: "${MAINTAINER}"
+description: "${description}"
+license: "${LICENSE}"
+homepage: "${HOMEPAGE}"
+contents:
+  - src: "${src}"
+    dst: "/usr/bin/${binary}"
+    file_info:
+      mode: 0755
+EOF
+}
+
+main() {
+    local version
+    version="$(resolve_version "${1:-}")"
+    require_nfpm
+
+    echo "Building packages for AURA ${version}"
+
+    # Global (not local) so the EXIT trap can still see it once main returns.
+    config="$(mktemp)"
+    trap 'rm -f "${config}"' EXIT
+
+    local entry name binary description arch src packager
+    for entry in "${PACKAGES[@]}"; do
+        IFS='|' read -r name binary description <<<"${entry}"
+        for arch in ${ARCHS}; do
+            src="${DIST_DIR}/${binary}-linux-${arch}"
+            if [ ! -f "${src}" ]; then
+                echo "error: missing binary: ${src}" >&2
+                exit 1
+            fi
+            write_config "${name}" "${binary}" "${description}" "${arch}" "${version}" "${src}" >"${config}"
+            for packager in ${PACKAGERS}; do
+                echo "  ${name} ${arch} -> ${packager}"
+                "${NFPM}" package --config "${config}" --packager "${packager}" --target "${DIST_DIR}/"
+            done
+        done
+    done
+
+    echo ""
+    echo "Packages written to ${DIST_DIR}"
+}
+
+main "$@"


### PR DESCRIPTION
Package the release binaries into .deb and .rpm artifacts with nfpm (no dpkg/rpmbuild or root needed) and attach them to the GitHub release alongside the existing binaries.

Generate checksums.txt once during the release prepare step, after packaging, so it covers every published artifact; verify-binaries is now a presence and execution-smoke gate. nfpm is pinned by version and sha256 in the build image.