### PR TITLE
Mshearer/276 hitl header forwarding

### DIFF
--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -1151,13 +1151,10 @@ pub enum DecisionRouteConfig {
         url: WebhookUrl,
         #[serde(default = "default_webhook_timeout_secs")]
         timeout_secs: u64,
-        /// Static headers always sent on the webhook POST.
+        /// Static webhook headers.
         #[serde(default)]
         headers: HashMap<String, String>,
-        /// Opt-in mapping of outbound header name → inbound request header
-        /// name. Nothing is forwarded unless listed here; the operator owns
-        /// the risk. Static `headers` values serve as fallback when the
-        /// mapped request header is absent.
+        /// Outbound header name → inbound request header name mapping.
         #[serde(default)]
         headers_from_request: HashMap<String, String>,
     },

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -1000,6 +1000,8 @@ mod tests {
             route: DecisionRouteConfig::Webhook {
                 url: WebhookUrl::new("http://localhost:9999").unwrap(),
                 timeout_secs: 300,
+                headers: HashMap::new(),
+                headers_from_request: HashMap::new(),
             },
         };
         assert!(hitl_timeout_conflict_warning(&hitl, 0).is_none());
@@ -1012,6 +1014,8 @@ mod tests {
             route: DecisionRouteConfig::Webhook {
                 url: WebhookUrl::new("http://localhost:9999").unwrap(),
                 timeout_secs: 30,
+                headers: HashMap::new(),
+                headers_from_request: HashMap::new(),
             },
         };
         assert!(hitl_timeout_conflict_warning(&hitl, 60).is_none());
@@ -1024,6 +1028,8 @@ mod tests {
             route: DecisionRouteConfig::Webhook {
                 url: WebhookUrl::new("http://localhost:9999").unwrap(),
                 timeout_secs: 60,
+                headers: HashMap::new(),
+                headers_from_request: HashMap::new(),
             },
         };
         let msg = hitl_timeout_conflict_warning(&hitl, 60).unwrap();
@@ -1038,6 +1044,8 @@ mod tests {
             route: DecisionRouteConfig::Webhook {
                 url: WebhookUrl::new("http://localhost:9999").unwrap(),
                 timeout_secs: 120,
+                headers: HashMap::new(),
+                headers_from_request: HashMap::new(),
             },
         };
         let msg = hitl_timeout_conflict_warning(&hitl, 60).unwrap();
@@ -1054,6 +1062,57 @@ mod tests {
         };
         let msg = hitl_timeout_conflict_warning(&hitl, 60).unwrap();
         assert!(msg.contains("120s"));
+    }
+
+    #[test]
+    fn hitl_webhook_headers_parse_from_toml() {
+        let toml = r#"
+require_approval = ["kubectl_*"]
+
+[route]
+mode = "webhook"
+url = "https://approvals.example.com/decide"
+headers = { "x-tenant" = "sre-prod" }
+headers_from_request = { "authorization" = "authorization" }
+"#;
+        let hitl: HitlConfig = toml::from_str(toml).unwrap();
+        match hitl.route {
+            DecisionRouteConfig::Webhook {
+                headers,
+                headers_from_request,
+                ..
+            } => {
+                assert_eq!(headers.get("x-tenant"), Some(&"sre-prod".to_string()));
+                assert_eq!(
+                    headers_from_request.get("authorization"),
+                    Some(&"authorization".to_string())
+                );
+            }
+            other => panic!("expected Webhook route, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn hitl_webhook_headers_default_empty_when_absent() {
+        let toml = r#"
+require_approval = ["kubectl_*"]
+
+[route]
+mode = "webhook"
+url = "https://approvals.example.com/decide"
+"#;
+        let hitl: HitlConfig = toml::from_str(toml).unwrap();
+        match hitl.route {
+            DecisionRouteConfig::Webhook {
+                headers,
+                headers_from_request,
+                ..
+            } => {
+                assert!(headers.is_empty());
+                assert!(headers_from_request.is_empty());
+            }
+            other => panic!("expected Webhook route, got {:?}", other),
+        }
     }
 }
 
@@ -1092,6 +1151,15 @@ pub enum DecisionRouteConfig {
         url: WebhookUrl,
         #[serde(default = "default_webhook_timeout_secs")]
         timeout_secs: u64,
+        /// Static headers always sent on the webhook POST.
+        #[serde(default)]
+        headers: HashMap<String, String>,
+        /// Opt-in mapping of outbound header name → inbound request header
+        /// name. Nothing is forwarded unless listed here; the operator owns
+        /// the risk. Static `headers` values serve as fallback when the
+        /// mapped request header is absent.
+        #[serde(default)]
+        headers_from_request: HashMap<String, String>,
     },
 }
 

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1175,6 +1175,8 @@ mod tests {
         let config = make_hitl_config(aura_config::DecisionRouteConfig::Webhook {
             url: aura_config::WebhookUrl::new("http://127.0.0.1:8080/approve").unwrap(),
             timeout_secs: 300,
+            headers: std::collections::HashMap::new(),
+            headers_from_request: std::collections::HashMap::new(),
         });
         let req = chat_request_with_stream(None);
 

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -202,17 +202,8 @@ pub(crate) fn build_webhook_client() -> reqwest::Client {
 /// a warning (matching `mcp_streamable_http.rs`).
 ///
 /// Opt-in only: nothing is forwarded unless the operator configures it.
-/// Resolved per request at agent-build time (orchestration resolves once
-/// before workers spawn).
-///
-/// NOTE (271 board, ADR decision 13): the 271 park/reify board adds header
-/// classification (`identity` vs `credential`) at park time. Unclassified
-/// headers default to credential (fail-closed) there — they refuse to park.
-/// That classification's only enforcement point is park time, which does not
-/// exist on main. This wave ships the plain `headers` / `headers_from_request`
-/// surface without classification; adding a classification key later is purely
-/// additive TOML, never a retrofit break. Forwarded headers are never
-/// persisted anywhere in this wave.
+/// Classification is deliberately absent from this surface — see
+/// [`apply_request_header_mappings`](crate::rig_builder::apply_request_header_mappings).
 fn resolve_webhook_headers(
     static_headers: &HashMap<String, String>,
     headers_from_request: &HashMap<String, String>,
@@ -221,12 +212,18 @@ fn resolve_webhook_headers(
     let empty = HashMap::new();
     let req_headers = req_headers.unwrap_or(&empty);
 
-    let mut resolved = static_headers.clone();
-    crate::rig_builder::apply_request_header_mappings(
+    let mut resolved: HashMap<String, String> = static_headers
+        .iter()
+        .map(|(k, v)| (k.to_lowercase(), v.clone()))
+        .collect();
+    let resolved_count = crate::rig_builder::apply_request_header_mappings(
         &mut resolved,
         headers_from_request,
         req_headers,
     );
+    if resolved_count > 0 {
+        tracing::info!("Webhook route: resolved {resolved_count} header(s) from request");
+    }
 
     let mut header_map = HeaderMap::new();
     for (key, value) in &resolved {
@@ -253,11 +250,7 @@ fn resolve_webhook_headers(
 pub struct WebhookClient {
     client: reqwest::Client,
     url: WebhookUrl,
-    /// Operator-configured headers resolved at agent-build time: static
-    /// `headers` overlaid with `headers_from_request` values from the
-    /// inbound client request. Invalid header names/values were skipped
-    /// with a warning at resolution time. Empty when no headers are
-    /// configured, producing the same bare POST as before.
+    /// Resolved webhook headers.
     headers: HeaderMap,
 }
 
@@ -300,8 +293,7 @@ impl WebhookClient {
             .timeout(timeout);
 
         // Apply resolved operator-configured headers on top of the JSON body
-        // (which already set Content-Type). An empty map adds nothing, so the
-        // POST is byte-for-byte identical to the pre-header-forwarding path.
+        // (which already set Content-Type).
         for (name, value) in self.headers.iter() {
             builder = builder.header(name.clone(), value.clone());
         }
@@ -817,6 +809,29 @@ mod tests {
     }
 
     #[test]
+    fn webhook_headers_mixed_casing_static_and_dynamic_keys() {
+        // Static headers use "Authorization" (capitalized) while the
+        // headers_from_request outbound key uses "authorization" (lowercase).
+        // Both refer to the same HTTP header; the dynamic value must override
+        // the static fallback deterministically, not non-deterministically
+        // based on HashMap iteration order.
+        let static_headers = make_req_headers(&[("Authorization", "static-token")]);
+        let headers_from_request = make_req_headers(&[("authorization", "x-incoming-auth")]);
+        let req_headers = make_req_headers(&[("x-incoming-auth", "dynamic-token")]);
+
+        let header_map = super::resolve_webhook_headers(
+            &static_headers,
+            &headers_from_request,
+            Some(&req_headers),
+        );
+        assert_eq!(
+            header_map.get("authorization").unwrap(),
+            "dynamic-token",
+            "dynamic header must override static fallback regardless of key casing"
+        );
+    }
+
+    #[test]
     fn webhook_headers_invalid_skipped() {
         // Header name with a space is invalid per RFC 7230; the entry must
         // be skipped with a warning, not panic.
@@ -912,9 +927,8 @@ mod tests {
     #[test]
     fn webhook_headers_empty_config_produces_bare_post() {
         // Empty config (no static, no from_request, no req_headers) must
-        // produce an empty HeaderMap. With an empty HeaderMap, the
-        // request_approval loop does not execute, so the POST is
-        // byte-for-byte identical to the pre-header-forwarding path.
+        // produce an empty HeaderMap, so the header loop in request_approval
+        // adds nothing to the POST.
         let static_headers = std::collections::HashMap::new();
         let headers_from_request = std::collections::HashMap::new();
 
@@ -1060,7 +1074,7 @@ mod tests {
     async fn webhook_empty_config_sends_no_custom_headers() {
         let (port, mut rx) = spawn_capturing_webhook(1).await;
 
-        // Empty HeaderMap — same as the pre-header-forwarding path.
+        // Empty HeaderMap: the POST carries no custom headers.
         let client = super::WebhookClient::new_with_headers(
             super::build_webhook_client(),
             aura_config::WebhookUrl::new(format!("http://127.0.0.1:{port}")).unwrap(),
@@ -1085,7 +1099,7 @@ mod tests {
     #[tokio::test]
     async fn webhook_empty_headers_match_bare_client_byte_for_byte() {
         // Empty configuration must produce a request byte-for-byte identical
-        // to the pre-header-forwarding path (`WebhookClient::new`). Here we
+        // to the bare constructor (`WebhookClient::new`). Here we
         // capture the COMPLETE raw request (headers AND body) from both
         // constructors run sequentially against the SAME mock server (so Host
         // and port are identical) and assert the captured request texts are
@@ -1105,7 +1119,7 @@ mod tests {
         // guarantees the body was actually captured.
         let decision_id = request.decision_id.to_string();
 
-        // Capture 1: the pre-header-forwarding constructor (no headers field).
+        // Capture 1: the bare constructor (no headers configured).
         let bare = super::DecisionRoute::Webhook {
             client: super::WebhookClient::new(super::build_webhook_client(), url.clone()),
             timeout: std::time::Duration::from_secs(5),

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -852,11 +852,9 @@ mod tests {
 
     #[test]
     fn webhook_headers_invalid_value_skipped_with_warning_and_no_leak() {
-        // FINDING 2: a header VALUE with forbidden control characters must be
-        // skipped, a warning must be emitted, and the value must NOT appear in
-        // the captured log (the header name may). The prior invalid-header
-        // test exercised only an invalid NAME and never checked the warning or
-        // the no-value-leak contract.
+        // A header VALUE with forbidden control characters must be skipped,
+        // a warning must be emitted, and the value must NOT appear in the
+        // captured log (the header name may).
         use std::sync::Arc;
 
         let buf = Arc::new(CapturedLog(std::sync::Mutex::new(Vec::new())));
@@ -870,7 +868,8 @@ mod tests {
         // in field values per RFC 7230) alongside a valid entry that must
         // survive. HashMap iteration order is nondeterministic, but the invalid
         // entry warns exactly once regardless of order.
-        let static_headers = make_req_headers(&[("x-bad", "bad\r\nvalue"), ("x-valid", "ok")]);
+        let static_headers =
+            make_req_headers(&[("x-bad", "unique-secret\r\ninvalid"), ("x-valid", "ok")]);
         let headers_from_request = std::collections::HashMap::new();
 
         let header_map = tracing::subscriber::with_default(subscriber, || {
@@ -896,9 +895,16 @@ mod tests {
             "warning must name the skipped header, got log: {log}"
         );
 
-        // (c) the forbidden value must not leak into the log.
+        // (c) the forbidden value must not leak into the log. The secret
+        // substring survives debug escaping, so its absence proves the value
+        // itself was not logged — not just that the exact raw byte sequence
+        // was absent.
         assert!(
-            !log.contains("bad\r\nvalue"),
+            !log.contains("unique-secret"),
+            "secret substring from the invalid header value must not appear in the log, got: {log:?}"
+        );
+        assert!(
+            !log.contains("unique-secret\r\ninvalid"),
             "invalid header value must not appear in the log, got: {log:?}"
         );
     }
@@ -997,6 +1003,7 @@ mod tests {
         if remaining > 0 {
             let mut body_buf = vec![0u8; remaining];
             socket.read_exact(&mut body_buf).await.unwrap();
+            buf.extend_from_slice(&body_buf);
         }
 
         String::from_utf8_lossy(&buf).to_string()
@@ -1077,22 +1084,26 @@ mod tests {
 
     #[tokio::test]
     async fn webhook_empty_headers_match_bare_client_byte_for_byte() {
-        // FINDING 1: empty configuration must produce a request byte-for-byte
-        // identical to the pre-header-forwarding path (`WebhookClient::new`).
-        // The prior unit test only checked an empty `HeaderMap`; the prior
-        // integration test only checked that `x-tenant` was absent — neither
-        // excluded other request differences. Here we capture the COMPLETE raw
-        // request (headers AND body) from both constructors run sequentially
-        // against the SAME mock server (so Host and port are identical) and
-        // assert the captured request texts are equal.
+        // Empty configuration must produce a request byte-for-byte identical
+        // to the pre-header-forwarding path (`WebhookClient::new`). Here we
+        // capture the COMPLETE raw request (headers AND body) from both
+        // constructors run sequentially against the SAME mock server (so Host
+        // and port are identical) and assert the captured request texts are
+        // equal.
         //
         // A single request is cloned for both calls so every wire field
         // (notably decision_id) is identical — the body must not differ
-        // between the two captures.
+        // between the two captures. Each capture is checked for the body's
+        // decision_id before comparing, so a dropped body can never pass
+        // silently.
         let (port, mut rx) = spawn_capturing_webhook(2).await;
         let url = aura_config::WebhookUrl::new(format!("http://127.0.0.1:{port}")).unwrap();
         let cancel = crate::request_cancellation::RequestCancelToken::unbound();
         let request = make_approval_request();
+        // The decision_id appears only in the JSON body, not in the request
+        // line or headers. Checking each capture for it before comparing
+        // guarantees the body was actually captured.
+        let decision_id = request.decision_id.to_string();
 
         // Capture 1: the pre-header-forwarding constructor (no headers field).
         let bare = super::DecisionRoute::Webhook {
@@ -1118,6 +1129,18 @@ mod tests {
 
         let captured_bare = rx.recv().await.expect("first capture");
         let captured_empty = rx.recv().await.expect("second capture");
+
+        // Each capture must contain the body's decision_id before we compare
+        // the two — otherwise a dropped body could produce two identical
+        // header-only captures and pass silently.
+        assert!(
+            captured_bare.contains(&decision_id),
+            "first capture must contain the request body's decision_id ({decision_id}), got: {captured_bare}"
+        );
+        assert!(
+            captured_empty.contains(&decision_id),
+            "second capture must contain the request body's decision_id ({decision_id}), got: {captured_empty}"
+        );
 
         assert_eq!(
             captured_bare, captured_empty,

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -5,10 +5,12 @@
 //! [`DecisionRoute::decide`] holds the shared semantics (deadline, fail-closed
 //! mapping, event emission) in one place instead of per-impl.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use aura_config::{DecisionRouteConfig, GlobPattern, HitlConfig, WebhookUrl};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
 use super::decision::{ApprovalDecision, ApprovalOutcome};
 use super::events;
@@ -38,11 +40,28 @@ impl HitlRuntime {
     /// Resolve the request-stable runtime from parsed `[hitl]` config: share the
     /// compiled globs and build the decision route once (the webhook client and
     /// its connection pool are created here).
+    ///
+    /// `req_headers` is the inbound client request's HTTP headers, used to
+    /// resolve `[hitl.route]` `headers_from_request` mappings. Pass `None`
+    /// outside an HTTP request context (e.g. CLI standalone mode).
     #[must_use]
-    pub fn from_config(config: &HitlConfig, pending_approvals: &PendingApprovals) -> Self {
+    pub fn from_config(
+        config: &HitlConfig,
+        pending_approvals: &PendingApprovals,
+        req_headers: Option<&HashMap<String, String>>,
+    ) -> Self {
         let route = match &config.route {
-            DecisionRouteConfig::Webhook { url, timeout_secs } => DecisionRoute::Webhook {
-                client: WebhookClient::new(build_webhook_client(), url.clone()),
+            DecisionRouteConfig::Webhook {
+                url,
+                timeout_secs,
+                headers,
+                headers_from_request,
+            } => DecisionRoute::Webhook {
+                client: WebhookClient::new_with_headers(
+                    build_webhook_client(),
+                    url.clone(),
+                    resolve_webhook_headers(headers, headers_from_request, req_headers),
+                ),
                 timeout: Duration::from_secs(*timeout_secs),
             },
             DecisionRouteConfig::Conversational { timeout_secs } => DecisionRoute::Conversational {
@@ -177,17 +196,90 @@ pub(crate) fn build_webhook_client() -> reqwest::Client {
         .expect("reqwest client builder only fails on TLS backend init")
 }
 
+/// Resolve operator-configured webhook headers into a validated [`HeaderMap`]:
+/// static `headers` overlaid with `headers_from_request` values from the
+/// inbound client request. Invalid header names or values are skipped with
+/// a warning (matching `mcp_streamable_http.rs`).
+///
+/// Opt-in only: nothing is forwarded unless the operator configures it.
+/// Resolved per request at agent-build time (orchestration resolves once
+/// before workers spawn).
+///
+/// NOTE (271 board, ADR decision 13): the 271 park/reify board adds header
+/// classification (`identity` vs `credential`) at park time. Unclassified
+/// headers default to credential (fail-closed) there — they refuse to park.
+/// That classification's only enforcement point is park time, which does not
+/// exist on main. This wave ships the plain `headers` / `headers_from_request`
+/// surface without classification; adding a classification key later is purely
+/// additive TOML, never a retrofit break. Forwarded headers are never
+/// persisted anywhere in this wave.
+fn resolve_webhook_headers(
+    static_headers: &HashMap<String, String>,
+    headers_from_request: &HashMap<String, String>,
+    req_headers: Option<&HashMap<String, String>>,
+) -> HeaderMap {
+    let empty = HashMap::new();
+    let req_headers = req_headers.unwrap_or(&empty);
+
+    let mut resolved = static_headers.clone();
+    crate::rig_builder::apply_request_header_mappings(
+        &mut resolved,
+        headers_from_request,
+        req_headers,
+    );
+
+    let mut header_map = HeaderMap::new();
+    for (key, value) in &resolved {
+        match (
+            HeaderName::from_bytes(key.as_bytes()),
+            HeaderValue::from_str(value),
+        ) {
+            (Ok(name), Ok(val)) => {
+                header_map.insert(name, val);
+            }
+            _ => {
+                tracing::warn!(
+                    "Skipping invalid webhook header '{}' (failed to convert)",
+                    key
+                );
+            }
+        }
+    }
+    header_map
+}
+
 /// HTTP client for the webhook route. Carried over from the spike's
 /// `HttpApprovalDispatch`.
 pub struct WebhookClient {
     client: reqwest::Client,
     url: WebhookUrl,
+    /// Operator-configured headers resolved at agent-build time: static
+    /// `headers` overlaid with `headers_from_request` values from the
+    /// inbound client request. Invalid header names/values were skipped
+    /// with a warning at resolution time. Empty when no headers are
+    /// configured, producing the same bare POST as before.
+    headers: HeaderMap,
 }
 
 impl WebhookClient {
     #[must_use]
     pub fn new(client: reqwest::Client, url: WebhookUrl) -> Self {
-        Self { client, url }
+        Self {
+            client,
+            url,
+            headers: HeaderMap::new(),
+        }
+    }
+
+    /// Create a webhook client with resolved operator-configured headers
+    /// applied to every approval POST.
+    #[must_use]
+    pub fn new_with_headers(client: reqwest::Client, url: WebhookUrl, headers: HeaderMap) -> Self {
+        Self {
+            client,
+            url,
+            headers,
+        }
     }
 
     /// POST the request and resolve a decision, failing closed on timeout or
@@ -201,14 +293,20 @@ impl WebhookClient {
         // `origin` as the flat `aura_events` DTOs instead of leaking Rust enum
         // variant names onto the webhook contract.
         let wire = ApprovalRequestWire::from(request);
-        match self
+        let mut builder = self
             .client
             .post(self.url.as_str())
             .json(&wire)
-            .timeout(timeout)
-            .send()
-            .await
-        {
+            .timeout(timeout);
+
+        // Apply resolved operator-configured headers on top of the JSON body
+        // (which already set Content-Type). An empty map adds nothing, so the
+        // POST is byte-for-byte identical to the pre-header-forwarding path.
+        for (name, value) in self.headers.iter() {
+            builder = builder.header(name.clone(), value.clone());
+        }
+
+        match builder.send().await {
             Err(e) if e.is_timeout() => Ok(ApprovalOutcome::TimedOut { waited: timeout }),
             Err(e) => Err(ApprovalError::Transport(e.to_string())),
             Ok(resp) => {
@@ -628,5 +726,264 @@ mod tests {
         }
 
         crate::approval_event_broker::unsubscribe(&request_id).await;
+    }
+
+    // -----------------------------------------------------------------
+    // resolve_webhook_headers unit tests
+    // -----------------------------------------------------------------
+
+    fn make_req_headers(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn webhook_headers_static_only() {
+        let static_headers = make_req_headers(&[("x-tenant", "sre-prod")]);
+        let headers_from_request = std::collections::HashMap::new();
+        let header_map =
+            super::resolve_webhook_headers(&static_headers, &headers_from_request, None);
+        assert_eq!(header_map.get("x-tenant").unwrap(), "sre-prod");
+        assert_eq!(header_map.len(), 1);
+    }
+
+    #[test]
+    fn webhook_headers_mapped_only() {
+        let static_headers = std::collections::HashMap::new();
+        let headers_from_request = make_req_headers(&[("x-tenant", "x-incoming-tenant")]);
+        let req_headers = make_req_headers(&[("x-incoming-tenant", "forwarded-value")]);
+
+        let header_map = super::resolve_webhook_headers(
+            &static_headers,
+            &headers_from_request,
+            Some(&req_headers),
+        );
+        assert_eq!(header_map.get("x-tenant").unwrap(), "forwarded-value");
+        assert_eq!(header_map.len(), 1);
+    }
+
+    #[test]
+    fn webhook_headers_fallback_precedence() {
+        // When the mapped request header IS present, it overrides the static value.
+        let static_headers = make_req_headers(&[("authorization", "static-token")]);
+        let headers_from_request = make_req_headers(&[("authorization", "x-incoming-auth")]);
+        let req_headers = make_req_headers(&[("x-incoming-auth", "dynamic-token")]);
+
+        let header_map = super::resolve_webhook_headers(
+            &static_headers,
+            &headers_from_request,
+            Some(&req_headers),
+        );
+        assert_eq!(
+            header_map.get("authorization").unwrap(),
+            "dynamic-token",
+            "request header should override static"
+        );
+
+        // When the mapped request header is ABSENT, the static value is the fallback.
+        let req_headers_empty = std::collections::HashMap::new();
+        let header_map_fallback = super::resolve_webhook_headers(
+            &static_headers,
+            &headers_from_request,
+            Some(&req_headers_empty),
+        );
+        assert_eq!(
+            header_map_fallback.get("authorization").unwrap(),
+            "static-token",
+            "static header should be used when request header is absent"
+        );
+    }
+
+    #[test]
+    fn webhook_headers_case_insensitive_lookup() {
+        // TOML config uses "Authorization" (capitalized) but the inbound
+        // request header arrives lowercased. The lookup must be case-insensitive.
+        let static_headers = std::collections::HashMap::new();
+        let headers_from_request = make_req_headers(&[("Authorization", "Authorization")]);
+        let req_headers = make_req_headers(&[("authorization", "Token my-token")]);
+
+        let header_map = super::resolve_webhook_headers(
+            &static_headers,
+            &headers_from_request,
+            Some(&req_headers),
+        );
+        assert_eq!(
+            header_map.get("authorization").unwrap(),
+            "Token my-token",
+            "case-insensitive lookup should resolve lowercased request header"
+        );
+    }
+
+    #[test]
+    fn webhook_headers_invalid_skipped() {
+        // Header name with a space is invalid per RFC 7230; the entry must
+        // be skipped with a warning, not panic.
+        let static_headers = make_req_headers(&[("invalid header!", "value"), ("x-valid", "ok")]);
+        let headers_from_request = std::collections::HashMap::new();
+
+        let header_map =
+            super::resolve_webhook_headers(&static_headers, &headers_from_request, None);
+        assert_eq!(header_map.get("x-valid").unwrap(), "ok");
+        assert_eq!(
+            header_map.len(),
+            1,
+            "invalid header must be skipped, valid one must remain"
+        );
+    }
+
+    #[test]
+    fn webhook_headers_empty_config_produces_bare_post() {
+        // Empty config (no static, no from_request, no req_headers) must
+        // produce an empty HeaderMap. With an empty HeaderMap, the
+        // request_approval loop does not execute, so the POST is
+        // byte-for-byte identical to the pre-header-forwarding path.
+        let static_headers = std::collections::HashMap::new();
+        let headers_from_request = std::collections::HashMap::new();
+
+        let header_map =
+            super::resolve_webhook_headers(&static_headers, &headers_from_request, None);
+        assert!(
+            header_map.is_empty(),
+            "empty config must produce no headers (bare POST)"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Integration tests: mock webhook asserts headers arrive on the POST
+    // -----------------------------------------------------------------
+
+    /// Spawn a mock webhook on a random port that captures the raw HTTP
+    /// request text and responds with `{"approved": true}`. Returns the
+    /// port and a oneshot receiver for the captured request.
+    async fn spawn_mock_webhook() -> (u16, tokio::sync::oneshot::Receiver<String>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::sync::oneshot;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = oneshot::channel::<String>();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 4096];
+            // Read until we have the complete header section (\r\n\r\n).
+            loop {
+                let n = socket.read(&mut chunk).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                buf.extend_from_slice(&chunk[..n]);
+                if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            // Parse Content-Length so we can consume the request body before
+            // responding — otherwise reqwest may get a connection reset while
+            // still sending the POST body.
+            let header_end = buf.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
+            let header_section = String::from_utf8_lossy(&buf[..header_end]).to_string();
+            let content_length: usize = header_section
+                .lines()
+                .find(|line| line.to_lowercase().starts_with("content-length:"))
+                .and_then(|line| line.split(':').nth(1))
+                .and_then(|val| val.trim().parse().ok())
+                .unwrap_or(0);
+            let body_already_read = buf.len() - header_end;
+            let remaining = content_length.saturating_sub(body_already_read);
+            if remaining > 0 {
+                let mut body_buf = vec![0u8; remaining];
+                socket.read_exact(&mut body_buf).await.unwrap();
+            }
+
+            // Respond with a valid approval. Content-Length is computed from
+            // the actual body so there is no mismatch.
+            let body = "{\"approved\": true}";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+            let _ = tx.send(header_section);
+        });
+
+        (port, rx)
+    }
+
+    fn make_approval_request() -> ApprovalRequest {
+        ApprovalRequest {
+            version: PROTOCOL_VERSION,
+            decision_id: DecisionId::generate(),
+            request_id: "hdr-test".into(),
+            scope: AgentScope::Single { session_id: None },
+            origin: ApprovalOrigin::ConfigGate {
+                matched_pattern: "dangerous_*".into(),
+            },
+            items: vec![ApprovalItem {
+                tool_name: "dangerous_apply".into(),
+                arguments: serde_json::json!({}),
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn webhook_forwards_configured_headers_to_mock_server() {
+        let (port, rx) = spawn_mock_webhook().await;
+
+        // Build a webhook client with a static header.
+        let mut header_map = reqwest::header::HeaderMap::new();
+        header_map.insert(
+            "x-tenant",
+            reqwest::header::HeaderValue::from_static("sre-prod"),
+        );
+        let client = super::WebhookClient::new_with_headers(
+            super::build_webhook_client(),
+            aura_config::WebhookUrl::new(format!("http://127.0.0.1:{port}")).unwrap(),
+            header_map,
+        );
+
+        let route = super::DecisionRoute::Webhook {
+            client,
+            timeout: std::time::Duration::from_secs(5),
+        };
+        let cancel = crate::request_cancellation::RequestCancelToken::unbound();
+        let result = route.decide(make_approval_request(), &cancel).await;
+        assert!(result.is_ok(), "mock webhook should return a decision");
+
+        let captured = rx.await.unwrap();
+        assert!(
+            captured.contains("x-tenant: sre-prod"),
+            "configured header must appear in the webhook POST, got: {captured}"
+        );
+    }
+
+    #[tokio::test]
+    async fn webhook_empty_config_sends_no_custom_headers() {
+        let (port, rx) = spawn_mock_webhook().await;
+
+        // Empty HeaderMap — same as the pre-header-forwarding path.
+        let client = super::WebhookClient::new_with_headers(
+            super::build_webhook_client(),
+            aura_config::WebhookUrl::new(format!("http://127.0.0.1:{port}")).unwrap(),
+            reqwest::header::HeaderMap::new(),
+        );
+
+        let route = super::DecisionRoute::Webhook {
+            client,
+            timeout: std::time::Duration::from_secs(5),
+        };
+        let cancel = crate::request_cancellation::RequestCancelToken::unbound();
+        let result = route.decide(make_approval_request(), &cancel).await;
+        assert!(result.is_ok(), "mock webhook should return a decision");
+
+        let captured = rx.await.unwrap();
+        assert!(
+            !captured.contains("x-tenant"),
+            "no custom headers should appear with empty config, got: {captured}"
+        );
     }
 }

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -833,6 +833,76 @@ mod tests {
         );
     }
 
+    /// Minimal tracing-capture facility: a shared buffer that implements
+    /// `io::Write` by reference, so `Arc<CapturedLog>` satisfies
+    /// `tracing_subscriber`'s `MakeWriter` (`impl MakeWriter for Arc<W>` when
+    /// `&W: Write`). The workspace has no existing fmt-log-text capture helper,
+    /// so this is the minimal in-test subscriber.
+    struct CapturedLog(std::sync::Mutex<Vec<u8>>);
+
+    impl std::io::Write for &CapturedLog {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn webhook_headers_invalid_value_skipped_with_warning_and_no_leak() {
+        // FINDING 2: a header VALUE with forbidden control characters must be
+        // skipped, a warning must be emitted, and the value must NOT appear in
+        // the captured log (the header name may). The prior invalid-header
+        // test exercised only an invalid NAME and never checked the warning or
+        // the no-value-leak contract.
+        use std::sync::Arc;
+
+        let buf = Arc::new(CapturedLog(std::sync::Mutex::new(Vec::new())));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(buf.clone())
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .finish();
+
+        // A valid header name paired with a value containing CR/LF (forbidden
+        // in field values per RFC 7230) alongside a valid entry that must
+        // survive. HashMap iteration order is nondeterministic, but the invalid
+        // entry warns exactly once regardless of order.
+        let static_headers = make_req_headers(&[("x-bad", "bad\r\nvalue"), ("x-valid", "ok")]);
+        let headers_from_request = std::collections::HashMap::new();
+
+        let header_map = tracing::subscriber::with_default(subscriber, || {
+            super::resolve_webhook_headers(&static_headers, &headers_from_request, None)
+        });
+        let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
+
+        // (a) the invalid entry is skipped; the valid one remains.
+        assert_eq!(header_map.get("x-valid").unwrap(), "ok");
+        assert!(
+            header_map.get("x-bad").is_none(),
+            "invalid-value header must be skipped"
+        );
+        assert_eq!(header_map.len(), 1);
+
+        // (b) the warning is emitted and names the offending header.
+        assert!(
+            log.contains("Skipping invalid webhook header"),
+            "warning must be emitted, got log: {log}"
+        );
+        assert!(
+            log.contains("x-bad"),
+            "warning must name the skipped header, got log: {log}"
+        );
+
+        // (c) the forbidden value must not leak into the log.
+        assert!(
+            !log.contains("bad\r\nvalue"),
+            "invalid header value must not appear in the log, got: {log:?}"
+        );
+    }
+
     #[test]
     fn webhook_headers_empty_config_produces_bare_post() {
         // Empty config (no static, no from_request, no req_headers) must
@@ -854,64 +924,82 @@ mod tests {
     // Integration tests: mock webhook asserts headers arrive on the POST
     // -----------------------------------------------------------------
 
-    /// Spawn a mock webhook on a random port that captures the raw HTTP
-    /// request text and responds with `{"approved": true}`. Returns the
-    /// port and a oneshot receiver for the captured request.
-    async fn spawn_mock_webhook() -> (u16, tokio::sync::oneshot::Receiver<String>) {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-        use tokio::sync::oneshot;
+    /// Spawn a mock webhook on a random port that captures the COMPLETE raw
+    /// HTTP request (request line, headers, and body) for each of `count`
+    /// sequential connections, responding to each with `{"approved": true}`.
+    /// Returns the port and an mpsc receiver yielding one captured request
+    /// text per connection, in connection order.
+    ///
+    /// Capturing the full request (not just the header section) lets callers
+    /// assert byte-for-byte request equivalence between two client
+    /// constructors run sequentially against the SAME server — sequential
+    /// captures avoid Host/port drift between two separately-bound servers.
+    async fn spawn_capturing_webhook(count: usize) -> (u16, tokio::sync::mpsc::Receiver<String>) {
+        use tokio::io::AsyncWriteExt;
+        use tokio::sync::mpsc;
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
-        let (tx, rx) = oneshot::channel::<String>();
+        let (tx, rx) = mpsc::channel::<String>(count);
 
         tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let mut buf = Vec::new();
-            let mut chunk = [0u8; 4096];
-            // Read until we have the complete header section (\r\n\r\n).
-            loop {
-                let n = socket.read(&mut chunk).await.unwrap();
-                if n == 0 {
-                    break;
-                }
-                buf.extend_from_slice(&chunk[..n]);
-                if buf.windows(4).any(|w| w == b"\r\n\r\n") {
-                    break;
-                }
+            for _ in 0..count {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let captured = read_full_request(&mut socket).await;
+                let body = "{\"approved\": true}";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = tx.send(captured).await;
             }
-
-            // Parse Content-Length so we can consume the request body before
-            // responding — otherwise reqwest may get a connection reset while
-            // still sending the POST body.
-            let header_end = buf.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
-            let header_section = String::from_utf8_lossy(&buf[..header_end]).to_string();
-            let content_length: usize = header_section
-                .lines()
-                .find(|line| line.to_lowercase().starts_with("content-length:"))
-                .and_then(|line| line.split(':').nth(1))
-                .and_then(|val| val.trim().parse().ok())
-                .unwrap_or(0);
-            let body_already_read = buf.len() - header_end;
-            let remaining = content_length.saturating_sub(body_already_read);
-            if remaining > 0 {
-                let mut body_buf = vec![0u8; remaining];
-                socket.read_exact(&mut body_buf).await.unwrap();
-            }
-
-            // Respond with a valid approval. Content-Length is computed from
-            // the actual body so there is no mismatch.
-            let body = "{\"approved\": true}";
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            socket.write_all(response.as_bytes()).await.unwrap();
-            let _ = tx.send(header_section);
         });
 
         (port, rx)
+    }
+
+    /// Read one complete HTTP request (request line + headers + the
+    /// Content-Length-declared body) from `socket` and return it as a
+    /// lossy-UTF-8 string. Reading the body before responding prevents reqwest
+    /// from seeing a connection reset while it is still sending the POST body.
+    async fn read_full_request(socket: &mut tokio::net::TcpStream) -> String {
+        use tokio::io::AsyncReadExt;
+
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        // Read until we have the complete header section (\r\n\r\n).
+        loop {
+            let n = socket.read(&mut chunk).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        // Parse Content-Length so we can consume the request body before
+        // responding — otherwise reqwest may get a connection reset while
+        // still sending the POST body.
+        let header_end = buf.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
+        let header_section = String::from_utf8_lossy(&buf[..header_end]).to_string();
+        let content_length: usize = header_section
+            .lines()
+            .find(|line| line.to_lowercase().starts_with("content-length:"))
+            .and_then(|line| line.split(':').nth(1))
+            .and_then(|val| val.trim().parse().ok())
+            .unwrap_or(0);
+        let body_already_read = buf.len() - header_end;
+        let remaining = content_length.saturating_sub(body_already_read);
+        if remaining > 0 {
+            let mut body_buf = vec![0u8; remaining];
+            socket.read_exact(&mut body_buf).await.unwrap();
+        }
+
+        String::from_utf8_lossy(&buf).to_string()
     }
 
     fn make_approval_request() -> ApprovalRequest {
@@ -932,7 +1020,7 @@ mod tests {
 
     #[tokio::test]
     async fn webhook_forwards_configured_headers_to_mock_server() {
-        let (port, rx) = spawn_mock_webhook().await;
+        let (port, mut rx) = spawn_capturing_webhook(1).await;
 
         // Build a webhook client with a static header.
         let mut header_map = reqwest::header::HeaderMap::new();
@@ -954,7 +1042,7 @@ mod tests {
         let result = route.decide(make_approval_request(), &cancel).await;
         assert!(result.is_ok(), "mock webhook should return a decision");
 
-        let captured = rx.await.unwrap();
+        let captured = rx.recv().await.expect("mock webhook capture");
         assert!(
             captured.contains("x-tenant: sre-prod"),
             "configured header must appear in the webhook POST, got: {captured}"
@@ -963,7 +1051,7 @@ mod tests {
 
     #[tokio::test]
     async fn webhook_empty_config_sends_no_custom_headers() {
-        let (port, rx) = spawn_mock_webhook().await;
+        let (port, mut rx) = spawn_capturing_webhook(1).await;
 
         // Empty HeaderMap — same as the pre-header-forwarding path.
         let client = super::WebhookClient::new_with_headers(
@@ -980,10 +1068,61 @@ mod tests {
         let result = route.decide(make_approval_request(), &cancel).await;
         assert!(result.is_ok(), "mock webhook should return a decision");
 
-        let captured = rx.await.unwrap();
+        let captured = rx.recv().await.expect("mock webhook capture");
         assert!(
             !captured.contains("x-tenant"),
             "no custom headers should appear with empty config, got: {captured}"
+        );
+    }
+
+    #[tokio::test]
+    async fn webhook_empty_headers_match_bare_client_byte_for_byte() {
+        // FINDING 1: empty configuration must produce a request byte-for-byte
+        // identical to the pre-header-forwarding path (`WebhookClient::new`).
+        // The prior unit test only checked an empty `HeaderMap`; the prior
+        // integration test only checked that `x-tenant` was absent — neither
+        // excluded other request differences. Here we capture the COMPLETE raw
+        // request (headers AND body) from both constructors run sequentially
+        // against the SAME mock server (so Host and port are identical) and
+        // assert the captured request texts are equal.
+        //
+        // A single request is cloned for both calls so every wire field
+        // (notably decision_id) is identical — the body must not differ
+        // between the two captures.
+        let (port, mut rx) = spawn_capturing_webhook(2).await;
+        let url = aura_config::WebhookUrl::new(format!("http://127.0.0.1:{port}")).unwrap();
+        let cancel = crate::request_cancellation::RequestCancelToken::unbound();
+        let request = make_approval_request();
+
+        // Capture 1: the pre-header-forwarding constructor (no headers field).
+        let bare = super::DecisionRoute::Webhook {
+            client: super::WebhookClient::new(super::build_webhook_client(), url.clone()),
+            timeout: std::time::Duration::from_secs(5),
+        };
+        let result = bare.decide(request.clone(), &cancel).await;
+        assert!(result.is_ok(), "bare client should get a decision");
+
+        // Capture 2: the headers constructor with an empty `HeaderMap` — the
+        // documented "empty config" path. Same server, sequential, so the
+        // Host header and port do not drift between captures.
+        let with_empty = super::DecisionRoute::Webhook {
+            client: super::WebhookClient::new_with_headers(
+                super::build_webhook_client(),
+                url,
+                reqwest::header::HeaderMap::new(),
+            ),
+            timeout: std::time::Duration::from_secs(5),
+        };
+        let result = with_empty.decide(request, &cancel).await;
+        assert!(result.is_ok(), "empty-headers client should get a decision");
+
+        let captured_bare = rx.recv().await.expect("first capture");
+        let captured_empty = rx.recv().await.expect("second capture");
+
+        assert_eq!(
+            captured_bare, captured_empty,
+            "WebhookClient::new and new_with_headers(HeaderMap::new()) must produce \
+             byte-for-byte identical requests\n--- bare ---\n{captured_bare}\n--- empty ---\n{captured_empty}"
         );
     }
 }

--- a/crates/aura/src/rig_builder.rs
+++ b/crates/aura/src/rig_builder.rs
@@ -408,8 +408,8 @@ mod tests {
 
     #[test]
     fn apply_request_header_mappings_counts_overrides_and_misses() {
-        // FINDING 3: the resolved count is the number of mappings that found a
-        // request value, NOT the change in map length. An override (mapped key
+        // The resolved count is the number of mappings that found a request
+        // value, NOT the change in map length. An override (mapped key
         // already present as a static fallback) leaves length unchanged but
         // still counts as a resolution; a mapping whose request header is
         // absent resolves zero.
@@ -427,7 +427,7 @@ mod tests {
         assert_eq!(
             headers.len(),
             len_before,
-            "override must not change map length (the undercount bug's root cause)"
+            "override must not change map length"
         );
         assert_eq!(headers.get("authorization").unwrap(), "dynamic");
 

--- a/crates/aura/src/rig_builder.rs
+++ b/crates/aura/src/rig_builder.rs
@@ -32,8 +32,11 @@ impl RigBuilder {
 
     /// Get the runtime [`AgentRuntimeConfig`] (mainly for tests/debugging).
     /// Skips skill discovery; build methods use [`Self::discovered_agent_config`].
+    /// Passes `None` for request headers — production paths that need
+    /// `headers_from_request` resolution use [`Self::build_agent`] or
+    /// [`Self::build_streaming_agent_with_headers`].
     pub fn get_agent_config(&self) -> AgentRuntimeConfig {
-        self.to_agent_config()
+        self.to_agent_config(None)
     }
 
     /// Project the parsed `Config` into the runtime `AgentRuntimeConfig`.
@@ -44,7 +47,11 @@ impl RigBuilder {
     /// populated by callers (e.g. the orchestrator) as needed. Skills start
     /// empty here because discovery does filesystem IO and can fail; the
     /// fallible build paths run it via [`Self::discovered_agent_config`].
-    fn to_agent_config(&self) -> AgentRuntimeConfig {
+    ///
+    /// `req_headers` threads the inbound client request's HTTP headers through
+    /// to [`HitlRuntime::from_config`] for `[hitl.route]` `headers_from_request`
+    /// resolution. Pass `None` outside an HTTP request context.
+    fn to_agent_config(&self, req_headers: Option<&HashMap<String, String>>) -> AgentRuntimeConfig {
         let agent = AgentSettings {
             name: self.config.agent.name.clone(),
             system_prompt: self.config.agent.system_prompt.clone(),
@@ -67,11 +74,9 @@ impl RigBuilder {
             tools: self.config.tools.clone(),
             memory_dir: self.config.memory_dir.clone(),
             orchestration: self.config.orchestration.clone(),
-            hitl: self
-                .config
-                .hitl
-                .as_ref()
-                .map(|cfg| crate::hitl::HitlRuntime::from_config(cfg, &self.pending_approvals)),
+            hitl: self.config.hitl.as_ref().map(|cfg| {
+                crate::hitl::HitlRuntime::from_config(cfg, &self.pending_approvals, req_headers)
+            }),
             ..Default::default()
         }
     }
@@ -80,8 +85,11 @@ impl RigBuilder {
     ///
     /// Effective skill sources are the explicit `[agent.skills]` config.
     /// Relative sources resolve from the process current working directory.
-    fn discovered_agent_config(&self) -> Result<AgentRuntimeConfig, BuilderError> {
-        let mut agent_config = self.to_agent_config();
+    fn discovered_agent_config(
+        &self,
+        req_headers: Option<&HashMap<String, String>>,
+    ) -> Result<AgentRuntimeConfig, BuilderError> {
+        let mut agent_config = self.to_agent_config(req_headers);
 
         let skill_sources = self.config.agent.skills.local.clone();
         agent_config.agent.skills = aura_config::skills::discover_skills(&skill_sources)?;
@@ -120,7 +128,7 @@ impl RigBuilder {
         request_id: Option<String>,
         session_id: Option<String>,
     ) -> Result<Agent, BuilderError> {
-        let mut agent_config = self.discovered_agent_config()?;
+        let mut agent_config = self.discovered_agent_config(req_headers)?;
         resolve_mcp_headers(&mut agent_config, req_headers);
         agent_config.request_id = request_id;
         agent_config.session_id = session_id;
@@ -146,7 +154,7 @@ impl RigBuilder {
         client_tools: Option<Vec<ClientTool>>,
         request_id: Option<String>,
     ) -> Result<Arc<dyn StreamingAgent>, BuilderError> {
-        let mut agent_config = self.discovered_agent_config()?;
+        let mut agent_config = self.discovered_agent_config(req_headers)?;
         resolve_mcp_headers(&mut agent_config, req_headers);
         agent_config.session_id = session_id;
         agent_config.request_id = request_id;
@@ -154,6 +162,39 @@ impl RigBuilder {
         build_streaming_agent(&agent_config, client_tools)
             .await
             .map_err(|e| BuilderError::AgentError(format!("Failed to build streaming agent: {e}")))
+    }
+}
+
+/// Resolve `headers_from_request` mappings against the incoming request
+/// headers, overlaying resolved values on top of `headers`. Static values
+/// already present in `headers` serve as fallback when the mapped request
+/// header is absent.
+///
+/// HTTP header names are case-insensitive (RFC 7230): the inbound lookup
+/// lowercases both sides, so TOML config values using any casing match
+/// actix-web's lowercased header names.
+///
+/// NOTE (271 board, ADR decision 13): the 271 park/reify board adds header
+/// classification (`identity` vs `credential`) at park time. Unclassified
+/// headers default to credential (fail-closed) there — they refuse to park.
+/// That classification's only enforcement point is park time, which does not
+/// exist on main. This wave ships the plain `headers` / `headers_from_request`
+/// surface without classification; adding a classification key later is purely
+/// additive TOML. Forwarded headers are never persisted anywhere in this wave.
+pub(crate) fn apply_request_header_mappings(
+    headers: &mut HashMap<String, String>,
+    headers_from_request: &HashMap<String, String>,
+    req_headers: &HashMap<String, String>,
+) {
+    for (header_key, req_header_name) in headers_from_request.iter() {
+        let req_header_lower = req_header_name.to_lowercase();
+        if let Some(value) = req_headers
+            .iter()
+            .find(|(k, _)| k.to_lowercase() == req_header_lower)
+            .map(|(_, v)| v)
+        {
+            headers.insert(header_key.clone(), value.clone());
+        }
     }
 }
 
@@ -192,27 +233,16 @@ fn resolve_mcp_headers(
             }
         };
 
-        // Resolve headers_from_request mappings using the incoming request headers.
-        // Static TOML headers are already in server_headers; this only overrides
-        // when the mapped request header is found.
-        for (header_key, req_header_name) in headers_from_request.iter() {
-            // Note: HTTP header names are case-insensitive (RFC 7230), so we compare
-            // lowercased names. Actix-web lowercases header names, but TOML config
-            // values may use any casing.
-            let req_header_lower = req_header_name.to_lowercase();
-            let Some(value) = req_headers
-                .iter()
-                .find(|(k, _)| k.to_lowercase() == req_header_lower)
-                .map(|(_, v)| v)
-            else {
-                continue;
-            };
-            server_headers.insert(header_key.clone(), value.clone());
+        // Resolve headers_from_request mappings using the incoming request
+        // headers. Static TOML headers are already in server_headers; this
+        // only overrides when the mapped request header is found.
+        let before = server_headers.len();
+        apply_request_header_mappings(server_headers, headers_from_request, req_headers);
+        if server_headers.len() > before {
             tracing::info!(
-                "Server '{}': resolved header '{}' from request header '{}'",
+                "Server '{}': resolved {} header(s) from request",
                 server_name,
-                header_key,
-                req_header_name
+                server_headers.len() - before
             );
         }
     }
@@ -557,7 +587,7 @@ skills.local = []
 
         let config = aura_config::Config::parse_toml(&config_str).expect("config should parse");
         let agent_config = RigBuilder::new(config, PendingApprovals::new())
-            .discovered_agent_config()
+            .discovered_agent_config(None)
             .expect("discovery should succeed");
 
         match agent_config
@@ -613,7 +643,7 @@ source = '/nonexistent/path/to/worker/skills'
 "#;
         let config = aura_config::Config::parse_toml(config_str).expect("config should parse");
         let err = RigBuilder::new(config, PendingApprovals::new())
-            .discovered_agent_config()
+            .discovered_agent_config(None)
             .unwrap_err();
         assert!(err.to_string().contains("not found"));
     }

--- a/crates/aura/src/rig_builder.rs
+++ b/crates/aura/src/rig_builder.rs
@@ -224,6 +224,15 @@ fn resolve_mcp_headers(
             }
         };
 
+        // Lowercase static header keys so mapped overrides (inserted under
+        // lowercased keys by `apply_request_header_mappings`) replace the
+        // static fallback rather than coexisting as a case-distinct entry.
+        let normalized: HashMap<String, String> = server_headers
+            .iter()
+            .map(|(k, v)| (k.to_lowercase(), v.clone()))
+            .collect();
+        *server_headers = normalized;
+
         // Resolve headers_from_request mappings using the incoming request
         // headers. Static TOML headers are already in server_headers; this
         // only overrides when the mapped request header is found. Count
@@ -421,6 +430,41 @@ mod tests {
         let resolved_none =
             apply_request_header_mappings(&mut headers, &miss_mappings, &HashMap::new());
         assert_eq!(resolved_none, 0, "absent request header must not count");
+    }
+
+    #[test]
+    fn headers_from_request_overrides_static_header_mixed_casing() {
+        // Static headers use "Authorization" (capitalized) while the
+        // headers_from_request outbound key uses "authorization" (lowercase).
+        // Both refer to the same HTTP header; the dynamic value must override
+        // the static fallback deterministically, not nondeterministically
+        // based on HashMap iteration order.
+        let mut static_headers = HashMap::new();
+        static_headers.insert("Authorization".to_string(), "static-token".to_string());
+        let mut headers_from_request = HashMap::new();
+        headers_from_request.insert("authorization".to_string(), "x-incoming-auth".to_string());
+        let mut req_headers = HashMap::new();
+        req_headers.insert("x-incoming-auth".to_string(), "dynamic-token".to_string());
+
+        let mut config = make_agent_config(static_headers, headers_from_request);
+
+        resolve_mcp_headers(&mut config, Some(&req_headers));
+
+        let headers = get_server_headers(&config);
+        assert_eq!(
+            headers.get("authorization"),
+            Some(&"dynamic-token".to_string()),
+            "dynamic header must override static fallback regardless of key casing"
+        );
+        assert!(
+            headers.get("Authorization").is_none(),
+            "capitalized static key must not survive as a separate entry"
+        );
+        assert_eq!(
+            headers.len(),
+            1,
+            "exactly one entry after case-normalized override"
+        );
     }
 
     // ------------------------------------------------------------------

--- a/crates/aura/src/rig_builder.rs
+++ b/crates/aura/src/rig_builder.rs
@@ -169,22 +169,6 @@ impl RigBuilder {
 /// headers, overlaying resolved values on top of `headers`. Static values
 /// already present in `headers` serve as fallback when the mapped request
 /// header is absent.
-///
-/// Returns the number of mappings that resolved a value from the request,
-/// counting both new inserts and overrides of an existing static header —
-/// not the change in `headers` length, which an override leaves unchanged.
-///
-/// HTTP header names are case-insensitive (RFC 7230): the inbound lookup
-/// lowercases both sides, so TOML config values using any casing match
-/// actix-web's lowercased header names.
-///
-/// NOTE (271 board, ADR decision 13): the 271 park/reify board adds header
-/// classification (`identity` vs `credential`) at park time. Unclassified
-/// headers default to credential (fail-closed) there — they refuse to park.
-/// That classification's only enforcement point is park time, which does not
-/// exist on main. This wave ships the plain `headers` / `headers_from_request`
-/// surface without classification; adding a classification key later is purely
-/// additive TOML. Forwarded headers are never persisted anywhere in this wave.
 pub(crate) fn apply_request_header_mappings(
     headers: &mut HashMap<String, String>,
     headers_from_request: &HashMap<String, String>,
@@ -198,7 +182,7 @@ pub(crate) fn apply_request_header_mappings(
             .find(|(k, _)| k.to_lowercase() == req_header_lower)
             .map(|(_, v)| v)
         {
-            headers.insert(header_key.clone(), value.clone());
+            headers.insert(header_key.to_lowercase(), value.clone());
             resolved += 1;
         }
     }
@@ -400,7 +384,7 @@ mod tests {
 
         let headers = get_server_headers(&config);
         assert_eq!(
-            headers.get("Authorization"),
+            headers.get("authorization"),
             Some(&"Token my-token".to_string()),
             "case-insensitive lookup should resolve lowercased request header"
         );

--- a/crates/aura/src/rig_builder.rs
+++ b/crates/aura/src/rig_builder.rs
@@ -170,6 +170,10 @@ impl RigBuilder {
 /// already present in `headers` serve as fallback when the mapped request
 /// header is absent.
 ///
+/// Returns the number of mappings that resolved a value from the request,
+/// counting both new inserts and overrides of an existing static header —
+/// not the change in `headers` length, which an override leaves unchanged.
+///
 /// HTTP header names are case-insensitive (RFC 7230): the inbound lookup
 /// lowercases both sides, so TOML config values using any casing match
 /// actix-web's lowercased header names.
@@ -185,7 +189,8 @@ pub(crate) fn apply_request_header_mappings(
     headers: &mut HashMap<String, String>,
     headers_from_request: &HashMap<String, String>,
     req_headers: &HashMap<String, String>,
-) {
+) -> usize {
+    let mut resolved = 0;
     for (header_key, req_header_name) in headers_from_request.iter() {
         let req_header_lower = req_header_name.to_lowercase();
         if let Some(value) = req_headers
@@ -194,8 +199,10 @@ pub(crate) fn apply_request_header_mappings(
             .map(|(_, v)| v)
         {
             headers.insert(header_key.clone(), value.clone());
+            resolved += 1;
         }
     }
+    resolved
 }
 
 /// Resolve MCP server headers by applying `headers_from_request` mappings from the
@@ -235,14 +242,16 @@ fn resolve_mcp_headers(
 
         // Resolve headers_from_request mappings using the incoming request
         // headers. Static TOML headers are already in server_headers; this
-        // only overrides when the mapped request header is found.
-        let before = server_headers.len();
-        apply_request_header_mappings(server_headers, headers_from_request, req_headers);
-        if server_headers.len() > before {
+        // only overrides when the mapped request header is found. Count
+        // resolved mappings (inserts AND overrides), not the length delta —
+        // an override leaves the map size unchanged but is still a resolution.
+        let resolved =
+            apply_request_header_mappings(server_headers, headers_from_request, req_headers);
+        if resolved > 0 {
             tracing::info!(
                 "Server '{}': resolved {} header(s) from request",
                 server_name,
-                server_headers.len() - before
+                resolved
             );
         }
     }
@@ -395,6 +404,39 @@ mod tests {
             Some(&"Token my-token".to_string()),
             "case-insensitive lookup should resolve lowercased request header"
         );
+    }
+
+    #[test]
+    fn apply_request_header_mappings_counts_overrides_and_misses() {
+        // FINDING 3: the resolved count is the number of mappings that found a
+        // request value, NOT the change in map length. An override (mapped key
+        // already present as a static fallback) leaves length unchanged but
+        // still counts as a resolution; a mapping whose request header is
+        // absent resolves zero.
+        let mut headers = HashMap::new();
+        headers.insert("authorization".to_string(), "static".to_string());
+        let mut headers_from_request = HashMap::new();
+        headers_from_request.insert("authorization".to_string(), "x-incoming-auth".to_string());
+        let mut req_headers = HashMap::new();
+        req_headers.insert("x-incoming-auth".to_string(), "dynamic".to_string());
+
+        let len_before = headers.len();
+        let resolved =
+            apply_request_header_mappings(&mut headers, &headers_from_request, &req_headers);
+        assert_eq!(resolved, 1, "override must count as a resolution");
+        assert_eq!(
+            headers.len(),
+            len_before,
+            "override must not change map length (the undercount bug's root cause)"
+        );
+        assert_eq!(headers.get("authorization").unwrap(), "dynamic");
+
+        // A mapping whose request header is absent resolves nothing.
+        let mut miss_mappings = HashMap::new();
+        miss_mappings.insert("x-tenant".to_string(), "x-incoming-tenant".to_string());
+        let resolved_none =
+            apply_request_header_mappings(&mut headers, &miss_mappings, &HashMap::new());
+        assert_eq!(resolved_none, 0, "absent request header must not count");
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
Allows configuration of captured "headers-to-forward" from request ingress to configured mapping in the HITL webhook