### PR TITLE
feat(hitl): stamp the approval decision id on the gated call's span

### DIFF
--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -237,4 +237,381 @@ mod tests {
                 .to_string();
         assert!(channel_fault.contains("approval channel error"));
     }
+
+    /// Trace correlation: a gated call's `execute_tool` span carries the
+    /// `decision_id` of the approval that gated it.
+    ///
+    /// Gated on `otel` — without the feature `set_span_attribute` is a
+    /// documented no-op and there is no span data to assert against.
+    #[cfg(feature = "otel")]
+    mod decision_id_span {
+        use std::future::Future;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{Arc, Mutex, MutexGuard};
+
+        use futures::future::BoxFuture;
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
+        use opentelemetry_sdk::trace::TracerProvider;
+        use rig::completion::ToolDefinition;
+        use rig::tool::Tool as RigTool;
+        use serde_json::json;
+        use tokio::sync::mpsc::Receiver;
+        use tracing::Instrument;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        use super::super::super::registry::PendingApprovals;
+        use super::*;
+        use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
+        use crate::logging::ATTR_DECISION_ID;
+        use crate::tool_wrapper::WrappedTool;
+
+        /// Spans the test subscriber has exported.
+        #[derive(Debug, Clone, Default)]
+        struct CapturedSpans(Arc<Mutex<Vec<SpanData>>>);
+
+        impl CapturedSpans {
+            fn spans(&self) -> MutexGuard<'_, Vec<SpanData>> {
+                self.0.lock().expect("captured spans mutex")
+            }
+
+            fn contains(&self, name: &str) -> bool {
+                self.spans().iter().any(|span| span.name == name)
+            }
+
+            fn attribute(&self, name: &str, key: &str) -> Option<String> {
+                self.spans()
+                    .iter()
+                    .find(|span| span.name == name)
+                    .and_then(|span| span.attributes.iter().find(|kv| kv.key.as_str() == key))
+                    .map(|kv| kv.value.to_string())
+            }
+        }
+
+        impl SpanExporter for CapturedSpans {
+            fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+                self.spans().extend(batch);
+                Box::pin(std::future::ready(Ok(())))
+            }
+        }
+
+        /// Run `body` inside an `execute_tool` span — the span Rig opens around
+        /// a tool call — under a subscriber that exports to memory, returning
+        /// the body's output and the `decision_id` the exported span carries.
+        async fn traced_as_execute_tool<T>(body: impl Future<Output = T>) -> (T, Option<String>) {
+            let captured = CapturedSpans::default();
+            let provider = TracerProvider::builder()
+                .with_simple_exporter(captured.clone())
+                .build();
+            let _guard = tracing::subscriber::set_default(
+                tracing_subscriber::registry()
+                    .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test"))),
+            );
+
+            let output = body.instrument(tracing::info_span!("execute_tool")).await;
+
+            // The registry instruments a parked approval's wake task with the
+            // same span, so the export lands once that task has released it too.
+            for _ in 0..1_000 {
+                if captured.contains("execute_tool") {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            assert!(
+                captured.contains("execute_tool"),
+                "the execute_tool span was never exported",
+            );
+
+            (output, captured.attribute("execute_tool", ATTR_DECISION_ID))
+        }
+
+        /// What a trace backend actually receives, assembled the way the binary
+        /// assembles it: the real OTel filter, the OpenInference exporter, and
+        /// the span reaching the tool through Rig's tool-server task rather
+        /// than inline. Each of those can silently drop an attribute — a filter
+        /// that stops enabling Rig's span leaves it with nowhere to land, and
+        /// the exporter rewrites every span on its way out.
+        #[tokio::test]
+        async fn decision_id_reaches_the_exporter_through_the_binary_stack() {
+            use tracing_subscriber::Layer;
+
+            let captured = CapturedSpans::default();
+            let provider = TracerProvider::builder()
+                .with_simple_exporter(crate::openinference_exporter::OpenInferenceExporter::new(
+                    captured.clone(),
+                ))
+                .build();
+            let _guard = tracing::subscriber::set_default(
+                tracing_subscriber::registry().with(
+                    tracing_opentelemetry::layer()
+                        .with_tracer(provider.tracer("aura"))
+                        .with_filter(crate::logging::otel_filter("aura_web_server")),
+                ),
+            );
+
+            let request_id = unique_request_id();
+            let mut events = approval_event_broker::subscribe(&request_id).await;
+            let registry = PendingApprovals::new();
+            let (tool, ran) = gated_tool(
+                DecisionRoute::Conversational {
+                    registry: registry.clone(),
+                    timeout: Duration::from_secs(60),
+                },
+                &request_id,
+                "kubectl_apply",
+            );
+
+            // Rig's streaming loop opens this span and hands it to the tool
+            // server, which runs the toolset call instrumented with it.
+            let execute_tool = tracing::info_span!(
+                target: "rig::agent::prompt_request::streaming",
+                "execute_tool",
+                gen_ai.operation.name = "execute_tool",
+            );
+            let call = tokio::spawn(
+                async move { tool.call(json!({ "namespace": "prod" })).await }
+                    .instrument(execute_tool),
+            );
+
+            let payload_id = payload_decision_id(&mut events).await;
+            registry
+                .resolve(&payload_id, ApprovalDecision::Approved)
+                .await
+                .expect("parked approval resolves");
+            call.await
+                .expect("tool task did not panic")
+                .expect("an approved call proceeds");
+
+            for _ in 0..1_000 {
+                if captured.contains("execute_tool") {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            assert!(
+                ran.load(Ordering::SeqCst),
+                "an approved call must reach the inner tool",
+            );
+            assert_eq!(
+                captured
+                    .attribute("execute_tool", ATTR_DECISION_ID)
+                    .as_deref(),
+                Some(payload_id.to_string().as_str()),
+                "the exported execute_tool span must carry the decision id",
+            );
+            // Phoenix keys its TOOL classification off this, and the exporter
+            // adds it to the same span the id lands on.
+            assert_eq!(
+                captured
+                    .attribute("execute_tool", "openinference.span.kind")
+                    .as_deref(),
+                Some("TOOL"),
+            );
+
+            approval_event_broker::unsubscribe(&request_id).await;
+        }
+
+        /// Inner tool that records whether the gate let it run.
+        #[derive(Clone)]
+        struct StubTool {
+            name: String,
+            ran: Arc<AtomicBool>,
+        }
+
+        impl RigTool for StubTool {
+            const NAME: &'static str = "stub";
+
+            type Error = ToolError;
+            type Args = Value;
+            type Output = String;
+
+            fn name(&self) -> String {
+                self.name.clone()
+            }
+
+            async fn definition(&self, _prompt: String) -> ToolDefinition {
+                ToolDefinition {
+                    name: self.name.clone(),
+                    description: String::new(),
+                    parameters: json!({ "type": "object" }),
+                }
+            }
+
+            async fn call(&self, _args: Value) -> Result<String, ToolError> {
+                self.ran.store(true, Ordering::SeqCst);
+                Ok("done".to_string())
+            }
+        }
+
+        /// A tool behind the `kubectl_*` gate, wrapped the way production wraps
+        /// it, plus the flag that reports whether the inner tool ran.
+        fn gated_tool(
+            route: DecisionRoute,
+            request_id: &str,
+            tool_name: &str,
+        ) -> (WrappedTool<StubTool>, Arc<AtomicBool>) {
+            let ran = Arc::new(AtomicBool::new(false));
+            let inner = StubTool {
+                name: tool_name.to_string(),
+                ran: ran.clone(),
+            };
+            let gate = HitlApprovalWrapper::new(
+                Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
+                Arc::new(route),
+                AgentScope::Single { session_id: None },
+                request_id.to_string(),
+            );
+            (
+                WrappedTool::new(inner, Arc::new(gate) as Arc<dyn ToolWrapper>),
+                ran,
+            )
+        }
+
+        /// The decision id the approval payload carried, read off the
+        /// `Requested` lifecycle event the route publishes for it.
+        async fn payload_decision_id(events: &mut Receiver<ApprovalLifecycleEvent>) -> DecisionId {
+            match events.recv().await.expect("approval events channel open") {
+                ApprovalLifecycleEvent::Requested(event) => {
+                    DecisionId::parse(&event.decision_id).expect("valid decision id")
+                }
+                other => panic!("expected Requested, got {other:?}"),
+            }
+        }
+
+        fn unique_request_id() -> String {
+            format!("req_span_{}", uuid::Uuid::new_v4().simple())
+        }
+
+        /// The correlation the whole feature exists for: the id the approver
+        /// decided against is the id on the span of the execution it released.
+        #[tokio::test]
+        async fn approved_gate_stamps_the_payload_decision_id_on_the_execution_span() {
+            let request_id = unique_request_id();
+            let mut events = approval_event_broker::subscribe(&request_id).await;
+            let registry = PendingApprovals::new();
+            let (tool, ran) = gated_tool(
+                DecisionRoute::Conversational {
+                    registry: registry.clone(),
+                    timeout: Duration::from_secs(60),
+                },
+                &request_id,
+                "kubectl_apply",
+            );
+
+            let ((result, payload_id), span_id) = traced_as_execute_tool(async {
+                tokio::join!(tool.call(json!({ "namespace": "prod" })), async {
+                    let id = payload_decision_id(&mut events).await;
+                    registry
+                        .resolve(&id, ApprovalDecision::Approved)
+                        .await
+                        .expect("parked approval resolves");
+                    id
+                })
+            })
+            .await;
+
+            assert_eq!(result.expect("an approved call proceeds"), "done");
+            assert!(
+                ran.load(Ordering::SeqCst),
+                "an approved call must reach the inner tool",
+            );
+            assert_eq!(
+                span_id.as_deref(),
+                Some(payload_id.to_string().as_str()),
+                "the execution span must carry the approval payload's decision id",
+            );
+
+            approval_event_broker::unsubscribe(&request_id).await;
+        }
+
+        /// An attempt that never reaches a decision is exactly where the
+        /// correlation earns its keep: the trace still names the approval the
+        /// failed-closed execution was waiting on.
+        #[tokio::test(start_paused = true)]
+        async fn timed_out_gate_stamps_the_decision_id_on_the_execution_span() {
+            let request_id = unique_request_id();
+            let mut events = approval_event_broker::subscribe(&request_id).await;
+            let (tool, ran) = gated_tool(
+                DecisionRoute::Conversational {
+                    registry: PendingApprovals::new(),
+                    timeout: Duration::from_secs(30),
+                },
+                &request_id,
+                "kubectl_apply",
+            );
+
+            let ((result, payload_id), span_id) = traced_as_execute_tool(async {
+                tokio::join!(tool.call(json!({})), payload_decision_id(&mut events))
+            })
+            .await;
+
+            let error = result.expect_err("an undecided approval must fail closed");
+            assert!(
+                error.to_string().contains("approval timed out"),
+                "expected a timeout denial, got: {error}",
+            );
+            assert!(!ran.load(Ordering::SeqCst));
+            assert_eq!(span_id.as_deref(), Some(payload_id.to_string().as_str()));
+
+            approval_event_broker::unsubscribe(&request_id).await;
+        }
+
+        /// The webhook route stamps the same id from the same place, so the
+        /// correlation does not depend on which route the deployment picked.
+        #[tokio::test]
+        async fn webhook_gate_stamps_the_decision_id_on_the_execution_span() {
+            let request_id = unique_request_id();
+            let mut events = approval_event_broker::subscribe(&request_id).await;
+            let (tool, ran) = gated_tool(
+                DecisionRoute::Webhook {
+                    client: WebhookClient::new(
+                        build_webhook_client(),
+                        // Discard port: nothing listens, so the POST fails closed.
+                        WebhookUrl::new("http://127.0.0.1:9").unwrap(),
+                    ),
+                    timeout: Duration::from_secs(2),
+                },
+                &request_id,
+                "kubectl_delete",
+            );
+
+            let ((result, payload_id), span_id) = traced_as_execute_tool(async {
+                tokio::join!(tool.call(json!({})), payload_decision_id(&mut events))
+            })
+            .await;
+
+            assert!(
+                result.is_err(),
+                "an unreachable webhook must block the call",
+            );
+            assert!(!ran.load(Ordering::SeqCst));
+            assert_eq!(span_id.as_deref(), Some(payload_id.to_string().as_str()));
+
+            approval_event_broker::unsubscribe(&request_id).await;
+        }
+
+        /// A call no glob matches allocates no decision, so its span must not
+        /// claim one.
+        #[tokio::test]
+        async fn ungated_call_records_no_decision_id() {
+            let (tool, ran) = gated_tool(
+                DecisionRoute::Conversational {
+                    registry: PendingApprovals::new(),
+                    timeout: Duration::from_secs(60),
+                },
+                &unique_request_id(),
+                "ls",
+            );
+
+            let (result, span_id) = traced_as_execute_tool(tool.call(json!({}))).await;
+
+            assert_eq!(result.expect("an ungated call proceeds"), "done");
+            assert!(ran.load(Ordering::SeqCst));
+            assert_eq!(
+                span_id, None,
+                "an ungated call must not be correlated to any approval",
+            );
+        }
+    }
 }

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -131,6 +131,11 @@ pub enum DecisionRoute {
 impl DecisionRoute {
     /// Obtain a decision for `request`, applying the shared semantics (deadline,
     /// fail-closed mapping, event emission) in one place.
+    ///
+    /// Both surfaces await this inline from the gated call's `execute_tool`
+    /// span, so stamping the decision id on the current span here — ahead of
+    /// the route split and of any outcome — correlates the approval with the
+    /// execution it gates on either route, decided or not.
     pub async fn decide(
         &self,
         request: ApprovalRequest,
@@ -140,6 +145,12 @@ impl DecisionRoute {
         let request_id = request.request_id.clone();
         let decision_id = request.decision_id;
         let scope = request.scope.clone();
+
+        crate::logging::set_span_attribute(
+            &tracing::Span::current(),
+            crate::logging::ATTR_DECISION_ID,
+            decision_id.to_string(),
+        );
 
         match self {
             Self::Conversational { registry, timeout } => {

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -131,6 +131,12 @@ pub const ATTR_TOOL_RESULT: &str = "tool.result";
 pub const ATTR_TOOL_RESULT_LENGTH: &str = "tool.result.length";
 pub const ATTR_TOOL_CANCELLED: &str = "tool.cancelled";
 
+// HITL attribute (used by `hitl::route`)
+
+/// Handle of the human approval decision gating a tool call — the same
+/// `decision_id` the approval payload and lifecycle events carry.
+pub const ATTR_DECISION_ID: &str = "decision_id";
+
 // --- Content recording configuration ---
 
 static RECORD_CONTENT: AtomicBool = AtomicBool::new(false);

--- a/docs/design/hitl.md
+++ b/docs/design/hitl.md
@@ -416,6 +416,25 @@ already reach the client ungated (`streaming/handlers.rs:848-855`), because the
 attended prompt and the decision record are protocol rather than optional
 telemetry.
 
+## Trace correlation
+
+`DecisionRoute::decide` stamps the request's `decision_id` on the current span,
+which is the gated call's Rig `execute_tool` span: both surfaces await `decide`
+inline, and `WrappedTool` carries that span across the approval gate into the
+inner tool. One stamp, ahead of the route split, gives every approval-gated
+execution the id the payload and the lifecycle events carry:
+
+```text
+execute_tool
+  decision_id = "019f…"
+  └── mcp.tool_call
+        status = OK | ERROR
+```
+
+A trace consumer joins the approval to the result of the action it released
+without a second reporting channel. Ungated calls never reach `decide`, so they
+carry no `decision_id`.
+
 ## Orchestration behavior
 
 Workers share the parent's request id, so `approval_pending` events from a parked


### PR DESCRIPTION
AURA mints a decision_id for every approval and carries it on the webhook payload, the approval lifecycle events, and the decision ingress, but nothing tied it to the execution the approval released. A trace showed the approved tool call without saying which decision let it run, so correlating an approval with the outcome of the action it authorized meant joining on timestamps by hand.

DecisionRoute::decide now records the request's decision_id as a `decision_id` OpenTelemetry attribute on the current span, which is the gated call's Rig execute_tool span: both surfaces await decide inline, and WrappedTool carries that span across the approval gate into the inner tool, so the existing mcp.tool_call result stays nested underneath it.

Stamping at that single funnel, rather than at each call site, is what makes the guarantees structural:

- the value is read from the field that goes on the wire, so the span and the payload cannot diverge;
- it covers both routes (webhook, conversational) and both surfaces (the config gate and the agent-callable request_approval tool);
- it lands ahead of any outcome, so denied, timed-out, cancelled, and channel-fault attempts carry it too;
- ungated calls never reach decide, so they stay unstamped.

The approval protocol and wire formats are unchanged.

Five tests in hitl/gate.rs drive WrappedTool -> gate -> decide under an in-memory span exporter and assert the exported span carries the same id as the approval payload. One of them assembles the subscriber stack the binaries assemble - the real OTel filter, the OpenInference exporter, and the span reaching the tool through Rig's tool-server task - because a filter or the exporter could otherwise drop the attribute on its way out.

docs/design/hitl.md gains a Trace correlation section describing the resulting span shape.

<img width="2798" height="992" alt="image" src="https://github.com/user-attachments/assets/d50796bf-e31c-4b86-9f71-7867bf6f19c1" />


Fixes: GH-506