### PR TITLE
Clarify AURA positioning and production security

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
   <h1>AURA</h1>
   <p><strong>AURA is a production-tested SRE agent platform you can deploy in minutes.</strong></p>
   <img src="https://res.cloudinary.com/dmoknxebz/image/upload/v1785777937/github-header-aura-20260803.webp" alt="AURA investigating an incident from the terminal" width="720">
+  <p><em>In this demo, AURA investigates a payment failure by correlating Mezmo traces and logs, Prometheus latency, and Kubernetes deployment history. Three specialist agents identify an N+1 regression introduced by productcatalogservice 1.13.2, recommend rolling back to 1.13.1, and provide recovery checks and engineering follow-up.</em></p>
   <p>
     <a href="#quick-start"><strong>Quick Start</strong></a> ·
     <a href="#integrations"><strong>Integrations</strong></a> ·
-    <a href="http://docs.mezmo.com/aura"><strong>Documentation</strong></a> ·
+    <a href="https://docs.mezmo.com/aura"><strong>Documentation</strong></a> ·
     <a href="https://github.com/mezmo/aura/issues/views/4715"><strong>Roadmap</strong></a> ·
     <a href="#explore-aura"><strong>Explore</strong></a> ·
     <a href="https://mezmo.com/r/slack-aura"><strong>Community</strong></a>
@@ -15,11 +16,19 @@
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-compatible-green" alt="Model Context Protocol compatible"></a>
 </div>
 
-AURA handles the guardrails, APIs, state management, streaming, and failure handling required to put AI to work safely on production infrastructure. Connect your stack through guided setup, and AURA's preconfigured team of agents starts investigating incidents using the models you already rely on. From there, customize existing agents or add new ones to fit your infrastructure and SRE workflows.
+Connect your stack through guided setup, and AURA's preconfigured team of agents starts investigating incidents using the models you already rely on. From there, customize existing agents or add new ones to fit your infrastructure and SRE workflows.
+
+AURA handles the guardrails, APIs, state management, streaming, failure handling, and observability needed to connect AI models to production tools within operator-defined boundaries.
+
+## Proven in Production
+
+AURA began as Mezmo’s internal harness for operating our own SaaS. Our engineering and SRE teams still use it for production operations today, and teams outside Mezmo run AURA in their own production environments.
+
+AURA also powers thousands of agent sessions each month in Mezmo’s hosted observability platform.
 
 ## Quick Start
 
-Install AURA on Linux or macOS with the [install script](scripts/install.sh):
+Install AURA on Linux or macOS with the [install script](scripts/install.sh). It downloads published release artifacts and verifies their checksums.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/mezmo/aura/main/scripts/install.sh | bash
@@ -28,7 +37,7 @@ curl -fsSL https://raw.githubusercontent.com/mezmo/aura/main/scripts/install.sh 
 Create a ready-to-run local agent:
 
 ```bash
-aura init        # Choose an LLM provider & initial model, and write the initial config file
+aura init        # Choose an LLM provider and initial model, and write the initial config file
 ```
 
 Start the agent:
@@ -39,19 +48,31 @@ aura
 
 ## Why AURA
 
-- **Run entirely on your own infrastructure.** Deploy AURA in air-gapped and highly regulated environments.
-- **Define complete agent systems in readable TOML.** Configure orchestrated agent swarms, models, per-agent prompts, tools, and guardrails in one file.
-- **Use the LLM backends you already have.** Run OpenAI, Anthropic, Bedrock, Gemini, Ollama, or OpenRouter; switch providers with a one-section edit or mix models across workflows.
-- **Give agents real tools.** Connect any compatible MCP server over Streamable HTTP, SSE, or STDIO; its tools are discovered and callable at runtime.
-- **Keep humans in control.** Require webhook or in-conversation approval before sensitive tool calls execute.
-- **Handle huge tool outputs.** Park oversized results on disk and let agents retrieve only the slices they need, avoiding context floods.
-- **Fan work out to specialist agents.** A coordinator plans a task DAG, runs independent tasks in parallel, and consolidates the results.
-- **Inspect every run.** AURA can export [OpenTelemetry traces](http://docs.mezmo.com/aura/tracing-spans) for requests, LLM turns, tool calls, and orchestration decisions, giving you an end-to-end view of how each result was produced.
-- **Ground your agents in your data.** Use vector search with Qdrant or AWS Bedrock Knowledge Bases.
-- **Give agents reusable skills.** Add [Agent Skills](https://agentskills.io) directories to a config; agents load task-specific instructions and supporting files only when needed.
-- **Chat locally or through a server.** Run agents in-process from a config or connect the CLI to any OpenAI-compatible API.
-- **Interoperate or embed.** Connect with other agents over A2A or embed AURA's Rust core directly in your application.
-- **Use existing clients and SDKs.** Serve every agent through an OpenAI-compatible API so clients such as LibreChat and OpenWebUI work unchanged.
+- **Operate inside your own security boundary.** Run AURA in your infrastructure, including air-gapped and highly regulated environments, with control over model, tool, storage, and telemetry destinations.
+- **Define the entire agent system in reviewable TOML.** Keep models, specialist agent teams, per-agent prompts, tools, approval policies, and guardrails together in configuration that can be versioned and reviewed.
+- **Use different model providers without rebuilding workflows.** Run OpenAI, Anthropic, Bedrock, Gemini, Ollama, or OpenRouter; switch providers with a configuration change or assign different models to different roles.
+- **Put sensitive actions behind human approval.** Require webhook or in-conversation approval before configured tool calls execute, with denial, timeout, and transport failures handled fail-closed.
+- **Trace every model, tool, and orchestration decision.** Export [OpenTelemetry traces](https://docs.mezmo.com/aura/tracing-spans) for requests, LLM turns, tool calls, and multi-agent execution so each result can be investigated end to end.
+
+## Extensible Runtime
+
+- **Connect tools and RAG.** Discover tools from compatible MCP servers over Streamable HTTP, SSE, or STDIO, and ground agents through Qdrant or AWS Bedrock Knowledge Bases.
+- **Build multi-agent workflows.** Coordinate specialist agent teams with dependency-aware task execution while parking oversized tool results on disk for selective retrieval.
+- **Add reusable Agent Skills.** Load task-specific [Agent Skills](https://agentskills.io) instructions and supporting files only when they are needed.
+- **Interoperate or embed.** Connect AURA with other agents over A2A or embed its Rust core directly in your application.
+- **Use existing clients and SDKs.** Serve agents through an OpenAI-compatible API so clients such as LibreChat and OpenWebUI work unchanged, or run them locally through the AURA CLI.
+
+## Production Safety
+
+Production controls define an operator-managed boundary around AURA:
+
+- Runs in your infrastructure, including air-gapped environments when model providers and MCP servers are locally reachable.
+- Agent prompts and tool data are sent only to the model providers, MCP servers, approval services, storage backends, and tracing destinations you configure. Mezmo CLI product telemetry is separately disclosed and controlled.
+- Sensitive tool calls can require explicit human approval.
+- Credentials remain outside prompts and agent configuration when supplied through environment variables or secret mounts.
+- Tool, model, and orchestration activity can be exported as [OpenTelemetry traces](https://docs.mezmo.com/aura/tracing-spans).
+
+See the complete [security and data-handling model](SECURITY.md), including telemetry defaults, permission boundaries, prompt-injection risks, and supply-chain verification.
 
 ## Integrations
 
@@ -86,12 +107,12 @@ Through compatible [MCP](https://modelcontextprotocol.io) servers, AURA agents c
 
 ## Explore AURA
 
-- [Browse agent configurations and advanced quickstarts](http://docs.mezmo.com/aura/example-configs)
-- [Browse the annotated configuration reference](http://docs.mezmo.com/aura/configuration-reference)
-- [Build an orchestrated multi-agent workflow](http://docs.mezmo.com/aura/quickstart-orchestration-math)
-- [Run a Kubernetes SRE agent](http://docs.mezmo.com/aura/quickstart-k8s-sre)
-- [Learn the full AURA CLI](http://docs.mezmo.com/aura/cli-reference)
-- [Use AURA's streaming API](http://docs.mezmo.com/aura/streaming-api-guide)
+- [Browse agent configurations and advanced quickstarts](https://docs.mezmo.com/aura/example-configs)
+- [Browse the annotated configuration reference](https://docs.mezmo.com/aura/configuration-reference)
+- [Build an orchestrated multi-agent workflow](https://docs.mezmo.com/aura/quickstart-orchestration-math)
+- [Run a Kubernetes SRE agent](https://docs.mezmo.com/aura/quickstart-k8s-sre)
+- [Learn the full AURA CLI](https://docs.mezmo.com/aura/cli-reference)
+- [Use AURA's streaming API](https://docs.mezmo.com/aura/streaming-api-guide)
 - [Develop AURA](DEVELOPMENT.md) or [contribute](CONTRIBUTING.md)
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ aura
 Production controls define an operator-managed boundary around AURA:
 
 - Runs in your infrastructure, including air-gapped environments when model providers and MCP servers are locally reachable.
-- Agent prompts and tool data are sent only to the model providers, MCP servers, approval services, storage backends, and tracing destinations you configure. Mezmo CLI product telemetry is separately disclosed and controlled.
+- AURA sends agent prompts and tool data to the model providers, MCP servers, approval services, storage backends, and tracing destinations you configure. Enabled client-side tools and STDIO processes can initiate additional network traffic unless system-level network policy prevents it. Mezmo CLI product telemetry is separately disclosed and controlled.
 - Sensitive tool calls can require explicit human approval.
-- Credentials remain outside prompts and agent configuration when supplied through environment variables or secret mounts.
+- Credentials supplied through environment variables or secret mounts remain outside prompts only when referenced from designated authentication fields; environment substitution in prompt-bearing fields places their values into model context.
 - Tool, model, and orchestration activity can be exported as [OpenTelemetry traces](https://docs.mezmo.com/aura/tracing-spans).
 
 See the complete [security and data-handling model](SECURITY.md), including telemetry defaults, permission boundaries, prompt-injection risks, and supply-chain verification.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,265 @@
+# Security Policy and Data-Handling Model
+
+This document defines AURA's security boundary, deployment responsibilities,
+data flows, and vulnerability-reporting policy.
+
+## Safety Boundary
+
+AURA orchestrates model requests and tool calls under the identity and operating
+system privileges assigned by its operator. Its controls can limit which tools a
+model sees, require approval for configured tool-name patterns, and export an
+audit trail. They do not make model output trustworthy, sandbox tools, undo
+mutations, or enforce the retention policies of an LLM provider or MCP server.
+
+The operator is responsible for authenticating users, isolating the deployment,
+granting least-privilege credentials, selecting trusted model and MCP endpoints,
+restricting network egress, reviewing approval policy, and backing up systems a
+tool can change. Treat data returned by logs, runbooks, vector stores, webpages,
+and MCP servers as untrusted model input.
+
+`aura-web-server` does not provide end-user authentication or identity-aware
+RBAC for its OpenAI-compatible API. Bind it to a private interface or place it
+behind an authenticated TLS gateway or service mesh.
+
+An air-gapped deployment requires every enabled network dependency to be local
+or disabled. This includes model providers, MCP and RAG services, approval
+webhooks, Redis-compatible session stores, OTLP collectors, and any AURA server
+used by the CLI. Disable CLI product telemetry, use offline initialization when
+provider model-list endpoints are unavailable, and restrict or disable
+client-side tools and STDIO MCP processes that can open their own network
+connections. Enforce the boundary with network policy; AURA does not implement
+a general-purpose egress firewall.
+
+## Telemetry Defaults
+
+AURA exposes two independent mechanisms with different recipients and
+purposes. CLI product telemetry is usage data sent to Mezmo by default.
+OpenTelemetry is operational data exported only to a collector selected by the
+deployment operator.
+
+### Mezmo CLI Product Telemetry
+
+This mechanism gives Mezmo bounded usage signals, associated in the event
+payload with a random install ID rather than a user identity, for improving the
+AURA CLI. The payload disables PostHog IP and geolocation enrichment, but the
+network recipient can still observe transport metadata such as the source IP.
+It applies only to the interactive CLI; the web server and core library do not
+link or emit this product telemetry. The published server container runs the web
+server and therefore does not emit it.
+
+- With no recorded preference, telemetry starts in a held state. The first
+  interactive session displays a notice; no event is sent until the user sends
+  the first chat message. Sending that message enables telemetry. `aura init`
+  and non-interactive one-shot queries do not send product telemetry.
+- The event schema is allow-listed in code. It includes a random install ID,
+  random session ID, AURA version, coarse OS family and deployment method,
+  session mode, whether client tools are enabled, chat start/completion and
+  success, and session exit reason. It excludes prompts, responses, file paths,
+  host identifiers, model identifiers, token counts, latency, and error text.
+- Events are sent to Mezmo's PostHog project by default. An operator can
+  override the endpoint, in which case that operator-selected destination is
+  the recipient instead of Mezmo. Set `DO_NOT_TRACK=1`,
+  `AURA_TELEMETRY_DISABLED=1`, `AURA_TELEMETRY_ENABLED=false`, or
+  `[telemetry] enabled = false` in CLI preferences to prevent transmission. CI
+  and test environments are disabled automatically. `/telemetry status`,
+  `/telemetry recent`, and `/telemetry disable` expose the runtime state.
+- A local inspection log is written at
+  `~/.aura/telemetry/events.jsonl` by default, including events that were held
+  or failed to send. This local audit copy is for the operator and is not itself
+  transmitted. It rotates at 1,000 lines and retains one rotated file. Set
+  `AURA_TELEMETRY_LOG_EVENTS=0` to disable it. The install ID remains at
+  `~/.aura/install-id` until the operator removes it.
+- Mezmo and PostHog control retention when the default destination is used. The
+  destination owner controls retention when the endpoint is overridden. AURA
+  does not enforce remote retention. Disable product telemetry if the recipient
+  is outside the deployment's approved data boundary.
+
+### Operator OpenTelemetry Export
+
+This mechanism gives the deployment operator request, model, tool, and
+orchestration traces. It is off unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set, and
+AURA exports only to the collector at that operator-supplied endpoint. Mezmo
+does not receive these traces unless the operator deliberately selects a
+Mezmo-operated collector.
+
+Once OTLP export is enabled, treat the collector as a recipient of prompt,
+response, and tool content under the current implementation. For AURA-owned
+spans, `OTEL_RECORD_CONTENT=false` (the default) omits prompt/completion text and
+tool arguments/results, and `OTEL_RECORD_CONTENT=true` includes them subject to
+`OTEL_CONTENT_MAX_LENGTH`. However, Rig-owned chat, agent-turn, and tool spans
+currently record content independently of that flag; AURA translates their
+prompt, response, structured-message, tool-argument, and tool-result attributes
+for export. Those attributes are subject to `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`
+(65,536 bytes by default), not `OTEL_CONTENT_MAX_LENGTH`.
+
+Accordingly, `OTEL_RECORD_CONTENT=false` is not currently a complete content
+suppression control. Do not set `OTEL_EXPORTER_OTLP_ENDPOINT` unless the
+collector and its downstream systems are approved to receive model and tool
+content. The operator controls their access and retention.
+
+## Credentials
+
+Use environment-variable placeholders such as `{{ env.OPENAI_API_KEY }}`
+instead of literal credentials in source TOML, and arrange for the deployment's
+secret manager to populate those environment variables. The initialization
+flow keeps the placeholder in `config.toml`; if a user enters a new key, the CLI
+may write it to a local `.env`. That write uses the process's normal filesystem
+permissions rather than enforcing a dedicated restrictive mode, so the
+operator must restrict the file and exclude it from version control.
+
+Environment substitution is general-purpose: AURA replaces placeholders
+throughout the TOML document before parsing it, not only in credential fields.
+A secret referenced from `system_prompt`, another prompt-bearing field, or tool
+configuration will be placed there. Resolved credentials also exist in AURA's
+process memory and runtime configuration.
+
+When a credential is referenced only from a designated provider or transport
+authentication field, AURA passes it to that client and does not deliberately
+copy it into a model message. This is not a secret-isolation boundary. A broadly
+privileged MCP server, STDIO child process, or client-side shell/file tool may
+be able to read process environment, mounted secrets, credential files, or
+other host data and return them to the model or another destination. Run AURA
+and every MCP server with separate least-privilege identities where possible.
+
+`headers_from_request` can deliberately forward selected inbound headers to an
+MCP server or approval webhook. Forward only headers the destination is allowed
+to receive, and never use a catch-all proxy rule for authentication headers.
+
+## Data Retention and LLM Egress
+
+A model provider receives the system prompt, user input, relevant conversation
+history, and tool results placed into model context. An MCP server receives its
+selected tool name and arguments; tool arguments can contain user input or
+model-derived data. RAG services, approval webhooks, Redis-compatible session
+stores, and OTLP collectors are additional destinations only when configured.
+The interactive CLI sends its API requests to its configured AURA server and,
+unless disabled as described above, sends product telemetry to the configured
+telemetry endpoint. `aura init` can contact a selected provider's model-list
+endpoint unless offline mode is used.
+
+These are AURA’s direct application-level data flows. MCP servers, enabled
+client-side tools, and STDIO processes may independently initiate additional
+network traffic under their own operating-system privileges. Their downstream
+behavior and egress policies are outside AURA’s control. Evaluate those
+components separately and enforce system-level network policy where required.
+
+Enabled client-side tools and STDIO MCP processes execute with the operator's
+OS privileges and may initiate network traffic that AURA cannot enumerate or
+constrain. Use process isolation and egress allow-lists to enforce the intended
+set of destinations. Do not describe an AURA deployment as sending data "only"
+to model providers and MCP servers unless network policy independently enforces
+that narrower boundary and every other feature above is disabled.
+
+Provider-side and MCP-side logging, training, residency, and retention are
+governed by those services. AURA cannot override them. Select provider terms
+and endpoints that meet the deployment's requirements, or use local services.
+
+The OpenAI-compatible server does not persist ordinary chat history; clients
+resubmit it with later requests. The CLI saves conversations under
+`~/.aura/conversations/` until the user removes them. Scratchpad files,
+orchestration artifacts, optional diagnostic logs, and configured session-store
+records can also contain operational data. Their storage permissions, expiry,
+rotation, backup, and deletion are operator responsibilities.
+
+## RBAC and MCP Permission Boundaries
+
+AURA's `mcp_filter` and `client_tool_filter` settings control which named tools
+are exposed to an agent or specialist worker. An explicit empty `mcp_filter`
+grants no MCP tools; a missing filter can expose all discovered MCP tools. Use
+explicit allow-lists for every agent and worker.
+
+These filters are capability-reduction controls, not user-aware RBAC. The MCP
+server and the credential used to connect to it define the authoritative data
+and action permissions. Enforce user authentication and RBAC at the ingress,
+MCP server, cloud IAM, Kubernetes service account, and network layers. Do not
+give an AURA process broader credentials than any allowed tool call requires.
+
+## Read-Only and Mutating Tools
+
+AURA does not infer whether an arbitrary MCP tool is read-only or mutating from
+its name or schema. Separate read-only and mutating MCP servers or credentials,
+expose only required tools, and match all mutating tool names in the approval
+policy. Prefer read-only service accounts for investigative agents and a
+separate, narrowly scoped remediation agent for changes.
+
+Client-side tools are disabled by default and require opt-in from both the CLI
+and agent configuration. When enabled, `Shell`, file-reading, and file-update
+tools run on the client host with the user's privileges and without a sandbox.
+Project permission rules can allow, deny, or prompt for matching calls, but glob
+rules are not a hard security boundary and can be over-broad.
+
+## Approval and Fail-Closed Behavior
+
+The `[hitl]` policy gates only tool names matching its `require_approval` glob
+patterns. A specific matching call reaches its underlying tool only after the
+configured route returns an `Approved` decision. Denial short-circuits that
+call; timeout, client disconnect, shutdown, malformed or rejected approval,
+and approval transport, channel, or storage failure return an error before the
+underlying tool runs. These outcomes therefore fail closed for that matching
+call. They do not prevent the model from proposing another call.
+
+AURA does not establish that an approver is human. A conversational decision
+comes from the connected client, while a webhook decision can be produced by a
+person or an automated service. The deployment must authenticate users and
+enforce approver identity and authorization outside AURA.
+
+Webhook HMAC signing and response verification are optional. Without a signing
+secret, AURA sends unsigned requests, accepts unsigned well-formed responses,
+and permits a plaintext `http://` webhook URL. Production webhook deployments
+should use TLS and configure AURA's HMAC secret; when a secret is configured,
+AURA rejects unsigned or invalid responses and rejects plaintext webhook URLs.
+
+Tools omitted from `require_approval` are not protected by this gate. Approval
+also does not prove that a call is correct: the model-generated explanation and
+arguments may reflect hallucination or prompt injection. Approvers should
+inspect the exact tool, arguments, target, and expected effect, and reject calls
+whose impact cannot be determined.
+
+## Prompt Injection from Logs and Runbooks
+
+Logs, alerts, traces, tickets, runbooks, retrieved documents, webpages, and MCP
+responses can contain text that instructs the model to ignore policy, reveal
+data, or call tools. AURA treats this content as context; it does not guarantee
+that a model will distinguish instructions from evidence.
+
+Reduce this risk by combining independent controls:
+
+- Give investigative agents read-only tools and minimal data access.
+- Use explicit tool allow-lists and approval patterns for every mutation.
+- Keep credentials inaccessible to model-directed shell and file tools.
+- Restrict outbound network access and MCP destinations.
+- Require an approver to verify source data and exact arguments rather than
+  trusting the model's summary.
+- Test agents with hostile log lines and runbook content before production use.
+
+## Vulnerability Reporting
+
+Report suspected vulnerabilities privately to
+[security@mezmo.com](mailto:security@mezmo.com). GitHub private vulnerability
+reporting is not currently enabled for this repository, so do not rely on the
+repository's private-advisory submission URL. Include the affected version,
+deployment mode, reproduction steps, impact, and any proposed mitigation. Do
+not include live credentials, customer data, or an unredacted exploit in a
+public issue. Use a public issue only for non-sensitive hardening requests.
+
+AURA does not currently publish a multi-version security-support window.
+Security fixes are targeted at the latest released version; maintainers make no
+support commitment for older releases or unreleased builds from `main` unless a
+release announcement states otherwise. Upgrade to the newest release before
+reporting a problem that may already be fixed.
+
+## Release Integrity, Signing, and SBOMs
+
+Release binaries and `.deb`/`.rpm` packages are accompanied by SHA-256 checksums.
+The install script requires a matching checksum by default; a mismatch is always
+fatal. Keep `AURA_REQUIRE_CHECKSUM=1`, or provide a separately obtained trusted
+checksum with `AURA_CHECKSUMS`.
+
+Checksums detect corruption but, when downloaded from the same release location
+as an artifact, do not protect against compromise of that release account. AURA
+does not currently claim cryptographic signatures or provenance attestations for
+release packages or container images, and does not currently publish an SBOM as
+a release artifact. Where those controls are required, build from a reviewed
+source revision in a controlled pipeline, generate and retain an SBOM, scan the
+result, sign it with your organization's trusted identity, and pin deployments
+to verified package hashes or container digests.


### PR DESCRIPTION
This PR refreshes the README around five buying criteria, moves framework features into an Extensible Runtime section, adds a demo caption and production-safety overview, and upgrades documentation links to HTTPS.

It adds `SECURITY.md` defining telemetry, credential and egress behavior, permission boundaries, approvals, prompt injection, vulnerability reporting, release integrity, and SBOM limitations.

The security policy explicitly documents the current OTLP content-export limitation and operator responsibilities; no runtime behavior changes.

Validation: `git diff --check origin/main...HEAD` and local README targets verified.
