### PR TITLE
doc: surface pre-push quality gate in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,8 +166,16 @@ Confirmed sequential as of Rig 0.28: the streaming handler `.await`s each tool c
 make build                  # Build release binary
 cargo test --workspace      # Run all tests (the `make test` hook is empty)
 make docker-build           # Build Docker image
-make lint                   # Run clippy + fmt check
+make lint                   # Run clippy + fmt check (fmt uses cargo +nightly)
+make ci                     # Bundle: fmt-check + lint (test hook is empty)
 ```
+
+**Before committing, run `cargo +nightly fmt --check`, `cargo clippy
+--workspace`, and `cargo test --workspace`.** After committing, run
+`make lint-commits` to verify the commit message. fmt runs under
+`cargo +nightly` (see `.makefiles/rust.mk`), so use `cargo +nightly fmt
+--check` — not `cargo fmt` — to match CI. See `CONTRIBUTING.md` for the
+full workflow.
 
 ## Code Comment Conventions
 


### PR DESCRIPTION
## What

CLAUDE.md's CI/CD section listed `make lint` but did not state the pre-push gate or that fmt runs under `cargo +nightly`.

## Why

CONTRIBUTING.md already documents both, but CLAUDE.md is the agent-facing entry point. An agent that reads only CLAUDE.md misses the gate and pushes code that fails CI fmt-check (this happened on PR #515).

## Changes

- Add `make ci` to the CI/CD command block
- Add a pre-push note: run `make fmt-check`, `cargo test --workspace`, and `make lint` (or `make ci` plus `cargo test --workspace`, since the test hook is empty)
- Note that fmt runs under `cargo +nightly`, so `cargo fmt` on stable may diverge from CI
- Point at `CONTRIBUTING.md` for the full workflow