### PR TITLE
fix(a2a): durably record approval decisions on the redis backend

### DIFF
--- a/crates/aura-web-server/src/session_store/redis/approval_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/approval_store.rs
@@ -1,22 +1,28 @@
 //! Redis-backed HITL approval store: a parked approval is readable and
-//! resolvable from any instance.
+//! resolvable from any instance, and a resolution leaves a durable decision
+//! record the parking instance can recover if the bus wake is lost.
 //!
 //! Key schema (all under the configured `key_prefix`, default `aura`):
 //!
-//! | Key                            | Type                 | Purpose                  |
-//! | ------------------------------ | -------------------- | ------------------------ |
-//! | `{p}:approval:{decision_id}`   | string (record JSON) | parked approval record   |
-//! | `{p}:approval:req:{request_id}`| set of decision ids  | `cancel_request` fan-out |
+//! | Key                                    | Type                 | Purpose                  |
+//! | -------------------------------------- | -------------------- | ------------------------ |
+//! | `{p}:approval:{decision_id}`           | string (record JSON) | parked approval record   |
+//! | `{p}:approval:decision:{decision_id}`  | string (record JSON) | recorded decision        |
+//! | `{p}:approval:req:{request_id}`        | set of decision ids  | `cancel_request` fan-out |
 //!
 //! Approval records carry a TTL derived from the approval's `expires_at`, so
 //! abandoned entries self-clean; the parking instance's await remains the
-//! authoritative timeout. The request index is refreshed on every register
-//! with a margin over the record TTL and pruned best-effort on resolve/remove;
-//! a stale indexed id only costs `cancel_request` a `DEL` of a missing key.
+//! authoritative timeout. Decision records keep a margin past the parked
+//! record's remaining TTL, covering the parking instance's deadline-backstop
+//! read. The request index is refreshed on every register with a margin over
+//! the record TTL and pruned best-effort on resolve/remove; a stale indexed id
+//! only costs `cancel_request` a `DEL` of a missing key.
+
+use std::sync::LazyLock;
 
 use async_trait::async_trait;
 use aura::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
-use aura::session_store::{ApprovalStore, ParkedApprovalRecord, SessionStoreError};
+use aura::session_store::{ApprovalStore, DecisionRecord, ParkedApprovalRecord, SessionStoreError};
 use redis::AsyncCommands;
 use redis::aio::ConnectionManager;
 
@@ -27,6 +33,33 @@ use super::request_err;
 const MIN_TTL_SECS: u64 = 1;
 /// Margin the request index's TTL keeps over its newest record's TTL.
 const REQ_INDEX_TTL_MARGIN_SECS: u64 = 60;
+/// Margin the decision record's TTL keeps over the parked record's remaining
+/// TTL.
+const DECISION_TTL_MARGIN_MS: u64 = 60_000;
+
+/// The at-most-once claim plus the durable decision write, in one atomic step:
+/// take the parked record (KEYS[1]) and, only if it existed, record the
+/// decision (KEYS[2] = ARGV[1]) with the parked record's remaining TTL plus
+/// ARGV[2] milliseconds. Returns the parked record JSON, or nil when no live
+/// entry existed. Atomicity is what makes a resolver crash unable to consume
+/// the parked entry without leaving the decision behind.
+static RESOLVE_SCRIPT: LazyLock<redis::Script> = LazyLock::new(|| {
+    redis::Script::new(
+        r#"
+        local record = redis.call('GET', KEYS[1])
+        if not record then
+            return nil
+        end
+        local ttl_ms = redis.call('PTTL', KEYS[1])
+        if ttl_ms < 0 then
+            ttl_ms = 0
+        end
+        redis.call('DEL', KEYS[1])
+        redis.call('SET', KEYS[2], ARGV[1], 'PX', ttl_ms + tonumber(ARGV[2]))
+        return record
+        "#,
+    )
+});
 
 pub struct RedisApprovalStore {
     conn: ConnectionManager,
@@ -45,6 +78,10 @@ impl RedisApprovalStore {
         format!("{}:approval:{decision_id}", self.key_prefix)
     }
 
+    fn decision_key(&self, decision_id: &str) -> String {
+        format!("{}:approval:decision:{decision_id}", self.key_prefix)
+    }
+
     fn req_key(&self, request_id: &str) -> String {
         format!("{}:approval:req:{request_id}", self.key_prefix)
     }
@@ -61,12 +98,18 @@ impl RedisApprovalStore {
         let Some(json) = payload else {
             return Ok(None);
         };
-        if let Ok(record) = serde_json::from_str::<ParkedApprovalRecord>(&json) {
+        self.prune_req_index(id, &json).await;
+        Ok(Some(()))
+    }
+
+    /// Drop a taken record's id from its request index, best-effort.
+    async fn prune_req_index(&self, id: &DecisionId, record_json: &str) {
+        if let Ok(record) = serde_json::from_str::<ParkedApprovalRecord>(record_json) {
+            let mut conn = self.conn.clone();
             let _: Result<(), _> = conn
                 .srem(self.req_key(&record.request_id), id.to_string())
                 .await;
         }
-        Ok(Some(()))
     }
 }
 
@@ -100,15 +143,48 @@ impl ApprovalStore for RedisApprovalStore {
     async fn resolve(
         &self,
         id: &DecisionId,
-        _decision: ApprovalDecision,
+        decision: ApprovalDecision,
     ) -> Result<(), ResolveError> {
-        // The atomic take is the at-most-once guarantee: exactly one resolver
-        // gets the record; everyone else (and every later attempt) sees
-        // `NotFound`.
-        match self.take(id).await.map_err(ResolveError::Store)? {
-            Some(()) => Ok(()),
-            None => Err(ResolveError::NotFound),
-        }
+        // The script's atomic take is the at-most-once guarantee: exactly one
+        // resolver gets the record; everyone else (and every later attempt)
+        // sees `NotFound`. The same step writes the decision record, so a
+        // consumed parked entry always leaves a recoverable decision.
+        let payload = serde_json::to_string(&DecisionRecord::from(&decision))
+            .expect("decision record serializes to JSON");
+        let mut conn = self.conn.clone();
+        let taken: Option<String> = RESOLVE_SCRIPT
+            .key(self.approval_key(&id.to_string()))
+            .key(self.decision_key(&id.to_string()))
+            .arg(payload)
+            .arg(DECISION_TTL_MARGIN_MS)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(|e| ResolveError::Store(request_err(e)))?;
+        let Some(json) = taken else {
+            return Err(ResolveError::NotFound);
+        };
+        self.prune_req_index(id, &json).await;
+        Ok(())
+    }
+
+    async fn decision(
+        &self,
+        id: &DecisionId,
+    ) -> Result<Option<ApprovalDecision>, SessionStoreError> {
+        let mut conn = self.conn.clone();
+        let payload: Option<String> = conn
+            .get(self.decision_key(&id.to_string()))
+            .await
+            .map_err(request_err)?;
+        payload
+            .map(|json| {
+                serde_json::from_str::<DecisionRecord>(&json)
+                    .map(ApprovalDecision::from)
+                    .map_err(|e| SessionStoreError::Decode {
+                        reason: e.to_string(),
+                    })
+            })
+            .transpose()
     }
 
     async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError> {

--- a/crates/aura-web-server/src/session_store/redis/event_bus.rs
+++ b/crates/aura-web-server/src/session_store/redis/event_bus.rs
@@ -11,8 +11,8 @@
 //!
 //! Redis pub/sub is fire-and-forget: payloads published while a subscriber's
 //! instance is reconnecting are lost, and a slow subscriber that overflows its
-//! [`TOPIC_CAPACITY`] buffer skips missed payloads. Callers own the backstop —
-//! a parked approval that misses its wake fails closed at its timeout.
+//! [`TOPIC_CAPACITY`] buffer skips missed payloads. Callers own the recovery
+//! path for lost payloads (see `aura::hitl::registry` for the approval wake's).
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -416,6 +416,60 @@ async fn approval_concurrent_resolves_have_exactly_one_winner() {
     );
 }
 
+/// A resolution leaves a durable decision record readable from any instance
+/// (issue #474), and the (rejected) second resolve does not disturb it.
+#[tokio::test]
+async fn approval_resolve_records_decision_readable_cross_instance() {
+    let config = test_config(60);
+    let instance_a = connect(&config).await.approvals();
+    let instance_b = connect(&config).await.approvals();
+
+    let parked = make_parked("req-durable", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    instance_a.register(parked).await.unwrap();
+
+    let denied = ApprovalDecision::Denied {
+        reason: Some("not now".to_string()),
+    };
+    instance_b.resolve(&id, denied.clone()).await.unwrap();
+
+    assert_eq!(
+        instance_a.decision(&id).await.unwrap(),
+        Some(denied.clone())
+    );
+    assert_eq!(
+        instance_a.resolve(&id, ApprovalDecision::Approved).await,
+        Err(ResolveError::NotFound)
+    );
+    assert_eq!(instance_a.decision(&id).await.unwrap(), Some(denied));
+    assert_eq!(
+        instance_a.decision(&DecisionId::generate()).await.unwrap(),
+        None
+    );
+}
+
+/// The decision record's TTL keeps a margin past the parked record's, so the
+/// parking instance's deadline backstop can still read a decision that
+/// arrived just before expiry.
+#[tokio::test]
+async fn decision_record_outlives_parked_record_ttl() {
+    let approvals = connect(&test_config(60)).await.approvals();
+    let parked = make_parked("req-margin", Duration::from_secs(1));
+    let id = parked.request.decision_id;
+    approvals.register(parked).await.unwrap();
+    approvals
+        .resolve(&id, ApprovalDecision::Approved)
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(1600)).await;
+
+    assert_eq!(
+        approvals.decision(&id).await.unwrap(),
+        Some(ApprovalDecision::Approved)
+    );
+}
+
 #[tokio::test]
 async fn approval_remove_makes_resolve_not_found() {
     let approvals = connect(&test_config(60)).await.approvals();
@@ -595,6 +649,39 @@ async fn approval_parked_on_one_instance_wakes_when_resolved_on_another() {
     let outcome = tokio::time::timeout(Duration::from_secs(5), handle.outcome(&cancel))
         .await
         .expect("wake must arrive well before the approval timeout");
+    assert_eq!(
+        outcome,
+        ApprovalOutcome::Decided(ApprovalDecision::Approved)
+    );
+}
+
+/// The issue #474 repro over live Redis: the decision lands in the store but
+/// no wake is ever published (a suppressed wake channel, or a resolver crash
+/// after the claim). The parking instance's store poll recovers the decision
+/// well before the approval timeout instead of failing closed.
+#[tokio::test]
+async fn store_only_resolve_wakes_parking_instance_via_poll() {
+    let config = test_config(60);
+    let store_a = connect(&config).await;
+    let store_b = connect(&config).await;
+    let parker = PendingApprovals::with_backend(store_a.approvals(), store_a.bus());
+    let cancel = RequestCancelToken::unbound();
+
+    let parked = make_parked("req-poll", Duration::from_secs(60));
+    let request = parked.request;
+    let id = request.decision_id;
+    let handle = parker.register(request, Duration::from_secs(60)).await;
+
+    // Resolve against the store alone — no registry, no publish.
+    store_b
+        .approvals()
+        .resolve(&id, ApprovalDecision::Approved)
+        .await
+        .expect("store resolve succeeds");
+
+    let outcome = tokio::time::timeout(Duration::from_secs(15), handle.outcome(&cancel))
+        .await
+        .expect("store poll must deliver the decision well before the 60s timeout");
     assert_eq!(
         outcome,
         ApprovalOutcome::Decided(ApprovalDecision::Approved)

--- a/crates/aura/src/hitl/registry.rs
+++ b/crates/aura/src/hitl/registry.rs
@@ -8,17 +8,20 @@
 //!
 //! State is split along the serialization boundary:
 //!
-//! - the [`ParkedApproval`] record lives in an [`ApprovalStore`], and the
-//!   decision travels over an [`EventBus`] topic, so with a shared backend a
-//!   decision can be resolved by any process; while
+//! - the [`ParkedApproval`] record and the resolved decision live in an
+//!   [`ApprovalStore`] (the durable carrier), and the decision also travels
+//!   over an [`EventBus`] topic (the low-latency wake), so with a shared
+//!   backend a decision can be resolved by any process and survives a lost
+//!   publish; while
 //! - the `oneshot` wake handle that resumes the suspended tool call is
 //!   inherently process-local and stays in this registry's in-RAM map, fired
-//!   by a per-approval bus subscription.
+//!   by a per-approval task listening on the bus and polling the store.
 
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
+use bytes::Bytes;
 use futures::StreamExt;
 use tokio::sync::oneshot;
 use tokio::task::AbortHandle;
@@ -38,6 +41,10 @@ fn approval_topic(id: &DecisionId) -> String {
     format!("approval:{id}")
 }
 
+/// How often a parked approval's wake task falls back to reading the store
+/// for a recorded decision.
+const DECISION_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
 /// The cross-request registry of parked conversational approvals. A `Clone`
 /// newtype over an `Arc`.
 #[derive(Clone)]
@@ -51,20 +58,18 @@ struct PendingApprovalsInner {
     wakes: Mutex<BTreeMap<DecisionId, WakeEntry>>,
 }
 
-/// The process-local half of one parked approval: its wake handle and bus
-/// subscription.
+/// The process-local half of one parked approval: its wake handle and wake
+/// task.
 struct WakeEntry {
     request_id: String,
     wake: oneshot::Sender<ApprovalDecision>,
-    subscription: Option<AbortHandle>,
+    wake_task: AbortHandle,
 }
 
 impl WakeEntry {
-    /// Stop the bus-subscription task.
-    fn abort_subscription(&self) {
-        if let Some(subscription) = &self.subscription {
-            subscription.abort();
-        }
+    /// Stop the wake task (bus listener + store poll).
+    fn abort_wake_task(&self) {
+        self.wake_task.abort();
     }
 }
 
@@ -110,8 +115,10 @@ impl PendingApprovals {
 
     /// Park an approval, returning the await handle.
     ///
-    /// Store or bus faults do not fail registration: the call parks anyway,
-    /// cannot be resolved, and fails closed at its timeout.
+    /// Store or bus faults do not fail registration: the call parks anyway.
+    /// An unpersisted park cannot be resolved and fails closed at its
+    /// timeout; a park whose subscription failed still resolves through the
+    /// wake task's store poll.
     #[must_use]
     pub async fn register(&self, request: ApprovalRequest, timeout: Duration) -> AwaitingDecision {
         let id = request.decision_id;
@@ -127,32 +134,32 @@ impl PendingApprovals {
 
         // Subscribe before the store insert: once `store.register` returns,
         // any process may resolve and publish, and the wake must already be
-        // listening for the decision.
+        // listening for the decision. A failed subscription still parks a
+        // wakeable approval — the wake task's store poll remains as the
+        // (slower) carrier.
         let subscription = match self.0.bus.subscribe(&approval_topic(&id)).await {
-            Ok(decisions) => {
-                let inner = Arc::downgrade(&self.0);
-                // Instrument with the registering request's span so the wake
-                // (and any decode warning) lands in the parked call's trace.
-                let task = tracing::Instrument::instrument(
-                    wake_on_decision(inner, id, decisions),
-                    tracing::Span::current(),
-                );
-                Some(tokio::spawn(task).abort_handle())
-            }
+            Ok(decisions) => Some(decisions),
             Err(err) => {
                 warn!(
                     decision_id = %id, error = %err,
-                    "approval wake subscription failed; the parked call cannot be woken and will fail closed",
+                    "approval wake subscription failed; decision delivery falls back to store polling",
                 );
                 None
             }
         };
+        // Instrument with the registering request's span so the wake (and any
+        // decode warning) lands in the parked call's trace.
+        let task = tracing::Instrument::instrument(
+            wake_on_decision(Arc::downgrade(&self.0), id, subscription),
+            tracing::Span::current(),
+        );
+        let wake_task = tokio::spawn(task).abort_handle();
         self.0.wakes.lock().expect("registry lock poisoned").insert(
             id,
             WakeEntry {
                 request_id,
                 wake: tx,
-                subscription,
+                wake_task,
             },
         );
         if let Err(err) = self.0.store.register(parked).await {
@@ -164,9 +171,9 @@ impl PendingApprovals {
         AwaitingDecision::new(id, rx, Instant::now() + timeout)
     }
 
-    /// Resolve a parked approval: record the decision in the store (at most
-    /// once per `DecisionId`) and publish it on the bus, waking the parked
-    /// await wherever it lives.
+    /// Resolve a parked approval: durably record the decision in the store
+    /// (at most once per `DecisionId`) and publish it on the bus, waking the
+    /// parked await wherever it lives.
     pub async fn resolve(
         &self,
         id: &DecisionId,
@@ -180,11 +187,24 @@ impl PendingApprovals {
             .publish(&approval_topic(id), payload.into())
             .await
         {
-            // The decision is recorded but the wake may be lost; the parked
-            // await times out and fails closed.
+            // Only the fast path is lost: the parking side recovers the
+            // recorded decision from the store poll.
             warn!(decision_id = %id, error = %err, "approval decision publish failed");
         }
         Ok(())
+    }
+
+    /// The durably recorded decision for an already-resolved approval, if
+    /// any. A store fault reads as "no recorded decision" (logged), so
+    /// callers keep their fail-closed shape.
+    pub async fn recorded_decision(&self, id: &DecisionId) -> Option<ApprovalDecision> {
+        match self.0.store.decision(id).await {
+            Ok(decision) => decision,
+            Err(err) => {
+                warn!(decision_id = %id, error = %err, "recorded approval decision lookup failed");
+                None
+            }
+        }
     }
 
     /// Expire a parked approval after timeout/cancellation so later ingress
@@ -197,7 +217,7 @@ impl PendingApprovals {
             .expect("registry lock poisoned")
             .remove(id)
         {
-            entry.abort_subscription();
+            entry.abort_wake_task();
         }
         if let Err(err) = self.0.store.remove(id).await {
             warn!(decision_id = %id, error = %err, "parked approval removal failed");
@@ -214,7 +234,7 @@ impl PendingApprovals {
             .expect("registry lock poisoned")
             .retain(|_, entry| {
                 if entry.request_id == request_id {
-                    entry.abort_subscription();
+                    entry.abort_wake_task();
                     false
                 } else {
                     true
@@ -238,24 +258,56 @@ impl Default for PendingApprovals {
     }
 }
 
-/// Wait for a decision on one approval's bus topic and fire its local wake
-/// handle. One short-lived task per parked approval; ends after the first
-/// decision, when aborted (entry removed without a decision), or when the bus
-/// closes the topic.
+/// Wait for one approval's decision and fire its local wake handle. The
+/// decision arrives over the approval's bus topic (fast path) or, every
+/// [`DECISION_POLL_INTERVAL`], from the store's recorded decision — the
+/// durable fallback that recovers a lost publish. One short-lived task per
+/// parked approval; ends after the first decision or when aborted (entry
+/// removed without a decision).
 async fn wake_on_decision(
     inner: Weak<PendingApprovalsInner>,
     id: DecisionId,
-    mut decisions: Subscription,
+    mut decisions: Option<Subscription>,
 ) {
-    while let Some(payload) = decisions.next().await {
-        let decision = match serde_json::from_slice::<ApprovalDecision>(&payload) {
-            Ok(decision) => decision,
-            Err(err) => {
-                warn!(
-                    decision_id = %id, error = %err,
-                    "undecodable approval decision payload ignored",
-                );
-                continue;
+    let mut poll = tokio::time::interval_at(
+        Instant::now() + DECISION_POLL_INTERVAL,
+        DECISION_POLL_INTERVAL,
+    );
+    poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        let decision = tokio::select! {
+            payload = subscription_next(&mut decisions) => match payload {
+                Some(payload) => match serde_json::from_slice::<ApprovalDecision>(&payload) {
+                    Ok(decision) => decision,
+                    Err(err) => {
+                        warn!(
+                            decision_id = %id, error = %err,
+                            "undecodable approval decision payload ignored",
+                        );
+                        continue;
+                    }
+                },
+                // The bus closed the topic; the store poll carries on alone.
+                None => {
+                    decisions = None;
+                    continue;
+                }
+            },
+            _ = poll.tick() => {
+                let Some(inner) = inner.upgrade() else {
+                    return;
+                };
+                match inner.store.decision(&id).await {
+                    Ok(Some(decision)) => decision,
+                    Ok(None) => continue,
+                    Err(err) => {
+                        warn!(
+                            decision_id = %id, error = %err,
+                            "approval decision store poll failed",
+                        );
+                        continue;
+                    }
+                }
             }
         };
         let Some(inner) = inner.upgrade() else {
@@ -270,6 +322,15 @@ async fn wake_on_decision(
             let _ = entry.wake.send(decision);
         }
         return;
+    }
+}
+
+/// Next bus payload, pending forever without a subscription (the poll arm is
+/// then the only wake source).
+async fn subscription_next(subscription: &mut Option<Subscription>) -> Option<Bytes> {
+    match subscription {
+        Some(stream) => stream.next().await,
+        None => std::future::pending().await,
     }
 }
 
@@ -510,6 +571,101 @@ mod tests {
         assert_eq!(delta, chrono::Duration::from_std(timeout).unwrap());
         assert!(parked.registered_at >= before);
         assert!(parked.registered_at <= after);
+    }
+
+    /// Bus double whose `publish` drops every payload: the pub/sub loss
+    /// window, or a resolver crash between the store write and the publish.
+    struct LossyBus(InMemoryEventBus);
+
+    #[async_trait::async_trait]
+    impl EventBus for LossyBus {
+        async fn publish(&self, _topic: &str, _payload: Bytes) -> Result<(), SessionStoreError> {
+            Ok(())
+        }
+
+        async fn subscribe(&self, topic: &str) -> Result<Subscription, SessionStoreError> {
+            self.0.subscribe(topic).await
+        }
+    }
+
+    /// Bus double that cannot subscribe at all.
+    struct DeafBus;
+
+    #[async_trait::async_trait]
+    impl EventBus for DeafBus {
+        async fn publish(&self, _topic: &str, _payload: Bytes) -> Result<(), SessionStoreError> {
+            Ok(())
+        }
+
+        async fn subscribe(&self, _topic: &str) -> Result<Subscription, SessionStoreError> {
+            Err(SessionStoreError::Request {
+                reason: "subscriptions unavailable".to_string(),
+            })
+        }
+    }
+
+    /// The #474 shape: the decision is durably recorded but its wake publish
+    /// is lost. The parked await recovers the decision from the store within
+    /// the poll interval instead of failing closed at its timeout.
+    #[tokio::test(start_paused = true)]
+    async fn lost_wake_publish_is_recovered_from_the_store() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let bus: Arc<dyn EventBus> = Arc::new(LossyBus(InMemoryEventBus::new()));
+        let parker = PendingApprovals::with_backend(store.clone(), bus.clone());
+        let resolver = PendingApprovals::with_backend(store, bus);
+        let cancel = RequestCancelToken::unbound();
+
+        let req = test_request("req-lost-wake");
+        let id = req.decision_id;
+        let started = Instant::now();
+        let handle = parker.register(req, Duration::from_secs(60)).await;
+
+        resolver
+            .resolve(&id, ApprovalDecision::Approved)
+            .await
+            .expect("resolve succeeds");
+
+        assert_eq!(
+            handle.outcome(&cancel).await,
+            ApprovalOutcome::Decided(ApprovalDecision::Approved)
+        );
+        assert!(
+            started.elapsed() <= DECISION_POLL_INTERVAL,
+            "the decision must arrive via the store poll, not the timeout; took {:?}",
+            started.elapsed(),
+        );
+    }
+
+    /// A failed wake subscription still parks a wakeable approval: the store
+    /// poll is the only carrier, and the decision arrives through it.
+    #[tokio::test(start_paused = true)]
+    async fn failed_subscription_still_wakes_via_store_poll() {
+        let registry = PendingApprovals::with_backend(
+            Arc::new(InMemoryApprovalStore::new()),
+            Arc::new(DeafBus),
+        );
+        let cancel = RequestCancelToken::unbound();
+
+        let req = test_request("req-deaf");
+        let id = req.decision_id;
+        let handle = registry.register(req, Duration::from_secs(60)).await;
+
+        registry
+            .resolve(
+                &id,
+                ApprovalDecision::Denied {
+                    reason: Some("nope".into()),
+                },
+            )
+            .await
+            .expect("resolve succeeds");
+
+        assert_eq!(
+            handle.outcome(&cancel).await,
+            ApprovalOutcome::Decided(ApprovalDecision::Denied {
+                reason: Some("nope".into())
+            })
+        );
     }
 
     /// The cross-instance seam: two registries (as two instances) sharing one store and

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -161,12 +161,22 @@ impl DecisionRoute {
                 )
                 .await;
 
-                let outcome = handle.outcome(cancel).await;
+                let mut outcome = handle.outcome(cancel).await;
                 if matches!(
                     outcome,
                     ApprovalOutcome::TimedOut { .. } | ApprovalOutcome::Cancelled(_)
                 ) {
                     registry.remove(&decision_id).await;
+                }
+                // The deadline backstop consults the store before failing
+                // closed: a decision durably recorded but whose wake was lost
+                // (down to the final poll gap) still takes effect.
+                // Cancellation deliberately does not — a disconnected request
+                // must not execute a buffered approval.
+                if matches!(outcome, ApprovalOutcome::TimedOut { .. })
+                    && let Some(decision) = registry.recorded_decision(&decision_id).await
+                {
+                    outcome = ApprovalOutcome::Decided(decision);
                 }
 
                 let completed_event =
@@ -831,6 +841,72 @@ mod tests {
             Err(ResolveError::NotFound),
             "late decisions for timed-out approvals must be rejected as expired",
         );
+    }
+
+    /// A decision durably recorded whose wake never arrives still takes
+    /// effect at the deadline backstop instead of failing closed. The route
+    /// timeout sits below the wake task's poll interval, so only the
+    /// backstop can observe the recorded decision.
+    #[tokio::test(start_paused = true)]
+    async fn conversational_timeout_backstop_recovers_recorded_decision() {
+        use crate::session_store::{
+            ApprovalStore, EventBus, InMemoryApprovalStore, InMemoryEventBus, SessionStoreError,
+            Subscription,
+        };
+        use std::sync::Arc;
+
+        /// Bus double whose `publish` drops every payload.
+        struct LossyBus(InMemoryEventBus);
+
+        #[async_trait::async_trait]
+        impl EventBus for LossyBus {
+            async fn publish(
+                &self,
+                _topic: &str,
+                _payload: bytes::Bytes,
+            ) -> Result<(), SessionStoreError> {
+                Ok(())
+            }
+
+            async fn subscribe(&self, topic: &str) -> Result<Subscription, SessionStoreError> {
+                self.0.subscribe(topic).await
+            }
+        }
+
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let bus: Arc<dyn EventBus> = Arc::new(LossyBus(InMemoryEventBus::new()));
+        let registry = PendingApprovals::with_backend(store, bus);
+        let route = DecisionRoute::Conversational {
+            registry: registry.clone(),
+            timeout: Duration::from_secs(2),
+        };
+        let request = single_request(
+            "conv-req-backstop",
+            ApprovalOrigin::AgentRequested {
+                reason: "test".into(),
+            },
+        );
+        let decision_id = request.decision_id;
+        let cancel = crate::request_cancellation::RequestCancelToken::unbound();
+
+        let decide_handle = tokio::spawn({
+            let cancel = cancel.clone();
+            async move { route.decide(request, &cancel).await }
+        });
+
+        loop {
+            tokio::task::yield_now().await;
+            if registry
+                .resolve(&decision_id, ApprovalDecision::Approved)
+                .await
+                .is_ok()
+            {
+                break;
+            }
+        }
+
+        let result = decide_handle.await.unwrap().unwrap();
+        assert_eq!(result, ApprovalOutcome::Decided(ApprovalDecision::Approved));
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/aura/src/session_store/memory.rs
+++ b/crates/aura/src/session_store/memory.rs
@@ -8,19 +8,30 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use tokio::sync::broadcast;
 
-use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
+use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError, Timestamp};
 
 use super::{ApprovalStore, EventBus, SessionStoreError, Subscription};
 
 /// Buffered payloads per topic before slow subscribers start lagging.
 const TOPIC_CAPACITY: usize = 64;
 
+/// How long a recorded decision stays readable past its approval's expiry.
+const DECISION_RETENTION_MARGIN_SECS: i64 = 60;
+
+/// A recorded decision and the instant its entry may be dropped.
+struct DecidedEntry {
+    decision: ApprovalDecision,
+    keep_until: Timestamp,
+}
+
 /// The parked-approval registry as a plain map.
 #[derive(Default)]
 pub struct InMemoryApprovalStore {
-    // `std::sync::Mutex`: every operation is a synchronous map op; nothing
-    // awaits while holding the lock.
+    // `std::sync::Mutex` (both maps): every operation is a synchronous map
+    // op; nothing awaits while holding a lock, and the locks are never
+    // held together.
     entries: Mutex<BTreeMap<DecisionId, ParkedApproval>>,
+    decided: Mutex<BTreeMap<DecisionId, DecidedEntry>>,
 }
 
 impl InMemoryApprovalStore {
@@ -31,6 +42,15 @@ impl InMemoryApprovalStore {
 
     fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<DecisionId, ParkedApproval>> {
         self.entries.lock().expect("approval store lock poisoned")
+    }
+
+    /// Lock the decided map, dropping entries past their retention window (the
+    /// in-memory stand-in for a networked backend's TTL).
+    fn lock_decided(&self) -> std::sync::MutexGuard<'_, BTreeMap<DecisionId, DecidedEntry>> {
+        let mut decided = self.decided.lock().expect("approval store lock poisoned");
+        let now = chrono::Utc::now();
+        decided.retain(|_, entry| entry.keep_until > now);
+        decided
     }
 }
 
@@ -48,13 +68,26 @@ impl ApprovalStore for InMemoryApprovalStore {
     async fn resolve(
         &self,
         id: &DecisionId,
-        _decision: ApprovalDecision,
+        decision: ApprovalDecision,
     ) -> Result<(), ResolveError> {
         // Removal under the lock is the at-most-once guarantee.
-        match self.lock().remove(id) {
-            Some(_) => Ok(()),
-            None => Err(ResolveError::NotFound),
-        }
+        let parked = self.lock().remove(id).ok_or(ResolveError::NotFound)?;
+        self.lock_decided().insert(
+            *id,
+            DecidedEntry {
+                decision,
+                keep_until: parked.expires_at
+                    + chrono::Duration::seconds(DECISION_RETENTION_MARGIN_SECS),
+            },
+        );
+        Ok(())
+    }
+
+    async fn decision(
+        &self,
+        id: &DecisionId,
+    ) -> Result<Option<ApprovalDecision>, SessionStoreError> {
+        Ok(self.lock_decided().get(id).map(|e| e.decision.clone()))
     }
 
     async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError> {
@@ -196,6 +229,45 @@ mod tests {
             store.resolve(&id, ApprovalDecision::Approved).await,
             Err(ResolveError::NotFound),
         );
+    }
+
+    #[tokio::test]
+    async fn approval_store_resolve_records_readable_decision() {
+        let store = InMemoryApprovalStore::new();
+        let entry = parked("req-durable");
+        let id = entry.request.decision_id;
+        store.register(entry).await.unwrap();
+
+        let denied = ApprovalDecision::Denied {
+            reason: Some("not safe".into()),
+        };
+        store.resolve(&id, denied.clone()).await.unwrap();
+
+        assert_eq!(store.decision(&id).await.unwrap(), Some(denied.clone()));
+        // The recorded decision survives the (rejected) second resolve.
+        assert_eq!(
+            store.resolve(&id, ApprovalDecision::Approved).await,
+            Err(ResolveError::NotFound)
+        );
+        assert_eq!(store.decision(&id).await.unwrap(), Some(denied));
+        assert_eq!(store.decision(&DecisionId::generate()).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn recorded_decision_is_pruned_after_retention_window() {
+        let store = InMemoryApprovalStore::new();
+        let mut entry = parked("req-prune");
+        // Expired long enough ago that the retention margin is already past.
+        entry.expires_at =
+            chrono::Utc::now() - chrono::Duration::seconds(2 * DECISION_RETENTION_MARGIN_SECS);
+        let id = entry.request.decision_id;
+        store.register(entry).await.unwrap();
+        store
+            .resolve(&id, ApprovalDecision::Approved)
+            .await
+            .unwrap();
+
+        assert_eq!(store.decision(&id).await.unwrap(), None);
     }
 
     #[tokio::test]

--- a/crates/aura/src/session_store/mod.rs
+++ b/crates/aura/src/session_store/mod.rs
@@ -21,7 +21,7 @@ use futures::Stream;
 use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
 
 pub use memory::{InMemoryApprovalStore, InMemoryEventBus};
-pub use record::{InvalidRecord, OriginRecord, ParkedApprovalRecord, ScopeRecord};
+pub use record::{DecisionRecord, InvalidRecord, OriginRecord, ParkedApprovalRecord, ScopeRecord};
 
 /// A fault in the backing session-store/bus backend.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -60,12 +60,21 @@ pub trait ApprovalStore: Send + Sync {
     async fn get(&self, id: &DecisionId) -> Result<Option<ParkedApproval>, SessionStoreError>;
 
     /// Record a terminal decision and remove the parked entry, atomically —
-    /// at-most-once resolution is enforced here, in the store.
+    /// at-most-once resolution is enforced here, in the store. The recorded
+    /// decision must stay readable via [`Self::decision`] until at least the
+    /// approval's `expires_at`, so the parking process can recover a decision
+    /// whose bus wake was lost.
     async fn resolve(
         &self,
         id: &DecisionId,
         decision: ApprovalDecision,
     ) -> Result<(), ResolveError>;
+
+    /// Look up the decision recorded for an already-resolved approval.
+    async fn decision(
+        &self,
+        id: &DecisionId,
+    ) -> Result<Option<ApprovalDecision>, SessionStoreError>;
 
     /// Remove a parked entry.
     async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError>;

--- a/crates/aura/src/session_store/record.rs
+++ b/crates/aura/src/session_store/record.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::SessionId;
 use crate::hitl::{
-    AgentScope, ApprovalItem, ApprovalOrigin, ApprovalRequest, DecisionId, ParkedApproval,
-    Timestamp,
+    AgentScope, ApprovalDecision, ApprovalItem, ApprovalOrigin, ApprovalRequest, DecisionId,
+    ParkedApproval, Timestamp,
 };
 use crate::orchestration::{RunId, TaskIdentity};
 
@@ -59,6 +59,43 @@ pub enum ScopeRecord {
 pub enum OriginRecord {
     ConfigGate { matched_pattern: String },
     AgentRequested { reason: String },
+}
+
+/// Storage form of a recorded [`ApprovalDecision`]: the durable record that a
+/// resolution happened, what it was, and when. Same flat `approved`/`reason`
+/// shape as the webhook wire (`hitl::protocol::ApprovalDecisionWire`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DecisionRecord {
+    pub approved: bool,
+    pub reason: Option<String>,
+    pub decided_at: Timestamp,
+}
+
+/// Stamps `decided_at` with the conversion (i.e. resolve) time.
+impl From<&ApprovalDecision> for DecisionRecord {
+    fn from(decision: &ApprovalDecision) -> Self {
+        let (approved, reason) = match decision {
+            ApprovalDecision::Approved => (true, None),
+            ApprovalDecision::Denied { reason } => (false, reason.clone()),
+        };
+        Self {
+            approved,
+            reason,
+            decided_at: chrono::Utc::now(),
+        }
+    }
+}
+
+impl From<DecisionRecord> for ApprovalDecision {
+    fn from(record: DecisionRecord) -> Self {
+        if record.approved {
+            ApprovalDecision::Approved
+        } else {
+            ApprovalDecision::Denied {
+                reason: record.reason,
+            }
+        }
+    }
 }
 
 /// A stored approval record whose contents cannot be restored to the domain.

--- a/docs/design/session-storage.md
+++ b/docs/design/session-storage.md
@@ -209,9 +209,15 @@ pub trait ApprovalStore: Send + Sync {
 
     /// Record a terminal decision and remove the parked entry, atomically.
     /// Returns `NotFound` if unknown / already resolved / expired — preserving
-    /// today's at-most-once semantics.
+    /// today's at-most-once semantics. The recorded decision stays readable
+    /// via `decision()` until at least the approval's expiry, so the parking
+    /// pod can recover a decision whose bus wake was lost (#474).
     async fn resolve(&self, id: &DecisionId, decision: ApprovalDecision)
         -> Result<(), ResolveError>;
+
+    /// Look up the decision recorded for an already-resolved approval.
+    async fn decision(&self, id: &DecisionId)
+        -> Result<Option<ApprovalDecision>, SessionStoreError>;
 
     /// Remove a parked entry (timeout / cancellation).
     async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError>;
@@ -318,7 +324,8 @@ Changes:
   `Arc<dyn EventBus>`.
 - `register()` now (a) inserts the local `oneshot` as today **and** (b)
   `approvals.register(parked)` + `bus.subscribe("approval:{id}")`, with a small task that
-  fires the local `oneshot` when the bus yields a decision.
+  fires the local `oneshot` when the bus yields a decision — or when its periodic store
+  poll finds one recorded, the durable fallback for a lost publish.
 - The `POST /v1/approvals/{id}` handler calls `approvals.resolve()` then
   `bus.publish("approval:{id}", decision)`. It no longer needs the parked entry to be
   local — it may run on any pod.
@@ -397,6 +404,7 @@ default `aura`), so multiple AURA deployments can share a cluster.
 | Key / channel                     | Type                                  | Purpose                                | TTL                      |
 | --------------------------------- | ------------------------------------- | -------------------------------------- | ------------------------ |
 | `{p}:approval:{decision_id}`      | string (JSON `ParkedApprovalRecord`)  | parked approval record                 | `expires_at`             |
+| `{p}:approval:decision:{decision_id}` | string (JSON `DecisionRecord`)    | durable record of the resolution       | parked remainder + margin |
 | `{p}:approval:req:{request_id}`   | set of `decision_id`                  | `cancel_request` fan-out               | record TTL + margin      |
 | `{p}:bus:approval:{decision_id}`  | pub/sub channel                       | wake the parking pod with the decision | —                        |
 | `{p}:a2a:task:{task_id}`          | hash (`version`, `task` as JSON)      | A2A task record + version counter      | configurable (e.g. 24h)  |
@@ -412,11 +420,14 @@ Notes:
   stable field/tag names. The domain types stay unserializable so no wire can
   leak Rust variant names; the SSE/webhook DTOs (`hitl::events`) and the storage
   record are separately-owned projections.
-- `resolve` is a single atomic `GETDEL`: exactly one resolver takes the record and
-  every later attempt sees `NotFound`, matching today's `remove`-on-resolve
-  at-most-once semantics. (Simpler than the Lua/`MULTI` originally sketched — the
-  decision itself is not persisted, mirroring the in-memory store; it travels
-  over the bus.)
+- `resolve` is one Lua script covering the claim and the decision write
+  atomically: it takes the parked record and, only if one existed, stores the
+  `DecisionRecord` under `{p}:approval:decision:{id}`. Exactly one resolver
+  takes the record and every later attempt sees `NotFound`; a consumed parked
+  entry always leaves a recoverable decision behind, so neither a lost publish
+  nor a resolver crash between claim and publish can lose a granted approval
+  (#474). The decision record's TTL keeps a margin past the parked record's
+  remaining TTL, covering the parking pod's deadline-backstop read.
 - Each task create/update is one Lua script covering the exists-check, `version`
   bump, terminal-state gate (updates to a terminal task are rejected, except a
   rewrite of the state already recorded, which leaves it alone), record
@@ -561,10 +572,12 @@ phases 2 and 3 are independent and can land in either order; phase 4 needs both.
 ## 13. Open questions
 
 - **Bus reliability for wake.** Redis pub/sub is fire-and-forget; if the parking pod
-  briefly disconnects it can miss the decision. The store TTL + await timeout make this
-  fail-closed (safe) but a missed wake wastes the timeout window. Redis **Streams**
-  (consumer read-after-write) would make the wake reliable at some complexity cost —
-  decide per-subsystem.
+  briefly disconnects it can miss the decision. The bus is only the low-latency path:
+  `resolve` records the decision durably, the parking pod's wake task polls the store
+  as fallback, and the await's deadline backstop reads the store once more before
+  failing closed — a lost wake costs at most one poll interval, not the timeout
+  window. Redis **Streams** (consumer read-after-write) could still replace the
+  poll's latency bound for other subsystems — decide per-subsystem.
 - **At-most-once resolve across pods** must be enforced in the store (the atomic
   `GETDEL`), not in application code, since two `POST /v1/approvals/{id}` could race on
   different pods.
@@ -575,13 +588,10 @@ phases 2 and 3 are independent and can land in either order; phase 4 needs both.
   timeout. With a networked backend (phase 3), consider short-circuiting to an immediate
   terminal outcome (or failing the gate) instead of emitting `Pending` for a dead park.
 - **Resolve atomicity across store + bus.** `PendingApprovals::resolve` records the
-  decision in the store, then publishes the wake. In-memory, both futures complete on
-  their first poll, so the pair runs without a yield point and cannot be interrupted.
-  With a networked backend, the resolving request can be dropped between the two calls
-  (client disconnect mid-await) — decision consumed, wake never published, parked side
-  fails closed at its timeout. Phase 3 accepts and documents this window (the Redis bus
-  module doc): pub/sub is fire-and-forget end to end, and the fail-closed timeout is the
-  single backstop for every lost-wake path.
+  decision in the store, then publishes the wake. The store write is the durable step
+  (claim + decision record in one atomic script); a resolving request dropped between
+  the two calls loses only the publish, and the parking side recovers the recorded
+  decision through its store poll (#474).
 - **Teardown latency behind store I/O.** The request `Drop` guard cancels wake handles
   synchronously (`cancel_request_local`), but the spawned cleanup task awaits
   `ApprovalStore::cancel_request` before `RequestCancellation::unregister` and the


### PR DESCRIPTION
Resolving a HITL approval deleted the parked record and carried the decision only on the fire-and-forget wake publish: a lost publish (or a resolver crash between the claim and the publish) lost an operator's decision, and the parked call failed closed at its timeout despite the grant, leaving no record that a decision happened.

The store is now the durable carrier and the bus only the low-latency wake:

- ApprovalStore::resolve records the decision atomically with the at-most-once claim (one Lua script on redis; a decided map in memory), readable back through the new ApprovalStore::decision.
- The parked approval's wake task polls the store as a fallback, so a lost publish costs at most one poll interval, and a failed wake subscription no longer means an unwakeable park.
- The await's timeout backstop reads the store once more before failing closed, covering a decision recorded inside the final poll gap. Cancellation still fails closed without a store read.

Fixes: #474