### PR TITLE
fix(bedrock): support managed knowledge bases in bedrock_kb store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-bedrockagentruntime",
  "aws-sdk-bedrockruntime",
+ "aws-smithy-types",
  "base64",
  "bytes",
  "chrono",
@@ -418,8 +419,8 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -438,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -472,15 +473,15 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.3"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-eventstream 0.61.1",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -498,19 +499,21 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockagentruntime"
-version = "1.126.0"
+version = "1.134.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20f8d4690582476a0a294e7fda165512fe917cbe1e2a67642329574a0ae9c5c"
+checksum = "c14c6767f383bf9b9a40fcab12a4bbb873dd3f8d6b6e3b2f8cc27e7c74d4db76"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-eventstream 0.61.1",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -531,10 +534,10 @@ dependencies = [
  "aws-runtime",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-eventstream 0.60.20",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.6",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -557,9 +560,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.6",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -581,9 +584,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.6",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -605,9 +608,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.6",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -623,13 +626,13 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-eventstream 0.61.1",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -646,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -667,12 +670,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-eventstream"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
- "aws-smithy-eventstream",
+ "aws-smithy-eventstream 0.60.20",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-eventstream 0.61.1",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -690,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -725,7 +761,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
 dependencies = [
  "aws-smithy-runtime-api",
- "aws-smithy-schema",
+ "aws-smithy-schema 0.1.0",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
 ]
 
@@ -734,6 +781,15 @@ name = "aws-smithy-observability"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -750,16 +806,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-http-client",
- "aws-smithy-observability",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-runtime-api",
- "aws-smithy-schema",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -776,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -794,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -815,10 +871,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.8"
+name = "aws-smithy-schema"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -851,13 +918,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
  "rustc_version",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ strum = { version = "0.26", features = ["derive"] }
 # AWS Bedrock dependencies
 aws-config = "1.8.0"
 aws-sdk-bedrockruntime = "1.95.0"
-aws-sdk-bedrockagentruntime = "1.125.0"
+aws-sdk-bedrockagentruntime = "1.134.0"
 aws-smithy-types = "1.3.2"
 base64 = "0.22.1"
 async-stream = "0.3.6"

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -649,6 +649,9 @@ pub enum VectorStoreType {
         region: String,
         #[serde(default)]
         profile: Option<String>,
+        /// Bedrock managed knowledge base (vs. classic vector-store-backed)
+        #[serde(default)]
+        managed: bool,
     },
 }
 

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -1256,10 +1256,42 @@ system_prompt = "Test"
                 knowledge_base_id,
                 region,
                 profile,
+                managed,
             } => {
                 assert_eq!(knowledge_base_id, "KB12345");
                 assert_eq!(region, "us-west-2");
                 assert_eq!(profile, &Some("my-profile".to_string()));
+                assert!(!managed);
+            }
+            _ => panic!("Expected BedrockKb vector store"),
+        }
+    }
+
+    #[test]
+    fn test_bedrock_kb_managed_flag_parsing() {
+        let config_str = r#"
+[agent.llm]
+provider = "bedrock"
+model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+region = "us-east-1"
+
+[[vector_stores]]
+name = "managed_docs"
+type = "bedrock_kb"
+knowledge_base_id = "KB67890"
+region = "us-east-1"
+managed = true
+
+[agent]
+name = "Test"
+system_prompt = "Test"
+"#;
+        let config =
+            load_config_from_str(config_str).expect("Failed to parse managed bedrock_kb config");
+
+        match &config.vector_stores[0].store {
+            crate::config::VectorStoreType::BedrockKb { managed, .. } => {
+                assert!(managed);
             }
             _ => panic!("Expected BedrockKb vector store"),
         }

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -16,6 +16,7 @@ rig-bedrock = { workspace = true }
 aws-config = { workspace = true }
 aws-sdk-bedrockruntime = { workspace = true }
 aws-sdk-bedrockagentruntime = { workspace = true }
+aws-smithy-types = { workspace = true }
 
 rmcp = { workspace = true }
 base64 = "0.22"

--- a/crates/aura/src/vector_store.rs
+++ b/crates/aura/src/vector_store.rs
@@ -34,6 +34,7 @@ pub struct VectorStoreManager {
     qdrant_store: Option<Arc<QdrantStoreKind>>,
     bedrock_kb_client: Option<Arc<aws_sdk_bedrockagentruntime::Client>>,
     bedrock_kb_id: Option<String>,
+    bedrock_kb_managed: bool,
     embedding_provider: String,
     embedding_model_name: String,
     pub context_prefix: Option<String>,
@@ -59,10 +60,17 @@ impl VectorStoreManager {
                 knowledge_base_id,
                 region,
                 profile,
+                managed,
             } => {
                 info!("Initializing vector store: bedrock_kb");
-                Self::create_bedrock_kb_store(config, knowledge_base_id, region, profile.as_deref())
-                    .await
+                Self::create_bedrock_kb_store(
+                    config,
+                    knowledge_base_id,
+                    region,
+                    profile.as_deref(),
+                    *managed,
+                )
+                .await
             }
         }
     }
@@ -190,6 +198,7 @@ impl VectorStoreManager {
             in_memory_store: Some(Arc::new(store)),
             bedrock_kb_client: None,
             bedrock_kb_id: None,
+            bedrock_kb_managed: false,
             embedding_provider: embedding.provider().to_string(),
             embedding_model_name: embedding.model().to_string(),
             context_prefix: config.context_prefix.clone(),
@@ -268,6 +277,7 @@ impl VectorStoreManager {
             in_memory_store: None,
             bedrock_kb_client: None,
             bedrock_kb_id: None,
+            bedrock_kb_managed: false,
             embedding_provider: embedding.provider().to_string(),
             embedding_model_name: embedding.model().to_string(),
             context_prefix: config.context_prefix.clone(),
@@ -280,6 +290,7 @@ impl VectorStoreManager {
         knowledge_base_id: &str,
         region: &str,
         profile: Option<&str>,
+        managed: bool,
     ) -> Result<Self, BuilderError> {
         info!("Creating Bedrock Knowledge Base store");
         info!("  Knowledge Base ID: {}", knowledge_base_id);
@@ -299,6 +310,7 @@ impl VectorStoreManager {
             in_memory_store: None,
             bedrock_kb_client: Some(Arc::new(client)),
             bedrock_kb_id: Some(knowledge_base_id.to_string()),
+            bedrock_kb_managed: managed,
             embedding_provider: "bedrock_kb".to_string(),
             embedding_model_name: "managed".to_string(),
             context_prefix: config.context_prefix.clone(),
@@ -413,14 +425,23 @@ impl VectorStoreManager {
             .text(query)
             .build();
 
-        let retrieval_config =
-            aws_sdk_bedrockagentruntime::types::KnowledgeBaseRetrievalConfiguration::builder()
-                .vector_search_configuration(
-                    aws_sdk_bedrockagentruntime::types::KnowledgeBaseVectorSearchConfiguration::builder()
-                        .number_of_results(limit as i32)
-                        .build(),
-                )
-                .build();
+        // Managed and classic KBs each reject the other's search configuration.
+        let retrieval_config_builder =
+            aws_sdk_bedrockagentruntime::types::KnowledgeBaseRetrievalConfiguration::builder();
+        let retrieval_config = if self.bedrock_kb_managed {
+            retrieval_config_builder.managed_search_configuration(
+                aws_sdk_bedrockagentruntime::types::ManagedSearchConfiguration::builder()
+                    .number_of_results(limit as i32)
+                    .build(),
+            )
+        } else {
+            retrieval_config_builder.vector_search_configuration(
+                aws_sdk_bedrockagentruntime::types::KnowledgeBaseVectorSearchConfiguration::builder()
+                    .number_of_results(limit as i32)
+                    .build(),
+            )
+        }
+        .build();
 
         let response = client
             .retrieve()
@@ -430,7 +451,12 @@ impl VectorStoreManager {
             .send()
             .await
             .map_err(|e| {
-                BuilderError::VectorStoreError(format!("Bedrock KB retrieve failed: {e}"))
+                // DisplayErrorContext surfaces service errors that SdkError's Display
+                // collapses to "service error".
+                BuilderError::VectorStoreError(format!(
+                    "Bedrock KB retrieve failed: {}",
+                    aws_smithy_types::error::display::DisplayErrorContext(&e)
+                ))
             })?;
 
         let results: Vec<SearchResult> = response


### PR DESCRIPTION
Bedrock **managed** knowledge bases reject retrieve requests carrying `vectorSearchConfiguration`:

```
ValidationException: Incompatible configuration: vectorSearchConfiguration is not supported for managed knowledge bases. Use managedSearchConfiguration instead.
```

Since the `bedrock_kb` store always sends `vectorSearchConfiguration` (to set `numberOfResults`), every search against a managed KB failed. Classic vector-store-backed KBs are unaffected.

Changes:
- New opt-in `managed = true` flag on the `bedrock_kb` store config; when set, the retrieve request uses `managedSearchConfiguration` (which also carries `numberOfResults`, so `limit` keeps working). Default `false` preserves existing behavior. There is no way to auto-detect the KB type from the runtime API, hence the explicit flag.
- Bump `aws-sdk-bedrockagentruntime` 1.125 → 1.134.0, which introduces `ManagedSearchConfiguration`.
- Format retrieve errors with `DisplayErrorContext` — `SdkError`'s `Display` collapses service errors to the literal string `service error`, which is exactly what hid the ValidationException in production logs.

Verified against a live managed KB with both settings: `managed = true` retrieves successfully; `managed = false` fails with the full ValidationException now visible in the error. `cargo test --workspace`, clippy, and fmt are green.

Fixes: #499