### PR TITLE
fix(init): pin default openai model to gpt-5.5

### DIFF
--- a/crates/aura-cli/src/init/provider.rs
+++ b/crates/aura-cli/src/init/provider.rs
@@ -78,9 +78,10 @@ pub(crate) fn default_key_env(provider: Provider) -> Option<&'static str> {
 /// editorial choice — keep them current as providers ship new flagships.
 pub(crate) fn family_roots(provider: Provider) -> &'static [&'static str] {
     match provider {
-        // GPT-5.6 ships as three flavors; `terra` (balanced) is the default —
-        // `sol` is the pricier frontier tier, `luna` the cheapest.
-        Provider::OpenAI => &["gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.6-luna"],
+        // gpt-5.5 is the recommended default. gpt-5.6-* models are reasoning
+        // models that reject function tools on /v1/chat/completions unless
+        // reasoning_effort is set to "none" (issue #511).
+        Provider::OpenAI => &["gpt-5.5"],
         Provider::Anthropic => &["claude-opus-5", "claude-sonnet-4-6", "claude-haiku-4-5"],
         Provider::Gemini => &["gemini-3.5-flash", "gemini-3.1-pro"],
         // Uncurated providers (and bedrock, which has no list endpoint).

--- a/crates/aura-cli/src/init/ranking.rs
+++ b/crates/aura-cli/src/init/ranking.rs
@@ -57,6 +57,11 @@ pub(crate) fn filter_chat_models(models: &[String]) -> Vec<String> {
         .collect()
 }
 
+/// Model prefixes excluded from the fallback shortlist because they are
+/// reasoning models incompatible with function tools on /v1/chat/completions
+/// (issue #511). The operator can still type any model id manually.
+const BLOCKED_FALLBACK_PREFIXES: &[&str] = &["gpt-5.6"];
+
 /// Version key for natural ("human") ordering of model ids: the sequence of
 /// digit runs parsed as integers (`gpt-5.6` → `[5, 6]`, `o3` → `[3]`). Compared
 /// lexicographically, a higher key means a newer model within a family.
@@ -140,7 +145,10 @@ pub(crate) fn rank_shortlist(provider: Provider, models: &[String]) -> Vec<Strin
     }
 
     if shortlist.is_empty() {
-        let mut fallback = chat;
+        let mut fallback = chat
+            .into_iter()
+            .filter(|m| !BLOCKED_FALLBACK_PREFIXES.iter().any(|p| m.starts_with(p)))
+            .collect::<Vec<_>>();
         fallback.sort_by(|a, b| {
             natural_key(b)
                 .cmp(&natural_key(a))
@@ -231,26 +239,21 @@ mod tests {
             "o4-mini",
             "gpt-4.1",
             "gpt-5.5",
+            "gpt-5.5-mini",
             "gpt-5.6-sol",
             "gpt-5.6-terra",
-            "gpt-5.6-terra-2026-07-09", // dated snapshot of a recommended id
-            "gpt-5.6-luna",
             "text-embedding-3-small",
         ]
         .iter()
         .map(|s| s.to_string())
         .collect();
 
-        // Only the recommended gpt-5.6 flavors are shown, best-first per
-        // `family_roots` (terra default), and the clean id wins over its dated
-        // snapshot. gpt-5.5 / o-series / 4o / 3.5 are dropped.
+        // Only the recommended gpt-5.5 family is shown, best-first per
+        // `family_roots`. The base id wins over `-mini`. gpt-5.6-* /
+        // o-series / 4o / 3.5 are dropped.
         assert_eq!(
             rank_shortlist(Provider::OpenAI, &models),
-            vec![
-                "gpt-5.6-terra".to_string(),
-                "gpt-5.6-sol".to_string(),
-                "gpt-5.6-luna".to_string(),
-            ]
+            vec!["gpt-5.5".to_string()]
         );
     }
 
@@ -301,5 +304,16 @@ mod tests {
         let shortlist = rank_shortlist(Provider::OpenAI, &models);
         assert!(shortlist.contains(&"weird-model".to_string()));
         assert!(shortlist.contains(&"another-thing".to_string()));
+    }
+
+    #[test]
+    fn rank_shortlist_fallback_drops_incompatible_reasoning_models() {
+        let models: Vec<String> = ["gpt-5.6-terra", "gpt-5.4", "gpt-5.2"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let shortlist = rank_shortlist(Provider::OpenAI, &models);
+        assert!(shortlist.contains(&"gpt-5.4".to_string()));
+        assert!(!shortlist.contains(&"gpt-5.6-terra".to_string()));
     }
 }

--- a/crates/aura-cli/src/init/spec.rs
+++ b/crates/aura-cli/src/init/spec.rs
@@ -504,7 +504,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(spec.provider, Provider::OpenAI);
-        assert_eq!(spec.model, "gpt-5.6-terra");
+        assert_eq!(spec.model, "gpt-5.5");
         assert_eq!(
             spec.api_key,
             Some(ApiKeySource::EnvVar("OPENAI_API_KEY".to_string()))

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -2343,6 +2343,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 api_key,
                 model,
                 base_url,
+                reasoning_effort,
                 ..
             } => {
                 let mut cb =
@@ -2355,11 +2356,22 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     .map_err(|e| format!("Failed to build OpenAI coordinator: {}", e))?
                     .completions_api()
                     .completion_model(model);
+                let mut combined_params: Option<serde_json::Value> = None;
+                if let Some(effort) = reasoning_effort {
+                    combined_params =
+                        Some(serde_json::json!({"reasoning_effort": effort.to_string()}));
+                }
+                if let Some(params) = &additional_params {
+                    combined_params = Some(match combined_params {
+                        Some(existing) => crate::builder::merge_json(existing, params.clone()),
+                        None => params.clone(),
+                    });
+                }
                 Ok(ProviderAgent::OpenAI(Self::build_agent_with_tools(
                     cm,
                     preamble,
                     temperature,
-                    additional_params,
+                    combined_params,
                     max_tokens,
                     tools,
                 )))


### PR DESCRIPTION
## Root Cause

`gpt-5.6-terra` is a **reasoning model** — OpenAI enables reasoning by default for this model family. AURA hardcodes the Chat Completions endpoint (`/v1/chat/completions`) via `.completions_api()` and attaches function tools (MCP tools) to every agent. OpenAI rejects `tools` + default reasoning for `gpt-5.6-terra` on `/v1/chat/completions`:

```
Function tools with reasoning_effort are not supported for gpt-5.6-terra
in /v1/chat/completions. To use function tools, use /v1/responses or set
reasoning_effort to 'none'.
```

The default config from `aura init` does **not** set `reasoning_effort` (it is `None` by default), so AURA never sends `reasoning_effort = "none"` to suppress the model's default reasoning. The default model was pinned in `family_roots(Provider::OpenAI)` at `provider.rs:83`: `&["gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.6-luna"]`.

## Fix

**Pin the recommended default to `gpt-5.5`**, which does not have the reasoning + tools conflict on the Chat Completions endpoint.

### Secondary fix: coordinator `reasoning_effort` injection

The smoke test uncovered a pre-existing bug: the orchestration coordinator builder (`orchestrator.rs:2341-2365`) used `..` to skip `reasoning_effort` from `LlmConfig::OpenAI`, so the coordinator silently dropped `reasoning_effort` from the config. Only the worker builder (`orchestrator.rs:2520-2567`) injected it. This is now fixed — the coordinator builds `combined_params` with `reasoning_effort` + `additional_params`, matching the worker and single-agent patterns.

## Changes

| File | Change |
|------|--------|
| `crates/aura-cli/src/init/provider.rs` | `family_roots(OpenAI)`: `gpt-5.6-*` → `gpt-5.5` |
| `crates/aura-cli/src/init/ranking.rs` | Updated `rank_shortlist_curates_openai_to_recommended_ids` test for `gpt-5.5` |
| `crates/aura-cli/src/init/spec.rs` | Updated `interactive_model_defaults_to_suggestion` assertion: `gpt-5.6-terra` → `gpt-5.5` |
| `crates/aura/src/orchestration/orchestrator.rs` | Coordinator now injects `reasoning_effort` into `additional_params` (was silently dropped) |

## Smoke Tests

Mock wiretap tests (in `aura-sandbox/reasoning-smoke/`) verify `reasoning_effort` reaches the wire for both single-agent and orchestration (coordinator + worker), across all 3 variants:

```
=== Mock wiretap mode ===
  single-default (expect reasoning_effort=absent) ... PASS (1 request(s), all reasoning_effort=absent)
  single-none    (expect reasoning_effort=none)    ... PASS (1 request(s), all reasoning_effort=none)
  single-medium  (expect reasoning_effort=medium) ... PASS (1 request(s), all reasoning_effort=medium)
  orch-default   (expect reasoning_effort=absent) ... PASS (9 request(s), all reasoning_effort=absent)
  orch-none      (expect reasoning_effort=none)    ... PASS (10 request(s), all reasoning_effort=none)
  orch-medium    (expect reasoning_effort=medium) ... PASS (10 request(s), all reasoning_effort=medium)

Mock results: 6 passed, 0 failed
```

Real service tests verify gpt-5.5 + function tools does not 400 on the real OpenAI API:

```
=== Real service mode ===
  real-single ... PASS (no 400 error)
  real-orch    ... PASS (no 400 error)

Real results: 2 passed, 0 failed
```

Fixes: #511