### PR TITLE
Mshearer/421 memory dir network storage

### DIFF
--- a/crates/aura-web-server/src/a2a/legacy/types.rs
+++ b/crates/aura-web-server/src/a2a/legacy/types.rs
@@ -460,8 +460,7 @@ impl From<TaskArtifactUpdateEvent> for LegacyTaskArtifactUpdateEvent {
     }
 }
 
-/// A v0.3 agent event — a task, a message, or a task update — discriminated on
-/// the wire by each variant's own `kind` field.
+/// A v0.3 agent event.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum LegacyEvent {

--- a/crates/aura-web-server/src/session_store/redis/approval_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/approval_store.rs
@@ -33,16 +33,10 @@ use super::request_err;
 const MIN_TTL_SECS: u64 = 1;
 /// Margin the request index's TTL keeps over its newest record's TTL.
 const REQ_INDEX_TTL_MARGIN_SECS: u64 = 60;
-/// Margin the decision record's TTL keeps over the parked record's remaining
-/// TTL.
+/// Decision TTL margin over the parked record's remaining TTL.
 const DECISION_TTL_MARGIN_MS: u64 = 60_000;
 
-/// The at-most-once claim plus the durable decision write, in one atomic step:
-/// take the parked record (KEYS[1]) and, only if it existed, record the
-/// decision (KEYS[2] = ARGV[1]) with the parked record's remaining TTL plus
-/// ARGV[2] milliseconds. Returns the parked record JSON, or nil when no live
-/// entry existed. Atomicity is what makes a resolver crash unable to consume
-/// the parked entry without leaving the decision behind.
+/// Atomic script for the at-most-once claim and durable decision write.
 static RESOLVE_SCRIPT: LazyLock<redis::Script> = LazyLock::new(|| {
     redis::Script::new(
         r#"

--- a/crates/aura-web-server/src/session_store/redis/task_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/task_store.rs
@@ -128,12 +128,7 @@ impl RedisTaskStore {
         }
     }
 
-    /// Answer a write the script refused because the record is already
-    /// terminal. Re-recording the state that is already stored is a duplicate
-    /// of an outcome two instances both write (a routed cancel is recorded by
-    /// the instance that received it and by the one executing the task), so it
-    /// leaves the record alone and reports its unchanged version; any other
-    /// state is the conflict the script exists to reject.
+    /// Answer a write the script refused because the record is already terminal.
     async fn resolve_terminal_write(&self, task: &Task) -> Result<Option<u64>, A2AError> {
         let mut conn = self.conn.clone();
         let (stored, version): (Option<String>, Option<u64>) = redis::pipe()

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -416,8 +416,7 @@ async fn approval_concurrent_resolves_have_exactly_one_winner() {
     );
 }
 
-/// A resolution leaves a durable decision record readable from any instance
-/// (issue #474), and the (rejected) second resolve does not disturb it.
+/// A resolution leaves a durable decision record readable from any instance (issue #474).
 #[tokio::test]
 async fn approval_resolve_records_decision_readable_cross_instance() {
     let config = test_config(60);
@@ -448,9 +447,7 @@ async fn approval_resolve_records_decision_readable_cross_instance() {
     );
 }
 
-/// The decision record's TTL keeps a margin past the parked record's, so the
-/// parking instance's deadline backstop can still read a decision that
-/// arrived just before expiry.
+/// The decision record's TTL keeps a margin past the parked record's.
 #[tokio::test]
 async fn decision_record_outlives_parked_record_ttl() {
     let approvals = connect(&test_config(60)).await.approvals();
@@ -655,10 +652,7 @@ async fn approval_parked_on_one_instance_wakes_when_resolved_on_another() {
     );
 }
 
-/// The issue #474 repro over live Redis: the decision lands in the store but
-/// no wake is ever published (a suppressed wake channel, or a resolver crash
-/// after the claim). The parking instance's store poll recovers the decision
-/// well before the approval timeout instead of failing closed.
+/// Store poll recovers the decision well before the approval timeout.
 #[tokio::test]
 async fn store_only_resolve_wakes_parking_instance_via_poll() {
     let config = test_config(60);
@@ -923,10 +917,7 @@ mod a2a_bridge {
         assert_eq!(stored.status.state, TaskState::Canceled);
     }
 
-    /// The executing instance's own subscribers must learn the outcome of a
-    /// cancel driven from elsewhere: stopping the execution ends its stream
-    /// with no terminal event, so without the routed cancel's status they see
-    /// only a bare close and cannot tell a cancel from a dropped connection.
+    /// Subscribers on the executing instance learn the outcome of a routed cancel.
     #[tokio::test]
     async fn cancel_on_other_instance_terminates_subscribers_on_the_executing_one() {
         let config = test_config(60);
@@ -1005,9 +996,7 @@ async fn update_of_terminal_task_is_rejected() {
     assert_eq!(got.status.state, TaskState::Canceled);
 }
 
-/// Immutability rejects a *different* terminal state, not a second write of
-/// the one already recorded: both ends of a routed cancel record `Canceled`,
-/// and neither may see its write fail.
+/// Immutability rejects a *different* terminal state, not a second write of the same state.
 #[tokio::test]
 async fn rewriting_the_recorded_terminal_state_is_accepted() {
     let tasks = connect(&test_config(60)).await.tasks();

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -1993,7 +1993,7 @@ mod tests {
                 TransformArgsResult::new(args)
             }
 
-            fn transform_output(
+            async fn transform_output(
                 &self,
                 output: String,
                 _outcome: &CallOutcome,
@@ -2054,7 +2054,9 @@ mod tests {
         // it to a pointer.
         let raw: String = (0..500).map(|i| format!("entry_{} ", i)).collect();
         let outcome = CallOutcome::Success(raw.clone());
-        let result = composed.transform_output(raw.clone(), &outcome, &ctx, None);
+        let result = composed
+            .transform_output(raw.clone(), &outcome, &ctx, None)
+            .await;
 
         assert_eq!(
             recording.output_seen.lock().unwrap().as_deref(),

--- a/crates/aura/src/hitl/registry.rs
+++ b/crates/aura/src/hitl/registry.rs
@@ -58,8 +58,7 @@ struct PendingApprovalsInner {
     wakes: Mutex<BTreeMap<DecisionId, WakeEntry>>,
 }
 
-/// The process-local half of one parked approval: its wake handle and wake
-/// task.
+/// The process-local half of one parked approval.
 struct WakeEntry {
     request_id: String,
     wake: oneshot::Sender<ApprovalDecision>,

--- a/crates/aura/src/orchestration/duplicate_call_guard.rs
+++ b/crates/aura/src/orchestration/duplicate_call_guard.rs
@@ -108,7 +108,7 @@ impl ToolWrapper for DuplicateCallGuard {
         TransformArgsResult::with_extracted(args, extracted)
     }
 
-    fn transform_output(
+    async fn transform_output(
         &self,
         output: String,
         outcome: &CallOutcome,
@@ -212,7 +212,7 @@ mod tests {
         (guard, flag)
     }
 
-    fn call(
+    async fn call(
         guard: &DuplicateCallGuard,
         ctx: &ToolCallContext,
         args: &Value,
@@ -220,7 +220,9 @@ mod tests {
         outcome: &CallOutcome,
     ) -> TransformOutputResult {
         let r = guard.transform_args(args.clone(), ctx);
-        guard.transform_output(output.to_string(), outcome, ctx, r.extracted.as_ref())
+        guard
+            .transform_output(output.to_string(), outcome, ctx, r.extracted.as_ref())
+            .await
     }
 
     fn success(s: &str) -> CallOutcome {
@@ -257,70 +259,70 @@ mod tests {
         assert_eq!(canonicalize_args(&a), canonicalize_args(&b));
     }
 
-    #[test]
-    fn test_no_annotation_below_nudge() {
+    #[tokio::test]
+    async fn test_no_annotation_below_nudge() {
         let (guard, flag) = make_guard(3, 5);
         let ctx = ToolCallContext::new("mean");
         let args = serde_json::json!({"numbers": [1, 2, 3]});
 
         for _ in 0..2 {
-            let r = call(&guard, &ctx, &args, "2.0", &success("2.0"));
+            let r = call(&guard, &ctx, &args, "2.0", &success("2.0")).await;
             assert!(!r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
             assert!(!r.output.contains("[DUPLICATE_CALL_ABORT]"));
         }
         assert!(!flag.load(Ordering::SeqCst));
     }
 
-    #[test]
-    fn test_nudge_at_threshold() {
+    #[tokio::test]
+    async fn test_nudge_at_threshold() {
         let (guard, flag) = make_guard(3, 5);
         let ctx = ToolCallContext::new("mean");
         let args = serde_json::json!({"numbers": [1, 2, 3]});
 
         for _ in 0..2 {
-            call(&guard, &ctx, &args, "2.0", &success("2.0"));
+            call(&guard, &ctx, &args, "2.0", &success("2.0")).await;
         }
 
-        let r = call(&guard, &ctx, &args, "2.0", &success("2.0"));
+        let r = call(&guard, &ctx, &args, "2.0", &success("2.0")).await;
         assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
         assert!(r.output.starts_with("2.0"));
         assert!(!flag.load(Ordering::SeqCst));
     }
 
-    #[test]
-    fn test_block_at_threshold_sets_flag() {
+    #[tokio::test]
+    async fn test_block_at_threshold_sets_flag() {
         let (guard, flag) = make_guard(3, 5);
         let ctx = ToolCallContext::new("mean");
         let args = serde_json::json!({"numbers": [1, 2, 3]});
 
         for _ in 0..4 {
-            call(&guard, &ctx, &args, "2.0", &success("2.0"));
+            call(&guard, &ctx, &args, "2.0", &success("2.0")).await;
         }
 
-        let r = call(&guard, &ctx, &args, "2.0", &success("2.0"));
+        let r = call(&guard, &ctx, &args, "2.0", &success("2.0")).await;
         assert!(r.output.contains("[DUPLICATE_CALL_ABORT]"));
         assert!(r.output.starts_with("2.0"));
         assert!(flag.load(Ordering::SeqCst));
     }
 
-    #[test]
-    fn test_general_error_does_not_increment() {
+    #[tokio::test]
+    async fn test_general_error_does_not_increment() {
         let (guard, flag) = make_guard(2, 4);
         let ctx = ToolCallContext::new("api");
         let args = serde_json::json!({"q": "test"});
 
-        call(&guard, &ctx, &args, "timeout", &success("timeout"));
+        call(&guard, &ctx, &args, "timeout", &success("timeout")).await;
 
         for _ in 0..5 {
-            let r = call(&guard, &ctx, &args, "timeout", &general_error("timeout"));
+            let r = call(&guard, &ctx, &args, "timeout", &general_error("timeout")).await;
             assert!(!r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
             assert!(!r.output.contains("[DUPLICATE_CALL_ABORT]"));
         }
         assert!(!flag.load(Ordering::SeqCst));
     }
 
-    #[test]
-    fn test_schema_error_increments() {
+    #[tokio::test]
+    async fn test_schema_error_increments() {
         let (guard, flag) = make_guard(2, 4);
         let ctx = ToolCallContext::new("api");
         let args = serde_json::json!({"bad": "field"});
@@ -331,7 +333,8 @@ mod tests {
             &args,
             "missing param",
             &schema_error("missing param"),
-        );
+        )
+        .await;
 
         let r = call(
             &guard,
@@ -339,75 +342,76 @@ mod tests {
             &args,
             "missing param",
             &schema_error("missing param"),
-        );
+        )
+        .await;
         assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
         assert!(!flag.load(Ordering::SeqCst));
     }
 
-    #[test]
-    fn test_different_result_resets() {
+    #[tokio::test]
+    async fn test_different_result_resets() {
         let (guard, _flag) = make_guard(2, 4);
         let ctx = ToolCallContext::new("get_time");
         let args = serde_json::json!({"tz": "UTC"});
 
-        call(&guard, &ctx, &args, "12:00", &success("12:00"));
-        call(&guard, &ctx, &args, "12:01", &success("12:01"));
+        call(&guard, &ctx, &args, "12:00", &success("12:00")).await;
+        call(&guard, &ctx, &args, "12:01", &success("12:01")).await;
 
-        let r = call(&guard, &ctx, &args, "12:01", &success("12:01"));
+        let r = call(&guard, &ctx, &args, "12:01", &success("12:01")).await;
         assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
     }
 
-    #[test]
-    fn test_different_tool_resets() {
+    #[tokio::test]
+    async fn test_different_tool_resets() {
         let (guard, _flag) = make_guard(2, 4);
         let args = serde_json::json!({"x": 1});
         let ctx_a = ToolCallContext::new("tool_a");
         let ctx_b = ToolCallContext::new("tool_b");
 
-        call(&guard, &ctx_a, &args, "1", &success("1"));
-        call(&guard, &ctx_a, &args, "1", &success("1"));
+        call(&guard, &ctx_a, &args, "1", &success("1")).await;
+        call(&guard, &ctx_a, &args, "1", &success("1")).await;
 
-        let r = call(&guard, &ctx_b, &args, "1", &success("1"));
+        let r = call(&guard, &ctx_b, &args, "1", &success("1")).await;
         assert!(!r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
     }
 
-    #[test]
-    fn test_flag_monotonic_after_block() {
+    #[tokio::test]
+    async fn test_flag_monotonic_after_block() {
         let (guard, flag) = make_guard(2, 3);
         let ctx = ToolCallContext::new("t");
         let args = serde_json::json!({"x": 1});
 
         for _ in 0..3 {
-            call(&guard, &ctx, &args, "r", &success("r"));
+            call(&guard, &ctx, &args, "r", &success("r")).await;
         }
         assert!(flag.load(Ordering::SeqCst));
 
-        let r = call(&guard, &ctx, &args, "r", &success("r"));
+        let r = call(&guard, &ctx, &args, "r", &success("r")).await;
         assert!(!r.output.contains("[DUPLICATE_CALL_ABORT]"));
         assert!(flag.load(Ordering::SeqCst));
     }
 
-    #[test]
-    fn test_real_output_preserved() {
+    #[tokio::test]
+    async fn test_real_output_preserved() {
         let (guard, _flag) = make_guard(2, 4);
         let ctx = ToolCallContext::new("calc");
         let args = serde_json::json!({"x": 5});
 
-        call(&guard, &ctx, &args, "25", &success("25"));
-        let r = call(&guard, &ctx, &args, "25", &success("25"));
+        call(&guard, &ctx, &args, "25", &success("25")).await;
+        let r = call(&guard, &ctx, &args, "25", &success("25")).await;
         assert!(r.output.starts_with("25"));
         assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
     }
 
-    #[test]
-    fn test_nudge_then_block_progression() {
+    #[tokio::test]
+    async fn test_nudge_then_block_progression() {
         let (guard, flag) = make_guard(3, 5);
         let ctx = ToolCallContext::new("calc");
         let args = serde_json::json!({"x": 5});
 
         // Calls 1-2: below nudge_threshold=3
         for i in 1..=2 {
-            let r = call(&guard, &ctx, &args, "25", &success("25"));
+            let r = call(&guard, &ctx, &args, "25", &success("25")).await;
             assert!(
                 !r.output.contains("[DUPLICATE_CALL"),
                 "unexpected annotation on call {i}"
@@ -416,20 +420,20 @@ mod tests {
 
         // Calls 3-4: at/above nudge, below block
         for _ in 3..=4 {
-            let r = call(&guard, &ctx, &args, "25", &success("25"));
+            let r = call(&guard, &ctx, &args, "25", &success("25")).await;
             assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
             assert!(!r.output.contains("[DUPLICATE_CALL_ABORT]"));
         }
         assert!(!flag.load(Ordering::SeqCst));
 
         // Call 5: block + flag
-        let r = call(&guard, &ctx, &args, "25", &success("25"));
+        let r = call(&guard, &ctx, &args, "25", &success("25")).await;
         assert!(r.output.contains("[DUPLICATE_CALL_ABORT]"));
         assert!(flag.load(Ordering::SeqCst));
     }
 
-    #[test]
-    fn test_ping_pong_tracked_independently() {
+    #[tokio::test]
+    async fn test_ping_pong_tracked_independently() {
         let (guard, flag) = make_guard(3, 5);
         let args_a = serde_json::json!({"x": 1});
         let args_b = serde_json::json!({"x": 2});
@@ -437,16 +441,16 @@ mod tests {
 
         // Alternate: A, B, A, B — each pair's counter is independent
         for _ in 0..2 {
-            call(&guard, &ctx, &args_a, "1", &success("1"));
-            call(&guard, &ctx, &args_b, "2", &success("2"));
+            call(&guard, &ctx, &args_a, "1", &success("1")).await;
+            call(&guard, &ctx, &args_b, "2", &success("2")).await;
         }
 
         // A at count=3 → nudge
-        let r = call(&guard, &ctx, &args_a, "1", &success("1"));
+        let r = call(&guard, &ctx, &args_a, "1", &success("1")).await;
         assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
 
         // B at count=3 → nudge
-        let r = call(&guard, &ctx, &args_b, "2", &success("2"));
+        let r = call(&guard, &ctx, &args_b, "2", &success("2")).await;
         assert!(r.output.contains("[DUPLICATE_CALL_GUIDANCE]"));
 
         assert!(!flag.load(Ordering::SeqCst));

--- a/crates/aura/src/orchestration/observer_wrapper.rs
+++ b/crates/aura/src/orchestration/observer_wrapper.rs
@@ -10,11 +10,8 @@ use async_trait::async_trait;
 use serde_json::Value;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::mcp_response::CallOutcome;
 use crate::tool_call_observer::{RetryHint, ToolCallObserver, ToolEvent};
-use crate::tool_wrapper::{
-    ToolCallContext, ToolWrapper, TransformArgsResult, TransformOutputResult,
-};
+use crate::tool_wrapper::{ToolCallContext, ToolWrapper, TransformArgsResult};
 use rig::tool::ToolError;
 
 /// Counter for generating unique tool call IDs within a process.
@@ -71,16 +68,6 @@ impl ToolWrapper for ObserverWrapper {
             args,
             extracted: Some(extracted),
         }
-    }
-
-    fn transform_output(
-        &self,
-        output: String,
-        _outcome: &CallOutcome,
-        _ctx: &ToolCallContext,
-        _extracted: Option<&Value>,
-    ) -> TransformOutputResult {
-        TransformOutputResult::new(output)
     }
 
     fn handle_error(

--- a/crates/aura/src/orchestration/persistence.rs
+++ b/crates/aura/src/orchestration/persistence.rs
@@ -920,8 +920,11 @@ const SESSION_HISTORY_TEMPLATE: &str = include_str!("../prompts/session_history.
 
 /// Load run manifests from prior runs in a session directory.
 ///
-/// Reads `{base_path}/{session_id}/*/manifest.json`, sorts by timestamp
-/// descending, excludes the current run, and returns up to `limit` manifests.
+/// Reads `{base_path}/{session_id}/*/manifest.json`, excludes the current
+/// run, selects the `limit` most recently *created* runs (UUIDv7 dir-name
+/// order), and returns their manifests sorted by recorded timestamp
+/// descending. Creation order and completion-timestamp order diverge only
+/// for overlapping runs of one session.
 pub async fn load_session_manifests(
     base_path: &Path,
     session_id: &str,
@@ -936,12 +939,9 @@ pub async fn load_session_manifests(
     };
 
     // Collect candidate run dirs first, newest first, so manifest reads can
-    // stop at `limit` instead of reading every prior run. Run IDs are UUIDv7,
-    // so lexicographic order is creation order (the same invariant
-    // prune_session_runs relies on). Selection is therefore by creation
-    // order, not the manifest's completion timestamp; the two diverge only
-    // for overlapping runs of one session, and either is a defensible
-    // "most recent".
+    // stop at `limit` instead of reading every prior run. Run IDs are UUIDv7
+    // (since e689c79e), so lexicographic order is creation order (the same
+    // invariant prune_session_runs relies on).
     let mut run_dirs: Vec<String> = Vec::new();
     while let Some(entry) = entries.next_entry().await? {
         match entry.file_type().await {
@@ -957,9 +957,19 @@ pub async fn load_session_manifests(
     }
     run_dirs.sort_unstable_by(|a, b| b.cmp(a));
 
+    // Sessions created before the v7 switch hold UUIDv4 run dirs, and v4
+    // names have no chronology — a v4 starting with 'f' would outrank every
+    // v7 starting with '0' and starve recent runs out of the limit. If any
+    // candidate is not v7, read every manifest and let the timestamp sort
+    // pick, matching the run's actual recency.
+    let all_v7 = run_dirs
+        .iter()
+        .all(|name| uuid::Uuid::parse_str(name).is_ok_and(|u| u.get_version_num() == 7));
+    let read_cap = if all_v7 { limit } else { usize::MAX };
+
     let mut manifests = Vec::new();
     for dir_name in run_dirs {
-        if manifests.len() >= limit {
+        if manifests.len() >= read_cap {
             break;
         }
         let manifest_path = session_dir.join(&dir_name).join("manifest.json");
@@ -990,6 +1000,7 @@ pub async fn load_session_manifests(
     // Manifests were read in dir-name (creation) order; sort by recorded
     // timestamp so the documented contract holds even if the two disagree.
     manifests.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    manifests.truncate(limit);
 
     Ok(manifests)
 }
@@ -1653,9 +1664,10 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let session_dir = temp_dir.path().join("cs_test");
 
-        // Timestamps deliberately DESCEND as dir names ascend: selection is
-        // by dir-name (creation) order, so run-4/run-3 must survive even
-        // though run-0 carries the newest completion timestamp.
+        // Non-UUID names (legacy-style) with timestamps DESCENDING as names
+        // ascend: the non-v7 fallback reads every manifest, so selection is
+        // by timestamp and run-0 (newest, 05:00) wins despite sorting last
+        // by name.
         for i in 0..5 {
             let id = format!("run-{}", i);
             let dir = session_dir.join(&id);
@@ -1674,9 +1686,49 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.len(), 2);
-        // Output order is by manifest timestamp: run-3 (02:00) before run-4 (01:00).
-        assert_eq!(result[0].run_id, "run-3");
-        assert_eq!(result[1].run_id, "run-4");
+        assert_eq!(result[0].run_id, "run-0");
+        assert_eq!(result[1].run_id, "run-1");
+    }
+
+    #[tokio::test]
+    async fn test_load_session_manifests_v7_bounded_by_creation_order() {
+        let temp_dir = TempDir::new().unwrap();
+        let session_dir = temp_dir.path().join("cs_test");
+
+        // All-v7 session: selection walks dir names newest-created-first and
+        // stops at `limit`, so the last two created runs survive even though
+        // their manifests carry the OLDEST timestamps.
+        let ids: Vec<String> = (0..4)
+            .map(|i| {
+                uuid::Uuid::new_v7(uuid::Timestamp::from_unix(
+                    uuid::NoContext,
+                    1_750_000_000 + i,
+                    0,
+                ))
+                .to_string()
+            })
+            .collect();
+        for (i, id) in ids.iter().enumerate() {
+            let dir = session_dir.join(id);
+            fs::create_dir_all(&dir).await.unwrap();
+            let m = make_test_manifest(id, &format!("2026-03-20T0{}:00:00Z", 5 - i), "Query");
+            fs::write(
+                dir.join("manifest.json"),
+                serde_json::to_string_pretty(&m).unwrap(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let result = load_session_manifests(temp_dir.path(), "cs_test", "exclude-none", 2)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+        // ids[2] and ids[3] are the newest-created; output is timestamp-sorted
+        // so ids[2] (03:00) precedes ids[3] (02:00).
+        assert_eq!(result[0].run_id, ids[2]);
+        assert_eq!(result[1].run_id, ids[3]);
     }
 
     #[tokio::test]

--- a/crates/aura/src/orchestration/persistence.rs
+++ b/crates/aura/src/orchestration/persistence.rs
@@ -924,7 +924,9 @@ const SESSION_HISTORY_TEMPLATE: &str = include_str!("../prompts/session_history.
 /// run, selects the `limit` most recently *created* runs (UUIDv7 dir-name
 /// order), and returns their manifests sorted by recorded timestamp
 /// descending. Creation order and completion-timestamp order diverge only
-/// for overlapping runs of one session.
+/// for overlapping runs of one session. A session containing any
+/// non-canonical-v7 run dir (e.g. pre-e689c79e UUIDv4 names) falls back to
+/// reading every manifest and selecting by completion timestamp.
 pub async fn load_session_manifests(
     base_path: &Path,
     session_id: &str,
@@ -960,11 +962,14 @@ pub async fn load_session_manifests(
     // Sessions created before the v7 switch hold UUIDv4 run dirs, and v4
     // names have no chronology — a v4 starting with 'f' would outrank every
     // v7 starting with '0' and starve recent runs out of the limit. If any
-    // candidate is not v7, read every manifest and let the timestamp sort
-    // pick, matching the run's actual recency.
-    let all_v7 = run_dirs
-        .iter()
-        .all(|name| uuid::Uuid::parse_str(name).is_ok_and(|u| u.get_version_num() == 7));
+    // candidate is not a canonical (lowercase hyphenated) v7 name — parse
+    // alone also accepts braced/URN/uppercase forms whose string order is
+    // not UUID order — read every manifest and let the timestamp sort pick,
+    // matching the run's actual recency.
+    let all_v7 = run_dirs.iter().all(|name| {
+        uuid::Uuid::parse_str(name)
+            .is_ok_and(|u| u.get_version_num() == 7 && u.hyphenated().to_string() == *name)
+    });
     let read_cap = if all_v7 { limit } else { usize::MAX };
 
     let mut manifests = Vec::new();

--- a/crates/aura/src/orchestration/persistence.rs
+++ b/crates/aura/src/orchestration/persistence.rs
@@ -925,7 +925,7 @@ const SESSION_HISTORY_TEMPLATE: &str = include_str!("../prompts/session_history.
 /// order), and returns their manifests sorted by recorded timestamp
 /// descending. Creation order and completion-timestamp order diverge only
 /// for overlapping runs of one session. A session containing any
-/// non-canonical-v7 run dir (e.g. pre-e689c79e UUIDv4 names) falls back to
+/// non-canonical-v7 run dir (e.g. a UUIDv4 name) falls back to
 /// reading every manifest and selecting by completion timestamp.
 pub async fn load_session_manifests(
     base_path: &Path,
@@ -941,8 +941,8 @@ pub async fn load_session_manifests(
     };
 
     // Collect candidate run dirs first, newest first, so manifest reads can
-    // stop at `limit` instead of reading every prior run. Run IDs are UUIDv7
-    // (since e689c79e), so lexicographic order is creation order (the same
+    // stop at `limit` instead of reading every prior run. Run IDs are UUIDv7,
+    // so lexicographic order is creation order (the same
     // invariant prune_session_runs relies on).
     let mut run_dirs: Vec<String> = Vec::new();
     while let Some(entry) = entries.next_entry().await? {
@@ -959,8 +959,8 @@ pub async fn load_session_manifests(
     }
     run_dirs.sort_unstable_by(|a, b| b.cmp(a));
 
-    // Sessions created before the v7 switch hold UUIDv4 run dirs, and v4
-    // names have no chronology — a v4 starting with 'f' would outrank every
+    // UUIDv4 run dir names carry no chronology — a v4 starting with 'f'
+    // would outrank every
     // v7 starting with '0' and starve recent runs out of the limit. If any
     // candidate is not a canonical (lowercase hyphenated) v7 name — parse
     // alone also accepts braced/URN/uppercase forms whose string order is

--- a/crates/aura/src/orchestration/persistence.rs
+++ b/crates/aura/src/orchestration/persistence.rs
@@ -935,23 +935,34 @@ pub async fn load_session_manifests(
         Err(e) => return Err(e),
     };
 
-    let mut manifests = Vec::new();
-
+    // Collect candidate run dirs first, newest first, so manifest reads can
+    // stop at `limit` instead of reading every prior run. Run IDs are UUIDv7,
+    // so lexicographic order is creation order (the same invariant
+    // prune_session_runs relies on). Selection is therefore by creation
+    // order, not the manifest's completion timestamp; the two diverge only
+    // for overlapping runs of one session, and either is a defensible
+    // "most recent".
+    let mut run_dirs: Vec<String> = Vec::new();
     while let Some(entry) = entries.next_entry().await? {
-        let path = entry.path();
         match entry.file_type().await {
             Ok(ft) if ft.is_dir() => {}
             _ => continue,
         }
-
-        // Skip the current run and the "latest" symlink
-        if let Some(dir_name) = path.file_name().and_then(|n| n.to_str())
-            && (dir_name == exclude_run_id || dir_name == "latest")
+        if let Ok(dir_name) = entry.file_name().into_string()
+            && dir_name != exclude_run_id
+            && dir_name != "latest"
         {
-            continue;
+            run_dirs.push(dir_name);
         }
+    }
+    run_dirs.sort_unstable_by(|a, b| b.cmp(a));
 
-        let manifest_path = path.join("manifest.json");
+    let mut manifests = Vec::new();
+    for dir_name in run_dirs {
+        if manifests.len() >= limit {
+            break;
+        }
+        let manifest_path = session_dir.join(&dir_name).join("manifest.json");
         match fs::read_to_string(&manifest_path).await {
             Ok(content) => match serde_json::from_str::<RunManifest>(&content) {
                 Ok(manifest) => manifests.push(manifest),
@@ -976,11 +987,9 @@ pub async fn load_session_manifests(
         }
     }
 
-    // Sort by timestamp descending (most recent first)
+    // Manifests were read in dir-name (creation) order; sort by recorded
+    // timestamp so the documented contract holds even if the two disagree.
     manifests.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
-
-    // Take the most recent `limit` manifests
-    manifests.truncate(limit);
 
     Ok(manifests)
 }
@@ -1644,11 +1653,14 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let session_dir = temp_dir.path().join("cs_test");
 
+        // Timestamps deliberately DESCEND as dir names ascend: selection is
+        // by dir-name (creation) order, so run-4/run-3 must survive even
+        // though run-0 carries the newest completion timestamp.
         for i in 0..5 {
             let id = format!("run-{}", i);
             let dir = session_dir.join(&id);
             fs::create_dir_all(&dir).await.unwrap();
-            let m = make_test_manifest(&id, &format!("2026-03-20T0{}:00:00Z", i), "Query");
+            let m = make_test_manifest(&id, &format!("2026-03-20T0{}:00:00Z", 5 - i), "Query");
             fs::write(
                 dir.join("manifest.json"),
                 serde_json::to_string_pretty(&m).unwrap(),
@@ -1662,6 +1674,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.len(), 2);
+        // Output order is by manifest timestamp: run-3 (02:00) before run-4 (01:00).
+        assert_eq!(result[0].run_id, "run-3");
+        assert_eq!(result[1].run_id, "run-4");
     }
 
     #[tokio::test]

--- a/crates/aura/src/orchestration/persistence.rs
+++ b/crates/aura/src/orchestration/persistence.rs
@@ -384,8 +384,9 @@ impl ExecutionPersistence {
 
         while let Ok(Some(entry)) = entries.next_entry().await {
             let path = entry.path();
-            if !path.is_dir() {
-                continue;
+            match entry.file_type().await {
+                Ok(ft) if ft.is_dir() => {}
+                _ => continue,
             }
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                 if name == "latest" || name == self.run_id {
@@ -695,11 +696,12 @@ impl ExecutionPersistence {
             .base_path
             .parent()
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "No parent directory"))?;
-        let canonical_session = session_dir
-            .canonicalize()
-            .unwrap_or_else(|_| session_dir.to_path_buf());
-        let canonical_artifact = artifact_path
-            .canonicalize()
+        let canonical_session = match fs::canonicalize(session_dir).await {
+            Ok(p) => p,
+            Err(_) => session_dir.to_path_buf(),
+        };
+        let canonical_artifact = fs::canonicalize(&artifact_path)
+            .await
             .map_err(|e| io::Error::new(e.kind(), format!("Artifact not found: {e}")))?;
         if !canonical_artifact.starts_with(&canonical_session) {
             return Err(io::Error::new(
@@ -761,11 +763,11 @@ impl ExecutionPersistence {
         }
 
         let artifacts_dir = self.artifacts_path();
-        if !artifacts_dir.exists() {
-            return Ok(Vec::new());
-        }
-
-        let mut entries = fs::read_dir(&artifacts_dir).await?;
+        let mut entries = match fs::read_dir(&artifacts_dir).await {
+            Ok(e) => e,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e),
+        };
         let mut filenames = Vec::new();
         while let Some(entry) = entries.next_entry().await? {
             if let Some(name) = entry.file_name().to_str() {
@@ -783,11 +785,11 @@ impl ExecutionPersistence {
         }
 
         let artifacts_dir = self.artifacts_path();
-        if !artifacts_dir.exists() {
-            return Ok(Vec::new());
-        }
-
-        let mut entries = fs::read_dir(&artifacts_dir).await?;
+        let mut entries = match fs::read_dir(&artifacts_dir).await {
+            Ok(e) => e,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e),
+        };
         let mut results = Vec::new();
         while let Some(entry) = entries.next_entry().await? {
             if let Some(name) = entry.file_name().to_str() {
@@ -813,9 +815,6 @@ impl ExecutionPersistence {
 
         for iter_num in 1..=self.current_iteration {
             let iter_dir = self.base_path.join(format!("iteration-{iter_num}"));
-            if !iter_dir.exists() {
-                continue;
-            }
             let Ok(mut entries) = fs::read_dir(&iter_dir).await else {
                 continue;
             };
@@ -888,11 +887,10 @@ impl ExecutionPersistence {
         let tool_calls_path = iter_path.join(&tool_file);
 
         // Read existing tool calls or start fresh
-        let mut tool_calls: Vec<ToolCallRecord> = if tool_calls_path.exists() {
-            let content = fs::read_to_string(&tool_calls_path).await?;
-            serde_json::from_str(&content).unwrap_or_default()
-        } else {
-            Vec::new()
+        let mut tool_calls: Vec<ToolCallRecord> = match fs::read_to_string(&tool_calls_path).await {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Vec::new(),
+            Err(e) => return Err(e),
         };
 
         // Append new record
@@ -931,17 +929,19 @@ pub async fn load_session_manifests(
     limit: usize,
 ) -> io::Result<Vec<RunManifest>> {
     let session_dir = base_path.join(session_id);
-    if !session_dir.exists() {
-        return Ok(Vec::new());
-    }
+    let mut entries = match fs::read_dir(&session_dir).await {
+        Ok(e) => e,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
 
     let mut manifests = Vec::new();
-    let mut entries = fs::read_dir(&session_dir).await?;
 
     while let Some(entry) = entries.next_entry().await? {
         let path = entry.path();
-        if !path.is_dir() {
-            continue;
+        match entry.file_type().await {
+            Ok(ft) if ft.is_dir() => {}
+            _ => continue,
         }
 
         // Skip the current run and the "latest" symlink
@@ -952,10 +952,6 @@ pub async fn load_session_manifests(
         }
 
         let manifest_path = path.join("manifest.json");
-        if !manifest_path.exists() {
-            continue;
-        }
-
         match fs::read_to_string(&manifest_path).await {
             Ok(content) => match serde_json::from_str::<RunManifest>(&content) {
                 Ok(manifest) => manifests.push(manifest),
@@ -967,6 +963,9 @@ pub async fn load_session_manifests(
                     );
                 }
             },
+            // A run dir without a manifest is expected (crashed or in-flight
+            // run) and skipped without noise.
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
             Err(e) => {
                 tracing::warn!(
                     "Failed to read manifest at {}: {}",
@@ -2356,6 +2355,31 @@ mod tests {
 
         let empty = persistence.load_tool_records_for_task(99).await;
         assert!(empty.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_append_tool_call_accumulates() {
+        let temp_dir = TempDir::new().unwrap();
+        let persistence = ExecutionPersistence::new(temp_dir.path().join("memory"), None)
+            .await
+            .unwrap();
+
+        let record = ToolCallRecord {
+            tool: "log_search".to_string(),
+            arguments: serde_json::json!({"query": "errors"}),
+            reasoning: "Searching".to_string(),
+            output: Some("found".to_string()),
+            error: None,
+            duration_ms: 10,
+            artifact_filename: None,
+        };
+
+        // First append lands on a missing file (fresh vec), second reads it back.
+        persistence.append_tool_call(0, 1, &record).await.unwrap();
+        persistence.append_tool_call(0, 1, &record).await.unwrap();
+
+        let records = persistence.load_tool_records_for_task(0).await;
+        assert_eq!(records.len(), 2);
     }
 
     #[tokio::test]

--- a/crates/aura/src/orchestration/persistence.rs
+++ b/crates/aura/src/orchestration/persistence.rs
@@ -1669,10 +1669,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let session_dir = temp_dir.path().join("cs_test");
 
-        // Non-UUID names (legacy-style) with timestamps DESCENDING as names
-        // ascend: the non-v7 fallback reads every manifest, so selection is
-        // by timestamp and run-0 (newest, 05:00) wins despite sorting last
-        // by name.
+        // Non-UUID names fall back to full traversal and timestamp sorting.
         for i in 0..5 {
             let id = format!("run-{}", i);
             let dir = session_dir.join(&id);
@@ -1700,9 +1697,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let session_dir = temp_dir.path().join("cs_test");
 
-        // All-v7 session: selection walks dir names newest-created-first and
-        // stops at `limit`, so the last two created runs survive even though
-        // their manifests carry the OLDEST timestamps.
+        // All-v7 session: selection stops at `limit` based on directory names.
         let ids: Vec<String> = (0..4)
             .map(|i| {
                 uuid::Uuid::new_v7(uuid::Timestamp::from_unix(
@@ -1730,8 +1725,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.len(), 2);
-        // ids[2] and ids[3] are the newest-created; output is timestamp-sorted
-        // so ids[2] (03:00) precedes ids[3] (02:00).
+        // Output is timestamp-sorted.
         assert_eq!(result[0].run_id, ids[2]);
         assert_eq!(result[1].run_id, ids[3]);
     }

--- a/crates/aura/src/orchestration/persistence_wrapper.rs
+++ b/crates/aura/src/orchestration/persistence_wrapper.rs
@@ -203,7 +203,7 @@ impl ToolWrapper for PersistenceWrapper {
     /// Duration-based promotion is handled in `on_complete` — those artifacts
     /// are written for observability but lack an inline footer because the
     /// output has already been returned to the LLM by that point.
-    fn transform_output(
+    async fn transform_output(
         &self,
         output: String,
         _outcome: &CallOutcome,
@@ -842,7 +842,9 @@ mod tests {
 
         let raw = "gigantic raw tool output that scratchpad would rewrite to a pointer";
         let outcome = crate::mcp_response::CallOutcome::Success(raw.to_string());
-        let _ = wrapper.transform_output(raw.to_string(), &outcome, &ctx, Some(&extracted));
+        let _ = wrapper
+            .transform_output(raw.to_string(), &outcome, &ctx, Some(&extracted))
+            .await;
 
         // Cached under the call id until on_complete consumes it.
         assert_eq!(
@@ -924,7 +926,9 @@ mod tests {
         // Use varied content to avoid tokenizer compression masking the threshold.
         let raw: String = (0..500).map(|i| format!("entry_{} ", i)).collect();
         let outcome = crate::mcp_response::CallOutcome::Success(raw.clone());
-        let result = composed.transform_output(raw.clone(), &outcome, &ctx, Some(&extracted));
+        let result = composed
+            .transform_output(raw.clone(), &outcome, &ctx, Some(&extracted))
+            .await;
 
         assert!(
             result.output.contains("[scratchpad:"),
@@ -1057,8 +1061,8 @@ mod tests {
         })
     }
 
-    #[test]
-    fn test_transform_output_appends_footer_when_size_exceeded() {
+    #[tokio::test]
+    async fn test_transform_output_appends_footer_when_size_exceeded() {
         let wrapper = promotion_wrapper(Some("sre".to_string()), 2, true, 10, 5000);
 
         let ctx = ToolCallContext::new("log_search").with_task_context(0, "sre".to_string(), 1);
@@ -1066,37 +1070,41 @@ mod tests {
         let outcome = CallOutcome::Success(String::new());
         let long_output = "x".repeat(20);
 
-        let result =
-            wrapper.transform_output(long_output.clone(), &outcome, &ctx, Some(&extracted));
+        let result = wrapper
+            .transform_output(long_output.clone(), &outcome, &ctx, Some(&extracted))
+            .await;
         assert!(result.output.contains(
             "[Tool output saved to artifact: task-0-sre-iter-2-log-search-0-output.txt]"
         ));
         assert!(result.output.starts_with(&long_output));
     }
 
-    #[test]
-    fn test_transform_output_no_footer_when_below_threshold() {
+    #[tokio::test]
+    async fn test_transform_output_no_footer_when_below_threshold() {
         let wrapper = promotion_wrapper(Some("sre".to_string()), 1, true, 500, 5000);
 
         let ctx = ToolCallContext::new("log_search").with_task_context(0, "sre".to_string(), 1);
         let extracted = serde_json::json!({"reasoning": "", "call_idx": 0});
         let outcome = CallOutcome::Success(String::new());
 
-        let result =
-            wrapper.transform_output("short output".to_string(), &outcome, &ctx, Some(&extracted));
+        let result = wrapper
+            .transform_output("short output".to_string(), &outcome, &ctx, Some(&extracted))
+            .await;
         assert_eq!(result.output, "short output");
         assert!(!result.output.contains("[Tool output saved to artifact"));
     }
 
-    #[test]
-    fn test_transform_output_promotes_all_when_size_zero() {
+    #[tokio::test]
+    async fn test_transform_output_promotes_all_when_size_zero() {
         let wrapper = promotion_wrapper(None, 1, true, 0, 5000);
 
         let ctx = ToolCallContext::new("my_tool").with_task_context(3, "w".to_string(), 1);
         let extracted = serde_json::json!({"reasoning": "", "call_idx": 0});
         let outcome = CallOutcome::Success(String::new());
 
-        let result = wrapper.transform_output("tiny".to_string(), &outcome, &ctx, Some(&extracted));
+        let result = wrapper
+            .transform_output("tiny".to_string(), &outcome, &ctx, Some(&extracted))
+            .await;
         assert!(result.output.contains(
             "[Tool output saved to artifact: task-3-default-iter-1-my-tool-0-output.txt]"
         ));
@@ -1234,16 +1242,17 @@ mod tests {
         assert_eq!(extract_call_idx(Some(&serde_json::json!({}))), 0);
     }
 
-    #[test]
-    fn test_tool_output_artifact_filename_sanitization() {
+    #[tokio::test]
+    async fn test_tool_output_artifact_filename_sanitization() {
         let wrapper = promotion_wrapper(Some("SRE/Ops Worker".to_string()), 1, true, 0, 5000);
 
         let ctx = ToolCallContext::new("my_search tool").with_task_context(0, "sre".to_string(), 1);
         let extracted = serde_json::json!({"reasoning": "", "call_idx": 0});
         let outcome = CallOutcome::Success(String::new());
 
-        let result =
-            wrapper.transform_output("output".to_string(), &outcome, &ctx, Some(&extracted));
+        let result = wrapper
+            .transform_output("output".to_string(), &outcome, &ctx, Some(&extracted))
+            .await;
         assert!(
             result
                 .output
@@ -1251,20 +1260,22 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_transform_output_no_footer_when_persistence_disabled() {
+    #[tokio::test]
+    async fn test_transform_output_no_footer_when_persistence_disabled() {
         let wrapper = promotion_wrapper(Some("sre".to_string()), 1, false, 0, 5000);
 
         let ctx = ToolCallContext::new("log_search").with_task_context(0, "sre".to_string(), 1);
         let extracted = serde_json::json!({"reasoning": "", "call_idx": 0});
         let outcome = CallOutcome::Success(String::new());
 
-        let result = wrapper.transform_output(
-            "big output here".to_string(),
-            &outcome,
-            &ctx,
-            Some(&extracted),
-        );
+        let result = wrapper
+            .transform_output(
+                "big output here".to_string(),
+                &outcome,
+                &ctx,
+                Some(&extracted),
+            )
+            .await;
         assert_eq!(result.output, "big output here");
         assert!(!result.output.contains("[Tool output saved to artifact"));
     }

--- a/crates/aura/src/orchestration/tools/read_artifact.rs
+++ b/crates/aura/src/orchestration/tools/read_artifact.rs
@@ -55,7 +55,7 @@ impl ReadArtifactTool {
     ///
     /// `abs_path` is the artifact's absolute path (already resolved & validated
     /// by the caller); it's used to build the in-place `file=` reference.
-    fn surface_content(&self, filename: &str, abs_path: &Path, content: String) -> String {
+    async fn surface_content(&self, filename: &str, abs_path: &Path, content: String) -> String {
         let Some(sp) = &self.scratchpad else {
             return content;
         };
@@ -67,7 +67,7 @@ impl ReadArtifactTool {
         let tokens = sp.budget.count_tokens(&content);
         let line_count = content.lines().count();
         let (format, _) = ContentFormat::detect_and_parse(&content);
-        match sp.storage.relative_ref(abs_path) {
+        match sp.storage.relative_ref(abs_path).await {
             Ok(file_ref) => {
                 let headline = format!(
                     "[artifact '{filename}' is too large for the context window \
@@ -182,7 +182,7 @@ impl Tool for ReadArtifactTool {
         match result {
             Ok(content) => {
                 let content = match abs_path {
-                    Some(path) => self.surface_content(&args.filename, &path, content),
+                    Some(path) => self.surface_content(&args.filename, &path, content).await,
                     // No resolvable path (shouldn't happen on a successful
                     // read) — inline rather than dropping content.
                     None => content,

--- a/crates/aura/src/orchestration/tools/read_artifact.rs
+++ b/crates/aura/src/orchestration/tools/read_artifact.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::orchestration::persistence::ExecutionPersistence;
-use crate::scratchpad::storage::ContentFormat;
+use crate::scratchpad::storage::{ContentFormat, ScratchpadPathError};
 use crate::scratchpad::tools::check_and_record_budget;
 use crate::scratchpad::wrapper::build_file_pointer;
 use crate::scratchpad::{ContextBudget, ScratchpadStorage};
@@ -75,6 +75,21 @@ impl ReadArtifactTool {
                     fmt = format.as_str(),
                 );
                 build_file_pointer(&headline, &file_ref)
+            }
+            // A validation-time I/O fault (stale mount, permission error) is
+            // transient territory: tell the model storage failed and a retry
+            // may work, instead of telling it to narrow the task.
+            Err(e @ ScratchpadPathError::Io { .. }) => {
+                tracing::warn!(
+                    "read_artifact: storage error building in-place reference for {}: {}",
+                    filename,
+                    e
+                );
+                format!(
+                    "[artifact '{filename}' was read (~{tokens} tokens) but a storage \
+                     error prevented building an in-place reference: {e}. This may be \
+                     transient - retry the read_artifact call.]"
+                )
             }
             Err(e) => {
                 // Can't reference the artifact in place (e.g. it lives outside

--- a/crates/aura/src/scratchpad/storage.rs
+++ b/crates/aura/src/scratchpad/storage.rs
@@ -300,11 +300,15 @@ impl ScratchpadStorage {
     /// any filename that would escape the dir (defense-in-depth behind the
     /// `slugify_component` applied upstream).
     async fn safe_companion_path(&self, filename: &str) -> std::io::Result<PathBuf> {
-        self.validate_path(filename).await.map_err(|e| {
-            std::io::Error::new(
+        self.validate_path(filename).await.map_err(|e| match e {
+            // A genuine I/O fault keeps its kind (EIO on a stale mount must
+            // not read as an invalid filename); containment rejections
+            // become InvalidInput.
+            ScratchpadPathError::Io { source, .. } => source,
+            containment => std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
-                format!("Rejected companion filename {filename:?}: {e}"),
-            )
+                format!("Rejected companion filename {filename:?}: {containment}"),
+            ),
         })
     }
 
@@ -447,8 +451,21 @@ impl ScratchpadStorage {
                     });
                 }
             }
-            // The file doesn't exist yet; the lexical check stands.
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            // NotFound usually means the file doesn't exist yet (a write
+            // destination) and the lexical check stands — but a *dangling
+            // symlink* also canonicalizes to NotFound, and a later write
+            // through it would create a file wherever it points. Reject the
+            // symlink case; symlink_metadata does not follow the link.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                if let Ok(meta) = fs::symlink_metadata(&normalized).await
+                    && meta.file_type().is_symlink()
+                {
+                    return Err(ScratchpadPathError::OutsideDirectory {
+                        path: file_path.to_string(),
+                        dir: self.read_root.display().to_string(),
+                    });
+                }
+            }
             Err(source) => {
                 return Err(ScratchpadPathError::Io {
                     path: file_path.to_string(),
@@ -958,12 +975,41 @@ mod tests {
 
         // Remove search permission so canonicalize fails with EACCES.
         std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o000)).unwrap();
+        // Root (CAP_DAC_OVERRIDE) traverses 000 dirs anyway; the fault can't
+        // be established there, so skip rather than assert a non-failure.
+        let denial_holds = std::fs::metadata(sub.join("f.txt")).is_err();
         let result = storage.validate_path("locked/f.txt").await;
         std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o755)).unwrap();
 
+        if !denial_holds {
+            eprintln!("skipping: process bypasses directory permissions (running as root?)");
+            return;
+        }
         assert!(
             matches!(result, Err(ScratchpadPathError::Io { .. })),
             "expected Io error, got {result:?}"
+        );
+    }
+
+    /// A dangling symlink canonicalizes to NotFound, which must NOT be
+    /// treated as a safe not-yet-written destination: a write through it
+    /// would create a file wherever the link points.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_validate_path_dangling_symlink_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-dangle")
+            .await
+            .unwrap();
+
+        let link = storage.dir().join("dangle.txt");
+        std::os::unix::fs::symlink(outside.path().join("planted.txt"), &link).unwrap();
+
+        let result = storage.validate_path("dangle.txt").await;
+        assert!(
+            matches!(result, Err(ScratchpadPathError::OutsideDirectory { .. })),
+            "expected containment rejection for dangling symlink, got {result:?}"
         );
     }
 

--- a/crates/aura/src/scratchpad/storage.rs
+++ b/crates/aura/src/scratchpad/storage.rs
@@ -190,7 +190,7 @@ impl ScratchpadStorage {
     /// `{run}/iteration-1/scratchpad`, this returns `../../artifacts/x.txt`.
     /// The result is validated through [`validate_path`](Self::validate_path),
     /// so a path outside the read root is rejected.
-    pub fn relative_ref(&self, abs: &Path) -> Result<String, ScratchpadPathError> {
+    pub async fn relative_ref(&self, abs: &Path) -> Result<String, ScratchpadPathError> {
         let abs_norm = normalize_path(abs);
         let dir_norm = normalize_path(&self.dir);
 
@@ -216,7 +216,7 @@ impl ScratchpadStorage {
 
         let token = rel.to_string_lossy().to_string();
         // Defense-in-depth: confirm the token resolves back inside the read root.
-        self.validate_path(&token)?;
+        self.validate_path(&token).await?;
         Ok(token)
     }
 
@@ -282,7 +282,7 @@ impl ScratchpadStorage {
     ) -> std::io::Result<Vec<CompanionFile>> {
         let mut companions = Vec::new();
         for pending in Self::plan_companions(tool_call_id, value) {
-            let path = self.safe_companion_path(&pending.filename)?;
+            let path = self.safe_companion_path(&pending.filename).await?;
             fs::write(&path, &pending.content).await?;
             debug!(
                 "Companion file extracted: {} (key={}, {} lines, {})",
@@ -299,8 +299,8 @@ impl ScratchpadStorage {
     /// Resolve a companion filename inside the scratchpad directory. Rejects
     /// any filename that would escape the dir (defense-in-depth behind the
     /// `slugify_component` applied upstream).
-    fn safe_companion_path(&self, filename: &str) -> std::io::Result<PathBuf> {
-        self.validate_path(filename).map_err(|e| {
+    async fn safe_companion_path(&self, filename: &str) -> std::io::Result<PathBuf> {
+        self.validate_path(filename).await.map_err(|e| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 format!("Rejected companion filename {filename:?}: {e}"),
@@ -411,9 +411,11 @@ impl ScratchpadStorage {
     /// process can write to `/tmp`).
     ///
     /// For files that don't exist yet (e.g., the destination path during a
-    /// write), stage 2 is skipped — `canonicalize` would fail with
-    /// `ENOENT`. The lexical check still applies.
-    pub fn validate_path(&self, file_path: &str) -> Result<PathBuf, ScratchpadPathError> {
+    /// write), stage 2 is skipped — `canonicalize` reports `NotFound`. The
+    /// lexical check still applies. Any other canonicalize failure (stale
+    /// network mount, permission error) is a real I/O fault and surfaces as
+    /// [`ScratchpadPathError::Io`], not as a containment violation.
+    pub async fn validate_path(&self, file_path: &str) -> Result<PathBuf, ScratchpadPathError> {
         let requested = self.dir.join(file_path);
 
         // Stage 1: lexical normalization (handles ../).
@@ -426,28 +428,31 @@ impl ScratchpadStorage {
             });
         }
 
-        // Stage 2: symlink resolution if the file exists. We compare the
-        // canonicalized request against the canonicalized read root
-        // (canonicalize is consistent on macOS where /tmp is a symlink for
-        // /private/tmp — comparing one canonical to one non-canonical
-        // would always reject).
-        if normalized.exists() {
-            let canonical_root = std::fs::canonicalize(&self.read_root).map_err(|_| {
-                ScratchpadPathError::OutsideDirectory {
-                    path: file_path.to_string(),
-                    dir: self.read_root.display().to_string(),
+        // Stage 2: symlink resolution. We compare the canonicalized request
+        // against the canonicalized read root (canonicalize is consistent on
+        // macOS where /tmp is a symlink for /private/tmp — comparing one
+        // canonical to one non-canonical would always reject).
+        match fs::canonicalize(&normalized).await {
+            Ok(canonical_path) => {
+                let canonical_root = fs::canonicalize(&self.read_root).await.map_err(|source| {
+                    ScratchpadPathError::Io {
+                        path: file_path.to_string(),
+                        source,
+                    }
+                })?;
+                if !canonical_path.starts_with(&canonical_root) {
+                    return Err(ScratchpadPathError::OutsideDirectory {
+                        path: file_path.to_string(),
+                        dir: self.read_root.display().to_string(),
+                    });
                 }
-            })?;
-            let canonical_path = std::fs::canonicalize(&normalized).map_err(|_| {
-                ScratchpadPathError::OutsideDirectory {
+            }
+            // The file doesn't exist yet; the lexical check stands.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(source) => {
+                return Err(ScratchpadPathError::Io {
                     path: file_path.to_string(),
-                    dir: self.read_root.display().to_string(),
-                }
-            })?;
-            if !canonical_path.starts_with(&canonical_root) {
-                return Err(ScratchpadPathError::OutsideDirectory {
-                    path: file_path.to_string(),
-                    dir: self.read_root.display().to_string(),
+                    source,
                 });
             }
         }
@@ -546,8 +551,12 @@ fn normalize_path(path: &Path) -> PathBuf {
 pub enum ScratchpadPathError {
     #[error("Path '{path}' is outside scratchpad directory '{dir}'")]
     OutsideDirectory { path: String, dir: String },
-    #[error("File not found: {0}")]
-    NotFound(String),
+    #[error("I/O error while validating path '{path}': {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 #[cfg(test)]
@@ -789,7 +798,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = storage.validate_path("call-1.json");
+        let result = storage.validate_path("call-1.json").await;
         assert!(result.is_ok());
     }
 
@@ -814,11 +823,11 @@ mod tests {
         std::fs::write(&artifact, "artifact content").unwrap();
 
         // relative_ref builds the token the read tools accept.
-        let token = storage.relative_ref(&artifact).unwrap();
+        let token = storage.relative_ref(&artifact).await.unwrap();
         assert!(token.contains("artifacts/result.txt"), "got token: {token}");
 
         // The token validates and resolves to the artifact on disk.
-        let resolved = storage.validate_path(&token).unwrap();
+        let resolved = storage.validate_path(&token).await.unwrap();
         assert_eq!(
             std::fs::canonicalize(&resolved).unwrap(),
             std::fs::canonicalize(&artifact).unwrap()
@@ -837,7 +846,7 @@ mod tests {
             .with_read_root(run_dir.clone());
 
         // ../../.. climbs above the run dir (read_root) → rejected.
-        let result = storage.validate_path("../../../etc/passwd");
+        let result = storage.validate_path("../../../etc/passwd").await;
         assert!(result.is_err(), "path escaping read_root must be rejected");
     }
 
@@ -853,7 +862,7 @@ mod tests {
             .with_read_root(run_dir.clone());
 
         let outside = tmp.path().join("other").join("secret.txt");
-        assert!(storage.relative_ref(&outside).is_err());
+        assert!(storage.relative_ref(&outside).await.is_err());
     }
 
     /// `with_read_root` ignores a root that is not an ancestor of the write
@@ -878,7 +887,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = storage.validate_path("../../etc/passwd");
+        let result = storage.validate_path("../../etc/passwd").await;
         assert!(result.is_err());
     }
 
@@ -907,7 +916,7 @@ mod tests {
 
         // Lexical check passes (the path string is "link.txt", inside the
         // dir), but the canonicalization step must catch the escape.
-        let result = storage.validate_path("link.txt");
+        let result = storage.validate_path("link.txt").await;
         assert!(
             result.is_err(),
             "validate_path must reject a symlink that escapes the scratchpad dir"
@@ -923,10 +932,38 @@ mod tests {
         let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-nx")
             .await
             .unwrap();
-        let result = storage.validate_path("not_yet_written.json");
+        let result = storage.validate_path("not_yet_written.json").await;
         assert!(
             result.is_ok(),
             "non-existent paths inside the dir must validate (used during writes)"
+        );
+    }
+
+    /// A canonicalize failure that is NOT NotFound (here: a search-permission
+    /// denial on the parent dir) must surface as `Io`, not as a containment
+    /// violation — on a stale network mount the LLM should see a truthful
+    /// I/O error, not a fabricated "outside scratchpad directory".
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_validate_path_io_error_is_not_containment_violation() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-io")
+            .await
+            .unwrap();
+        let sub = storage.dir().join("locked");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(sub.join("f.txt"), "x").unwrap();
+
+        // Remove search permission so canonicalize fails with EACCES.
+        std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let result = storage.validate_path("locked/f.txt").await;
+        std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            matches!(result, Err(ScratchpadPathError::Io { .. })),
+            "expected Io error, got {result:?}"
         );
     }
 

--- a/crates/aura/src/scratchpad/storage.rs
+++ b/crates/aura/src/scratchpad/storage.rs
@@ -274,42 +274,7 @@ impl ScratchpadStorage {
         })
     }
 
-    /// Write tool output synchronously (for use in sync callbacks like `transform_output`).
-    ///
-    /// JSON content is pretty-printed before writing. Large string values
-    /// inside JSON that contain structured content (markdown, escaped JSON)
-    /// are extracted to companion files for direct exploration with line-based tools.
-    pub fn write_output_sync(
-        &self,
-        tool_call_id: &str,
-        content: &str,
-    ) -> std::io::Result<WriteResult> {
-        let (path, format, to_write, parsed) = self.prepare_write(tool_call_id, content);
-        let line_count = to_write.lines().count();
-        std::fs::write(&path, &to_write)?;
-        debug!(
-            "Scratchpad file written: {} ({} bytes, {} lines, {})",
-            path.display(),
-            to_write.len(),
-            line_count,
-            format.as_str()
-        );
-
-        let companions = if let Some(value) = &parsed {
-            self.extract_companions_sync(tool_call_id, value)?
-        } else {
-            vec![]
-        };
-
-        Ok(WriteResult {
-            path,
-            format,
-            line_count,
-            companions,
-        })
-    }
-
-    /// Extract large structured string values from JSON as companion files (async).
+    /// Extract large structured string values from JSON as companion files.
     async fn extract_companions_async(
         &self,
         tool_call_id: &str,
@@ -319,28 +284,6 @@ impl ScratchpadStorage {
         for pending in Self::plan_companions(tool_call_id, value) {
             let path = self.safe_companion_path(&pending.filename)?;
             fs::write(&path, &pending.content).await?;
-            debug!(
-                "Companion file extracted: {} (key={}, {} lines, {})",
-                path.display(),
-                pending.companion.source_key,
-                pending.companion.line_count,
-                pending.companion.format.as_str()
-            );
-            companions.push(pending.companion);
-        }
-        Ok(companions)
-    }
-
-    /// Extract large structured string values from JSON as companion files (sync).
-    fn extract_companions_sync(
-        &self,
-        tool_call_id: &str,
-        value: &serde_json::Value,
-    ) -> std::io::Result<Vec<CompanionFile>> {
-        let mut companions = Vec::new();
-        for pending in Self::plan_companions(tool_call_id, value) {
-            let path = self.safe_companion_path(&pending.filename)?;
-            std::fs::write(&path, &pending.content)?;
             debug!(
                 "Companion file extracted: {} (key={}, {} lines, {})",
                 path.display(),
@@ -462,7 +405,7 @@ impl ScratchpadStorage {
     /// **Trust boundary**: this only matters if a process with write access
     /// to `memory_dir` is hostile. In the orchestration flow only aura
     /// itself writes to the scratchpad directory (via
-    /// `ScratchpadStorage::write_output_sync`), and aura never creates
+    /// `ScratchpadStorage::write_output`), and aura never creates
     /// symlinks. Stage 2 is therefore defense-in-depth against an
     /// out-of-band adversary (e.g., a multi-tenant host where another
     /// process can write to `/tmp`).

--- a/crates/aura/src/scratchpad/storage.rs
+++ b/crates/aura/src/scratchpad/storage.rs
@@ -433,9 +433,7 @@ impl ScratchpadStorage {
         }
 
         // Stage 2: symlink resolution. We compare the canonicalized request
-        // against the canonicalized read root (canonicalize is consistent on
-        // macOS where /tmp is a symlink for /private/tmp — comparing one
-        // canonical to one non-canonical would always reject).
+        // against the canonicalized read root.
         match fs::canonicalize(&normalized).await {
             Ok(canonical_path) => {
                 let canonical_root = fs::canonicalize(&self.read_root).await.map_err(|source| {
@@ -452,18 +450,57 @@ impl ScratchpadStorage {
                 }
             }
             // NotFound usually means the file doesn't exist yet (a write
-            // destination) and the lexical check stands — but a *dangling
-            // symlink* also canonicalizes to NotFound, and a later write
-            // through it would create a file wherever it points. Reject the
-            // symlink case; symlink_metadata does not follow the link.
+            // destination) and the lexical check stands — but a dangling symlink
+            // also canonicalizes to NotFound. Walk from the leaf up: reject the
+            // first existing component if it is a symlink, otherwise require it
+            // to canonicalize inside the root.
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                if let Ok(meta) = fs::symlink_metadata(&normalized).await
-                    && meta.file_type().is_symlink()
-                {
-                    return Err(ScratchpadPathError::OutsideDirectory {
+                let canonical_root = fs::canonicalize(&self.read_root).await.map_err(|source| {
+                    ScratchpadPathError::Io {
                         path: file_path.to_string(),
-                        dir: self.read_root.display().to_string(),
-                    });
+                        source,
+                    }
+                })?;
+                let mut cursor = Some(normalized.as_path());
+                while let Some(component) = cursor {
+                    match fs::symlink_metadata(component).await {
+                        // First existing component: containment is judged on
+                        // its canonical target; a dangling link is rejected.
+                        Ok(_) => {
+                            match fs::canonicalize(component).await {
+                                Ok(canonical) => {
+                                    if !canonical.starts_with(&canonical_root) {
+                                        return Err(ScratchpadPathError::OutsideDirectory {
+                                            path: file_path.to_string(),
+                                            dir: self.read_root.display().to_string(),
+                                        });
+                                    }
+                                }
+                                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                                    return Err(ScratchpadPathError::OutsideDirectory {
+                                        path: file_path.to_string(),
+                                        dir: self.read_root.display().to_string(),
+                                    });
+                                }
+                                Err(source) => {
+                                    return Err(ScratchpadPathError::Io {
+                                        path: file_path.to_string(),
+                                        source,
+                                    });
+                                }
+                            }
+                            break;
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                            cursor = component.parent();
+                        }
+                        Err(source) => {
+                            return Err(ScratchpadPathError::Io {
+                                path: file_path.to_string(),
+                                source,
+                            });
+                        }
+                    }
                 }
             }
             Err(source) => {
@@ -956,10 +993,7 @@ mod tests {
         );
     }
 
-    /// A canonicalize failure that is NOT NotFound (here: a search-permission
-    /// denial on the parent dir) must surface as `Io`, not as a containment
-    /// violation — on a stale network mount the LLM should see a truthful
-    /// I/O error, not a fabricated "outside scratchpad directory".
+    /// A canonicalize failure that is NOT NotFound surfaces as `Io`.
     #[tokio::test]
     #[cfg(unix)]
     async fn test_validate_path_io_error_is_not_containment_violation() {
@@ -991,9 +1025,7 @@ mod tests {
         );
     }
 
-    /// A dangling symlink canonicalizes to NotFound, which must NOT be
-    /// treated as a safe not-yet-written destination: a write through it
-    /// would create a file wherever the link points.
+    /// A dangling symlink must NOT be treated as a safe not-yet-written destination.
     #[tokio::test]
     #[cfg(unix)]
     async fn test_validate_path_dangling_symlink_rejected() {
@@ -1010,6 +1042,47 @@ mod tests {
         assert!(
             matches!(result, Err(ScratchpadPathError::OutsideDirectory { .. })),
             "expected containment rejection for dangling symlink, got {result:?}"
+        );
+    }
+
+    /// A symlinked *ancestor* directory with a not-yet-created leaf is rejected.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_validate_path_symlinked_ancestor_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-alias")
+            .await
+            .unwrap();
+
+        // `alias` points at a real directory outside the read root.
+        let alias = storage.dir().join("alias");
+        std::os::unix::fs::symlink(outside.path(), &alias).unwrap();
+
+        let result = storage.validate_path("alias/new.json").await;
+        assert!(
+            matches!(result, Err(ScratchpadPathError::OutsideDirectory { .. })),
+            "expected containment rejection for symlinked ancestor, got {result:?}"
+        );
+    }
+
+    /// A symlink resolving *inside* the read root is legitimate.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_validate_path_in_root_symlink_ancestor_accepted() {
+        let tmp = TempDir::new().unwrap();
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-inlink")
+            .await
+            .unwrap();
+
+        let real = storage.dir().join("real");
+        std::fs::create_dir(&real).unwrap();
+        std::os::unix::fs::symlink(&real, storage.dir().join("alias")).unwrap();
+
+        let result = storage.validate_path("alias/new.json").await;
+        assert!(
+            result.is_ok(),
+            "in-root symlinked ancestor must validate, got {result:?}"
         );
     }
 

--- a/crates/aura/src/scratchpad/tools.rs
+++ b/crates/aura/src/scratchpad/tools.rs
@@ -37,9 +37,7 @@ pub enum ScratchpadToolError {
 
 impl From<ScratchpadPathError> for ScratchpadToolError {
     /// Containment violations stay path errors; validation-time I/O faults
-    /// (stale network mount, permission error) surface as I/O errors so the
-    /// LLM sees a truthful, retryable failure instead of a fabricated
-    /// containment violation.
+    /// surface as I/O errors.
     fn from(e: ScratchpadPathError) -> Self {
         match e {
             ScratchpadPathError::Io { source, .. } => ScratchpadToolError::Io(source),

--- a/crates/aura/src/scratchpad/tools.rs
+++ b/crates/aura/src/scratchpad/tools.rs
@@ -8,7 +8,7 @@ use super::schema::{
     MAX_SCHEMA_DEPTH, analyze_json_structure, analyze_markdown_structure, format_markdown_schema,
     format_schema,
 };
-use super::storage::ScratchpadStorage;
+use super::storage::{ScratchpadPathError, ScratchpadStorage};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -33,6 +33,19 @@ pub enum ScratchpadToolError {
     NotJson,
     #[error("Key path not found: {0}")]
     KeyNotFound(String),
+}
+
+impl From<ScratchpadPathError> for ScratchpadToolError {
+    /// Containment violations stay path errors; validation-time I/O faults
+    /// (stale network mount, permission error) surface as I/O errors so the
+    /// LLM sees a truthful, retryable failure instead of a fabricated
+    /// containment violation.
+    fn from(e: ScratchpadPathError) -> Self {
+        match e {
+            ScratchpadPathError::Io { source, .. } => ScratchpadToolError::Io(source),
+            other => ScratchpadToolError::Path(other.to_string()),
+        }
+    }
 }
 
 // ============================================================================
@@ -105,9 +118,7 @@ async fn read_scratchpad_file(
     storage: &ScratchpadStorage,
     file: &str,
 ) -> Result<String, ScratchpadToolError> {
-    let path = storage
-        .validate_path(file)
-        .map_err(|e| ScratchpadToolError::Path(e.to_string()))?;
+    let path = storage.validate_path(file).await?;
     tokio::fs::read_to_string(&path)
         .await
         .map_err(ScratchpadToolError::Io)
@@ -1591,7 +1602,7 @@ impl Tool for ReadTool {
         // rejection only, biased toward the common case of obviously oversized
         // files. If the estimate already exceeds the per-call limit, bail out.
         if let Some(limit) = self.budget.max_extraction_tokens()
-            && let Ok(path) = self.storage.validate_path(&args.file)
+            && let Ok(path) = self.storage.validate_path(&args.file).await
             && let Ok(meta) = tokio::fs::metadata(&path).await
         {
             let approx_tokens = (meta.len() as usize) / 3;

--- a/crates/aura/src/scratchpad/wrapper.rs
+++ b/crates/aura/src/scratchpad/wrapper.rs
@@ -69,7 +69,7 @@ impl ScratchpadWrapper {
 
 #[async_trait]
 impl ToolWrapper for ScratchpadWrapper {
-    fn transform_output(
+    async fn transform_output(
         &self,
         output: String,
         outcome: &CallOutcome,
@@ -130,24 +130,11 @@ impl ToolWrapper for ScratchpadWrapper {
         )
         .replace(['/', '\\', ':', ' '], "_");
 
-        // Sync write: actix-web spawns one current_thread tokio runtime per
-        // worker, so `block_in_place` would panic ("can call blocking only
-        // when running on the multi-threaded runtime").
-        //
-        // Going async here is a larger refactor than it looks: `#[async_trait]`
-        // on `ToolWrapper` produces `Send`-only futures, but `WrappedTool::call`
-        // (and `definition`) self-imposes `+ Send + Sync` on its return type.
-        // Making `transform_output` async would force dropping that `+ Sync`
-        // bound on the wrapper plumbing, async-ifying the trait method (a
-        // breaking change for ToolWrapper impls), updating ComposedWrapper to
-        // chain async transforms, and updating all four wrapper impls
-        // (Scratchpad/Persistence/Observer/DuplicateCallGuard).
-        //
-        // KB-sized writes complete in sub-millisecond time — far cheaper than
-        // the LLM round-trip that follows — so briefly blocking the actix
-        // worker is acceptable (for now). Revisit if scratchpad payloads grow into the
-        // multi-MB range or if profiling shows the sync write on the hot path.
-        let write = self.storage.write_output_sync(&file_id, content);
+        // The write is awaited before the pointer is returned: the LLM's next
+        // tool call may read the file, so durability must precede pointer
+        // visibility. On slow (network) storage the latency lands on this one
+        // tool result, not on the runtime thread.
+        let write = self.storage.write_output(&file_id, content).await;
         match write {
             Ok(result) => {
                 let filename = result
@@ -292,7 +279,9 @@ mod tests {
         ctx.tool_initiator_id = "incident".to_string();
         ctx.attempt = Some(0);
 
-        let result = wrapper.transform_output(large_output, &ok(), &ctx, None);
+        let result = wrapper
+            .transform_output(large_output, &ok(), &ctx, None)
+            .await;
         assert!(
             result.output.contains("[scratchpad:"),
             "exact-name lookup must intercept; got: {}",
@@ -330,8 +319,12 @@ mod tests {
         ctx.tool_initiator_id = "worker_loop".to_string();
         ctx.attempt = Some(0);
 
-        let r1 = wrapper.transform_output(large_output.clone(), &ok(), &ctx, None);
-        let r2 = wrapper.transform_output(large_output, &ok(), &ctx, None);
+        let r1 = wrapper
+            .transform_output(large_output.clone(), &ok(), &ctx, None)
+            .await;
+        let r2 = wrapper
+            .transform_output(large_output, &ok(), &ctx, None)
+            .await;
         assert_eq!(
             r1.output, r2.output,
             "identical raw output must produce identical pointer strings so DuplicateCallGuard can detect loops"
@@ -360,7 +353,9 @@ mod tests {
         ctx.tool_initiator_id = "worker_abc".to_string();
         ctx.attempt = Some(0);
 
-        let result = wrapper.transform_output(large_output, &ok(), &ctx, None);
+        let result = wrapper
+            .transform_output(large_output, &ok(), &ctx, None)
+            .await;
         let output = result.output;
 
         assert!(output.contains("[scratchpad:"));
@@ -417,7 +412,9 @@ mod tests {
         ctx.tool_initiator_id = "metrics".to_string();
         ctx.attempt = Some(0);
 
-        let result = wrapper.transform_output(with_footer, &ok(), &ctx, None);
+        let result = wrapper
+            .transform_output(with_footer, &ok(), &ctx, None)
+            .await;
         assert!(result.output.contains("[scratchpad:"), "must intercept");
 
         let files = storage.list_files().await.unwrap();
@@ -457,7 +454,9 @@ mod tests {
         let small_output = "small result".to_string();
         let ctx = ToolCallContext::new("search_knowledge_base");
 
-        let result = wrapper.transform_output(small_output.clone(), &ok(), &ctx, None);
+        let result = wrapper
+            .transform_output(small_output.clone(), &ok(), &ctx, None)
+            .await;
         assert_eq!(
             result.output, small_output,
             "small output should pass through unchanged"
@@ -493,7 +492,9 @@ mod tests {
         let large_output = "x".repeat(500);
         let ctx = ToolCallContext::new("other_tool");
 
-        let result = wrapper.transform_output(large_output.clone(), &ok(), &ctx, None);
+        let result = wrapper
+            .transform_output(large_output.clone(), &ok(), &ctx, None)
+            .await;
         assert_eq!(result.output, large_output);
     }
 
@@ -519,7 +520,9 @@ mod tests {
         let large_output = (0..500).map(|i| format!("line_{} ", i)).collect::<String>();
         for tool_name in ["load_skill", "read_skill_file"] {
             let ctx = ToolCallContext::new(tool_name);
-            let result = wrapper.transform_output(large_output.clone(), &ok(), &ctx, None);
+            let result = wrapper
+                .transform_output(large_output.clone(), &ok(), &ctx, None)
+                .await;
             assert_eq!(
                 result.output, large_output,
                 "{tool_name} output must pass through unintercepted"
@@ -557,7 +560,9 @@ mod tests {
         ctx.tool_initiator_id = "worker".to_string();
         ctx.attempt = Some(0);
 
-        let result = wrapper.transform_output(content.clone(), &ok(), &ctx, None);
+        let result = wrapper
+            .transform_output(content.clone(), &ok(), &ctx, None)
+            .await;
         assert!(
             result.output.contains("[scratchpad:"),
             "Output at exact threshold should be intercepted, got: {}",
@@ -570,7 +575,9 @@ mod tests {
         let budget2 = ContextBudget::new(128_000, 0.20, 0, Arc::new(counter2));
         let wrapper2 = ScratchpadWrapper::new(tools_above, storage, budget2);
 
-        let result2 = wrapper2.transform_output(content.clone(), &ok(), &ctx, None);
+        let result2 = wrapper2
+            .transform_output(content.clone(), &ok(), &ctx, None)
+            .await;
         assert_eq!(
             result2.output, content,
             "Output below threshold should pass through unchanged"
@@ -603,7 +610,7 @@ mod tests {
 
         assert_eq!(budget.scratchpad_usage(), (0, 0));
 
-        let result = wrapper.transform_output(content, &ok(), &ctx, None);
+        let result = wrapper.transform_output(content, &ok(), &ctx, None).await;
         assert!(result.output.contains("[scratchpad:"));
 
         let (intercepted, _) = budget.scratchpad_usage();
@@ -616,7 +623,7 @@ mod tests {
     #[tokio::test]
     async fn test_wrapper_falls_back_on_write_failure() {
         // Point storage at a non-existent directory that we then remove,
-        // so write_output_sync will fail with an I/O error.
+        // so the write will fail with an I/O error.
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
             ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-fail")
@@ -638,7 +645,9 @@ mod tests {
         ctx.tool_initiator_id = "worker".to_string();
         ctx.attempt = Some(0);
 
-        let result = wrapper.transform_output(large_output.clone(), &ok(), &ctx, None);
+        let result = wrapper
+            .transform_output(large_output.clone(), &ok(), &ctx, None)
+            .await;
 
         // Returning the raw payload would re-introduce the overflow scratchpad
         // exists to prevent. The wrapper must instead surface a compact error
@@ -698,7 +707,9 @@ mod tests {
         ctx.tool_initiator_id = "worker_a".to_string();
         ctx.attempt = Some(0);
 
-        let result = wrapper.transform_output(outer.to_string(), &ok(), &ctx, None);
+        let result = wrapper
+            .transform_output(outer.to_string(), &ok(), &ctx, None)
+            .await;
         let output = result.output;
 
         // The companion was a JSON tree, so the pointer must list JSON-aware
@@ -759,7 +770,9 @@ mod tests {
         ctx.tool_initiator_id = "worker_rca".to_string();
         ctx.attempt = Some(0);
 
-        let result = wrapper.transform_output(large_output, &ok(), &ctx, None);
+        let result = wrapper
+            .transform_output(large_output, &ok(), &ctx, None)
+            .await;
         let output = result.output;
 
         // Primary file pointer

--- a/crates/aura/src/scratchpad/wrapper.rs
+++ b/crates/aura/src/scratchpad/wrapper.rs
@@ -130,10 +130,7 @@ impl ToolWrapper for ScratchpadWrapper {
         )
         .replace(['/', '\\', ':', ' '], "_");
 
-        // The write is awaited before the pointer is returned: the LLM's next
-        // tool call may read the file, so durability must precede pointer
-        // visibility. On slow (network) storage the latency lands on this one
-        // tool result, not on the runtime thread.
+        // The write is awaited before returning the pointer.
         let write = self.storage.write_output(&file_id, content).await;
         match write {
             Ok(result) => {

--- a/crates/aura/src/session_store/memory.rs
+++ b/crates/aura/src/session_store/memory.rs
@@ -15,10 +15,10 @@ use super::{ApprovalStore, EventBus, SessionStoreError, Subscription};
 /// Buffered payloads per topic before slow subscribers start lagging.
 const TOPIC_CAPACITY: usize = 64;
 
-/// How long a recorded decision stays readable past its approval's expiry.
+/// Decision retention margin.
 const DECISION_RETENTION_MARGIN_SECS: i64 = 60;
 
-/// A recorded decision and the instant its entry may be dropped.
+/// A recorded decision and its retention deadline.
 struct DecidedEntry {
     decision: ApprovalDecision,
     keep_until: Timestamp,
@@ -27,9 +27,7 @@ struct DecidedEntry {
 /// The parked-approval registry as a plain map.
 #[derive(Default)]
 pub struct InMemoryApprovalStore {
-    // `std::sync::Mutex` (both maps): every operation is a synchronous map
-    // op; nothing awaits while holding a lock, and the locks are never
-    // held together.
+    // Synchronous mutexes.
     entries: Mutex<BTreeMap<DecisionId, ParkedApproval>>,
     decided: Mutex<BTreeMap<DecisionId, DecidedEntry>>,
 }
@@ -44,8 +42,7 @@ impl InMemoryApprovalStore {
         self.entries.lock().expect("approval store lock poisoned")
     }
 
-    /// Lock the decided map, dropping entries past their retention window (the
-    /// in-memory stand-in for a networked backend's TTL).
+    /// Lock the decided map, dropping entries past their retention window.
     fn lock_decided(&self) -> std::sync::MutexGuard<'_, BTreeMap<DecisionId, DecidedEntry>> {
         let mut decided = self.decided.lock().expect("approval store lock poisoned");
         let now = chrono::Utc::now();
@@ -244,7 +241,7 @@ mod tests {
         store.resolve(&id, denied.clone()).await.unwrap();
 
         assert_eq!(store.decision(&id).await.unwrap(), Some(denied.clone()));
-        // The recorded decision survives the (rejected) second resolve.
+        // Recorded decision survives rejected second resolve.
         assert_eq!(
             store.resolve(&id, ApprovalDecision::Approved).await,
             Err(ResolveError::NotFound)
@@ -257,7 +254,7 @@ mod tests {
     async fn recorded_decision_is_pruned_after_retention_window() {
         let store = InMemoryApprovalStore::new();
         let mut entry = parked("req-prune");
-        // Expired long enough ago that the retention margin is already past.
+        // Retention margin is already past.
         entry.expires_at =
             chrono::Utc::now() - chrono::Duration::seconds(2 * DECISION_RETENTION_MARGIN_SECS);
         let id = entry.request.decision_id;

--- a/crates/aura/src/session_store/mod.rs
+++ b/crates/aura/src/session_store/mod.rs
@@ -59,11 +59,7 @@ pub trait ApprovalStore: Send + Sync {
     /// Look up a parked approval.
     async fn get(&self, id: &DecisionId) -> Result<Option<ParkedApproval>, SessionStoreError>;
 
-    /// Record a terminal decision and remove the parked entry, atomically —
-    /// at-most-once resolution is enforced here, in the store. The recorded
-    /// decision must stay readable via [`Self::decision`] until at least the
-    /// approval's `expires_at`, so the parking process can recover a decision
-    /// whose bus wake was lost.
+    /// Record a terminal decision and remove the parked entry atomically.
     async fn resolve(
         &self,
         id: &DecisionId,

--- a/crates/aura/src/session_store/record.rs
+++ b/crates/aura/src/session_store/record.rs
@@ -61,9 +61,7 @@ pub enum OriginRecord {
     AgentRequested { reason: String },
 }
 
-/// Storage form of a recorded [`ApprovalDecision`]: the durable record that a
-/// resolution happened, what it was, and when. Same flat `approved`/`reason`
-/// shape as the webhook wire (`hitl::protocol::ApprovalDecisionWire`).
+/// Storage form of a recorded [`ApprovalDecision`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DecisionRecord {
     pub approved: bool,
@@ -71,7 +69,7 @@ pub struct DecisionRecord {
     pub decided_at: Timestamp,
 }
 
-/// Stamps `decided_at` with the conversion (i.e. resolve) time.
+/// Stamps `decided_at` with the resolve time.
 impl From<&ApprovalDecision> for DecisionRecord {
     fn from(decision: &ApprovalDecision) -> Self {
         let (approved, reason) = match decision {

--- a/crates/aura/src/tool_wrapper.rs
+++ b/crates/aura/src/tool_wrapper.rs
@@ -244,7 +244,7 @@ pub trait ToolWrapper: Send + Sync {
     ///
     /// # Returns
     /// Transformed output
-    fn transform_output(
+    async fn transform_output(
         &self,
         output: String,
         _outcome: &CallOutcome,
@@ -435,7 +435,7 @@ where
     fn call(
         &self,
         args: Self::Args,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send + Sync + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send + '_>> {
         let inner = self.inner.clone();
         let wrapper = self.wrapper.clone();
         let tool_name = self.inner.name();
@@ -582,8 +582,9 @@ where
             match result {
                 Ok(output) => {
                     let outcome = CallOutcome::classify_from_output(&output);
-                    let transformed =
-                        wrapper.transform_output(output, &outcome, &ctx, extracted.as_ref());
+                    let transformed = wrapper
+                        .transform_output(output, &outcome, &ctx, extracted.as_ref())
+                        .await;
 
                     if let Some(warning) = &transformed.warning {
                         tracing::warn!("Tool wrapper warning for {}: {}", tool_name, warning);
@@ -741,7 +742,7 @@ impl ToolWrapper for ComposedWrapper {
         Ok(PreCallOutcome::Proceed { overrides })
     }
 
-    fn transform_output(
+    async fn transform_output(
         &self,
         mut output: String,
         outcome: &CallOutcome,
@@ -749,7 +750,9 @@ impl ToolWrapper for ComposedWrapper {
         extracted: Option<&Value>,
     ) -> TransformOutputResult {
         for wrapper in self.wrappers.iter().rev() {
-            let result = wrapper.transform_output(output, outcome, ctx, extracted);
+            let result = wrapper
+                .transform_output(output, outcome, ctx, extracted)
+                .await;
             output = result.output;
         }
         TransformOutputResult::new(output)
@@ -833,8 +836,8 @@ mod tests {
         assert_eq!(result.warning, Some("minor issue".to_string()));
     }
 
-    #[test]
-    fn test_noop_wrapper_passthrough() {
+    #[tokio::test]
+    async fn test_noop_wrapper_passthrough() {
         let wrapper = NoOpWrapper;
 
         // Schema unchanged
@@ -851,7 +854,9 @@ mod tests {
         // Output unchanged
         let output = "test output".to_string();
         let outcome = CallOutcome::Success(output.clone());
-        let result = wrapper.transform_output(output.clone(), &outcome, &ctx, None);
+        let result = wrapper
+            .transform_output(output.clone(), &outcome, &ctx, None)
+            .await;
         assert_eq!(result.output, output);
     }
 

--- a/crates/aura/src/tool_wrapper.rs
+++ b/crates/aura/src/tool_wrapper.rs
@@ -29,10 +29,21 @@
 //! // Create a wrapper that adds metrics
 //! struct MetricsWrapper { /* ... */ }
 //!
+//! #[async_trait::async_trait]
 //! impl ToolWrapper for MetricsWrapper {
 //!     fn wrap_schema(&self, schema: Value) -> Value { schema }
-//!     fn transform_args(&self, args: Value) -> Value { args }
-//!     fn transform_output(&self, output: String) -> String { output }
+//!     fn transform_args(&self, args: Value, ctx: &ToolCallContext) -> TransformArgsResult {
+//!         TransformArgsResult::new(args)
+//!     }
+//!     async fn transform_output(
+//!         &self,
+//!         output: String,
+//!         outcome: &CallOutcome,
+//!         ctx: &ToolCallContext,
+//!         extracted: Option<&Value>,
+//!     ) -> TransformOutputResult {
+//!         TransformOutputResult::new(output)
+//!     }
 //! }
 //!
 //! // Wrap a tool
@@ -581,30 +592,60 @@ where
             // Transform result
             match result {
                 Ok(output) => {
-                    let outcome = CallOutcome::classify_from_output(&output);
-                    let transformed = wrapper
-                        .transform_output(output, &outcome, &ctx, extracted.as_ref())
-                        .await;
+                    // Supervise the transform + completion hook in a spawned
+                    // task: transform_output can suspend (the scratchpad
+                    // wrapper awaits a filesystem write), and if this request
+                    // were cancelled mid-await the tool's success would
+                    // otherwise vanish — no persistence record, no observer
+                    // completion, a half-written scratchpad batch. The
+                    // spawned task runs to completion even after the caller
+                    // drops the JoinHandle.
+                    let wrapper_clone = wrapper.clone();
+                    let ctx_clone = ctx.clone();
+                    let extracted_clone = extracted.clone();
+                    let span = tracing::Span::current();
+                    let transform_handle = tokio::spawn(tracing::Instrument::instrument(
+                        async move {
+                            let outcome = CallOutcome::classify_from_output(&output);
+                            let transformed = wrapper_clone
+                                .transform_output(
+                                    output,
+                                    &outcome,
+                                    &ctx_clone,
+                                    extracted_clone.as_ref(),
+                                )
+                                .await;
+
+                            // Completion hook is fire-and-forget so it never
+                            // blocks the response; spawned from inside the
+                            // supervised task so it fires even when the
+                            // request has already been cancelled.
+                            let output_clone = transformed.output.clone();
+                            tokio::spawn(async move {
+                                wrapper_clone
+                                    .on_complete(
+                                        &ctx_clone,
+                                        extracted_clone.as_ref(),
+                                        Ok(&output_clone),
+                                        duration_ms,
+                                    )
+                                    .await;
+                            });
+
+                            transformed
+                        },
+                        span,
+                    ));
+                    let transformed = match transform_handle.await {
+                        Ok(t) => t,
+                        Err(join_error) => {
+                            return Err(ToolError::ToolCallError(join_error.into()));
+                        }
+                    };
 
                     if let Some(warning) = &transformed.warning {
                         tracing::warn!("Tool wrapper warning for {}: {}", tool_name, warning);
                     }
-
-                    // Spawn async completion hook (fire-and-forget, don't block the response)
-                    let wrapper_clone = wrapper.clone();
-                    let ctx_clone = ctx.clone();
-                    let extracted_clone = extracted.clone();
-                    let output_clone = transformed.output.clone();
-                    tokio::spawn(async move {
-                        wrapper_clone
-                            .on_complete(
-                                &ctx_clone,
-                                extracted_clone.as_ref(),
-                                Ok(&output_clone),
-                                duration_ms,
-                            )
-                            .await;
-                    });
 
                     Ok(transformed.output)
                 }

--- a/crates/aura/src/tool_wrapper.rs
+++ b/crates/aura/src/tool_wrapper.rs
@@ -507,14 +507,7 @@ where
 
             // Async pre-call gate (e.g. HITL approval): may call an external
             // service or park for a human decision before the tool runs.
-            // Spawned so the gate survives caller cancellation: a parked HITL
-            // approval owns registry state and timeout bookkeeping that its
-            // future must live to release — dropping it mid-await would strand
-            // the approval entry. The JoinHandle await is the cancellation
-            // point instead; the detached gate observes the request's
-            // cancellation token and cleans up. Like validate_args, a
-            // rejection still runs on_complete so wrappers can clean up, and
-            // the error is returned to the LLM.
+            // Spawned so the gate survives caller cancellation.
             let pre_wrapper = wrapper.clone();
             let pre_args = clean_args.clone();
             let pre_ctx = ctx.clone();
@@ -576,12 +569,8 @@ where
                 }
             };
 
-            // Call inner tool in a spawned task: a panic in a third-party
-            // tool then surfaces as a JoinError-backed ToolError and flows
-            // through handle_error + on_complete like any tool failure,
-            // instead of unwinding the request task with observer and
-            // persistence state stranded mid-call. The current span is
-            // propagated so mcp.tool_call nests under execute_tool.
+            // Call inner tool in a spawned task to isolate panics.
+            // Propagate the current span so mcp.tool_call nests under execute_tool.
             let inner_clone = inner.clone();
             let args_clone = clean_args.clone();
             let tool_span = tracing::Span::current();
@@ -601,14 +590,8 @@ where
             // Transform result
             match result {
                 Ok(output) => {
-                    // Supervise the transform + completion hook in a spawned
-                    // task: transform_output can suspend (the scratchpad
-                    // wrapper awaits a filesystem write), and if this request
-                    // were cancelled mid-await the tool's success would
-                    // otherwise vanish — no persistence record, no observer
-                    // completion, a half-written scratchpad batch. The
-                    // spawned task runs to completion even after the caller
-                    // drops the JoinHandle.
+                    // Supervise the transform + completion hook in a spawned task
+                    // so it runs to completion even if the request is cancelled.
                     let wrapper_clone = wrapper.clone();
                     let ctx_clone = ctx.clone();
                     let extracted_clone = extracted.clone();
@@ -625,10 +608,7 @@ where
                                 )
                                 .await;
 
-                            // Completion hook is fire-and-forget so it never
-                            // blocks the response; spawned from inside the
-                            // supervised task so it fires even when the
-                            // request has already been cancelled.
+                            // Fire-and-forget completion hook.
                             let output_clone = transformed.output.clone();
                             tokio::spawn(async move {
                                 wrapper_clone
@@ -648,9 +628,7 @@ where
                     let transformed = match transform_handle.await {
                         Ok(t) => t,
                         Err(join_error) => {
-                            // A panicked transform never reached its own
-                            // on_complete spawn; emit the failure completion
-                            // here so observer and persistence state close out.
+                            // Emit failure completion on transform panic to close state.
                             let error = ToolError::ToolCallError(join_error.into());
                             let error_msg = error.to_string();
                             let wrapper_clone = wrapper.clone();

--- a/crates/aura/src/tool_wrapper.rs
+++ b/crates/aura/src/tool_wrapper.rs
@@ -24,30 +24,33 @@
 //! # Example
 //!
 //! ```ignore
-//! use aura::tool_wrapper::{ToolWrapper, ToolWrapperConfig, WrappedTool};
+//! use std::sync::Arc;
 //!
-//! // Create a wrapper that adds metrics
-//! struct MetricsWrapper { /* ... */ }
+//! use aura::mcp_response::CallOutcome;
+//! use aura::tool_wrapper::{
+//!     ToolCallContext, ToolWrapper, TransformOutputResult, WrappedTool,
+//! };
+//! use serde_json::Value;
+//!
+//! // A wrapper that observes tool output; every method has a passthrough
+//! // default, so override only what you need.
+//! struct MetricsWrapper;
 //!
 //! #[async_trait::async_trait]
 //! impl ToolWrapper for MetricsWrapper {
-//!     fn wrap_schema(&self, schema: Value) -> Value { schema }
-//!     fn transform_args(&self, args: Value, ctx: &ToolCallContext) -> TransformArgsResult {
-//!         TransformArgsResult::new(args)
-//!     }
 //!     async fn transform_output(
 //!         &self,
 //!         output: String,
-//!         outcome: &CallOutcome,
-//!         ctx: &ToolCallContext,
-//!         extracted: Option<&Value>,
+//!         _outcome: &CallOutcome,
+//!         _ctx: &ToolCallContext,
+//!         _extracted: Option<&Value>,
 //!     ) -> TransformOutputResult {
 //!         TransformOutputResult::new(output)
 //!     }
 //! }
 //!
-//! // Wrap a tool
-//! let wrapped = WrappedTool::new(inner_tool, Arc::new(metrics_wrapper));
+//! // Wrap a tool (inner_tool: any rig Tool with Value args / String output)
+//! let wrapped = WrappedTool::new(inner_tool, Arc::new(MetricsWrapper));
 //! ```
 
 use async_trait::async_trait;
@@ -503,12 +506,15 @@ where
             }
 
             // Async pre-call gate (e.g. HITL approval): may call an external
-            // service or park for a human decision before the tool runs. Spawned
-            // (like the inner call below) so this future stays `Sync` — the
-            // async_trait `pre_call` future is `Send` but not `Sync`, and awaiting
-            // it inline would taint `call`'s returned future. Like validate_args,
-            // a rejection still runs on_complete so wrappers can clean up, and the
-            // error is returned to the LLM.
+            // service or park for a human decision before the tool runs.
+            // Spawned so the gate survives caller cancellation: a parked HITL
+            // approval owns registry state and timeout bookkeeping that its
+            // future must live to release — dropping it mid-await would strand
+            // the approval entry. The JoinHandle await is the cancellation
+            // point instead; the detached gate observes the request's
+            // cancellation token and cleans up. Like validate_args, a
+            // rejection still runs on_complete so wrappers can clean up, and
+            // the error is returned to the LLM.
             let pre_wrapper = wrapper.clone();
             let pre_args = clean_args.clone();
             let pre_ctx = ctx.clone();
@@ -570,8 +576,12 @@ where
                 }
             };
 
-            // Call inner tool (spawn to handle non-Sync futures).
-            // Propagate the current span so mcp.tool_call nests under execute_tool.
+            // Call inner tool in a spawned task: a panic in a third-party
+            // tool then surfaces as a JoinError-backed ToolError and flows
+            // through handle_error + on_complete like any tool failure,
+            // instead of unwinding the request task with observer and
+            // persistence state stranded mid-call. The current span is
+            // propagated so mcp.tool_call nests under execute_tool.
             let inner_clone = inner.clone();
             let args_clone = clean_args.clone();
             let tool_span = tracing::Span::current();
@@ -581,7 +591,6 @@ where
                 }),
                 tool_span,
             ));
-
             let result = match result_handle.await {
                 Ok(r) => r,
                 Err(join_error) => Err(ToolError::ToolCallError(join_error.into())),
@@ -639,7 +648,25 @@ where
                     let transformed = match transform_handle.await {
                         Ok(t) => t,
                         Err(join_error) => {
-                            return Err(ToolError::ToolCallError(join_error.into()));
+                            // A panicked transform never reached its own
+                            // on_complete spawn; emit the failure completion
+                            // here so observer and persistence state close out.
+                            let error = ToolError::ToolCallError(join_error.into());
+                            let error_msg = error.to_string();
+                            let wrapper_clone = wrapper.clone();
+                            let ctx_clone = ctx.clone();
+                            let extracted_clone = extracted.clone();
+                            tokio::spawn(async move {
+                                wrapper_clone
+                                    .on_complete(
+                                        &ctx_clone,
+                                        extracted_clone.as_ref(),
+                                        Err(&error_msg),
+                                        duration_ms,
+                                    )
+                                    .await;
+                            });
+                            return Err(error);
                         }
                     };
 

--- a/crates/aura/src/turn_nudge.rs
+++ b/crates/aura/src/turn_nudge.rs
@@ -163,7 +163,7 @@ impl TurnNudgeWrapper {
 
 #[async_trait]
 impl ToolWrapper for TurnNudgeWrapper {
-    fn transform_output(
+    async fn transform_output(
         &self,
         output: String,
         _outcome: &CallOutcome,


### PR DESCRIPTION
consistent file handles and drains to support consistent writes in a timely manner to cause less competition when working with a VFS like Archil https://archil.com/. This leads the way to the file based park/reify slated for one of the backends in #271 