### PR TITLE
fix(a2a): include assistant turns in conversation history

### DIFF
--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -1,4 +1,3 @@
-use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -23,6 +22,12 @@ use crate::{
 };
 
 const PLAIN_TEXT: &str = "text/plain";
+
+/// Artifact id of the assistant's reply text, one part per streamed chunk.
+const RESPONSE_ARTIFACT_ID: &str = "response";
+
+/// Artifact id of the assistant's complete reply and the turn's token usage.
+const FINAL_ARTIFACT_ID: &str = "final";
 
 pub struct AuraAgentExecutor {
     app_state: Arc<AppState>,
@@ -286,15 +291,14 @@ impl AgentExecutor for AuraAgentExecutor {
                     Ok(StreamItem::StreamAssistantItem(StreamedAssistantContent::Text(t))) => {
                         event!(Level::DEBUG, request_id, t, "stream content received");
 
-                        const ARTIFACT_ID: &str = "response";
-                        let append = append_tracker.entry((task_id.clone(), context_id.clone(), ARTIFACT_ID.to_owned()))
+                        let append = append_tracker.entry((task_id.clone(), context_id.clone(), RESPONSE_ARTIFACT_ID.to_owned()))
                             .and_modify(|e| *e = true)
                             .or_insert(false);
 
                         event!(Level::DEBUG, request_id, "response returned and should be appended: {}", *append);
 
                         let artifact = Artifact {
-                            artifact_id: ARTIFACT_ID.to_owned(),
+                            artifact_id: RESPONSE_ARTIFACT_ID.to_owned(),
                             name: Some("Response".to_owned()),
                             description: None,
                             parts: vec![Part::text(t)],
@@ -413,13 +417,12 @@ impl AgentExecutor for AuraAgentExecutor {
                         event!(Level::DEBUG, request_id, "reasoning delta");
                     }
                     Ok(StreamItem::Final(final_info)) => {
-                        const ARTIFACT_ID: &str = "final";
-                        let append = append_tracker.entry((task_id.clone(), context_id.clone(), ARTIFACT_ID.to_owned()))
+                        let append = append_tracker.entry((task_id.clone(), context_id.clone(), FINAL_ARTIFACT_ID.to_owned()))
                             .and_modify(|e| *e = true)
                             .or_insert(false);
 
                         let artifact = Artifact {
-                            artifact_id: ARTIFACT_ID.to_owned(),
+                            artifact_id: FINAL_ARTIFACT_ID.to_owned(),
                             name: Some("Final Info".into()),
                             description: None,
                             parts: vec![Part::text(final_info.content)],
@@ -581,9 +584,9 @@ async fn get_history_for_context(
     task_store: SharedTaskStore,
     request_id: &str,
     context_id: &str,
-    task_id: &String,
+    task_id: &str,
 ) -> Result<Vec<aura::Message>, A2AError> {
-    let mut task_history: Vec<a2a::Task> = Vec::new();
+    let mut tasks: Vec<a2a::Task> = Vec::new();
 
     let mut next_page_token: Option<String> = None;
     loop {
@@ -594,11 +597,12 @@ async fn get_history_for_context(
             "processing history for context"
         );
 
-        let loop_history = task_store
+        let page = task_store
             .list(&ListTasksRequest {
                 context_id: Some(context_id.into()),
                 history_length: None, // get all history in one shot
-                include_artifacts: Some(false),
+                // The assistant turn is rebuilt from the artifacts (see `task_turns`).
+                include_artifacts: Some(true),
                 page_size: Some(1000), // override the default of 50
                 page_token: next_page_token,
                 status: None,
@@ -612,30 +616,75 @@ async fn get_history_for_context(
             request_id,
             context_id,
             "found {} tasks, continue token '{}'",
-            loop_history.tasks.len(),
-            loop_history.next_page_token
+            page.tasks.len(),
+            page.next_page_token
         );
-        task_history.extend(loop_history.tasks);
+        tasks.extend(page.tasks);
 
-        if !loop_history.next_page_token.is_empty() {
-            next_page_token = Some(loop_history.next_page_token);
+        if !page.next_page_token.is_empty() {
+            next_page_token = Some(page.next_page_token);
         } else {
             break;
         }
     }
 
-    // keep all other tasks and sort by descending
-    task_history.retain(|t| t.id != *task_id && t.history.clone().is_some_and(|h| !h.is_empty()));
-    task_history.sort_by_key(|t| Reverse(t.status.timestamp));
+    // Skip the task being executed: its only recorded turn is the prompt this
+    // call is about to send. Everything else replays oldest exchange first.
+    tasks.retain(|t| t.id != task_id);
+    tasks.sort_by_key(|t| t.status.timestamp);
 
-    let chat_history: Vec<aura::Message> = task_history
-        .into_iter()
-        .flat_map(|t| t.history.unwrap())
-        .filter_map(|m| convert_a2a_msg_to_aura(&m))
-        .collect();
+    let chat_history: Vec<aura::Message> = tasks.iter().flat_map(task_turns).collect();
 
     event!(Level::DEBUG, request_id, context_id, chat_history = ?chat_history, "determined this following history to use");
     Ok(chat_history)
+}
+
+/// One task's conversation turns, oldest first.
+///
+/// The request handler records only the prompt in `Task::history`; the agent's
+/// reply is streamed out as artifacts and never written back. So the assistant
+/// turn is rebuilt from the text the client saw — the streamed
+/// [`RESPONSE_ARTIFACT_ID`] chunks, or [`FINAL_ARTIFACT_ID`] for a task whose
+/// reply only arrived as a final response. A task that already carries an
+/// agent message in `history` is taken at its word instead.
+fn task_turns(task: &a2a::Task) -> Vec<aura::Message> {
+    let recorded = task.history.as_deref().unwrap_or_default();
+    let mut turns: Vec<aura::Message> = recorded
+        .iter()
+        .filter_map(convert_a2a_msg_to_aura)
+        .collect();
+
+    if !recorded.iter().any(|m| matches!(m.role, Role::Agent))
+        && let Some(answer) = assistant_answer(task)
+    {
+        turns.push(aura::Message::assistant(&answer));
+    }
+
+    turns
+}
+
+/// The assistant text a task produced, or `None` if it produced none.
+fn assistant_answer(task: &a2a::Task) -> Option<String> {
+    let artifacts = task.artifacts.as_deref()?;
+
+    // Parts of one artifact are fragments of a single message — streamed mid-word,
+    // so they concatenate with no separator.
+    let joined = |artifact_id: &str| {
+        artifacts
+            .iter()
+            .filter(|a| a.artifact_id == artifact_id)
+            .flat_map(|a| a.parts.iter())
+            .filter_map(|p| match &p.content {
+                PartContent::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<String>()
+    };
+
+    [RESPONSE_ARTIFACT_ID, FINAL_ARTIFACT_ID]
+        .into_iter()
+        .map(joined)
+        .find(|text| !text.trim().is_empty())
 }
 
 fn convert_a2a_msg_to_aura(msg: &a2a::Message) -> Option<aura::Message> {
@@ -890,5 +939,203 @@ mod tests {
 
         assert!(!lock_cancel_state(&state).contains_key(&task_id));
         assert!(RequestCancellation::token_for_id(&request_id).is_none());
+    }
+
+    fn at(secs: i64) -> Option<chrono::DateTime<chrono::Utc>> {
+        chrono::DateTime::from_timestamp(secs, 0)
+    }
+
+    fn artifact(artifact_id: &str, chunks: &[&str]) -> Artifact {
+        Artifact {
+            artifact_id: artifact_id.to_owned(),
+            name: None,
+            description: None,
+            parts: chunks.iter().map(|c| Part::text(*c)).collect(),
+            metadata: None,
+            extensions: None,
+        }
+    }
+
+    /// A completed task shaped like one the executor produces: the prompt in
+    /// `history`, the reply only in artifacts.
+    fn completed_task(id: &str, prompt: &str, artifacts: Vec<Artifact>, secs: i64) -> a2a::Task {
+        a2a::Task {
+            id: id.to_owned(),
+            context_id: "ctx".to_owned(),
+            status: TaskStatus {
+                state: TaskState::Completed,
+                message: None,
+                timestamp: at(secs),
+            },
+            artifacts: Some(artifacts),
+            history: Some(vec![Message::new(Role::User, vec![Part::text(prompt)])]),
+            metadata: None,
+        }
+    }
+
+    /// The turn as `(role, text)`, so assertions read as the conversation does.
+    fn turn(message: &aura::Message) -> (&'static str, String) {
+        match message {
+            aura::Message::User { content } => (
+                "user",
+                content
+                    .iter()
+                    .filter_map(|c| match c {
+                        aura::UserContent::Text(t) => Some(t.text.clone()),
+                        _ => None,
+                    })
+                    .collect(),
+            ),
+            aura::Message::Assistant { content, .. } => (
+                "assistant",
+                content
+                    .iter()
+                    .filter_map(|c| match c {
+                        aura::AssistantContent::Text(t) => Some(t.text.clone()),
+                        _ => None,
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    fn turns(messages: &[aura::Message]) -> Vec<(&'static str, String)> {
+        messages.iter().map(turn).collect()
+    }
+
+    async fn history_of(tasks: Vec<a2a::Task>, executing: &str) -> Vec<aura::Message> {
+        let store = SharedTaskStore::default();
+        for task in tasks {
+            store.create(task).await.expect("task created");
+        }
+        get_history_for_context(store, "req", "ctx", executing)
+            .await
+            .expect("history built")
+    }
+
+    #[tokio::test]
+    async fn history_carries_the_assistant_turn_from_streamed_artifacts() {
+        let history = history_of(
+            vec![completed_task(
+                "t1",
+                "how many sentences?",
+                vec![
+                    artifact(RESPONSE_ARTIFACT_ID, &["Three ", "sen", "tences."]),
+                    artifact(FINAL_ARTIFACT_ID, &["Three sentences."]),
+                ],
+                10,
+            )],
+            "t2",
+        )
+        .await;
+
+        assert_eq!(
+            turns(&history),
+            vec![
+                ("user", "how many sentences?".to_owned()),
+                ("assistant", "Three sentences.".to_owned()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn history_falls_back_to_the_final_artifact() {
+        let history = history_of(
+            vec![completed_task(
+                "t1",
+                "hi",
+                vec![
+                    artifact(RESPONSE_ARTIFACT_ID, &[]),
+                    artifact(FINAL_ARTIFACT_ID, &["hello"]),
+                ],
+                10,
+            )],
+            "t2",
+        )
+        .await;
+
+        assert_eq!(
+            turns(&history),
+            vec![("user", "hi".to_owned()), ("assistant", "hello".to_owned()),]
+        );
+    }
+
+    #[tokio::test]
+    async fn history_ignores_non_response_artifacts() {
+        let history = history_of(
+            vec![completed_task(
+                "t1",
+                "call the tool",
+                vec![
+                    artifact("tool_call_1", &["Tool was called: mock_tool"]),
+                    artifact("reasoning_1", &["thinking about it"]),
+                ],
+                10,
+            )],
+            "t2",
+        )
+        .await;
+
+        assert_eq!(turns(&history), vec![("user", "call the tool".to_owned())]);
+    }
+
+    #[tokio::test]
+    async fn history_replays_exchanges_oldest_first() {
+        let history = history_of(
+            vec![
+                completed_task("t2", "second", vec![artifact("final", &["two"])], 20),
+                completed_task("t1", "first", vec![artifact("final", &["one"])], 10),
+            ],
+            "t3",
+        )
+        .await;
+
+        assert_eq!(
+            turns(&history),
+            vec![
+                ("user", "first".to_owned()),
+                ("assistant", "one".to_owned()),
+                ("user", "second".to_owned()),
+                ("assistant", "two".to_owned()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn history_skips_the_executing_task() {
+        let history = history_of(
+            vec![
+                completed_task("t1", "first", vec![artifact("final", &["one"])], 10),
+                completed_task("t2", "second", vec![], 20),
+            ],
+            "t2",
+        )
+        .await;
+
+        assert_eq!(
+            turns(&history),
+            vec![
+                ("user", "first".to_owned()),
+                ("assistant", "one".to_owned()),
+            ]
+        );
+    }
+
+    /// A store that records the agent turn in `history` must not have it
+    /// duplicated from the artifacts.
+    #[tokio::test]
+    async fn history_prefers_a_recorded_agent_message() {
+        let mut task = completed_task("t1", "hi", vec![artifact("final", &["hello"])], 10);
+        task.history
+            .as_mut()
+            .unwrap()
+            .push(Message::new(Role::Agent, vec![Part::text("hello")]));
+
+        let history = history_of(vec![task], "t2").await;
+
+        assert_eq!(
+            turns(&history),
+            vec![("user", "hi".to_owned()), ("assistant", "hello".to_owned()),]
+        );
     }
 }

--- a/crates/aura-web-server/tests/a2a_test.rs
+++ b/crates/aura-web-server/tests/a2a_test.rs
@@ -892,8 +892,9 @@ async fn test_sequential_tasks_share_context() {
         .and_then(|v| v.as_str())
         .expect("First task did not contain 'contextId' field");
 
-    // Wait for task 1 to complete so its full history (tool call, tool result,
-    // assistant response) is persisted in the task store before task 2 starts.
+    // Wait for task 1 to complete so its prompt and its artifacts — which is
+    // where the assistant's answer lives — are in the task store before task 2
+    // starts building history for the context.
     let poll_interval = Duration::from_millis(500);
     let deadline = tokio::time::Instant::now() + TEST_TIMEOUT;
     loop {
@@ -1084,6 +1085,174 @@ async fn test_sequential_tasks_share_context() {
         expected_uuid,
         part_text
     );
+}
+
+// Sibling of test_sequential_tasks_share_context covering the other half of the
+// exchange: that a follow-up sees the agent's own prior answer.
+//
+// The recalled secret reaches the conversation only through the first task's
+// assistant turn — it is absent from every user message, and the header that
+// carried it is not sent with the follow-up, so the tool cannot surface it a
+// second time. The follow-up is additionally asserted to have called no tool at
+// all, leaving the assistant turn as the sole possible source.
+#[tokio::test]
+async fn test_sequential_tasks_share_the_assistant_turn() {
+    let client = reqwest::Client::new();
+    let secret = format!("aura-secret-{}", uuid::Uuid::new_v4());
+
+    let task1 = send_a2a_message(
+        &client,
+        json!({
+            "messageId": format!("{}", uuid::Uuid::new_v4()),
+            "role": "ROLE_USER",
+            "parts": [{"text": "Call the echo_headers tool. Then reply with only the \
+                value of the x-test-header1 header from its output, and nothing else."}]
+        }),
+        &[("X-Test-Header1", secret.as_str())],
+    )
+    .await;
+    let context_id = task1
+        .get("contextId")
+        .and_then(|v| v.as_str())
+        .expect("First task did not contain 'contextId' field")
+        .to_owned();
+    let task1_id = task1
+        .get("id")
+        .and_then(|v| v.as_str())
+        .expect("First task did not contain 'id' field")
+        .to_owned();
+
+    let completed1 = poll_until_completed(&client, &task1_id).await;
+    let answer1 = final_info_text(&completed1);
+    // Guards the test itself: without this the follow-up would have nothing to
+    // recall and the assertion below could never distinguish the two halves.
+    assert!(
+        answer1.contains(&secret),
+        "First task did not report the forwarded header value '{secret}': {answer1}"
+    );
+
+    // No X-Test-Header1 this time — echo_headers cannot hand the secret over again.
+    let task2 = send_a2a_message(
+        &client,
+        json!({
+            "messageId": format!("{}", uuid::Uuid::new_v4()),
+            "contextId": context_id,
+            "role": "ROLE_USER",
+            "parts": [{"text": "Without calling any tools, repeat the exact value you \
+                reported in your previous reply. Answer with only that value."}]
+        }),
+        &[],
+    )
+    .await;
+    let task2_id = task2
+        .get("id")
+        .and_then(|v| v.as_str())
+        .expect("Second task did not contain 'id' field")
+        .to_owned();
+
+    let completed2 = poll_until_completed(&client, &task2_id).await;
+
+    let tool_calls: Vec<&str> = completed2
+        .artifacts
+        .iter()
+        .flatten()
+        .map(|a| a.artifact_id.as_str())
+        .filter(|id| id.starts_with("tool_call_"))
+        .collect();
+    assert!(
+        tool_calls.is_empty(),
+        "Follow-up called tools ({tool_calls:?}), so the recalled value could have come \
+         from somewhere other than the prior assistant turn"
+    );
+
+    let answer2 = final_info_text(&completed2);
+    assert!(
+        answer2.contains(&secret),
+        "Follow-up did not recall the prior assistant turn's value '{secret}': {answer2}"
+    );
+}
+
+// Sends `message` to message:send with the given extra headers and returns the
+// queued task object.
+async fn send_a2a_message(
+    client: &reqwest::Client,
+    message: Value,
+    headers: &[(&str, &str)],
+) -> Value {
+    let mut request = client
+        .post(format!("{}/a2a/v1/message:send", AURA_SERVER))
+        .header("Content-Type", "application/json")
+        .header("A2A-Version", "1.0");
+    for (name, value) in headers {
+        request = request.header(*name, *value);
+    }
+
+    let body = request
+        .json(&json!({ "message": message }))
+        .timeout(TEST_TIMEOUT)
+        .send()
+        .await
+        .expect("Failed to send request - is aura-web-server running?")
+        .text()
+        .await
+        .expect("Failed to read response");
+
+    println!("Task response body: {}", body);
+    serde_json::from_str::<Value>(&body)
+        .expect("Response was not valid JSON")
+        .get("task")
+        .expect("Response did not contain 'task' field")
+        .clone()
+}
+
+async fn poll_until_completed(client: &reqwest::Client, task_id: &str) -> Task {
+    let poll_interval = Duration::from_millis(500);
+    let deadline = tokio::time::Instant::now() + TEST_TIMEOUT;
+
+    loop {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Task {task_id} did not reach TASK_STATE_COMPLETED within timeout"
+        );
+
+        let body = client
+            .get(format!("{}/a2a/v1/tasks/{}", AURA_SERVER, task_id))
+            .header("A2A-Version", "1.0")
+            .timeout(TEST_TIMEOUT)
+            .send()
+            .await
+            .expect("Failed to poll task status")
+            .text()
+            .await
+            .expect("Failed to read poll response");
+
+        let polled: Task = serde_json::from_str(&body).expect("Poll response was not valid JSON");
+        match polled.status.state {
+            TaskState::Completed => return polled,
+            TaskState::Failed | TaskState::Canceled => {
+                panic!(
+                    "Task {task_id} ended in unexpected state: {:?}",
+                    polled.status.state
+                )
+            }
+            _ => tokio::time::sleep(poll_interval).await,
+        }
+    }
+}
+
+fn final_info_text(task: &Task) -> String {
+    task.artifacts
+        .iter()
+        .flatten()
+        .find(|a| a.name.as_deref() == Some("Final Info"))
+        .expect("Completed task has no 'Final Info' artifact")
+        .parts
+        .iter()
+        .find_map(|p| match &p.content {
+            PartContent::Text(t) => Some(t.clone()),
+            _ => None,
+        })
+        .expect("'Final Info' artifact has no text part")
 }
 
 // validates the input content to the package also forwards appropriate headers


### PR DESCRIPTION
A follow-up message on an existing contextId was given the prior user turns but never the agent's own replies, so it answered as if it had never spoken.

get_history_for_context rebuilt history from Task::history alone. The upstream request handler writes that field once, with the prompt, and never appends to it; the agent's reply is streamed out as artifacts instead, leaving the Role::Agent arm of convert_a2a_msg_to_aura unreachable. The same call also passed include_artifacts: Some(false), so the reply was never fetched, and sorted the context's tasks newest-first, which would have replayed a multi-task exchange backwards.

History now rebuilds the assistant turn from the artifacts the client saw: the streamed "response" chunks concatenated with no separator, falling back to "final" for a reply that only arrived as a final response. Tool-call, reasoning, and scratchpad artifacts are skipped. Tasks replay oldest-first, and a task already carrying a ROLE_AGENT message keeps it rather than gaining a second one. The two artifact ids are now module consts shared with the sites that emit them, so reader and writer cannot drift apart.

A2A clients still see only the prompt in task.history. The upstream handler owns every task write and carries a stale in-memory task across events, so writing the agent turn back would either race it or have to go through SharedTaskStore, which conflicts with the Redis store's terminal-immutability rule. Reconstructing on read works with both stores and touches no write path.

test_sequential_tasks_share_the_assistant_turn covers the half that test_sequential_tasks_share_context cannot. It routes a per-run secret in through a forwarded header that the agent reports, then sends the follow-up without that header so the tool cannot surface the value again, and asserts the follow-up made no tool call at all, leaving the prior assistant turn as the only possible source.

Fixes: #368