### PR TITLE
fix(helm): add default values for command/args

### DIFF
--- a/deployment/helm/aura/templates/deployment.yaml
+++ b/deployment/helm/aura/templates/deployment.yaml
@@ -46,12 +46,9 @@ spec:
           command:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.args }}
+          {{- with .Values.server.args }}
           args:
-            {{- toYaml .Values.server.args | nindent 12 }}
-          {{- else }}
-          args:
-            - "--verbose"
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
             - name: http

--- a/deployment/helm/aura/values.yaml
+++ b/deployment/helm/aura/values.yaml
@@ -61,9 +61,12 @@ server:
   # -- Default agent name or alias when multiple configs are loaded via config.configs.
   # Not required when only one configuration is loaded.
   defaultAgent: ""
-  # -- Command override (leave empty for default)
+  # -- The Aura image sets CMD to ./aura-web-server (no ENTRYPOINT).
+  # Helm maps command to ENTRYPOINT and args to CMD at runtime.
+  # Set command to ./aura-web-server when providing args.
+  # If args are specified without setting command, the pod will not start.
   command: ['./aura-web-server']
-  # -- Args override (leave empty for default)
+  # -- Args override (Overrides ENTRYPOINT ./aura-web-server from aura docker image)
   args: ['--verbose']
 
 # Streaming configuration

--- a/deployment/helm/aura/values.yaml
+++ b/deployment/helm/aura/values.yaml
@@ -62,9 +62,9 @@ server:
   # Not required when only one configuration is loaded.
   defaultAgent: ""
   # -- Command override (leave empty for default)
-  command: []
-  # -- Args override (leave empty for default --verbose)
-  args: []
+  command: ['./aura-web-server']
+  # -- Args override (leave empty for default)
+  args: ['--verbose']
 
 # Streaming configuration
 streaming:


### PR DESCRIPTION
Because the Dockerfile uses `CMD` for starting the webserver, it gets overwritten if `args` is set to anything when running `helm install`.

The deployment template sets `args` to `--verbose` if not specified at runtime, so without this PR merged, `helm install` will fail to start the webserver, unless you manually set `command` to `./aura-web-server`.

I moved the `--verbose` default out of the deployment template and into `values.yaml` (along with forcing `command` to `./aura-web-server`.

We should consider changing our Dockerfile to use `ENTRYPOINT` instead of `CMD` to launch `./aura-web-server`, but for now this fixes the helm chart.