### PR TITLE
feat(cli): enable scratchpad for servers added via /mcp add

### DIFF
--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -1,5 +1,6 @@
 //! Guided `/mcp add` flow: pick a catalog or custom server, collect
-//! credentials with masked input, write the config + `.env`.
+//! credentials with masked input, enable scratchpad interception for the
+//! server's tool outputs, write the config + `.env`.
 //!
 //! Standalone mode only, and deliberately deterministic: no LLM ever
 //! sees a credential.
@@ -9,6 +10,7 @@ use std::fs;
 use std::path::Path;
 use std::time::Duration;
 
+use aura_config::ScratchpadToolEntry;
 use aura_config::config::McpServerConfig;
 
 use super::catalog::{CATALOG, CatalogEntry, Template};
@@ -119,9 +121,11 @@ fn drive(ctx: &mut CommandContext, config_path: &Path) -> WizardEnd {
         Some(entry) => collect_catalog(ctx, entry, config_path),
         None => collect_custom(ctx, config_path),
     };
-    let Some(collected) = collected else {
+    let Some(mut collected) = collected else {
         return WizardEnd::Aborted;
     };
+
+    enable_scratchpad(config_path, &mut collected.server);
 
     let new_secrets: Vec<(String, String)> = collected
         .secrets
@@ -348,6 +352,44 @@ fn verify_server(
     })
 }
 
+/// The `"*"` entry is written even when `[agent.scratchpad]` is off — it
+/// is inert until scratchpad's prerequisites are met.
+fn enable_scratchpad(config_path: &Path, server: &mut McpServerConfig) {
+    let entry = ScratchpadToolEntry::default();
+    let min_tokens = entry.min_tokens;
+    server.scratchpad_mut().insert("*".to_string(), entry);
+    if agent_scratchpad_enabled(config_path) {
+        println!(
+            "\nTool outputs over {min_tokens} tokens will be diverted to the \
+             scratchpad instead of the context window."
+        );
+    } else {
+        println!(
+            "\nScratchpad interception is configured for this server's tool \
+             outputs (over {min_tokens} tokens), but stays inactive until the \
+             config also sets `[agent.scratchpad] enabled = true`, a top-level \
+             `memory_dir`, and `[agent.llm].context_window`. \
+             See https://docs.mezmo.com/aura/scratchpad"
+        );
+    }
+}
+
+/// Best-effort parse of the config file; unreadable or malformed is `None`.
+fn read_config_doc(config_path: &Path) -> Option<toml_edit::DocumentMut> {
+    fs::read_to_string(config_path).ok()?.parse().ok()
+}
+
+fn agent_scratchpad_enabled(config_path: &Path) -> bool {
+    let Some(doc) = read_config_doc(config_path) else {
+        return false;
+    };
+    doc.get("agent")
+        .and_then(|agent| agent.get("scratchpad"))
+        .and_then(|scratchpad| scratchpad.get("enabled"))
+        .and_then(toml_edit::Item::as_bool)
+        .unwrap_or(false)
+}
+
 /// Offer per-worker access to a freshly verified server: workers without
 /// an `mcp_filter` already see it (omitted = every tool) and get a
 /// lockdown choice; workers with one don't and get an append-style grant.
@@ -460,13 +502,10 @@ fn print_allowlist_hint(config_path: &Path, server: &str) {
 }
 
 /// `(worker, mcp_filter)` pairs from the config file; empty unless
-/// orchestration is enabled (or on any parse problem — a convenience
-/// step, not a gate). `None` = no `mcp_filter` key.
+/// orchestration is enabled — a convenience step, not a gate. `None` =
+/// no `mcp_filter` key.
 fn orchestrated_workers(config_path: &Path) -> Vec<(String, Option<Vec<String>>)> {
-    let Ok(content) = fs::read_to_string(config_path) else {
-        return Vec::new();
-    };
-    let Ok(doc) = content.parse::<toml_edit::DocumentMut>() else {
+    let Some(doc) = read_config_doc(config_path) else {
         return Vec::new();
     };
     let Some(orchestration) = doc.get("orchestration") else {
@@ -848,13 +887,8 @@ fn ask_server_name(
     Some(name)
 }
 
-/// Best-effort check whether `[mcp.servers.<name>]` already exists; a
-/// malformed config reads as "absent" here and fails properly at write time.
 fn config_has_server(config_path: &Path, name: &str) -> bool {
-    let Ok(content) = fs::read_to_string(config_path) else {
-        return false;
-    };
-    let Ok(doc) = content.parse::<toml_edit::DocumentMut>() else {
+    let Some(doc) = read_config_doc(config_path) else {
         return false;
     };
     doc.get("mcp")
@@ -1289,6 +1323,45 @@ mod tests {
 
         fs::write(&path, base.replace("%E%", "false")).unwrap();
         assert!(orchestrated_workers(&path).is_empty());
+    }
+
+    #[test]
+    fn reads_agent_scratchpad_enabled_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        fs::write(
+            &path,
+            "[agent]\nname = \"a\"\n\n[agent.scratchpad]\nenabled = true\n",
+        )
+        .unwrap();
+        assert!(agent_scratchpad_enabled(&path));
+
+        fs::write(
+            &path,
+            "[agent]\nname = \"a\"\n\n[agent.scratchpad]\nenabled = false\n",
+        )
+        .unwrap();
+        assert!(!agent_scratchpad_enabled(&path));
+
+        fs::write(&path, "[agent]\nname = \"a\"\n").unwrap();
+        assert!(!agent_scratchpad_enabled(&path));
+
+        assert!(!agent_scratchpad_enabled(&dir.path().join("missing.toml")));
+    }
+
+    #[test]
+    fn scratchpad_wildcard_entry_renders_into_server_config() {
+        let mut server = http_streamable(
+            "https://mcp.example.com/mcp".to_string(),
+            HashMap::new(),
+            "",
+        );
+        server
+            .scratchpad_mut()
+            .insert("*".to_string(), ScratchpadToolEntry::default());
+        let rendered = aura_config::writer::upsert_mcp_server_in_str("", "srv", &server).unwrap();
+        assert!(rendered.contains("min_tokens = 5120"), "{rendered}");
     }
 
     #[test]

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -617,6 +617,15 @@ impl McpServerConfig {
             McpServerConfig::Sse { scratchpad, .. } => scratchpad,
         }
     }
+
+    /// Get the per-tool scratchpad thresholds for this server, mutably.
+    pub fn scratchpad_mut(&mut self) -> &mut HashMap<String, ScratchpadToolEntry> {
+        match self {
+            McpServerConfig::Stdio { scratchpad, .. } => scratchpad,
+            McpServerConfig::HttpStreamable { scratchpad, .. } => scratchpad,
+            McpServerConfig::Sse { scratchpad, .. } => scratchpad,
+        }
+    }
 }
 
 /// Vector store configuration (in-memory, Qdrant, and Bedrock KB)

--- a/crates/aura-config/src/writer.rs
+++ b/crates/aura-config/src/writer.rs
@@ -420,6 +420,28 @@ url = "https://old.example.com/mcp"
     }
 
     #[test]
+    fn round_trips_scratchpad_entries_through_loader() {
+        let server = McpServerConfig::Stdio {
+            cmd: vec!["npx".to_owned(), "-y".to_owned(), "some-mcp".to_owned()],
+            args: vec![],
+            env: HashMap::new(),
+            description: None,
+            scratchpad: HashMap::from([(
+                "*".to_owned(),
+                crate::ScratchpadToolEntry { min_tokens: 5120 },
+            )]),
+        };
+        let updated = upsert_mcp_server_in_str(BASE_CONFIG, "srv", &server).unwrap();
+        let config = load_config_from_str(&updated).expect("written config must parse");
+        let parsed = &config.mcp.expect("mcp table present").servers["srv"];
+        assert_eq!(
+            parsed.scratchpad().get("*").map(|e| e.min_tokens),
+            Some(5120),
+            "wildcard scratchpad entry must survive the round trip:\n{updated}"
+        );
+    }
+
+    #[test]
     fn round_trips_nonempty_maps_through_loader() {
         let server = McpServerConfig::HttpStreamable {
             url: "https://mcp.example.com/mcp".to_owned(),


### PR DESCRIPTION
Fixes #512

## What

Servers written by the `/mcp add` wizard now get a wildcard scratchpad entry:

```toml
[mcp.servers.<name>.scratchpad]
"*" = { min_tokens = 5120 }
```

Large tool outputs are diverted to scratchpad storage instead of filling the context window. The entry shows in the wizard's config preview before the write is confirmed, so declining the write still declines everything.

## Why not prompt, and why not touch [agent.scratchpad]

- The entry is inert while agent-level scratchpad is off, so writing it unconditionally is safe and saves a wizard question.
- When the config lacks `[agent.scratchpad] enabled = true`, the wizard prints the prerequisites (`enabled = true`, top-level `memory_dir`, `[agent.llm].context_window`) instead of editing them — flipping the flag on a config missing the other two would fail validation on restart.

## Changes

- `aura-cli`: new `enable_scratchpad` step in the wizard; consolidated the three read-and-parse config readers (`orchestrated_workers`, `config_has_server`, and the new `agent_scratchpad_enabled`) onto a shared `read_config_doc` helper
- `aura-config`: added `McpServerConfig::scratchpad_mut` alongside the existing accessor
- Tests: writer round-trip proving the wildcard entry survives serialization and reloads through the loader; rendered-config assertion; `[agent.scratchpad].enabled` reader coverage (true/false/absent/missing file)

## Verification

- `cargo test -p aura-cli -p aura-config` — all green (438 + 196)
- `cargo clippy --all-targets` clean on both crates; `cargo check -p aura-cli --no-default-features` confirms the HTTP-only build is unaffected

Docs note: the `/mcp add` page in `mezmo/documentation` needs a line about the new scratchpad step.