### PR TITLE
feat(hitl): forward reasoning as tool_call_intent on approvals (#277)

### DIFF
--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -347,7 +347,9 @@ fn make_parked(request_id: &str, ttl: Duration) -> ParkedApproval {
             items: vec![ApprovalItem {
                 tool_name: "kubectl_delete".to_string(),
                 arguments: serde_json::json!({"pod": "web-1"}),
-                tool_call_intent: None,
+                // Some(...), not None, so the round trip exercises the
+                // field's presence on the stored wire format.
+                tool_call_intent: Some("restarting to pick up the config change".to_string()),
             }],
         },
         registered_at: now,

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -347,6 +347,7 @@ fn make_parked(request_id: &str, ttl: Duration) -> ParkedApproval {
             items: vec![ApprovalItem {
                 tool_name: "kubectl_delete".to_string(),
                 arguments: serde_json::json!({"pod": "web-1"}),
+                tool_call_intent: None,
             }],
         },
         registered_at: now,

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -84,6 +84,7 @@ impl ToolWrapper for HitlApprovalWrapper {
             items: vec![ApprovalItem {
                 tool_name: ctx.tool_name.clone(),
                 arguments: args.clone(),
+                tool_call_intent: ctx.tool_call_intent.clone(),
             }],
         };
         let cancel =

--- a/crates/aura/src/hitl/protocol.rs
+++ b/crates/aura/src/hitl/protocol.rs
@@ -46,6 +46,21 @@ pub struct ApprovalRequest {
 pub struct ApprovalItem {
     pub tool_name: String,
     pub arguments: Value,
+    /// Model-authored reasoning for this call, captured from
+    /// `_aura_reasoning` BEFORE `PersistenceWrapper` strips it.
+    ///
+    /// ADVISORY METADATA ONLY. MUST NOT enter any digest or binding
+    /// computation, now or in P7's exactly-once FSM — see the 271 ADR
+    /// addendum and DECISIONS-2026-07-28 ruling 5 (R5). The digest binds
+    /// `tool_name + arguments` only (what runs); this field is what the
+    /// model *thought* and stays out of the binding. Structurally
+    /// excluded because it is a sibling of `arguments`, not nested in it.
+    ///
+    /// Wire: omitted entirely when the model supplied no reasoning
+    /// (never null). One field per item. v1 receivers parse new payloads
+    /// unchanged (`#[serde(default)]`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_intent: Option<String>,
 }
 
 /// Wire form of a single decision: the `{ "approved": bool, "reason": ... }`

--- a/crates/aura/src/hitl/protocol.rs
+++ b/crates/aura/src/hitl/protocol.rs
@@ -46,19 +46,11 @@ pub struct ApprovalRequest {
 pub struct ApprovalItem {
     pub tool_name: String,
     pub arguments: Value,
-    /// Model-authored reasoning for this call, captured from
-    /// `_aura_reasoning` BEFORE `PersistenceWrapper` strips it.
-    ///
-    /// ADVISORY METADATA ONLY. MUST NOT enter any digest or binding
-    /// computation, now or in P7's exactly-once FSM — see the 271 ADR
-    /// addendum and DECISIONS-2026-07-28 ruling 5 (R5). The digest binds
-    /// `tool_name + arguments` only (what runs); this field is what the
-    /// model *thought* and stays out of the binding. Structurally
-    /// excluded because it is a sibling of `arguments`, not nested in it.
-    ///
-    /// Wire: omitted entirely when the model supplied no reasoning
-    /// (never null). One field per item. v1 receivers parse new payloads
-    /// unchanged (`#[serde(default)]`).
+    /// Model-authored reasoning for this call. Advisory metadata only: the
+    /// digest binds `tool_name + arguments` (what runs); this field is what
+    /// the model *thought* and stays out of any binding computation — see
+    /// the 271 ADR addendum and DECISIONS-2026-07-28 ruling 5 (R5).
+    /// Structurally excluded as a sibling of `arguments`, not nested in it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_call_intent: Option<String>,
 }

--- a/crates/aura/src/hitl/registry.rs
+++ b/crates/aura/src/hitl/registry.rs
@@ -298,6 +298,7 @@ mod tests {
             items: vec![ApprovalItem {
                 tool_name: "test_tool".to_string(),
                 arguments: json!({}),
+                tool_call_intent: None,
             }],
         }
     }

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -343,8 +343,6 @@ mod tests {
             items[0]["tool_call_intent"],
             "rollout restart to pick up the new config map"
         );
-        // arguments stays clean — _aura_reasoning never leaks into it
-        assert!(items[0]["arguments"].get("_aura_reasoning").is_none());
     }
 
     #[test]
@@ -403,7 +401,6 @@ mod tests {
             items[0]["tool_call_intent"],
             "namespace cleanup is the fastest path to unblock"
         );
-        assert!(items[0]["arguments"].get("_aura_reasoning").is_none());
     }
 
     #[test]

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -255,6 +255,7 @@ mod tests {
             items: vec![ApprovalItem {
                 tool_name: "shell_exec".to_string(),
                 arguments: json!({ "cmd": "ls -la" }),
+                tool_call_intent: None,
             }],
         };
 
@@ -278,6 +279,8 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0]["tool_name"], "shell_exec");
         assert_eq!(items[0]["arguments"]["cmd"], "ls -la");
+        // tool_call_intent is omitted when absent (never null on the wire)
+        assert!(items[0].get("tool_call_intent").is_none());
     }
 
     #[test]
@@ -314,6 +317,93 @@ mod tests {
         // regression guard: no externally-tagged domain variant keys.
         assert!(value["scope"].get("Worker").is_none());
         assert!(value["origin"].get("AgentRequested").is_none());
+    }
+
+    #[test]
+    fn config_gate_item_tool_call_intent_present_on_wire() {
+        let request = ApprovalRequest {
+            version: PROTOCOL_VERSION,
+            decision_id: DecisionId::generate(),
+            request_id: "req-cg-intent".to_string(),
+            scope: AgentScope::Single { session_id: None },
+            origin: ApprovalOrigin::ConfigGate {
+                matched_pattern: "kubectl_*".to_string(),
+            },
+            items: vec![ApprovalItem {
+                tool_name: "kubectl_delete".to_string(),
+                arguments: json!({ "namespace": "prod" }),
+                tool_call_intent: Some("rollout restart to pick up the new config map".to_string()),
+            }],
+        };
+
+        let value =
+            serde_json::to_value(ApprovalRequestWire::from(&request)).expect("serializable");
+        let items = value["items"].as_array().expect("items array");
+        assert_eq!(
+            items[0]["tool_call_intent"],
+            "rollout restart to pick up the new config map"
+        );
+        // arguments stays clean — _aura_reasoning never leaks into it
+        assert!(items[0]["arguments"].get("_aura_reasoning").is_none());
+    }
+
+    #[test]
+    fn agent_requested_item_tool_call_intent_omitted_when_absent() {
+        let request = ApprovalRequest {
+            version: PROTOCOL_VERSION,
+            decision_id: DecisionId::generate(),
+            request_id: "req-ar-none".to_string(),
+            scope: AgentScope::Single { session_id: None },
+            origin: ApprovalOrigin::AgentRequested {
+                reason: "touches prod".to_string(),
+            },
+            items: vec![ApprovalItem {
+                tool_name: "request_approval".to_string(),
+                arguments: json!({
+                    "action_description": "Delete namespace",
+                    "risk_rationale": "touches prod"
+                }),
+                tool_call_intent: None,
+            }],
+        };
+
+        let value =
+            serde_json::to_value(ApprovalRequestWire::from(&request)).expect("serializable");
+        let items = value["items"].as_array().expect("items array");
+        // omitted entirely when absent (never null)
+        assert!(items[0].get("tool_call_intent").is_none());
+    }
+
+    #[test]
+    fn agent_requested_item_tool_call_intent_present_on_wire() {
+        let request = ApprovalRequest {
+            version: PROTOCOL_VERSION,
+            decision_id: DecisionId::generate(),
+            request_id: "req-ar-intent".to_string(),
+            scope: AgentScope::Single { session_id: None },
+            origin: ApprovalOrigin::AgentRequested {
+                reason: "touches prod".to_string(),
+            },
+            items: vec![ApprovalItem {
+                tool_name: "request_approval".to_string(),
+                arguments: json!({
+                    "action_description": "Delete namespace",
+                    "risk_rationale": "touches prod"
+                }),
+                tool_call_intent: Some(
+                    "namespace cleanup is the fastest path to unblock".to_string(),
+                ),
+            }],
+        };
+
+        let value =
+            serde_json::to_value(ApprovalRequestWire::from(&request)).expect("serializable");
+        let items = value["items"].as_array().expect("items array");
+        assert_eq!(
+            items[0]["tool_call_intent"],
+            "namespace cleanup is the fastest path to unblock"
+        );
+        assert!(items[0]["arguments"].get("_aura_reasoning").is_none());
     }
 
     #[test]
@@ -597,6 +687,7 @@ mod tests {
             items: vec![ApprovalItem {
                 tool_name: "dangerous_apply".into(),
                 arguments: serde_json::json!({}),
+                tool_call_intent: None,
             }],
         };
 

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -50,10 +50,8 @@ pub struct RequestApprovalArgs {
     /// Optional structured metadata for the reviewer.
     #[serde(default)]
     pub context: Option<Value>,
-    /// Captured from the model's `_aura_reasoning`. `skip_serializing`
-    /// keeps it OUT of `items[].arguments` (the strip invariant); the
-    /// tool moves it to `ApprovalItem.tool_call_intent`. Not required,
-    /// matching PersistenceWrapper's optional reasoning schema.
+    /// The model's reasoning for requesting approval. Advisory only — see
+    /// `ApprovalItem.tool_call_intent` for the digest-exclusion rule (R5).
     #[serde(default, rename = "_aura_reasoning", skip_serializing)]
     pub tool_call_intent: Option<String>,
 }
@@ -89,11 +87,11 @@ fn approval_outcome_to_tool_result(
     }
 }
 
-/// Normalize model reasoning into a `tool_call_intent`: empty or
-/// whitespace-only means absent (`None`), consistent with the config_gate
-/// reasoning filter (`.filter(|r| !r.trim().is_empty())`).
+/// Normalize model reasoning into a `tool_call_intent` via
+/// [`crate::tool_wrapper::non_blank`].
 fn normalize_tool_call_intent(raw: Option<&str>) -> Option<String> {
-    raw.filter(|r| !r.trim().is_empty()).map(str::to_string)
+    raw.and_then(crate::tool_wrapper::non_blank)
+        .map(str::to_string)
 }
 
 impl Tool for RequestApprovalTool {
@@ -136,7 +134,7 @@ impl Tool for RequestApprovalTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-        // Empty/whitespace-only reasoning means absent, consistent with the config_gate path.
+        // Blank reasoning collapses to absent, consistent with the config_gate path.
         let tool_call_intent = normalize_tool_call_intent(args.tool_call_intent.as_deref());
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
@@ -283,12 +281,10 @@ mod tests {
     // --------------------------------------------------------------------
     // agent_requested path: drive `RequestApprovalTool::call` end-to-end
     // through a real `DecisionRoute::Conversational` and inspect the parked
-    // `ApprovalItem` the production call site builds. The round-3 tests only
-    // exercised `normalize_tool_call_intent` + a hand-built item, so reverting
-    // the call site (tool.rs `tool_call_intent,` -> `args.tool_call_intent.clone()`)
-    // left them green. These tests fail under that revert: the blank case
-    // asserts the parked item's `tool_call_intent` is `None`, which only holds
-    // when the production path normalizes `Some("")`/`Some("   ")` away.
+    // `ApprovalItem` the production call site builds. These pin the call
+    // site's normalization: the blank case asserts the parked item's
+    // `tool_call_intent` is `None`, which only holds when the production
+    // path normalizes `Some("")`/`Some("   ")` away.
     // --------------------------------------------------------------------
 
     /// Drive `RequestApprovalTool::call` through a real conversational route

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -50,6 +50,12 @@ pub struct RequestApprovalArgs {
     /// Optional structured metadata for the reviewer.
     #[serde(default)]
     pub context: Option<Value>,
+    /// Captured from the model's `_aura_reasoning`. `skip_serializing`
+    /// keeps it OUT of `items[].arguments` (the strip invariant); the
+    /// tool moves it to `ApprovalItem.tool_call_intent`. Not required,
+    /// matching PersistenceWrapper's optional reasoning schema.
+    #[serde(default, rename = "_aura_reasoning", skip_serializing)]
+    pub tool_call_intent: Option<String>,
 }
 
 /// Map [`DecisionRoute::decide`] outcome to [`Tool::Output`] / [`Tool::Error`].
@@ -111,6 +117,10 @@ impl Tool for RequestApprovalTool {
                     "context": {
                         "type": "object",
                         "description": "Optional additional structured metadata for the reviewer."
+                    },
+                    "_aura_reasoning": {
+                        "type": "string",
+                        "description": "Explain your reasoning for requesting this approval. Why does this specific action need a human decision?"
                     }
                 },
                 "required": ["action_description", "risk_rationale"]
@@ -130,6 +140,7 @@ impl Tool for RequestApprovalTool {
             items: vec![ApprovalItem {
                 tool_name: Self::NAME.to_string(),
                 arguments: serde_json::to_value(&args).unwrap_or_default(),
+                tool_call_intent: args.tool_call_intent.clone(),
             }],
         };
         let cancel =
@@ -216,5 +227,43 @@ mod tests {
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("Approval request failed"));
+    }
+
+    #[test]
+    fn request_approval_args_serialization_strips_aura_reasoning() {
+        let args = RequestApprovalArgs {
+            action_description: "deploy".to_string(),
+            risk_rationale: "prod change".to_string(),
+            context: None,
+            tool_call_intent: Some("need to unblock the migration".to_string()),
+        };
+        let serialized = serde_json::to_value(&args).unwrap();
+        // skip_serializing keeps _aura_reasoning OUT of the wire arguments
+        assert!(serialized.get("_aura_reasoning").is_none());
+        assert!(serialized.get("tool_call_intent").is_none());
+    }
+
+    #[test]
+    fn request_approval_args_deserializes_aura_reasoning_into_tool_call_intent() {
+        let json = serde_json::json!({
+            "action_description": "deploy",
+            "risk_rationale": "prod change",
+            "_aura_reasoning": "need to unblock the migration"
+        });
+        let args: RequestApprovalArgs = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            args.tool_call_intent.as_deref(),
+            Some("need to unblock the migration")
+        );
+    }
+
+    #[test]
+    fn request_approval_args_deserializes_without_aura_reasoning() {
+        let json = serde_json::json!({
+            "action_description": "deploy",
+            "risk_rationale": "prod change"
+        });
+        let args: RequestApprovalArgs = serde_json::from_value(json).unwrap();
+        assert!(args.tool_call_intent.is_none());
     }
 }

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -89,6 +89,13 @@ fn approval_outcome_to_tool_result(
     }
 }
 
+/// Normalize model reasoning into a `tool_call_intent`: empty or
+/// whitespace-only means absent (`None`), consistent with the config_gate
+/// reasoning filter (`.filter(|r| !r.trim().is_empty())`).
+fn normalize_tool_call_intent(raw: Option<&str>) -> Option<String> {
+    raw.filter(|r| !r.trim().is_empty()).map(str::to_string)
+}
+
 impl Tool for RequestApprovalTool {
     const NAME: &'static str = "request_approval";
 
@@ -129,6 +136,8 @@ impl Tool for RequestApprovalTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        // Empty/whitespace-only reasoning means absent, consistent with the config_gate path.
+        let tool_call_intent = normalize_tool_call_intent(args.tool_call_intent.as_deref());
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
             decision_id: DecisionId::generate(),
@@ -140,7 +149,7 @@ impl Tool for RequestApprovalTool {
             items: vec![ApprovalItem {
                 tool_name: Self::NAME.to_string(),
                 arguments: serde_json::to_value(&args).unwrap_or_default(),
-                tool_call_intent: args.tool_call_intent.clone(),
+                tool_call_intent,
             }],
         };
         let cancel =
@@ -265,5 +274,93 @@ mod tests {
         });
         let args: RequestApprovalArgs = serde_json::from_value(json).unwrap();
         assert!(args.tool_call_intent.is_none());
+    }
+
+    // --------------------------------------------------------------------
+    // agent_requested path: blank _aura_reasoning must not reach the wire.
+    // Explicit "" or whitespace deserializes to Some(...); normalization
+    // collapses it to None before the ApprovalItem is built.
+    // --------------------------------------------------------------------
+
+    #[test]
+    fn request_approval_normalizes_blank_reasoning_to_absent() {
+        // Both empty and whitespace-only _aura_reasoning deserialize to
+        // Some(...) — the bug precondition. Normalization must collapse them
+        // to None before the ApprovalItem is built, so the field is omitted on
+        // the wire (never null, never empty string).
+        for raw in ["", "   "] {
+            let args: RequestApprovalArgs = serde_json::from_value(serde_json::json!({
+                "action_description": "deploy",
+                "risk_rationale": "prod change",
+                "_aura_reasoning": raw,
+            }))
+            .unwrap();
+            assert_eq!(
+                args.tool_call_intent.as_deref(),
+                Some(raw),
+                "blank _aura_reasoning {:?} must deserialize to Some(...) first",
+                raw,
+            );
+
+            let intent = normalize_tool_call_intent(args.tool_call_intent.as_deref());
+
+            // Built ApprovalItem: blank reasoning must not reach it.
+            let item = ApprovalItem {
+                tool_name: RequestApprovalTool::NAME.to_string(),
+                arguments: serde_json::Value::Null,
+                tool_call_intent: intent,
+            };
+            assert!(
+                item.tool_call_intent.is_none(),
+                "built ApprovalItem must have tool_call_intent None for blank _aura_reasoning {:?}",
+                raw,
+            );
+
+            // Wire: tool_call_intent must be omitted entirely (skip_serializing_if).
+            let wire = serde_json::to_value(&item).unwrap();
+            assert!(
+                wire.get("tool_call_intent").is_none(),
+                "tool_call_intent must be omitted on the wire for blank _aura_reasoning {:?}, got: {}",
+                raw,
+                wire,
+            );
+        }
+    }
+
+    #[test]
+    fn request_approval_preserves_non_blank_reasoning() {
+        // Non-blank intent must flow through unchanged, surrounding whitespace
+        // included — guards against over-filtering (e.g. trimming the value).
+        let args: RequestApprovalArgs = serde_json::from_value(serde_json::json!({
+            "action_description": "deploy",
+            "risk_rationale": "prod change",
+            "_aura_reasoning": "  need to unblock the migration  ",
+        }))
+        .unwrap();
+
+        let intent = normalize_tool_call_intent(args.tool_call_intent.as_deref());
+        assert_eq!(
+            intent.as_deref(),
+            Some("  need to unblock the migration  "),
+            "non-blank reasoning must pass through unchanged",
+        );
+
+        let item = ApprovalItem {
+            tool_name: RequestApprovalTool::NAME.to_string(),
+            arguments: serde_json::Value::Null,
+            tool_call_intent: intent,
+        };
+        assert_eq!(
+            item.tool_call_intent.as_deref(),
+            Some("  need to unblock the migration  "),
+            "built ApprovalItem must carry non-blank tool_call_intent",
+        );
+
+        let wire = serde_json::to_value(&item).unwrap();
+        assert_eq!(
+            wire.get("tool_call_intent").and_then(|v| v.as_str()),
+            Some("  need to unblock the migration  "),
+            "non-blank tool_call_intent must appear on the wire unchanged",
+        );
     }
 }

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -167,6 +167,10 @@ mod tests {
     use super::super::decision::{ApprovalOutcome, CancelReason};
     use super::*;
 
+    use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
+    use crate::hitl::PendingApprovals;
+    use crate::session_store::{ApprovalStore, EventBus, InMemoryApprovalStore, InMemoryEventBus};
+
     #[test]
     fn mapping_approved_returns_ok_with_action() {
         let result = approval_outcome_to_tool_result(
@@ -277,17 +281,87 @@ mod tests {
     }
 
     // --------------------------------------------------------------------
-    // agent_requested path: blank _aura_reasoning must not reach the wire.
-    // Explicit "" or whitespace deserializes to Some(...); normalization
-    // collapses it to None before the ApprovalItem is built.
+    // agent_requested path: drive `RequestApprovalTool::call` end-to-end
+    // through a real `DecisionRoute::Conversational` and inspect the parked
+    // `ApprovalItem` the production call site builds. The round-3 tests only
+    // exercised `normalize_tool_call_intent` + a hand-built item, so reverting
+    // the call site (tool.rs `tool_call_intent,` -> `args.tool_call_intent.clone()`)
+    // left them green. These tests fail under that revert: the blank case
+    // asserts the parked item's `tool_call_intent` is `None`, which only holds
+    // when the production path normalizes `Some("")`/`Some("   ")` away.
     // --------------------------------------------------------------------
 
-    #[test]
-    fn request_approval_normalizes_blank_reasoning_to_absent() {
+    /// Drive `RequestApprovalTool::call` through a real conversational route
+    /// backed by an inspectable in-memory store, returning the production-built
+    /// `ApprovalItem` parked for the request. Approves the request so the
+    /// spawned call completes and the caller can await it.
+    async fn drive_request_approval_tool(
+        store: &Arc<dyn ApprovalStore>,
+        registry: &PendingApprovals,
+        route: &Arc<DecisionRoute>,
+        args: RequestApprovalArgs,
+    ) -> ApprovalItem {
+        let request_id = format!("req_w2_{}", uuid::Uuid::new_v4().simple());
+        let tool = RequestApprovalTool::new(
+            route.clone(),
+            AgentScope::Single { session_id: None },
+            request_id.clone(),
+        );
+
+        // Subscribe before the call so the Requested event is captured.
+        let mut rx = approval_event_broker::subscribe(&request_id).await;
+
+        let call_handle: tokio::task::JoinHandle<Result<String, ToolError>> =
+            tokio::spawn(async move { tool.call(args).await });
+
+        // Learn the decision_id from the Requested event, then read the
+        // parked request the production call site registered.
+        let event = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("requested event should arrive")
+            .expect("event channel open");
+        let decision_id = match event {
+            ApprovalLifecycleEvent::Requested(req) => {
+                DecisionId::parse(&req.decision_id).expect("valid decision id")
+            }
+            other => panic!("expected Requested event, got {:?}", other),
+        };
+
+        let parked = store
+            .get(&decision_id)
+            .await
+            .unwrap()
+            .expect("parked approval exists");
+
+        // Approve so the spawned tool call completes.
+        registry
+            .resolve(&decision_id, ApprovalDecision::Approved)
+            .await
+            .expect("resolve");
+
+        let result = call_handle.await.expect("call task did not panic");
+        assert!(result.is_ok(), "approved call should succeed: {:?}", result);
+
+        approval_event_broker::unsubscribe(&request_id).await;
+
+        parked.request.items.into_iter().next().expect("one item")
+    }
+
+    #[tokio::test]
+    async fn request_approval_normalizes_blank_reasoning_to_absent() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let bus: Arc<dyn EventBus> = Arc::new(InMemoryEventBus::new());
+        let registry = PendingApprovals::with_backend(store.clone(), bus);
+        let registry_for_resolve = registry.clone();
+        let route = Arc::new(DecisionRoute::Conversational {
+            registry,
+            timeout: std::time::Duration::from_secs(60),
+        });
+
         // Both empty and whitespace-only _aura_reasoning deserialize to
-        // Some(...) — the bug precondition. Normalization must collapse them
-        // to None before the ApprovalItem is built, so the field is omitted on
-        // the wire (never null, never empty string).
+        // Some(...) — the bug precondition. The production call site must
+        // normalize them to None before the ApprovalItem is built, so the
+        // field is omitted on the wire (never null, never empty string).
         for raw in ["", "   "] {
             let args: RequestApprovalArgs = serde_json::from_value(serde_json::json!({
                 "action_description": "deploy",
@@ -295,6 +369,8 @@ mod tests {
                 "_aura_reasoning": raw,
             }))
             .unwrap();
+            // Precondition: serde reads blank _aura_reasoning as Some(...),
+            // so only the production path's normalization can collapse it.
             assert_eq!(
                 args.tool_call_intent.as_deref(),
                 Some(raw),
@@ -302,21 +378,16 @@ mod tests {
                 raw,
             );
 
-            let intent = normalize_tool_call_intent(args.tool_call_intent.as_deref());
+            let item =
+                drive_request_approval_tool(&store, &registry_for_resolve, &route, args).await;
 
-            // Built ApprovalItem: blank reasoning must not reach it.
-            let item = ApprovalItem {
-                tool_name: RequestApprovalTool::NAME.to_string(),
-                arguments: serde_json::Value::Null,
-                tool_call_intent: intent,
-            };
             assert!(
                 item.tool_call_intent.is_none(),
-                "built ApprovalItem must have tool_call_intent None for blank _aura_reasoning {:?}",
+                "production-built item must have tool_call_intent None for blank _aura_reasoning {:?}, got: {:?}",
                 raw,
+                item.tool_call_intent,
             );
 
-            // Wire: tool_call_intent must be omitted entirely (skip_serializing_if).
             let wire = serde_json::to_value(&item).unwrap();
             assert!(
                 wire.get("tool_call_intent").is_none(),
@@ -324,13 +395,28 @@ mod tests {
                 raw,
                 wire,
             );
+            assert!(
+                item.arguments.get("_aura_reasoning").is_none(),
+                "items[].arguments must not contain _aura_reasoning for blank _aura_reasoning {:?}, got: {}",
+                raw,
+                item.arguments,
+            );
         }
     }
 
-    #[test]
-    fn request_approval_preserves_non_blank_reasoning() {
-        // Non-blank intent must flow through unchanged, surrounding whitespace
-        // included — guards against over-filtering (e.g. trimming the value).
+    #[tokio::test]
+    async fn request_approval_preserves_non_blank_reasoning() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let bus: Arc<dyn EventBus> = Arc::new(InMemoryEventBus::new());
+        let registry = PendingApprovals::with_backend(store.clone(), bus);
+        let registry_for_resolve = registry.clone();
+        let route = Arc::new(DecisionRoute::Conversational {
+            registry,
+            timeout: std::time::Duration::from_secs(60),
+        });
+
+        // Non-blank intent must flow through the production path unchanged,
+        // surrounding whitespace included — guards against over-filtering.
         let args: RequestApprovalArgs = serde_json::from_value(serde_json::json!({
             "action_description": "deploy",
             "risk_rationale": "prod change",
@@ -338,29 +424,25 @@ mod tests {
         }))
         .unwrap();
 
-        let intent = normalize_tool_call_intent(args.tool_call_intent.as_deref());
-        assert_eq!(
-            intent.as_deref(),
-            Some("  need to unblock the migration  "),
-            "non-blank reasoning must pass through unchanged",
-        );
+        let item = drive_request_approval_tool(&store, &registry_for_resolve, &route, args).await;
 
-        let item = ApprovalItem {
-            tool_name: RequestApprovalTool::NAME.to_string(),
-            arguments: serde_json::Value::Null,
-            tool_call_intent: intent,
-        };
         assert_eq!(
             item.tool_call_intent.as_deref(),
             Some("  need to unblock the migration  "),
-            "built ApprovalItem must carry non-blank tool_call_intent",
+            "production-built item must carry non-blank tool_call_intent unchanged",
         );
 
         let wire = serde_json::to_value(&item).unwrap();
         assert_eq!(
             wire.get("tool_call_intent").and_then(|v| v.as_str()),
             Some("  need to unblock the migration  "),
-            "non-blank tool_call_intent must appear on the wire unchanged",
+            "non-blank tool_call_intent must appear on the wire unchanged, got: {}",
+            wire,
+        );
+        assert!(
+            item.arguments.get("_aura_reasoning").is_none(),
+            "items[].arguments must not contain _aura_reasoning, got: {}",
+            item.arguments,
         );
     }
 }

--- a/crates/aura/src/orchestration/persistence_wrapper.rs
+++ b/crates/aura/src/orchestration/persistence_wrapper.rs
@@ -187,6 +187,12 @@ impl ToolWrapper for PersistenceWrapper {
         Ok(())
     }
 
+    fn write_context(&self, extracted: Option<&Value>, ctx: &mut ToolCallContext) {
+        if let Some(r) = find_field(extracted, "reasoning") {
+            ctx.tool_call_intent = Some(r.to_string());
+        }
+    }
+
     /// Captures the RAW tool output into `raw_outputs` (must run BEFORE any
     /// wrapper that rewrites the output, e.g. `ScratchpadWrapper`), then
     /// appends an artifact footer when size-based promotion qualifies.
@@ -1315,5 +1321,214 @@ mod tests {
             records[0].artifact_filename.as_deref(),
             Some("task-0-sre-iter-1-log-search-0-output.txt")
         );
+    }
+
+    // --------------------------------------------------------------------
+    // write_context: surfaces pre-strip reasoning as tool_call_intent
+    // --------------------------------------------------------------------
+
+    #[test]
+    fn test_write_context_surfaces_reasoning_as_tool_call_intent() {
+        let persistence = Arc::new(Mutex::new(ExecutionPersistence::disabled()));
+        let wrapper = test_wrapper(persistence);
+
+        // Simulate the extracted payload ComposedWrapper produces: an array
+        // with PersistenceWrapper's contribution.
+        let extracted = serde_json::json!([{
+            "reasoning": "need to verify the deployment config",
+            "_persistence_call_id": "abc-123",
+            "call_idx": 0
+        }]);
+
+        let mut ctx = ToolCallContext::new("test_tool");
+        wrapper.write_context(Some(&extracted), &mut ctx);
+
+        assert_eq!(
+            ctx.tool_call_intent.as_deref(),
+            Some("need to verify the deployment config")
+        );
+    }
+
+    #[test]
+    fn test_write_context_no_op_when_reasoning_absent() {
+        let persistence = Arc::new(Mutex::new(ExecutionPersistence::disabled()));
+        let wrapper = test_wrapper(persistence);
+
+        let extracted = serde_json::json!([{
+            "_persistence_call_id": "abc-123",
+            "call_idx": 0
+        }]);
+
+        let mut ctx = ToolCallContext::new("test_tool");
+        wrapper.write_context(Some(&extracted), &mut ctx);
+
+        assert!(ctx.tool_call_intent.is_none());
+    }
+
+    // --------------------------------------------------------------------
+    // Integration: config_gate forwards tool_call_intent (card W2)
+    // --------------------------------------------------------------------
+
+    #[derive(Clone)]
+    struct ArgsRecordingTool {
+        received: Arc<std::sync::Mutex<Option<Value>>>,
+    }
+
+    impl RigTool for ArgsRecordingTool {
+        const NAME: &'static str = "kubectl_delete";
+        type Error = ToolError;
+        type Args = Value;
+        type Output = String;
+
+        async fn definition(&self, _prompt: String) -> rig::completion::ToolDefinition {
+            rig::completion::ToolDefinition {
+                name: Self::NAME.to_string(),
+                description: String::new(),
+                parameters: serde_json::json!({"type": "object"}),
+            }
+        }
+
+        async fn call(&self, args: Value) -> Result<String, ToolError> {
+            *self.received.lock().unwrap() = Some(args);
+            Ok("executed".to_string())
+        }
+    }
+
+    /// Drives a hard-gated tool call carrying `_aura_reasoning` through the
+    /// full wrapper chain (PersistenceWrapper + HitlApprovalWrapper via
+    /// ComposedWrapper) and asserts:
+    /// - the approval payload item carries `tool_call_intent`
+    /// - `items[].arguments` does NOT contain `_aura_reasoning`
+    /// - the args the inner tool executes with do NOT contain `_aura_reasoning`
+    #[tokio::test]
+    async fn config_gate_forwards_tool_call_intent_and_strips_reasoning() {
+        use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
+        use crate::hitl::{
+            AgentScope, ApprovalDecision, DecisionId, DecisionRoute, HitlApprovalWrapper,
+            PendingApprovals,
+        };
+        use crate::orchestration::{RunId, TaskIdentity};
+        use crate::session_store::{
+            ApprovalStore, EventBus, InMemoryApprovalStore, InMemoryEventBus,
+        };
+        use crate::tool_wrapper::{ComposedWrapper, ToolCallContext, ToolWrapper, WrappedTool};
+        use aura_config::GlobPattern;
+
+        // Inspectable store so we can read the parked ApprovalRequest.
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let bus: Arc<dyn EventBus> = Arc::new(InMemoryEventBus::new());
+        let registry = PendingApprovals::with_backend(store.clone(), bus);
+        let registry_for_resolve = registry.clone();
+        let route = Arc::new(DecisionRoute::Conversational {
+            registry,
+            timeout: std::time::Duration::from_secs(60),
+        });
+
+        let run_id: RunId = "0191e8c0-1111-7000-8000-000000000000".parse().unwrap();
+        let scope = AgentScope::Worker {
+            run_id,
+            task: TaskIdentity::new(2, Some("k8s-agent".to_string())),
+            session_id: None,
+        };
+
+        let request_id = format!("req_w2_{}", uuid::Uuid::new_v4().simple());
+
+        // Gate first, persistence last — matches orchestrator.rs wrapper vec
+        // order so persistence.transform_args strips _aura_reasoning before
+        // the gate's pre_call reads the cleaned args.
+        let gate: Arc<dyn ToolWrapper> = Arc::new(HitlApprovalWrapper::new(
+            Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
+            route,
+            scope,
+            request_id.clone(),
+        ));
+        let persistence: Arc<dyn ToolWrapper> = Arc::new(test_wrapper(Arc::new(Mutex::new(
+            ExecutionPersistence::disabled(),
+        ))));
+        let composed = ComposedWrapper::new(vec![gate, persistence]);
+
+        let received = Arc::new(std::sync::Mutex::new(None::<Value>));
+        let inner = ArgsRecordingTool {
+            received: received.clone(),
+        };
+        let initiator = "k8s-agent".to_string();
+        let wrapped =
+            WrappedTool::new(inner, Arc::new(composed)).with_context_factory(move |tool_name| {
+                ToolCallContext::new(tool_name).with_task_context(2, initiator.clone(), 1)
+            });
+
+        // Subscribe before the call so the Requested event is captured.
+        let mut rx = approval_event_broker::subscribe(&request_id).await;
+
+        let args = serde_json::json!({
+            "namespace": "prod",
+            "resource": "deploy/web",
+            "_aura_reasoning": "rollout restart to pick up the new config map"
+        });
+        let call_handle: tokio::task::JoinHandle<Result<String, ToolError>> =
+            tokio::spawn(async move { wrapped.call(args).await });
+
+        // Wait for the Requested event and extract the decision_id.
+        let event = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("requested event should arrive")
+            .expect("event channel open");
+        let decision_id = match event {
+            ApprovalLifecycleEvent::Requested(req) => {
+                DecisionId::parse(&req.decision_id).expect("valid decision id")
+            }
+            other => panic!("expected Requested event, got {:?}", other),
+        };
+
+        // Inspect the parked request.
+        let parked = store
+            .get(&decision_id)
+            .await
+            .unwrap()
+            .expect("parked approval exists");
+        assert_eq!(parked.request.items.len(), 1);
+        let item = &parked.request.items[0];
+        assert_eq!(
+            item.tool_call_intent.as_deref(),
+            Some("rollout restart to pick up the new config map"),
+            "tool_call_intent must carry the pre-strip reasoning"
+        );
+        assert!(
+            item.arguments.get("_aura_reasoning").is_none(),
+            "items[].arguments must not contain _aura_reasoning"
+        );
+
+        // Verify the wire shape: ApprovalItem serializes with tool_call_intent
+        // present and _aura_reasoning absent from arguments.
+        let item_wire = serde_json::to_value(item).expect("item serializable");
+        assert_eq!(
+            item_wire["tool_call_intent"],
+            "rollout restart to pick up the new config map"
+        );
+        assert!(item_wire["arguments"].get("_aura_reasoning").is_none());
+
+        // Approve so the inner tool runs.
+        registry_for_resolve
+            .resolve(&decision_id, ApprovalDecision::Approved)
+            .await
+            .expect("resolve");
+
+        // Await the tool call.
+        let result = call_handle.await.expect("call task did not panic");
+        assert!(result.is_ok(), "approved call should succeed: {:?}", result);
+
+        // The inner tool received args WITHOUT _aura_reasoning.
+        let executed = received
+            .lock()
+            .unwrap()
+            .take()
+            .expect("inner tool was called");
+        assert!(
+            executed.get("_aura_reasoning").is_none(),
+            "executed args must not contain _aura_reasoning"
+        );
+        assert_eq!(executed["namespace"], "prod");
+
+        approval_event_broker::unsubscribe(&request_id).await;
     }
 }

--- a/crates/aura/src/orchestration/persistence_wrapper.rs
+++ b/crates/aura/src/orchestration/persistence_wrapper.rs
@@ -26,7 +26,7 @@ use tokio::sync::{Mutex, Notify};
 use super::persistence::{ExecutionPersistence, ToolCallRecord};
 use crate::mcp_response::CallOutcome;
 use crate::tool_wrapper::{
-    ToolCallContext, ToolWrapper, TransformArgsResult, TransformOutputResult,
+    ToolCallContext, ToolWrapper, TransformArgsResult, TransformOutputResult, non_blank,
 };
 
 /// The namespaced field name for reasoning (signals framework/internal field).
@@ -189,8 +189,8 @@ impl ToolWrapper for PersistenceWrapper {
 
     fn write_context(&self, extracted: Option<&Value>, ctx: &mut ToolCallContext) {
         // transform_args emits "reasoning": "" when the field was absent
-        // (it uses unwrap_or_default), so empty means absent.
-        if let Some(r) = find_field(extracted, "reasoning").filter(|r| !r.trim().is_empty()) {
+        // (it uses unwrap_or_default); non_blank collapses that to absent.
+        if let Some(r) = find_field(extracted, "reasoning").and_then(non_blank) {
             ctx.tool_call_intent = Some(r.to_string());
         }
     }

--- a/crates/aura/src/orchestration/persistence_wrapper.rs
+++ b/crates/aura/src/orchestration/persistence_wrapper.rs
@@ -425,6 +425,7 @@ pub fn extract_reasoning(mut args: Value) -> (Option<String>, Value) {
 #[cfg(test)]
 mod tests {
     use crate::WrappedTool;
+    use crate::hitl::ApprovalItem;
     use rig::tool::{Tool as RigTool, ToolError};
 
     fn test_wrapper(persistence: Arc<Mutex<ExecutionPersistence>>) -> PersistenceWrapper {
@@ -1406,14 +1407,12 @@ mod tests {
         }
     }
 
-    /// Drives a hard-gated tool call carrying `_aura_reasoning` through the
-    /// full wrapper chain (PersistenceWrapper + HitlApprovalWrapper via
-    /// ComposedWrapper) and asserts:
-    /// - the approval payload item carries `tool_call_intent`
-    /// - `items[].arguments` does NOT contain `_aura_reasoning`
-    /// - the args the inner tool executes with do NOT contain `_aura_reasoning`
-    #[tokio::test]
-    async fn config_gate_forwards_tool_call_intent_and_strips_reasoning() {
+    /// Drive one hard-gated `kubectl_*` tool call through the full wrapper
+    /// chain (gate first, persistence last — the orchestrator.rs order, so
+    /// `transform_args` strips `_aura_reasoning` before the gate reads the
+    /// cleaned args) and return the production-built parked `ApprovalItem`
+    /// plus the args the inner tool executed with.
+    async fn run_config_gate_tool(reasoning: Option<&str>) -> (ApprovalItem, Value) {
         use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
         use crate::hitl::{
             AgentScope, ApprovalDecision, DecisionId, DecisionRoute, HitlApprovalWrapper,
@@ -1426,7 +1425,6 @@ mod tests {
         use crate::tool_wrapper::{ComposedWrapper, ToolCallContext, ToolWrapper, WrappedTool};
         use aura_config::GlobPattern;
 
-        // Inspectable store so we can read the parked ApprovalRequest.
         let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
         let bus: Arc<dyn EventBus> = Arc::new(InMemoryEventBus::new());
         let registry = PendingApprovals::with_backend(store.clone(), bus);
@@ -1445,9 +1443,6 @@ mod tests {
 
         let request_id = format!("req_w2_{}", uuid::Uuid::new_v4().simple());
 
-        // Gate first, persistence last — matches orchestrator.rs wrapper vec
-        // order so persistence.transform_args strips _aura_reasoning before
-        // the gate's pre_call reads the cleaned args.
         let gate: Arc<dyn ToolWrapper> = Arc::new(HitlApprovalWrapper::new(
             Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
             route,
@@ -1469,18 +1464,19 @@ mod tests {
                 ToolCallContext::new(tool_name).with_task_context(2, initiator.clone(), 1)
             });
 
-        // Subscribe before the call so the Requested event is captured.
+        // Subscribe before the spawn so the Requested event is not missed.
         let mut rx = approval_event_broker::subscribe(&request_id).await;
 
-        let args = serde_json::json!({
+        let mut args = serde_json::json!({
             "namespace": "prod",
-            "resource": "deploy/web",
-            "_aura_reasoning": "rollout restart to pick up the new config map"
+            "resource": "deploy/web"
         });
+        if let Some(r) = reasoning {
+            args["_aura_reasoning"] = serde_json::Value::String(r.to_string());
+        }
         let call_handle: tokio::task::JoinHandle<Result<String, ToolError>> =
             tokio::spawn(async move { wrapped.call(args).await });
 
-        // Wait for the Requested event and extract the decision_id.
         let event = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
             .await
             .expect("requested event should arrive")
@@ -1492,14 +1488,38 @@ mod tests {
             other => panic!("expected Requested event, got {:?}", other),
         };
 
-        // Inspect the parked request.
         let parked = store
             .get(&decision_id)
             .await
             .unwrap()
             .expect("parked approval exists");
-        assert_eq!(parked.request.items.len(), 1);
-        let item = &parked.request.items[0];
+        assert_eq!(parked.request.items.len(), 1, "config_gate parks one item");
+        let item = parked.request.items.into_iter().next().expect("one item");
+
+        registry_for_resolve
+            .resolve(&decision_id, ApprovalDecision::Approved)
+            .await
+            .expect("resolve");
+
+        let result = call_handle.await.expect("call task did not panic");
+        assert!(result.is_ok(), "approved call should succeed: {:?}", result);
+
+        let executed = received
+            .lock()
+            .unwrap()
+            .take()
+            .expect("inner tool was called");
+
+        approval_event_broker::unsubscribe(&request_id).await;
+
+        (item, executed)
+    }
+
+    #[tokio::test]
+    async fn config_gate_forwards_tool_call_intent_and_strips_reasoning() {
+        let (item, executed) =
+            run_config_gate_tool(Some("rollout restart to pick up the new config map")).await;
+
         assert_eq!(
             item.tool_call_intent.as_deref(),
             Some("rollout restart to pick up the new config map"),
@@ -1510,157 +1530,43 @@ mod tests {
             "items[].arguments must not contain _aura_reasoning"
         );
 
-        // Verify the wire shape: ApprovalItem serializes with tool_call_intent
-        // present and _aura_reasoning absent from arguments.
-        let item_wire = serde_json::to_value(item).expect("item serializable");
+        let item_wire = serde_json::to_value(&item).expect("item serializable");
         assert_eq!(
             item_wire["tool_call_intent"],
             "rollout restart to pick up the new config map"
         );
         assert!(item_wire["arguments"].get("_aura_reasoning").is_none());
 
-        // Approve so the inner tool runs.
-        registry_for_resolve
-            .resolve(&decision_id, ApprovalDecision::Approved)
-            .await
-            .expect("resolve");
-
-        // Await the tool call.
-        let result = call_handle.await.expect("call task did not panic");
-        assert!(result.is_ok(), "approved call should succeed: {:?}", result);
-
-        // The inner tool received args WITHOUT _aura_reasoning.
-        let executed = received
-            .lock()
-            .unwrap()
-            .take()
-            .expect("inner tool was called");
         assert!(
             executed.get("_aura_reasoning").is_none(),
             "executed args must not contain _aura_reasoning"
         );
         assert_eq!(executed["namespace"], "prod");
-
-        approval_event_broker::unsubscribe(&request_id).await;
     }
 
-    /// Absent-reasoning counterpart to `config_gate_forwards_tool_call_intent_and_strips_reasoning`:
-    /// a hard-gated tool call carrying NO `_aura_reasoning` must produce an
+    /// A hard-gated tool call carrying NO `_aura_reasoning` must produce an
     /// approval payload item that OMITS `tool_call_intent` entirely (never
     /// `null`, never `""`) on the serialized wire.
     #[tokio::test]
     async fn config_gate_omits_tool_call_intent_when_reasoning_absent() {
-        use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
-        use crate::hitl::{
-            AgentScope, ApprovalDecision, DecisionId, DecisionRoute, HitlApprovalWrapper,
-            PendingApprovals,
-        };
-        use crate::orchestration::{RunId, TaskIdentity};
-        use crate::session_store::{
-            ApprovalStore, EventBus, InMemoryApprovalStore, InMemoryEventBus,
-        };
-        use crate::tool_wrapper::{ComposedWrapper, ToolCallContext, ToolWrapper, WrappedTool};
-        use aura_config::GlobPattern;
+        let (item, executed) = run_config_gate_tool(None).await;
 
-        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
-        let bus: Arc<dyn EventBus> = Arc::new(InMemoryEventBus::new());
-        let registry = PendingApprovals::with_backend(store.clone(), bus);
-        let registry_for_resolve = registry.clone();
-        let route = Arc::new(DecisionRoute::Conversational {
-            registry,
-            timeout: std::time::Duration::from_secs(60),
-        });
-
-        let run_id: RunId = "0191e8c0-2222-7000-8000-000000000000".parse().unwrap();
-        let scope = AgentScope::Worker {
-            run_id,
-            task: TaskIdentity::new(3, Some("k8s-agent".to_string())),
-            session_id: None,
-        };
-
-        let request_id = format!("req_w2_absent_{}", uuid::Uuid::new_v4().simple());
-
-        let gate: Arc<dyn ToolWrapper> = Arc::new(HitlApprovalWrapper::new(
-            Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
-            route,
-            scope,
-            request_id.clone(),
-        ));
-        let persistence: Arc<dyn ToolWrapper> = Arc::new(test_wrapper(Arc::new(Mutex::new(
-            ExecutionPersistence::disabled(),
-        ))));
-        let composed = ComposedWrapper::new(vec![gate, persistence]);
-
-        let received = Arc::new(std::sync::Mutex::new(None::<Value>));
-        let inner = ArgsRecordingTool {
-            received: received.clone(),
-        };
-        let initiator = "k8s-agent".to_string();
-        let wrapped =
-            WrappedTool::new(inner, Arc::new(composed)).with_context_factory(move |tool_name| {
-                ToolCallContext::new(tool_name).with_task_context(3, initiator.clone(), 1)
-            });
-
-        let mut rx = approval_event_broker::subscribe(&request_id).await;
-
-        // NO _aura_reasoning — the model omitted the optional field.
-        let args = serde_json::json!({
-            "namespace": "prod",
-            "resource": "deploy/web"
-        });
-        let call_handle: tokio::task::JoinHandle<Result<String, ToolError>> =
-            tokio::spawn(async move { wrapped.call(args).await });
-
-        let event = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
-            .await
-            .expect("requested event should arrive")
-            .expect("event channel open");
-        let decision_id = match event {
-            ApprovalLifecycleEvent::Requested(req) => {
-                DecisionId::parse(&req.decision_id).expect("valid decision id")
-            }
-            other => panic!("expected Requested event, got {:?}", other),
-        };
-
-        let parked = store
-            .get(&decision_id)
-            .await
-            .unwrap()
-            .expect("parked approval exists");
-        assert_eq!(parked.request.items.len(), 1);
-        let item = &parked.request.items[0];
         assert!(
             item.tool_call_intent.is_none(),
             "absent reasoning must not surface as tool_call_intent"
         );
 
-        // Wire shape: tool_call_intent must be OMITTED (never null, never "").
-        let item_wire = serde_json::to_value(item).expect("item serializable");
+        let item_wire = serde_json::to_value(&item).expect("item serializable");
         assert!(
             item_wire.get("tool_call_intent").is_none(),
             "tool_call_intent must be omitted on the wire when reasoning is absent, got: {}",
             item_wire
         );
 
-        registry_for_resolve
-            .resolve(&decision_id, ApprovalDecision::Approved)
-            .await
-            .expect("resolve");
-
-        let result = call_handle.await.expect("call task did not panic");
-        assert!(result.is_ok(), "approved call should succeed: {:?}", result);
-
-        let executed = received
-            .lock()
-            .unwrap()
-            .take()
-            .expect("inner tool was called");
         assert!(
             executed.get("_aura_reasoning").is_none(),
             "executed args must not contain _aura_reasoning"
         );
         assert_eq!(executed["namespace"], "prod");
-
-        approval_event_broker::unsubscribe(&request_id).await;
     }
 }

--- a/crates/aura/src/orchestration/persistence_wrapper.rs
+++ b/crates/aura/src/orchestration/persistence_wrapper.rs
@@ -188,7 +188,9 @@ impl ToolWrapper for PersistenceWrapper {
     }
 
     fn write_context(&self, extracted: Option<&Value>, ctx: &mut ToolCallContext) {
-        if let Some(r) = find_field(extracted, "reasoning") {
+        // transform_args emits "reasoning": "" when the field was absent
+        // (it uses unwrap_or_default), so empty means absent.
+        if let Some(r) = find_field(extracted, "reasoning").filter(|r| !r.trim().is_empty()) {
             ctx.tool_call_intent = Some(r.to_string());
         }
     }
@@ -1354,15 +1356,25 @@ mod tests {
         let persistence = Arc::new(Mutex::new(ExecutionPersistence::disabled()));
         let wrapper = test_wrapper(persistence);
 
-        let extracted = serde_json::json!([{
-            "_persistence_call_id": "abc-123",
-            "call_idx": 0
-        }]);
+        // Feed the actual transform_args output (which emits "reasoning": ""
+        // for absent input), not a hand-built object missing the key.
+        let probe_ctx = ToolCallContext::new("test_tool");
+        let result = wrapper.transform_args(serde_json::json!({"param": "value"}), &probe_ctx);
+        let extracted = result
+            .extracted
+            .expect("transform_args always produces extracted");
+        assert_eq!(
+            extracted["reasoning"], "",
+            "absent reasoning => empty string in extracted"
+        );
 
         let mut ctx = ToolCallContext::new("test_tool");
         wrapper.write_context(Some(&extracted), &mut ctx);
 
-        assert!(ctx.tool_call_intent.is_none());
+        assert!(
+            ctx.tool_call_intent.is_none(),
+            "absent reasoning (transform_args emits \"\") must not surface as tool_call_intent"
+        );
     }
 
     // --------------------------------------------------------------------
@@ -1518,6 +1530,126 @@ mod tests {
         assert!(result.is_ok(), "approved call should succeed: {:?}", result);
 
         // The inner tool received args WITHOUT _aura_reasoning.
+        let executed = received
+            .lock()
+            .unwrap()
+            .take()
+            .expect("inner tool was called");
+        assert!(
+            executed.get("_aura_reasoning").is_none(),
+            "executed args must not contain _aura_reasoning"
+        );
+        assert_eq!(executed["namespace"], "prod");
+
+        approval_event_broker::unsubscribe(&request_id).await;
+    }
+
+    /// Absent-reasoning counterpart to `config_gate_forwards_tool_call_intent_and_strips_reasoning`:
+    /// a hard-gated tool call carrying NO `_aura_reasoning` must produce an
+    /// approval payload item that OMITS `tool_call_intent` entirely (never
+    /// `null`, never `""`) on the serialized wire.
+    #[tokio::test]
+    async fn config_gate_omits_tool_call_intent_when_reasoning_absent() {
+        use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
+        use crate::hitl::{
+            AgentScope, ApprovalDecision, DecisionId, DecisionRoute, HitlApprovalWrapper,
+            PendingApprovals,
+        };
+        use crate::orchestration::{RunId, TaskIdentity};
+        use crate::session_store::{
+            ApprovalStore, EventBus, InMemoryApprovalStore, InMemoryEventBus,
+        };
+        use crate::tool_wrapper::{ComposedWrapper, ToolCallContext, ToolWrapper, WrappedTool};
+        use aura_config::GlobPattern;
+
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let bus: Arc<dyn EventBus> = Arc::new(InMemoryEventBus::new());
+        let registry = PendingApprovals::with_backend(store.clone(), bus);
+        let registry_for_resolve = registry.clone();
+        let route = Arc::new(DecisionRoute::Conversational {
+            registry,
+            timeout: std::time::Duration::from_secs(60),
+        });
+
+        let run_id: RunId = "0191e8c0-2222-7000-8000-000000000000".parse().unwrap();
+        let scope = AgentScope::Worker {
+            run_id,
+            task: TaskIdentity::new(3, Some("k8s-agent".to_string())),
+            session_id: None,
+        };
+
+        let request_id = format!("req_w2_absent_{}", uuid::Uuid::new_v4().simple());
+
+        let gate: Arc<dyn ToolWrapper> = Arc::new(HitlApprovalWrapper::new(
+            Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
+            route,
+            scope,
+            request_id.clone(),
+        ));
+        let persistence: Arc<dyn ToolWrapper> = Arc::new(test_wrapper(Arc::new(Mutex::new(
+            ExecutionPersistence::disabled(),
+        ))));
+        let composed = ComposedWrapper::new(vec![gate, persistence]);
+
+        let received = Arc::new(std::sync::Mutex::new(None::<Value>));
+        let inner = ArgsRecordingTool {
+            received: received.clone(),
+        };
+        let initiator = "k8s-agent".to_string();
+        let wrapped =
+            WrappedTool::new(inner, Arc::new(composed)).with_context_factory(move |tool_name| {
+                ToolCallContext::new(tool_name).with_task_context(3, initiator.clone(), 1)
+            });
+
+        let mut rx = approval_event_broker::subscribe(&request_id).await;
+
+        // NO _aura_reasoning — the model omitted the optional field.
+        let args = serde_json::json!({
+            "namespace": "prod",
+            "resource": "deploy/web"
+        });
+        let call_handle: tokio::task::JoinHandle<Result<String, ToolError>> =
+            tokio::spawn(async move { wrapped.call(args).await });
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("requested event should arrive")
+            .expect("event channel open");
+        let decision_id = match event {
+            ApprovalLifecycleEvent::Requested(req) => {
+                DecisionId::parse(&req.decision_id).expect("valid decision id")
+            }
+            other => panic!("expected Requested event, got {:?}", other),
+        };
+
+        let parked = store
+            .get(&decision_id)
+            .await
+            .unwrap()
+            .expect("parked approval exists");
+        assert_eq!(parked.request.items.len(), 1);
+        let item = &parked.request.items[0];
+        assert!(
+            item.tool_call_intent.is_none(),
+            "absent reasoning must not surface as tool_call_intent"
+        );
+
+        // Wire shape: tool_call_intent must be OMITTED (never null, never "").
+        let item_wire = serde_json::to_value(item).expect("item serializable");
+        assert!(
+            item_wire.get("tool_call_intent").is_none(),
+            "tool_call_intent must be omitted on the wire when reasoning is absent, got: {}",
+            item_wire
+        );
+
+        registry_for_resolve
+            .resolve(&decision_id, ApprovalDecision::Approved)
+            .await
+            .expect("resolve");
+
+        let result = call_handle.await.expect("call task did not panic");
+        assert!(result.is_ok(), "approved call should succeed: {:?}", result);
+
         let executed = received
             .lock()
             .unwrap()

--- a/crates/aura/src/session_store/memory.rs
+++ b/crates/aura/src/session_store/memory.rs
@@ -170,6 +170,7 @@ mod tests {
                 items: vec![ApprovalItem {
                     tool_name: "test_tool".to_string(),
                     arguments: serde_json::json!({}),
+                    tool_call_intent: None,
                 }],
             },
             registered_at: now,

--- a/crates/aura/src/session_store/record.rs
+++ b/crates/aura/src/session_store/record.rs
@@ -198,6 +198,7 @@ mod tests {
                 items: vec![ApprovalItem {
                     tool_name: "test_tool".to_string(),
                     arguments: serde_json::json!({"arg": 1}),
+                    tool_call_intent: None,
                 }],
             },
             registered_at: now,

--- a/crates/aura/src/tool_wrapper.rs
+++ b/crates/aura/src/tool_wrapper.rs
@@ -67,11 +67,8 @@ pub struct ToolCallContext {
     pub attempt: Option<usize>,
     /// Custom metadata that wrappers can use
     pub metadata: Option<Value>,
-    /// Model-authored reasoning, captured pre-strip by
-    /// `PersistenceWrapper::transform_args`. ADVISORY ONLY — see
-    /// `ApprovalItem.tool_call_intent` for the digest-exclusion rule (R5).
-    /// Surfaces on the wire as `items[].tool_call_intent`, never inside
-    /// `arguments`.
+    /// Model-authored reasoning for the pending tool call. Advisory only —
+    /// see `ApprovalItem.tool_call_intent` for the digest-exclusion rule (R5).
     pub tool_call_intent: Option<String>,
 }
 
@@ -108,12 +105,11 @@ impl ToolCallContext {
         self.metadata = Some(metadata);
         self
     }
+}
 
-    /// Set the model-authored tool call intent (advisory).
-    pub fn with_tool_call_intent(mut self, intent: impl Into<String>) -> Self {
-        self.tool_call_intent = Some(intent.into());
-        self
-    }
+/// Blank (empty or whitespace-only) reasoning counts as absent.
+pub(crate) fn non_blank(s: &str) -> Option<&str> {
+    (!s.trim().is_empty()).then_some(s)
 }
 
 /// Result of argument transformation.

--- a/crates/aura/src/tool_wrapper.rs
+++ b/crates/aura/src/tool_wrapper.rs
@@ -67,6 +67,12 @@ pub struct ToolCallContext {
     pub attempt: Option<usize>,
     /// Custom metadata that wrappers can use
     pub metadata: Option<Value>,
+    /// Model-authored reasoning, captured pre-strip by
+    /// `PersistenceWrapper::transform_args`. ADVISORY ONLY — see
+    /// `ApprovalItem.tool_call_intent` for the digest-exclusion rule (R5).
+    /// Surfaces on the wire as `items[].tool_call_intent`, never inside
+    /// `arguments`.
+    pub tool_call_intent: Option<String>,
 }
 
 impl ToolCallContext {
@@ -100,6 +106,12 @@ impl ToolCallContext {
     /// Set custom metadata.
     pub fn with_metadata(mut self, metadata: Value) -> Self {
         self.metadata = Some(metadata);
+        self
+    }
+
+    /// Set the model-authored tool call intent (advisory).
+    pub fn with_tool_call_intent(mut self, intent: impl Into<String>) -> Self {
+        self.tool_call_intent = Some(intent.into());
         self
     }
 }
@@ -290,6 +302,18 @@ pub trait ToolWrapper: Send + Sync {
         Ok(())
     }
 
+    /// Populate advisory context fields from data extracted during
+    /// `transform_args`.
+    ///
+    /// Called once between `transform_args` and `pre_call` in
+    /// `WrappedTool::call`, after the composed `extracted` payload is
+    /// available. Default is a no-op; wrappers that capture cross-cutting
+    /// data in `transform_args` (e.g. `PersistenceWrapper` stashes the
+    /// pre-strip reasoning) override this to surface it as a typed field
+    /// on the context rather than requiring every reader to search the
+    /// `extracted` `Value` blob by string key.
+    fn write_context(&self, _extracted: Option<&Value>, _ctx: &mut ToolCallContext) {}
+
     /// Async hook called before tool execution.
     ///
     /// Use this for async gates that must run before the tool executes, such as
@@ -433,6 +457,13 @@ where
 
             // Store clean args on context so on_complete can persist them
             ctx.metadata = Some(clean_args.clone());
+
+            // Let wrappers surface advisory fields from extracted data onto
+            // the context (e.g. PersistenceWrapper publishes the pre-strip
+            // reasoning as `tool_call_intent` for the HITL gate). Runs after
+            // transform_args (which produces `extracted`) and before pre_call
+            // (which reads it).
+            wrapper.write_context(extracted.as_ref(), &mut ctx);
 
             // Validate args (wrappers can reject tool calls here)
             if let Err(validation_error) =
@@ -663,6 +694,12 @@ impl ToolWrapper for ComposedWrapper {
             wrapper.validate_args(args, extracted, ctx)?;
         }
         Ok(())
+    }
+
+    fn write_context(&self, extracted: Option<&Value>, ctx: &mut ToolCallContext) {
+        for wrapper in &self.wrappers {
+            wrapper.write_context(extracted, ctx);
+        }
     }
 
     async fn pre_call(


### PR DESCRIPTION
Closes #277.

Forwards `_aura_reasoning` as `tool_call_intent` on approval items with blank intent normalized on the agent_requested path. New fields are named-optional on the approval payload.