### PR TITLE
fix(a2a): deliver a terminal frame on cross-instance cancel

### DIFF
--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -1,6 +1,6 @@
 use std::cmp::Reverse;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use a2a::{
     A2AError, AgentCapabilities, AgentCard, AgentInterface, AgentSkill, Artifact, ListTasksRequest,
@@ -14,7 +14,6 @@ use aura::{RequestCancellation, StreamItem, StreamedAssistantContent, StreamingA
 use futures_util::StreamExt;
 use futures_util::stream::BoxStream;
 use serde_json::Value;
-use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::{Level, event};
 
@@ -28,13 +27,46 @@ const PLAIN_TEXT: &str = "text/plain";
 pub struct AuraAgentExecutor {
     app_state: Arc<AppState>,
     task_store: SharedTaskStore,
-    task_cancel_state: Arc<Mutex<HashMap<String, TaskCancelEntry>>>,
+    task_cancel_state: Arc<TaskCancelState>,
 }
 
 struct TaskCancelEntry {
     token: CancellationToken,
     agent: Arc<dyn StreamingAgent>,
     request_id: String,
+}
+
+/// The live executions' cancel handles, keyed by task id.
+type TaskCancelState = Mutex<HashMap<String, TaskCancelEntry>>;
+
+/// Lock the cancel map, taking a poisoned lock's contents rather than
+/// panicking: nothing awaits while the map is held, so a panicking holder
+/// cannot have left it half-updated.
+fn lock_cancel_state(state: &TaskCancelState) -> MutexGuard<'_, HashMap<String, TaskCancelEntry>> {
+    state.lock().unwrap_or_else(|poisoned| {
+        event!(Level::ERROR, "task cancel state lock poisoned, recovering");
+        poisoned.into_inner()
+    })
+}
+
+/// Owns one execution's cancel-map entry and its cancellation-registry
+/// registration.
+struct TaskCancelGuard {
+    state: Arc<TaskCancelState>,
+    task_id: String,
+    request_id: String,
+}
+
+impl Drop for TaskCancelGuard {
+    /// Releases both on any generator exit — loop break, early return, panic,
+    /// or a consumer that stops polling after a terminal event and drops the
+    /// generator where it stands, which cleanup at the end of the body would
+    /// never reach. Releasing what another path already took is a no-op, so
+    /// this composes with the explicit removals.
+    fn drop(&mut self) {
+        lock_cancel_state(&self.state).remove(&self.task_id);
+        RequestCancellation::unregister(&self.request_id);
+    }
 }
 
 impl AuraAgentExecutor {
@@ -206,24 +238,20 @@ impl AgentExecutor for AuraAgentExecutor {
             // Register with the global cancellation registry for parity with the OpenAI handler
             // and to let any future code address this request by id.
             RequestCancellation::register(request_id.clone());
-            {
-                let mut cancel_map = task_cancel_state.lock().await;
-                cancel_map.insert(task_id.clone(), TaskCancelEntry {
-                    token: cancel_token.clone(),
-                    agent: agent.clone(),
-                    request_id: request_id.clone(),
-                });
-            }
+            let _cancel_guard = TaskCancelGuard {
+                state: task_cancel_state.clone(),
+                task_id: task_id.clone(),
+                request_id: request_id.clone(),
+            };
+            lock_cancel_state(&task_cancel_state).insert(task_id.clone(), TaskCancelEntry {
+                token: cancel_token.clone(),
+                agent: agent.clone(),
+                request_id: request_id.clone(),
+            });
 
             let mut stream = match agent.stream(&text, history, cancel_token.clone(), &request_id).await {
                 Ok(s) => s,
                 Err(e) => {
-                    {
-                        let mut cancel_map = task_cancel_state.lock().await;
-                        cancel_map.remove(&task_id);
-                    }
-                    RequestCancellation::unregister(&request_id);
-
                     yield Ok(fail_status(&task_id, &context_id, &e.to_string()));
                     return;
                 }
@@ -423,10 +451,7 @@ impl AgentExecutor for AuraAgentExecutor {
             // In that case the executor has to drive MCP cleanup itself and emit a
             // terminal Canceled status (the OpenAI handler does the equivalent in its
             // Shutdown post-loop arm).
-            let entry_still_present = {
-                let mut cancel_map = task_cancel_state.lock().await;
-                cancel_map.remove(&task_id).is_some()
-            };
+            let entry_still_present = lock_cancel_state(&task_cancel_state).remove(&task_id).is_some();
             let shutdown_initiated_cancel = cancel_token.is_cancelled() && entry_still_present;
             RequestCancellation::unregister(&request_id);
 
@@ -472,10 +497,7 @@ impl AgentExecutor for AuraAgentExecutor {
         let task_cancel_state = self.task_cancel_state.clone();
 
         Box::pin(futures_util::stream::once(async move {
-            let entry = {
-                let mut cancel_map = task_cancel_state.lock().await;
-                cancel_map.remove(&task_id)
-            };
+            let entry = lock_cancel_state(&task_cancel_state).remove(&task_id);
 
             // Token-cancel wakes execute()'s select! → loop breaks → generator drops
             // → ActiveRequestGuard drops → exactly one decrement. cancel() never
@@ -759,5 +781,106 @@ mod tests {
         );
         let result = ex.resolve_config(Some("B"));
         assert_eq!(result.map(|c| c.agent.name), Some("B".to_owned()));
+    }
+
+    /// Stand-in for a built agent, only ever parked in the cancel map.
+    struct IdleAgent;
+
+    #[async_trait::async_trait]
+    impl StreamingAgent for IdleAgent {
+        fn get_provider_info(&self) -> (&str, &str) {
+            ("test", "idle")
+        }
+
+        async fn stream(
+            &self,
+            _query: &str,
+            _chat_history: Vec<aura::Message>,
+            _cancel_token: CancellationToken,
+            _request_id: &str,
+        ) -> Result<
+            futures_util::stream::BoxStream<'static, Result<aura::StreamItem, aura::StreamError>>,
+            aura::StreamError,
+        > {
+            Ok(Box::pin(futures_util::stream::pending()))
+        }
+
+        async fn stream_with_timeout(
+            &self,
+            _query: &str,
+            _chat_history: Vec<aura::Message>,
+            _timeout: std::time::Duration,
+            _request_id: &str,
+        ) -> (
+            futures_util::stream::BoxStream<'static, Result<aura::StreamItem, aura::StreamError>>,
+            tokio::sync::watch::Sender<bool>,
+            aura::UsageState,
+        ) {
+            let (cancel_tx, _cancel_rx) = tokio::sync::watch::channel(false);
+            (
+                Box::pin(futures_util::stream::pending()),
+                cancel_tx,
+                aura::UsageState::new(),
+            )
+        }
+
+        async fn cancel_and_close_mcp(&self, _request_id: &str, _reason: &str) -> usize {
+            0
+        }
+    }
+
+    /// A consumer that stops polling after a terminal event drops the
+    /// execution generator mid-body, so the entry and the registry
+    /// registration have to be released by the guard rather than by cleanup
+    /// the generator never reaches.
+    #[test]
+    fn dropping_the_cancel_guard_releases_the_entry_and_registration() {
+        let task_id = format!("t_{}", uuid::Uuid::new_v4());
+        let request_id = format!("a2a_{task_id}");
+        let state: Arc<TaskCancelState> = Arc::new(Mutex::new(HashMap::new()));
+
+        RequestCancellation::register(request_id.clone());
+        let guard = TaskCancelGuard {
+            state: state.clone(),
+            task_id: task_id.clone(),
+            request_id: request_id.clone(),
+        };
+        lock_cancel_state(&state).insert(
+            task_id.clone(),
+            TaskCancelEntry {
+                token: CancellationToken::new(),
+                agent: Arc::new(IdleAgent),
+                request_id: request_id.clone(),
+            },
+        );
+        assert!(RequestCancellation::token_for_id(&request_id).is_some());
+
+        drop(guard);
+
+        assert!(!lock_cancel_state(&state).contains_key(&task_id));
+        assert!(RequestCancellation::token_for_id(&request_id).is_none());
+    }
+
+    /// `cancel()` takes the entry before the generator unwinds, so the guard
+    /// has to tolerate finding both already released.
+    #[test]
+    fn dropping_the_cancel_guard_after_an_explicit_cleanup_is_a_noop() {
+        let task_id = format!("t_{}", uuid::Uuid::new_v4());
+        let request_id = format!("a2a_{task_id}");
+        let state: Arc<TaskCancelState> = Arc::new(Mutex::new(HashMap::new()));
+
+        RequestCancellation::register(request_id.clone());
+        let guard = TaskCancelGuard {
+            state: state.clone(),
+            task_id: task_id.clone(),
+            request_id: request_id.clone(),
+        };
+        lock_cancel_state(&state).remove(&task_id);
+        RequestCancellation::unregister(&request_id);
+
+        drop(guard);
+
+        assert!(!lock_cancel_state(&state).contains_key(&task_id));
+        assert!(RequestCancellation::token_for_id(&request_id).is_none());
     }
 }

--- a/crates/aura-web-server/src/a2a/bus_bridge.rs
+++ b/crates/aura-web-server/src/a2a/bus_bridge.rs
@@ -10,7 +10,9 @@
 //!   an instance serving a subscribe for a task it is not executing relays
 //!   them ([`relay_subscription`]).
 //! - [`cancel_topic`] — a cancel publishes here; the executing instance is
-//!   subscribed and drives its local cancel machinery.
+//!   subscribed, drives its local cancel machinery, and folds the resulting
+//!   terminal status into the execution stream so its own subscribers see the
+//!   same outcome relays do.
 //!
 //! Bus delivery is fire-and-forget end to end, and the store stays the source
 //! of truth: fan-out frames are sequence-numbered so a relay that misses one
@@ -18,10 +20,11 @@
 //! content, a relay converges through its periodic store poll (and is
 //! lifetime-bounded, so a dead executing instance cannot hang it forever),
 //! and the instance that received the cancel writes the terminal status
-//! itself, whether or not the routed cancel arrives. The Redis store rejects
-//! updates to terminal tasks, so an execution that misses a routed cancel
-//! can burn work until it finishes, but cannot overwrite the recorded
-//! `Canceled`.
+//! itself, whether or not the routed cancel arrives. Both ends of a routed
+//! cancel therefore record the same terminal status, which the store takes
+//! idempotently; a *different* terminal state is still rejected, so an
+//! execution that misses a routed cancel can burn work until it finishes but
+//! cannot overwrite the recorded `Canceled`.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -33,6 +36,7 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use futures_util::stream::BoxStream;
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
 use tokio::task::AbortHandle;
 use tracing::warn;
 
@@ -93,11 +97,30 @@ impl<E: AgentExecutor> AgentExecutor for BusBridgedExecutor<E> {
         let events = self.inner.execute(ctx);
 
         Box::pin(async_stream::stream! {
-            let listener = spawn_cancel_listener(bus.clone(), inner, listener_ctx).await;
+            let (cancel_events, mut cancelled) = mpsc::unbounded_channel();
+            let listener =
+                spawn_cancel_listener(bus.clone(), inner, listener_ctx, cancel_events).await;
             let _stop_listener_on_drop = AbortOnDrop(listener);
             let mut events = publish_and_forward(bus, task_id, context_id, events);
-            while let Some(item) = events.next().await {
+            loop {
+                // A stopped execution says nothing more about its own outcome,
+                // so a routed cancel's frames outrank whatever is still
+                // draining out of it, and its terminal status ends the stream.
+                // They are not republished — the instance that received the
+                // cancel already puts that terminal frame on the fan-out topic
+                // for relays; this copy is for the subscribers attached here.
+                let (item, routed_cancel) = tokio::select! {
+                    biased;
+                    Some(item) = cancelled.recv() => (Some(item), true),
+                    item = events.next() => (item, false),
+                };
+                let Some(item) = item else { break };
+                let ends_stream =
+                    routed_cancel && matches!(&item, Ok(event) if is_terminal_event(event));
                 yield item;
+                if ends_stream {
+                    break;
+                }
             }
         })
     }
@@ -291,14 +314,17 @@ async fn publish_frame(bus: &dyn EventBus, topic: &str, seq: u64, event: &Stream
     }
 }
 
-/// Subscribe to the task's cancel topic and, on the first routed cancel,
-/// drive the inner executor's cancel to completion. Its events are discarded:
-/// the instance that received the cancel request writes the terminal status
-/// to the shared store, so this side only has to stop the execution.
+/// Subscribe to the task's cancel topic and, on the first routed cancel, drive
+/// the inner executor's cancel to completion, forwarding its events to `events`
+/// (until the execution stream that owns the receiver is gone). Stopping the
+/// execution leaves its stream ending without a terminal event, so forwarding
+/// the cancel's terminal status is what tells this instance's subscribers how
+/// the task ended.
 async fn spawn_cancel_listener<E: AgentExecutor>(
     bus: Arc<dyn EventBus>,
     inner: Arc<E>,
     ctx: ExecutorContext,
+    events: mpsc::UnboundedSender<Result<StreamResponse, A2AError>>,
 ) -> Option<AbortHandle> {
     let topic = cancel_topic(&ctx.task_id);
     match bus.subscribe(&topic).await {
@@ -306,7 +332,11 @@ async fn spawn_cancel_listener<E: AgentExecutor>(
             tokio::spawn(async move {
                 if requests.next().await.is_some() {
                     let mut cancelled = inner.cancel(ctx);
-                    while cancelled.next().await.is_some() {}
+                    while let Some(item) = cancelled.next().await {
+                        if events.send(item).is_err() {
+                            break;
+                        }
+                    }
                 }
             })
             .abort_handle(),
@@ -600,6 +630,63 @@ mod tests {
 
         let stored = store.get("t2").await.unwrap().expect("task in store");
         assert_eq!(stored.status.state, TaskState::Canceled);
+    }
+
+    /// A cancel routed from elsewhere stops the execution, whose stream then
+    /// ends with no terminal event of its own — the subscribers attached to it
+    /// still have to learn the outcome rather than seeing a bare close.
+    #[tokio::test]
+    async fn cancel_on_other_instance_terminates_local_subscribers() {
+        let store = SharedTaskStore::from_store(Arc::new(InMemoryTaskStore::new()));
+        let bus = Arc::new(InMemoryEventBus::new());
+        let (instance_a, _handles_a) = instance(&store, &bus);
+        let (instance_b, _handles_b) = instance(&store, &bus);
+        let params = ServiceParams::new();
+
+        instance_a
+            .send_message(&params, send_request("t8", "c8"))
+            .await
+            .expect("send succeeds");
+
+        let mut local = instance_a
+            .subscribe_to_task(
+                &params,
+                SubscribeToTaskRequest {
+                    id: "t8".to_string(),
+                    tenant: None,
+                },
+            )
+            .await
+            .expect("subscribe on the executing instance succeeds");
+
+        instance_b
+            .cancel_task(
+                &params,
+                CancelTaskRequest {
+                    id: "t8".to_string(),
+                    metadata: None,
+                    tenant: None,
+                },
+            )
+            .await
+            .expect("cancel on the non-executing instance succeeds");
+
+        loop {
+            match next_frame(&mut local).await {
+                StreamResponse::StatusUpdate(update) if update.status.state.is_terminal() => {
+                    assert_eq!(update.status.state, TaskState::Canceled);
+                    break;
+                }
+                StreamResponse::Task(task) => assert!(!task.status.state.is_terminal()),
+                _ => {}
+            }
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_secs(5), local.next())
+                .await
+                .expect("stream ends after the terminal frame")
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/aura-web-server/src/session_store/redis/task_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/task_store.rs
@@ -122,12 +122,36 @@ impl RedisTaskStore {
             .await
             .map_err(store_err)?;
         match version {
-            -1 => Err(A2AError::invalid_request(format!(
+            -1 => self.resolve_terminal_write(task).await,
+            0 => Ok(None),
+            v => Ok(Some(v as u64)),
+        }
+    }
+
+    /// Answer a write the script refused because the record is already
+    /// terminal. Re-recording the state that is already stored is a duplicate
+    /// of an outcome two instances both write (a routed cancel is recorded by
+    /// the instance that received it and by the one executing the task), so it
+    /// leaves the record alone and reports its unchanged version; any other
+    /// state is the conflict the script exists to reject.
+    async fn resolve_terminal_write(&self, task: &Task) -> Result<Option<u64>, A2AError> {
+        let mut conn = self.conn.clone();
+        let (stored, version): (Option<String>, Option<u64>) = redis::pipe()
+            .hget(self.task_key(&task.id), "task")
+            .hget(self.task_key(&task.id), "version")
+            .query_async(&mut conn)
+            .await
+            .map_err(store_err)?;
+
+        let stored = stored.map(|json| parse_task(&json)).transpose()?;
+        match (stored, version) {
+            (Some(stored), Some(version)) if stored.status.state == task.status.state => {
+                Ok(Some(version))
+            }
+            _ => Err(A2AError::invalid_request(format!(
                 "task {} is terminal and cannot be updated",
                 task.id
             ))),
-            0 => Ok(None),
-            v => Ok(Some(v as u64)),
         }
     }
 

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -835,6 +835,62 @@ mod a2a_bridge {
             .expect("task in store");
         assert_eq!(stored.status.state, TaskState::Canceled);
     }
+
+    /// The executing instance's own subscribers must learn the outcome of a
+    /// cancel driven from elsewhere: stopping the execution ends its stream
+    /// with no terminal event, so without the routed cancel's status they see
+    /// only a bare close and cannot tell a cancel from a dropped connection.
+    #[tokio::test]
+    async fn cancel_on_other_instance_terminates_subscribers_on_the_executing_one() {
+        let config = test_config(60);
+        let (instance_a, _handles_a) = instance(&config).await;
+        let (instance_b, _handles_b) = instance(&config).await;
+        let params = ServiceParams::new();
+
+        instance_a
+            .send_message(&params, send_request("t3", "c3"))
+            .await
+            .expect("send succeeds");
+
+        let mut local = instance_a
+            .subscribe_to_task(
+                &params,
+                SubscribeToTaskRequest {
+                    id: "t3".to_string(),
+                    tenant: None,
+                },
+            )
+            .await
+            .expect("subscribe on the executing instance succeeds");
+
+        instance_b
+            .cancel_task(
+                &params,
+                CancelTaskRequest {
+                    id: "t3".to_string(),
+                    metadata: None,
+                    tenant: None,
+                },
+            )
+            .await
+            .expect("cancel on the non-executing instance succeeds");
+
+        loop {
+            let frame = tokio::time::timeout(Duration::from_secs(5), local.next())
+                .await
+                .expect("frame within 5s")
+                .expect("stream stays open until a terminal frame")
+                .expect("frame ok");
+            match frame {
+                StreamResponse::StatusUpdate(update) if update.status.state.is_terminal() => {
+                    assert_eq!(update.status.state, TaskState::Canceled);
+                    break;
+                }
+                StreamResponse::Task(task) => assert!(!task.status.state.is_terminal()),
+                _ => {}
+            }
+        }
+    }
 }
 
 /// Terminal states are immutable in the store: once a task is recorded
@@ -857,6 +913,34 @@ async fn update_of_terminal_task_is_rejected() {
         .await
         .expect_err("terminal task must reject updates");
     assert!(err.to_string().contains("terminal"), "{err}");
+
+    let got = tasks.get("t1").await.unwrap().unwrap();
+    assert_eq!(got.status.state, TaskState::Canceled);
+}
+
+/// Immutability rejects a *different* terminal state, not a second write of
+/// the one already recorded: both ends of a routed cancel record `Canceled`,
+/// and neither may see its write fail.
+#[tokio::test]
+async fn rewriting_the_recorded_terminal_state_is_accepted() {
+    let tasks = connect(&test_config(60)).await.tasks();
+    tasks
+        .create(make_task("t1", "c1", TaskState::Submitted))
+        .await
+        .unwrap();
+    let version = tasks
+        .update(make_task("t1", "c1", TaskState::Canceled))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        tasks
+            .update(make_task("t1", "c1", TaskState::Canceled))
+            .await
+            .expect("re-recording the stored terminal state must succeed"),
+        version,
+        "the record is left as it was written"
+    );
 
     let got = tasks.get("t1").await.unwrap().unwrap();
     assert_eq!(got.status.state, TaskState::Canceled);

--- a/docs/design/session-storage.md
+++ b/docs/design/session-storage.md
@@ -346,7 +346,8 @@ TTL as a backstop so an abandoned parking pod's entry self-cleans.
     `subscribe` handler on **any** pod subscribes to it and relays frames to its own
     client. This is one-producer-to-many-subscribers **fan-out** across pods.
   - `a2a:cancel:{id}` — a `cancel` request landing on any pod publishes here; the owning
-    pod is subscribed and fires its local `CancellationToken`.
+    pod is subscribed, fires its local `CancellationToken`, and folds the resulting
+    terminal status into its execution stream so its own subscribers see the outcome.
   With the shared `TaskStore` and these two topics, **every** A2A flow — send, poll, list,
   history, stream, subscribe, cancel — is cross-pod. No session affinity is needed.
 
@@ -368,12 +369,17 @@ TTL as a backstop so an abandoned parking pod's entry self-cleans.
   state, and is lifetime-bounded so a dead owner cannot hang it indefinitely
   (clients resubscribe). A cancel always publishes the routed copy and then runs
   the local cancel: the pod that received the cancel writes the terminal status
-  to the shared store, the owning pod's listener only stops the execution.
-  Missing/terminal tasks stay `task_not_found` on subscribe, matching upstream
-  single-pod behavior. Terminal states are immutable in the Redis store (the
-  update script rejects writes to a terminal task), so an execution that misses
-  a routed cancel keeps running until it finishes but cannot record `Completed`
-  over the `Canceled` the cancelling pod wrote.
+  to the shared store, and the owning pod's listener both stops the execution and
+  yields the cancel's terminal status on the execution stream — stopping an
+  execution ends its stream with no terminal event, so without that its own
+  subscribers would see a bare close and could not tell a cancel from a dropped
+  connection. Missing/terminal tasks stay `task_not_found` on subscribe, matching
+  upstream single-pod behavior. Terminal states are immutable in the Redis store
+  (the update script rejects writes to a terminal task, and a rewrite of the state
+  already recorded is taken as the idempotent duplicate it is — both ends of a
+  routed cancel record the same `Canceled`), so an execution that misses a routed
+  cancel keeps running until it finishes but cannot record `Completed` over the
+  `Canceled` the cancelling pod wrote.
 
 ---
 
@@ -412,7 +418,8 @@ Notes:
   decision itself is not persisted, mirroring the in-memory store; it travels
   over the bus.)
 - Each task create/update is one Lua script covering the exists-check, `version`
-  bump, terminal-state gate (updates to a terminal task are rejected), record
+  bump, terminal-state gate (updates to a terminal task are rejected, except a
+  rewrite of the state already recorded, which leaves it alone), record
   write, and both index-set refreshes — atomically. `list` lazily prunes indexed
   ids whose task hash expired first and skips (without failing) records it cannot
   deserialize. The scripts touch the task key and its two index keys, so the


### PR DESCRIPTION
Cancelling an A2A task through an instance that is not executing it left the executing instance's own subscribers without a terminal frame: their stream closed after the last non-terminal event, while subscribers relaying through another instance received TASK_STATE_CANCELED normally. The task store ended correct and terminal — only local stream delivery was affected — so a client that keys off the terminal frame rather than polling the store could not tell a cancelled task from a dropped connection.

The routed-cancel listener ran the inner executor's cancel purely for its side effect and drained the resulting events into the void. Stopping an execution ends its stream without a terminal event by design, since cancel() is what emits Canceled, so discarding those events left the local execution stream with no outcome to report and the handler closed the subscription when that stream ended.

Forward the cancel's events into the execution stream instead. The merge is biased toward them — a stopped execution has nothing further to say about its own outcome — and the cancel's terminal status ends the stream. Fixing this at the executor covers every local consumer at once: tasks/{id}:subscribe, message:stream, and the stored record. The frames are deliberately not republished, because the instance that received the cancel already puts the terminal frame on the fan-out topic for relays.

That makes both ends of a routed cancel record the same terminal status, which the Redis update script rejected outright: it treated any write to a terminal record as a conflict. Left as it was, the losing side of the race turned a successful cancel into a failure — the cancelling instance's own cancelTask call returning "task ... is terminal and cannot be updated". Refuse a terminal write only when it would change the recorded state; re-recording the state already stored leaves the record alone and reports its unchanged version. Completed over Canceled is still rejected, so an execution that misses a routed cancel still cannot overwrite the outcome.

Separately, release the execution's cancel-map entry and its cancellation-registry registration from a Drop guard, the way the active-request tracker already does. A consumer stops polling after a terminal event, which drops the execution generator where it stands, so cleanup written at the end of the generator body never ran when an execution failed mid-stream — leaking the entry and the agent handle it owns, along with that agent's MCP connections. The guard runs on every exit path, including the two other drop points reachable while an execution is registered. This moves the cancel map to a std::sync::Mutex, since Drop cannot await; nothing holds the lock across an await, which the Send bound on the executor's streams enforces at compile time.

Fixes: #475