### PR TITLE
fix(cli): render concurrent worker reasoning per task

### DIFF
--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -283,16 +283,21 @@ fn open_top_level_reasoning_block(state: &mut LiveReasoning, agent_id: &str) {
 /// (via `register_orch_reasoning_in_tree`) and registers this entry in
 /// `ORCH_LAST_TOOL_LINES` so the next tool call can upgrade reasoning's
 /// connector in turn. Caller must already hold `lock_term()`.
-fn open_worker_reasoning_block(state: &mut LiveReasoning, task_id: &str) {
+fn open_worker_reasoning_block(
+    state: &mut LiveReasoning,
+    task_id: &str,
+    worker_id: &str,
+) -> Option<crate::ui::orchestrator::TreeShift> {
     crate::ui::orchestrator::register_orch_reasoning_in_tree(
         task_id,
+        worker_id,
         |bullet_line_num, body_line_num| {
             state.body_line_num = body_line_num;
             state.body_line_text = String::new();
             state.started = true;
             let _ = bullet_line_num;
         },
-    );
+    )
 }
 
 /// Apply a chunk of content to the currently-open live block.
@@ -444,6 +449,48 @@ fn flush_live_reasoning(state: &Arc<Mutex<Option<LiveReasoning>>>) -> bool {
         return false;
     }
     let was_top_level = !s.is_worker;
+    persist_reasoning_display_event(s);
+    was_top_level
+}
+
+/// Live worker reasoning blocks, one per concurrently-executing task.
+/// Keyed by `task_id` so interleaved deltas from same-wave workers each
+/// update their own tree row instead of contending for a single block.
+type LiveWorkerReasoningMap = Arc<Mutex<std::collections::HashMap<String, LiveReasoning>>>;
+
+/// Close one task's live worker reasoning block, persisting it as a
+/// `DisplayEvent::Reasoning`. No terminal output happens here — the body
+/// row already lives in scrollback at its recorded line.
+fn flush_worker_reasoning_for_task(map: &LiveWorkerReasoningMap, task_id: &str) {
+    let Some(s) = map.lock().ok().and_then(|mut g| g.remove(task_id)) else {
+        return;
+    };
+    if s.combined.is_empty() {
+        return;
+    }
+    persist_reasoning_display_event(s);
+}
+
+/// Close every live worker reasoning block (end of stream, or an event —
+/// e.g. an approval prompt — that takes over the terminal).
+fn flush_all_worker_reasoning(map: &LiveWorkerReasoningMap) {
+    let mut states: Vec<(String, LiveReasoning)> = match map.lock() {
+        Ok(mut g) => g.drain().collect(),
+        Err(_) => return,
+    };
+    // HashMap drain order is arbitrary; sort by task id so replay order is
+    // deterministic.
+    states.sort_by(|(a, _), (b, _)| a.cmp(b));
+    for (_, s) in states {
+        if !s.combined.is_empty() {
+            persist_reasoning_display_event(s);
+        }
+    }
+}
+
+/// Record a closed reasoning block as a `DisplayEvent::Reasoning` for
+/// replay/resume, with `content` holding the full accumulated text.
+fn persist_reasoning_display_event(s: LiveReasoning) {
     let mut fields = s.fields;
     fields.insert(
         "content".to_string(),
@@ -454,7 +501,6 @@ fn flush_live_reasoning(state: &Arc<Mutex<Option<LiveReasoning>>>) -> bool {
         agent_id: s.agent_id,
         fields,
     });
-    was_top_level
 }
 
 /// Orchestrator events that actually `println!` scrollback content.
@@ -903,6 +949,12 @@ pub fn run_repl(
                 // `aura.progress` messages.
                 let live_reasoning: Arc<Mutex<Option<LiveReasoning>>> = Arc::new(Mutex::new(None));
 
+                // Per-task live worker reasoning blocks — concurrent same-wave
+                // workers each stream into their own tree row.
+                let live_worker_reasoning: LiveWorkerReasoningMap =
+                    Arc::new(Mutex::new(std::collections::HashMap::new()));
+                let worker_reasoning_seen = Arc::new(AtomicBool::new(false));
+
                 let (anim, stop_flag) = WaveAnimation::start(
                     "Thinking",
                     vec![],
@@ -1053,6 +1105,8 @@ pub fn run_repl(
                             pending_args: pending_args.clone(),
                             turn_events: turn_events.clone(),
                             live_reasoning: live_reasoning.clone(),
+                            live_worker_reasoning: live_worker_reasoning.clone(),
+                            worker_reasoning_seen: worker_reasoning_seen.clone(),
                             stop_flag: stop_flag.clone(),
                             anim_cleared: anim_cleared.clone(),
                             cancel: cancel_flag.clone(),
@@ -1076,10 +1130,11 @@ pub fn run_repl(
                             .await
                     });
 
-                    // Close any live reasoning block left open by the stream
+                    // Close any live reasoning blocks left open by the stream
                     // (e.g., reasoning was the last thing the model emitted
                     // before the stream ended without a usage/tool event).
                     flush_live_reasoning(&live_reasoning);
+                    flush_all_worker_reasoning(&live_worker_reasoning);
 
                     // Check for cancellation
                     if cancel_flag.load(Ordering::Relaxed) {
@@ -2091,6 +2146,10 @@ struct ReplStreamHandler {
         Arc<Mutex<std::collections::HashMap<String, BTreeMap<String, serde_json::Value>>>>,
     turn_events: Arc<Mutex<Vec<DisplayEvent>>>,
     live_reasoning: Arc<Mutex<Option<LiveReasoning>>>,
+    live_worker_reasoning: LiveWorkerReasoningMap,
+    /// Set once the stream delivers an `aura.orchestrator.worker_reasoning`
+    /// event; gates dropping the per-delta `aura.reasoning` worker mirror.
+    worker_reasoning_seen: Arc<AtomicBool>,
     stop_flag: Arc<AtomicBool>,
     anim_cleared: Arc<AtomicBool>,
     cancel: Arc<AtomicBool>,
@@ -2108,6 +2167,141 @@ struct ReplStreamHandler {
     /// `PendingApprovals::resolve()` instead of an HTTP POST.
     #[cfg(feature = "standalone-cli")]
     pending_approvals: Option<aura::hitl::PendingApprovals>,
+}
+
+impl ReplStreamHandler {
+    /// Renumber handler-owned row records (task headers, live reasoning
+    /// bodies) after a tree-gap insertion moved rows at/below `shift.at`
+    /// down. The statically-tracked records were already renumbered by
+    /// `commit_tree_gap`.
+    fn apply_tree_shift(&self, shift: &crate::ui::orchestrator::TreeShift) {
+        if let Ok(mut os) = self.orch_state.lock() {
+            for info in os.tasks.values_mut() {
+                if info.header_line_num >= shift.at {
+                    info.header_line_num += shift.by;
+                }
+            }
+        }
+        if let Ok(mut guard) = self.live_worker_reasoning.lock() {
+            for state in guard.values_mut() {
+                if state.body_line_num >= shift.at {
+                    state.body_line_num += shift.by;
+                }
+            }
+        }
+        if let Ok(mut guard) = self.live_reasoning.lock()
+            && let Some(state) = guard.as_mut()
+            && state.body_line_num >= shift.at
+        {
+            state.body_line_num += shift.by;
+        }
+    }
+
+    /// Apply one `aura.orchestrator.worker_reasoning` delta to its task's
+    /// live block, opening the block (a `└─ ● Reasoning` tree entry with an
+    /// in-place-updated body row) on the task's first chunk. Concurrent
+    /// tasks each own an entry in `live_worker_reasoning`, so interleaved
+    /// deltas update separate rows instead of tearing down a shared block.
+    fn on_worker_reasoning(&mut self, val: &serde_json::Value) {
+        let content = val.get("content").and_then(|v| v.as_str()).unwrap_or("");
+        if content.is_empty() {
+            return;
+        }
+        let task_id = match val.get("task_id") {
+            Some(serde_json::Value::Number(n)) => n.to_string(),
+            Some(serde_json::Value::String(s)) => s.clone(),
+            _ => return,
+        };
+        let worker_id = val
+            .get("worker_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let need_init = match self.live_worker_reasoning.lock() {
+            Ok(g) => !g.contains_key(&task_id),
+            Err(_) => return,
+        };
+        if need_init {
+            // A live top-level block assumes nothing prints below its body
+            // rows (its extension path appends at the scrollback bottom) —
+            // close it before this block prints tree rows.
+            flush_live_reasoning(&self.live_reasoning);
+
+            // Same stop-anim/erase-frame dance as `on_reasoning`: opening
+            // the block prints scrollback rows.
+            let had_ptw = if let Ok(mut guard) = self.post_tool_wave.lock() {
+                if let Some((ptw_anim, _)) = guard.take() {
+                    ptw_anim.finish();
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+            if !had_ptw && !self.anim_cleared.load(Ordering::Relaxed) {
+                stop_and_clear_animation(&self.stop_flag);
+                self.anim_cleared.store(true, Ordering::Relaxed);
+            }
+
+            let fields: BTreeMap<String, serde_json::Value> = match val.as_object() {
+                Some(obj) => obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+                None => BTreeMap::new(),
+            };
+            let mut new_state = LiveReasoning {
+                agent_id: worker_id.clone(),
+                parent_agent_id: Some("coordinator".to_string()),
+                task_id: Some(task_id.clone()),
+                combined: String::new(),
+                fields,
+                started: false,
+                body_line_num: 0,
+                body_line_text: String::new(),
+                body_visual_rows: 1,
+                is_worker: true,
+            };
+            let tree_shift = {
+                let _term = lock_term();
+                erase_input_frame();
+                open_worker_reasoning_block(&mut new_state, &task_id, &worker_id)
+            };
+            // The new block's own rows carry post-gap numbers; shifting the
+            // map before inserting it renumbers only the other tasks' rows.
+            if let Some(shift) = tree_shift {
+                self.apply_tree_shift(&shift);
+            }
+            let (wave_anim, wave_stop) = {
+                let _term = lock_term();
+                WaveAnimation::start(
+                    "Thinking",
+                    vec![],
+                    self.input_buf.clone(),
+                    Some(self.cancel.clone()),
+                )
+            };
+            if let Ok(mut guard) = self.post_tool_wave.lock() {
+                *guard = Some((wave_anim, wave_stop));
+            }
+            prepare_input_line(&self.input_buf, Some(&self.cancel));
+            self.anim_cleared.store(false, Ordering::Relaxed);
+            if let Ok(mut guard) = self.live_worker_reasoning.lock() {
+                guard.insert(task_id.clone(), new_state);
+            }
+        }
+
+        if let Ok(mut guard) = self.live_worker_reasoning.lock() {
+            let Some(state) = guard.get_mut(&task_id) else {
+                return;
+            };
+            let _term = lock_term();
+            apply_reasoning_chunk(state, content);
+            // Keep `ORCH_LAST_TOOL_LINES` in sync so the next tool's
+            // connector upgrade redraws the body with the latest content.
+            let body = worker_reasoning_body_for_terminal(&state.body_line_text);
+            crate::ui::orchestrator::update_orch_last_tool_duration_text(&task_id, &body);
+        }
+    }
 }
 
 impl StreamHandler for ReplStreamHandler {
@@ -2227,6 +2421,16 @@ impl StreamHandler for ReplStreamHandler {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
+        // Worker deltas (parent_agent_id set) are rendered per-task from
+        // `aura.orchestrator.worker_reasoning`, which precedes this mirror
+        // on the wire and carries the task_id that demultiplexes concurrent
+        // workers. Drop the mirror so each delta renders once. A server
+        // that emits only the mirror never sets the flag, and the legacy
+        // single-block path below still renders its worker reasoning.
+        if parent_agent_id.is_some() && self.worker_reasoning_seen.load(Ordering::Relaxed) {
+            return;
+        }
+
         // Switching agents closes the previous block.
         let agent_changed = match self.live_reasoning.lock() {
             Ok(g) => g.as_ref().is_some_and(|s| s.agent_id != agent_id),
@@ -2296,15 +2500,19 @@ impl StreamHandler for ReplStreamHandler {
                 body_visual_rows: 1,
                 is_worker: effective_worker,
             };
-            {
+            let tree_shift = {
                 let _term = lock_term();
                 erase_input_frame();
                 if effective_worker {
                     let tid = task_id.as_deref().unwrap_or("");
-                    open_worker_reasoning_block(&mut new_state, tid);
+                    open_worker_reasoning_block(&mut new_state, tid, agent_id)
                 } else {
                     open_top_level_reasoning_block(&mut new_state, agent_id);
+                    None
                 }
+            };
+            if let Some(shift) = tree_shift {
+                self.apply_tree_shift(&shift);
             }
             // Restart the Thinking spinner so it
             // stays visible while reasoning chunks
@@ -2636,16 +2844,16 @@ impl StreamHandler for ReplStreamHandler {
             return;
         }
 
-        // The server emits `aura.orchestrator.worker_reasoning`
-        // alongside every `aura.reasoning` delta from a
-        // worker. We already render the reasoning via
-        // the dedicated `on_reasoning` path (which has
-        // the worker's agent_id and richer correlation
-        // context), and processing the orch mirror here
-        // would call `erase_input_frame` mid-stream and
-        // corrupt the running `● Reasoning - <agent>`
-        // block. Drop it before any frame work runs.
+        // Worker reasoning deltas carry the `task_id` that demultiplexes
+        // concurrent same-wave workers, so orchestrated runs render from
+        // this event (each task streams into its own tree row) and
+        // `on_reasoning` drops the per-delta `aura.reasoning` mirror the
+        // server emits right after it. Handled above the frame machinery:
+        // chunks after a block's first are in-place row rewrites that must
+        // not disturb the input frame.
         if event_name == event_names::WORKER_REASONING {
+            self.worker_reasoning_seen.store(true, Ordering::Relaxed);
+            self.on_worker_reasoning(val);
             return;
         }
 
@@ -2800,6 +3008,7 @@ impl StreamHandler for ReplStreamHandler {
                     );
                     crate::ui::prompt::increment_orch_scrollback();
                     // No blank line – tool calls follow directly
+                    crate::ui::orchestrator::note_orch_task_tree_end(&task_id);
                     if let Ok(mut os) = self.orch_state.lock() {
                         os.tasks.insert(
                             task_id.clone(),
@@ -2822,6 +3031,10 @@ impl StreamHandler for ReplStreamHandler {
                     let tool_initiator_id = get_str(val, "tool_initiator_id");
                     let tool_call_id = get_str(val, "tool_call_id");
                     let task_id_str = get_str(val, "task_id");
+                    // This task's reasoning stretch is over — close its live
+                    // block (other tasks' blocks keep streaming) so the
+                    // DisplayEvent lands before the tool's in replay order.
+                    flush_worker_reasoning_for_task(&self.live_worker_reasoning, &task_id_str);
                     let display_name = snake_to_pascal_case(&tool_name);
                     let args_obj = parse_args(val);
                     let args_summary = args_obj.as_ref()
@@ -2874,13 +3087,27 @@ impl StreamHandler for ReplStreamHandler {
                     } else {
                         &tool_initiator_id
                     };
-                    crate::ui::prompt::register_orch_tool(
-                        match_id,
-                        &task_id_str,
-                        &tool_display,
-                        std::time::Instant::now(),
-                        &fields,
-                    );
+                    // Coordinator-owned calls (worker "main") belong to no
+                    // task: render at the top level, outside any task tree.
+                    if get_str(val, "worker_id") == "main" {
+                        crate::ui::orchestrator::register_orch_top_level_tool(
+                            match_id,
+                            &tool_display,
+                            std::time::Instant::now(),
+                            &fields,
+                        );
+                    } else {
+                        let tree_shift = crate::ui::prompt::register_orch_tool(
+                            match_id,
+                            &task_id_str,
+                            &tool_display,
+                            std::time::Instant::now(),
+                            &fields,
+                        );
+                        if let Some(shift) = tree_shift {
+                            self.apply_tree_shift(&shift);
+                        }
+                    }
                     // Track tool under its task
                     if let Ok(mut os) = self.orch_state.lock() {
                         if let Some(task) = os.tasks.get_mut(&task_id_str) {
@@ -2927,6 +3154,7 @@ impl StreamHandler for ReplStreamHandler {
                     let worker_id = get_str(val, "worker_id");
                     let task_id = get_str(val, "task_id");
                     let result = get_str(val, "result");
+                    flush_worker_reasoning_for_task(&self.live_worker_reasoning, &task_id);
                     // Look up task info and overwrite the header line in-place
                     let task_info = if let Ok(mut os) = self.orch_state.lock() {
                         os.tasks.remove(&task_id)
@@ -3072,6 +3300,7 @@ impl StreamHandler for ReplStreamHandler {
 
     fn on_approval_pending(&mut self, pending: &aura_events::ApprovalPending) {
         flush_live_reasoning(&self.live_reasoning);
+        flush_all_worker_reasoning(&self.live_worker_reasoning);
 
         // Stop animation — same dance as on_tool_complete / on_orchestrator_event.
         let had_ptw = if let Ok(mut guard) = self.post_tool_wave.lock() {
@@ -3271,6 +3500,7 @@ impl StreamHandler for ReplStreamHandler {
 
     fn on_approval_completed(&mut self, completed: &aura_events::ApprovalCompleted) {
         flush_live_reasoning(&self.live_reasoning);
+        flush_all_worker_reasoning(&self.live_worker_reasoning);
 
         // Stop animation.
         let had_ptw = if let Ok(mut guard) = self.post_tool_wave.lock() {

--- a/crates/aura-cli/src/ui/animation.rs
+++ b/crates/aura-cli/src/ui/animation.rs
@@ -369,18 +369,22 @@ impl WaveAnimation {
                             let mut stdout = io::stdout();
                             let last_tool_map = ORCH_LAST_TOOL_LINES.lock().ok();
                             for tool in tools.iter() {
-                                let bullet_up = (total_sb + 3).saturating_sub(tool.bullet_line_num);
-                                let duration_up =
-                                    (total_sb + 3).saturating_sub(tool.duration_line_num);
+                                let tool_bullet_line = tool.bullet_line_num.load(Ordering::Relaxed);
+                                let tool_duration_line =
+                                    tool.duration_line_num.load(Ordering::Relaxed);
+                                let bullet_up = (total_sb + 3).saturating_sub(tool_bullet_line);
+                                let duration_up = (total_sb + 3).saturating_sub(tool_duration_line);
                                 if bullet_up >= th as u32 || duration_up >= th as u32 {
                                     continue;
                                 }
                                 let is_last = last_tool_map
                                     .as_ref()
                                     .and_then(|m| m.get(&tool.task_id))
-                                    .map(|info| info.bullet_line_num == tool.bullet_line_num)
+                                    .map(|info| info.bullet_line_num == tool_bullet_line)
                                     .unwrap_or(false);
-                                let (b_prefix, d_prefix) = if is_last {
+                                let (b_prefix, d_prefix) = if tool.top_level {
+                                    ("", "")
+                                } else if is_last {
                                     (
                                         super::orchestrator::TREE_END_BULLET,
                                         super::orchestrator::TREE_END_DURATION,

--- a/crates/aura-cli/src/ui/event_replay.rs
+++ b/crates/aura-cli/src/ui/event_replay.rs
@@ -351,6 +351,11 @@ pub fn replay_event_log_global() {
                         DisplayEvent::OrchestratorToolCallStarted {
                             tool_name, fields, ..
                         } => {
+                            // Coordinator-owned calls (worker "main") render
+                            // at the top level, not inside a task tree.
+                            if fields.get("worker_id").and_then(|v| v.as_str()) == Some("main") {
+                                break;
+                            }
                             let dn = snake_to_pascal_case(tool_name);
                             let args = format_orch_args_summary(fields);
                             entries.push(TaskEntry::Tool {
@@ -387,7 +392,7 @@ pub fn replay_event_log_global() {
                             content,
                             agent_id,
                             fields,
-                        } if agent_id == worker_id => {
+                        } if reasoning_event_matches_task(fields, agent_id, task_id, worker_id) => {
                             entries.push(TaskEntry::Reasoning {
                                 content: content.clone(),
                                 fields: fields.clone(),
@@ -507,11 +512,16 @@ pub fn replay_event_log_global() {
                             content,
                             fields: reasoning_fields,
                         } => {
+                            let label = if worker_id.is_empty() {
+                                "Reasoning".to_string()
+                            } else {
+                                format!("Reasoning - {worker_id}")
+                            };
                             println!(
                                 "{}{} {}",
                                 b_prefix.themed(AuraStyle::Connector),
                                 "●".with(bc),
-                                "Reasoning".themed(AuraStyle::Primary),
+                                label.as_str().themed(AuraStyle::Primary),
                             );
                             // Worker reasoning body is a single line in the
                             // live display; flatten whitespace and truncate
@@ -543,7 +553,44 @@ pub fn replay_event_log_global() {
                 println!();
                 i = j;
             }
-            DisplayEvent::OrchestratorToolCallStarted { .. } => {
+            DisplayEvent::OrchestratorToolCallStarted {
+                tool_name, fields, ..
+            } => {
+                // Coordinator-owned calls (worker "main") render at the top
+                // level; task-owned calls are rendered by the task walk above.
+                if fields.get("worker_id").and_then(|v| v.as_str()) == Some("main") {
+                    let dn = snake_to_pascal_case(tool_name);
+                    let args = format_orch_args_summary(fields);
+                    let call_id = fields.get("tool_call_id").and_then(|v| v.as_str());
+                    let duration_ms = events[i + 1..].iter().find_map(|e| match e {
+                        DisplayEvent::OrchestratorToolCallCompleted {
+                            duration_ms,
+                            fields: cf,
+                            ..
+                        } if call_id.is_none()
+                            || cf.get("tool_call_id").and_then(|v| v.as_str()) == call_id =>
+                        {
+                            *duration_ms
+                        }
+                        _ => None,
+                    });
+                    let bc = task_color_for("__orchestrator__");
+                    println!(
+                        "{} {}",
+                        "●".with(bc),
+                        format!("{dn}({args})").as_str().themed(AuraStyle::Primary),
+                    );
+                    if let Some(ms) = duration_ms {
+                        println!(
+                            "{} {}",
+                            "⎿".themed(AuraStyle::Connector),
+                            format!("completed in {}", format_orch_duration_ms(ms))
+                                .as_str()
+                                .themed(AuraStyle::Muted),
+                        );
+                    }
+                    println!();
+                }
                 i += 1;
             }
             DisplayEvent::OrchestratorToolCallCompleted { .. } => {
@@ -692,6 +739,23 @@ fn format_orch_args_summary(fields: &BTreeMap<String, serde_json::Value>) -> Str
             .collect::<Vec<_>>()
             .join(", "),
         None => String::new(),
+    }
+}
+
+/// A flushed reasoning block belongs to a task when its persisted `task_id`
+/// field matches. Blocks without one (single-agent runs, or servers that
+/// emit only the `aura.reasoning` worker mirror) fall back to matching the
+/// task's worker id.
+fn reasoning_event_matches_task(
+    fields: &BTreeMap<String, serde_json::Value>,
+    agent_id: &str,
+    task_id: &str,
+    worker_id: &str,
+) -> bool {
+    match fields.get("task_id") {
+        Some(serde_json::Value::Number(n)) => n.to_string() == task_id,
+        Some(serde_json::Value::String(s)) => s == task_id,
+        _ => agent_id == worker_id,
     }
 }
 

--- a/crates/aura-cli/src/ui/orchestrator.rs
+++ b/crates/aura-cli/src/ui/orchestrator.rs
@@ -17,7 +17,7 @@ use crate::theme::{AuraStyle, Themed};
 
 use super::state::{
     ACTIVE_ORCH_TOOLS, AGENT_REASONING, AGENT_REASONING_SEQ, EXPANDED_OUTPUT, ORCH_LAST_TOOL_LINES,
-    ORCH_SCROLLBACK_COUNTER, PROGRESS_TOKEN_TO_TOOL_ID, lock_term, term_size,
+    ORCH_SCROLLBACK_COUNTER, ORCH_TASK_TREE_END, PROGRESS_TOKEN_TO_TOOL_ID, lock_term, term_size,
 };
 
 // Tree connector prefixes for tool calls under tasks
@@ -27,13 +27,18 @@ pub(crate) const TREE_END_BULLET: &str = "└─ ";
 pub(crate) const TREE_END_DURATION: &str = "   ";
 
 /// Tracks an in-flight orchestrator tool call for live duration display.
+/// Line numbers are atomic so a tree-gap insertion above the entry can
+/// renumber them while the animation thread holds the `Arc`.
 pub struct ActiveOrchTool {
     pub tool_id: String,
     pub task_id: String,
     pub tool_display: String,
     pub start_time: Instant,
-    pub bullet_line_num: u32,
-    pub duration_line_num: u32,
+    pub bullet_line_num: std::sync::atomic::AtomicU32,
+    pub duration_line_num: std::sync::atomic::AtomicU32,
+    /// Coordinator-owned call rendered at the top level: bullet at column 0,
+    /// no tree connectors, outside any task tree.
+    pub top_level: bool,
     /// `true` when content (fields tree at register, or result lines at
     /// finalize) was printed below the duration line in expanded mode. Used
     /// at finalize time so the in-place duration overwrite keeps the right
@@ -91,14 +96,116 @@ pub(crate) fn visual_row_count(text: &str) -> u32 {
     }
 }
 
-/// Register an in-flight orchestrator tool call.
+/// Rows were inserted mid-scrollback: every tracked row number at or below
+/// `at` moved down by `by`. Callers that keep their own absolute row records
+/// (task headers, live reasoning bodies) must apply the same shift.
+pub struct TreeShift {
+    pub at: u32,
+    pub by: u32,
+}
+
+/// Record the tree anchor for a task: one past its last committed tree row.
+/// New entries for the task print here (via a tree gap) when later tasks'
+/// rows have landed below. Call right after the task header commits.
+pub fn note_orch_task_tree_end(task_id: &str) {
+    let total = ORCH_SCROLLBACK_COUNTER.load(Ordering::Relaxed);
+    if let Ok(mut guard) = ORCH_TASK_TREE_END.lock() {
+        guard.insert(task_id.to_string(), total);
+    }
+}
+
+/// Scrollback line where a new `rows`-row tree entry for `task_id` must
+/// print to sit directly under the task's previous row. `None` means append
+/// at the bottom instead: the task is already bottom-most (the common,
+/// sequential case), it has no recorded anchor, the anchor has scrolled
+/// off-screen, or the entry is too tall for the blank region the erased
+/// input frame provides.
+fn tree_gap_line_for(task_id: &str, rows: u32) -> Option<u32> {
+    let at = ORCH_TASK_TREE_END.lock().ok()?.get(task_id).copied()?;
+    let total = ORCH_SCROLLBACK_COUNTER.load(Ordering::Relaxed);
+    if at >= total {
+        return None;
+    }
+    let (_, th) = term_size();
+    if rows > 3 || (total - at) + rows >= th as u32 {
+        return None;
+    }
+    Some(at)
+}
+
+/// Open a `rows`-row gap at scrollback line `at`: rows from `at` down shift
+/// toward the blank region the erased input frame left at the screen
+/// bottom. Leaves the cursor at the gap's first row; the caller prints
+/// exactly `rows` visual rows there and then calls `commit_tree_gap`.
+/// Caller must hold the term lock with the cursor at the scrollback bottom
+/// (the position `erase_input_frame` leaves it in).
+fn open_tree_gap(at: u32, rows: u32) {
+    let total = ORCH_SCROLLBACK_COUNTER.load(Ordering::Relaxed);
+    let mut stdout = io::stdout();
+    let _ = execute!(
+        stdout,
+        cursor::MoveUp((total - at) as u16),
+        cursor::MoveToColumn(0)
+    );
+    print!("\x1b[{rows}L");
+    let _ = stdout.flush();
+}
+
+/// Return the cursor to the (new) scrollback bottom and renumber every
+/// statically-tracked row at or below the gap. The caller's own records are
+/// renumbered by propagating the returned `TreeShift`; the freshly printed
+/// entry's rows are recorded after this call, so they are never shifted.
+fn commit_tree_gap(shift: &TreeShift) {
+    let total = ORCH_SCROLLBACK_COUNTER.load(Ordering::Relaxed);
+    let mut stdout = io::stdout();
+    let _ = execute!(
+        stdout,
+        cursor::MoveDown((total - shift.at) as u16),
+        cursor::MoveToColumn(0)
+    );
+    let _ = stdout.flush();
+    if let Ok(mut guard) = ORCH_LAST_TOOL_LINES.lock() {
+        for info in guard.values_mut() {
+            if info.bullet_line_num >= shift.at {
+                info.bullet_line_num += shift.by;
+            }
+            if info.duration_line_num >= shift.at {
+                info.duration_line_num += shift.by;
+            }
+        }
+    }
+    if let Ok(tools) = ACTIVE_ORCH_TOOLS.lock() {
+        for tool in tools.iter() {
+            let b = tool.bullet_line_num.load(Ordering::Relaxed);
+            if b >= shift.at {
+                tool.bullet_line_num.store(b + shift.by, Ordering::Relaxed);
+            }
+            let d = tool.duration_line_num.load(Ordering::Relaxed);
+            if d >= shift.at {
+                tool.duration_line_num
+                    .store(d + shift.by, Ordering::Relaxed);
+            }
+        }
+    }
+    if let Ok(mut guard) = ORCH_TASK_TREE_END.lock() {
+        for end in guard.values_mut() {
+            if *end >= shift.at {
+                *end += shift.by;
+            }
+        }
+    }
+    ORCH_SCROLLBACK_COUNTER.fetch_add(shift.by, Ordering::Relaxed);
+}
+
+/// Register an in-flight orchestrator tool call. Returns the shift applied
+/// when the entry printed into a tree gap (see [`TreeShift`]).
 pub fn register_orch_tool(
     tool_id: &str,
     task_id: &str,
     tool_display: &str,
     start_time: Instant,
     fields: &BTreeMap<String, serde_json::Value>,
-) {
+) -> Option<TreeShift> {
     upgrade_last_tool_to_mid(task_id);
 
     // Count visual rows (not logical printlns) so the cursor math in
@@ -106,30 +213,55 @@ pub fn register_orch_tool(
     // right row when a long bullet/value wraps.
     let bullet_text = format!("{}● {}", TREE_END_BULLET, tool_display);
     let bullet_rows = visual_row_count(&bullet_text);
-    let bullet_line = ORCH_SCROLLBACK_COUNTER.fetch_add(bullet_rows, Ordering::Relaxed);
-    println!(
-        "{}{} {}",
-        TREE_END_BULLET.themed(AuraStyle::Connector),
-        "●".themed(AuraStyle::Muted),
-        tool_display.themed(AuraStyle::Primary),
-    );
     let running_text = format_orch_running(start_time);
     let has_content_below = EXPANDED_OUTPUT.load(Ordering::Relaxed) && !fields.is_empty();
     let dur_connector = if has_content_below { "├─" } else { "⎿" };
     let duration_text = format!("{}{} {}", TREE_END_DURATION, dur_connector, running_text);
     let duration_rows = visual_row_count(&duration_text);
-    let duration_line = ORCH_SCROLLBACK_COUNTER.fetch_add(duration_rows, Ordering::Relaxed);
-    println!(
-        "{}{} {}",
-        TREE_END_DURATION,
-        dur_connector.themed(AuraStyle::Connector),
-        running_text.as_str().themed(AuraStyle::Muted),
-    );
+    let entry_rows = bullet_rows + duration_rows;
 
-    // In expanded mode, print the fields tree below the duration line
-    if has_content_below {
-        print_fields_tree_indented_live(fields, TREE_END_DURATION);
-    }
+    let print_entry = || {
+        println!(
+            "{}{} {}",
+            TREE_END_BULLET.themed(AuraStyle::Connector),
+            "●".themed(AuraStyle::Muted),
+            tool_display.themed(AuraStyle::Primary),
+        );
+        println!(
+            "{}{} {}",
+            TREE_END_DURATION,
+            dur_connector.themed(AuraStyle::Connector),
+            running_text.as_str().themed(AuraStyle::Muted),
+        );
+    };
+
+    // Grouped placement: print directly under the task's previous row when
+    // other tasks' entries have landed below it. Expanded mode always
+    // appends — its fields tree and result blocks are variable-height.
+    let gap = if has_content_below {
+        None
+    } else {
+        tree_gap_line_for(task_id, entry_rows)
+    };
+    let (bullet_line, duration_line, shift) = if let Some(at) = gap {
+        open_tree_gap(at, entry_rows);
+        print_entry();
+        let shift = TreeShift { at, by: entry_rows };
+        // Renumbers the task's own tree-end anchor along with everything
+        // below the gap, leaving it one past the new entry.
+        commit_tree_gap(&shift);
+        (at, at + bullet_rows, Some(shift))
+    } else {
+        let bullet_line = ORCH_SCROLLBACK_COUNTER.fetch_add(bullet_rows, Ordering::Relaxed);
+        let duration_line = ORCH_SCROLLBACK_COUNTER.fetch_add(duration_rows, Ordering::Relaxed);
+        print_entry();
+        // In expanded mode, print the fields tree below the duration line
+        if has_content_below {
+            print_fields_tree_indented_live(fields, TREE_END_DURATION);
+        }
+        note_orch_task_tree_end(task_id);
+        (bullet_line, duration_line, None)
+    };
 
     if let Ok(mut guard) = ORCH_LAST_TOOL_LINES.lock() {
         guard.insert(
@@ -138,7 +270,7 @@ pub fn register_orch_tool(
                 bullet_line_num: bullet_line,
                 duration_line_num: duration_line,
                 tool_display: tool_display.to_string(),
-                duration_text: running_text,
+                duration_text: running_text.clone(),
                 has_content_below,
             },
         );
@@ -148,8 +280,58 @@ pub fn register_orch_tool(
         task_id: task_id.to_string(),
         tool_display: tool_display.to_string(),
         start_time,
-        bullet_line_num: bullet_line,
-        duration_line_num: duration_line,
+        bullet_line_num: std::sync::atomic::AtomicU32::new(bullet_line),
+        duration_line_num: std::sync::atomic::AtomicU32::new(duration_line),
+        top_level: false,
+        has_content_below,
+        progress_message: Mutex::new(None),
+    });
+    if let Ok(mut guard) = ACTIVE_ORCH_TOOLS.lock() {
+        guard.push(tool);
+    }
+    shift
+}
+
+/// Register an in-flight coordinator tool call, rendered at the top level:
+/// `● Display` at column 0 with a bare `⎿ running …` line, no tree
+/// connectors. Appends at the scrollback bottom and joins no task tree — no
+/// connector upgrades, no tree anchor.
+pub fn register_orch_top_level_tool(
+    tool_id: &str,
+    tool_display: &str,
+    start_time: Instant,
+    fields: &BTreeMap<String, serde_json::Value>,
+) {
+    let bullet_text = format!("● {}", tool_display);
+    let bullet_rows = visual_row_count(&bullet_text);
+    let bullet_line = ORCH_SCROLLBACK_COUNTER.fetch_add(bullet_rows, Ordering::Relaxed);
+    println!(
+        "{} {}",
+        "●".themed(AuraStyle::Muted),
+        tool_display.themed(AuraStyle::Primary),
+    );
+    let running_text = format_orch_running(start_time);
+    let has_content_below = EXPANDED_OUTPUT.load(Ordering::Relaxed) && !fields.is_empty();
+    let dur_connector = if has_content_below { "├─" } else { "⎿" };
+    let duration_text = format!("{} {}", dur_connector, running_text);
+    let duration_rows = visual_row_count(&duration_text);
+    let duration_line = ORCH_SCROLLBACK_COUNTER.fetch_add(duration_rows, Ordering::Relaxed);
+    println!(
+        "{} {}",
+        dur_connector.themed(AuraStyle::Connector),
+        running_text.as_str().themed(AuraStyle::Muted),
+    );
+    if has_content_below {
+        print_fields_tree_indented_live(fields, "");
+    }
+    let tool = std::sync::Arc::new(ActiveOrchTool {
+        tool_id: tool_id.to_string(),
+        task_id: String::new(),
+        tool_display: tool_display.to_string(),
+        start_time,
+        bullet_line_num: std::sync::atomic::AtomicU32::new(bullet_line),
+        duration_line_num: std::sync::atomic::AtomicU32::new(duration_line),
+        top_level: true,
         has_content_below,
         progress_message: Mutex::new(None),
     });
@@ -170,34 +352,64 @@ pub fn register_orch_tool(
 /// `on_lines(bullet_line_num, body_line_num)` runs while the orchestrator
 /// state lock is held — the caller should record the line numbers into its
 /// own `LiveReasoning` state without doing additional terminal I/O.
-pub fn register_orch_reasoning_in_tree(task_id: &str, on_lines: impl FnOnce(u32, u32)) {
+pub fn register_orch_reasoning_in_tree(
+    task_id: &str,
+    worker_id: &str,
+    on_lines: impl FnOnce(u32, u32),
+) -> Option<TreeShift> {
     upgrade_last_tool_to_mid(task_id);
 
-    let display = "Reasoning";
+    // Concurrent tasks interleave their tree entries in scrollback, so the
+    // label names the worker to keep each reasoning row attributable. The
+    // bullet takes the task color immediately — unlike tool entries there
+    // is no finalize step to recolor it later.
+    let display = if worker_id.is_empty() {
+        "Reasoning".to_string()
+    } else {
+        format!("Reasoning - {worker_id}")
+    };
+    let bullet_color = crate::ui::state::task_color_for(task_id);
     let bullet_text = format!("{}● {}", TREE_END_BULLET, display);
     let bullet_rows = visual_row_count(&bullet_text);
-    let bullet_line = ORCH_SCROLLBACK_COUNTER.fetch_add(bullet_rows, Ordering::Relaxed);
-    println!(
-        "{}{} {}",
-        TREE_END_BULLET.themed(AuraStyle::Connector),
-        "●".themed(AuraStyle::Muted),
-        display.themed(AuraStyle::Primary),
-    );
-
-    // Initial body row: empty. The reasoning callback will rewrite this
-    // in-place as chunks arrive.
     let body_text = format!("{}⎿ ", TREE_END_DURATION);
     let body_rows = visual_row_count(&body_text);
-    let body_line = ORCH_SCROLLBACK_COUNTER.fetch_add(body_rows, Ordering::Relaxed);
-    println!(
-        "{}{} ",
-        TREE_END_DURATION.themed(AuraStyle::Connector),
-        "⎿".themed(AuraStyle::Connector),
-    );
+    let entry_rows = bullet_rows + body_rows;
+
+    // Prints the bullet row plus an initial empty body row; the reasoning
+    // callback rewrites the body in-place as chunks arrive.
+    let print_entry = || {
+        println!(
+            "{}{} {}",
+            TREE_END_BULLET.themed(AuraStyle::Connector),
+            "●".with(bullet_color),
+            display.as_str().themed(AuraStyle::Primary),
+        );
+        println!(
+            "{}{} ",
+            TREE_END_DURATION.themed(AuraStyle::Connector),
+            "⎿".themed(AuraStyle::Connector),
+        );
+    };
+
+    // Grouped placement: print directly under the task's previous row when
+    // other tasks' entries have landed below it.
+    let (bullet_line, body_line, shift) = if let Some(at) = tree_gap_line_for(task_id, entry_rows) {
+        open_tree_gap(at, entry_rows);
+        print_entry();
+        let shift = TreeShift { at, by: entry_rows };
+        commit_tree_gap(&shift);
+        (at, at + bullet_rows, Some(shift))
+    } else {
+        let bullet_line = ORCH_SCROLLBACK_COUNTER.fetch_add(bullet_rows, Ordering::Relaxed);
+        let body_line = ORCH_SCROLLBACK_COUNTER.fetch_add(body_rows, Ordering::Relaxed);
+        print_entry();
+        note_orch_task_tree_end(task_id);
+        (bullet_line, body_line, None)
+    };
 
     // Insert into the per-task "last entry" map so the next tool registration
     // upgrades reasoning's `└─` to `├─`. We mirror tool semantics: the
-    // `tool_display` we record is just "Reasoning" (used by
+    // `tool_display` we record is the label (used by
     // `upgrade_last_tool_to_mid` to repaint the bullet line), and
     // `duration_text` stays empty initially (the reasoning callback owns
     // updating it as content streams in).
@@ -215,6 +427,7 @@ pub fn register_orch_reasoning_in_tree(task_id: &str, on_lines: impl FnOnce(u32,
     }
 
     on_lines(bullet_line, body_line);
+    shift
 }
 
 /// Update the recorded `duration_text` of the last entry under a task so
@@ -311,10 +524,16 @@ pub fn finalize_orch_tool(tool_id: &str, duration_ms: Option<u64>, result: Optio
     let ms = duration_ms.unwrap_or_else(|| tool.start_time.elapsed().as_millis() as u64);
     let dur_str = format_orch_duration_ms(ms);
     let total_scrollback = ORCH_SCROLLBACK_COUNTER.load(Ordering::Relaxed);
-    let bullet_color = crate::ui::state::task_color_for(&tool.task_id);
+    let bullet_color = crate::ui::state::task_color_for(if tool.top_level {
+        "__orchestrator__"
+    } else {
+        &tool.task_id
+    });
 
-    let bullet_up = total_scrollback.saturating_sub(tool.bullet_line_num);
-    let duration_up = total_scrollback.saturating_sub(tool.duration_line_num);
+    let tool_bullet_line = tool.bullet_line_num.load(Ordering::Relaxed);
+    let tool_duration_line = tool.duration_line_num.load(Ordering::Relaxed);
+    let bullet_up = total_scrollback.saturating_sub(tool_bullet_line);
+    let duration_up = total_scrollback.saturating_sub(tool_duration_line);
 
     let (_, th) = term_size();
     let on_screen = bullet_up < th as u32 && duration_up < th as u32;
@@ -322,12 +541,14 @@ pub fn finalize_orch_tool(tool_id: &str, duration_ms: Option<u64>, result: Optio
     let is_last = if let Ok(guard) = ORCH_LAST_TOOL_LINES.lock() {
         guard
             .get(&tool.task_id)
-            .map(|info| info.bullet_line_num == tool.bullet_line_num)
+            .map(|info| info.bullet_line_num == tool_bullet_line)
             .unwrap_or(false)
     } else {
         false
     };
-    let (b_prefix, d_prefix) = if is_last {
+    let (b_prefix, d_prefix) = if tool.top_level {
+        ("", "")
+    } else if is_last {
         (TREE_END_BULLET, TREE_END_DURATION)
     } else {
         (TREE_MID_BULLET, TREE_MID_DURATION)
@@ -384,21 +605,26 @@ pub fn finalize_orch_tool(tool_id: &str, duration_ms: Option<u64>, result: Optio
     }
 
     // Append the tool result as indented lines under the fields tree.
-    // Indented with TREE_END_DURATION (`   `) to match the live fields-tree
-    // indent emitted at register time. Tracks visual rows (not printlns)
-    // so a wrapped result line doesn't desync the cursor math for the next
-    // tool's `register_orch_tool`.
+    // Indented to match the live fields-tree indent emitted at register
+    // time (none for top-level coordinator calls). Tracks visual rows (not
+    // printlns) so a wrapped result line doesn't desync the cursor math for
+    // the next tool's `register_orch_tool`.
     if let Some(text) = result_text
         && expanded
     {
+        let indent = if tool.top_level {
+            ""
+        } else {
+            TREE_END_DURATION
+        };
         let normalized = crate::tools::normalize_tool_result_text(text);
         println!();
         ORCH_SCROLLBACK_COUNTER.fetch_add(1, Ordering::Relaxed);
         for line in normalized.lines() {
-            let line_text = format!("{}  {}", TREE_END_DURATION, line);
+            let line_text = format!("{}  {}", indent, line);
             println!(
                 "{}  {}",
-                TREE_END_DURATION.themed(AuraStyle::Connector),
+                indent.themed(AuraStyle::Connector),
                 line.themed(AuraStyle::Muted),
             );
             ORCH_SCROLLBACK_COUNTER.fetch_add(visual_row_count(&line_text), Ordering::Relaxed);
@@ -482,6 +708,9 @@ pub fn reset_orch_tools() {
     if let Ok(mut guard) = ORCH_LAST_TOOL_LINES.lock() {
         guard.clear();
     }
+    if let Ok(mut guard) = ORCH_TASK_TREE_END.lock() {
+        guard.clear();
+    }
     if let Ok(mut guard) = PROGRESS_TOKEN_TO_TOOL_ID.lock() {
         guard.clear();
     }
@@ -491,6 +720,9 @@ pub fn reset_orch_tools() {
 /// Clean up last-tool tracking for a completed task.
 pub fn clear_orch_task_tools(task_id: &str) {
     if let Ok(mut guard) = ORCH_LAST_TOOL_LINES.lock() {
+        guard.remove(task_id);
+    }
+    if let Ok(mut guard) = ORCH_TASK_TREE_END.lock() {
         guard.remove(task_id);
     }
 }

--- a/crates/aura-cli/src/ui/state.rs
+++ b/crates/aura-cli/src/ui/state.rs
@@ -129,6 +129,11 @@ pub(crate) static ORCH_LAST_TOOL_LINES: std::sync::LazyLock<
     Mutex<std::collections::HashMap<String, OrchLastToolInfo>>,
 > = std::sync::LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
 
+/// Per-task scrollback line one past the task's last tree row.
+pub(crate) static ORCH_TASK_TREE_END: std::sync::LazyLock<
+    Mutex<std::collections::HashMap<String, u32>>,
+> = std::sync::LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+
 /// Maps an MCP `progress_token` (canonical JSON repr) to the `tool_id` it
 /// belongs to. Populated from `aura.tool_start` events; consulted when an
 /// `aura.progress` arrives so the message can be rendered on the matching


### PR DESCRIPTION
In orchestration mode, same-wave workers stream reasoning deltas concurrently over one channel. The REPL kept a single live reasoning block keyed by agent id, so every delta from a different worker tore the block down and reopened it, slicing parallel reasoning into many one-line fragments.

Render worker reasoning from aura.orchestrator.worker_reasoning instead of the aura.reasoning mirror: the orchestrator event carries the task_id that demultiplexes concurrent workers. Each task now owns a live block in a map keyed by task_id, streaming into its own tree row. The mirror is dropped once a worker_reasoning event is seen; servers that only emit the mirror keep the legacy single-block path.

Reasoning tree entries are labeled "Reasoning - <worker>" and take the task color immediately (no finalize step ever recolored them, so the last entry used to stay grey).

Group tree entries under their own task header: each task records a tree anchor, and an entry for a non-bottom task opens a terminal insert-line gap at the anchor instead of appending at the scrollback bottom. All tracked row numbers at or below a gap are renumbered (task headers, in-flight tool lines - now atomics - the connector map, live reasoning rows, and the anchors). Falls back to appending when the anchor is off-screen, the entry is too tall, or expanded mode is on. Sequential runs keep the existing append path.

Coordinator tool calls (worker_id "main") belong to no task and now render at the top level - bullet at column 0, bare completion line, no tree connectors - in live output, the in-flight animation, and replay.

Replay matches reasoning to tasks by the persisted task_id (falling back to worker id), mirrors the worker labels, and renders top-level coordinator calls.

Fixes: GH-523