### PR TITLE
HITL forward approver headers to MCP calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "clap",
  "dotenvy",
  "globset",
+ "http 1.4.0",
  "regex",
  "serde",
  "serde_json",

--- a/crates/aura-config/Cargo.toml
+++ b/crates/aura-config/Cargo.toml
@@ -16,6 +16,7 @@ clap = { workspace = true }
 
 # Error handling
 thiserror = { workspace = true }
+http = { workspace = true }
 
 # Logging
 tracing = { workspace = true }

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -1,3 +1,4 @@
+use crate::error::ConfigError;
 use crate::lenient_bool;
 use crate::lenient_int;
 use crate::orchestration::OrchestrationConfig;
@@ -1055,6 +1056,7 @@ mod tests {
                 timeout_secs: 300,
                 headers: HashMap::new(),
                 headers_from_request: HashMap::new(),
+                tool_headers_from_response: ToolHeaderMappings::default(),
             },
         };
         assert!(hitl_timeout_conflict_warning(&hitl, 0).is_none());
@@ -1086,6 +1088,7 @@ mod tests {
                 timeout_secs: 30,
                 headers: HashMap::new(),
                 headers_from_request: HashMap::new(),
+                tool_headers_from_response: ToolHeaderMappings::default(),
             },
         };
         assert!(hitl_timeout_conflict_warning(&hitl, 60).is_none());
@@ -1100,6 +1103,7 @@ mod tests {
                 timeout_secs: 60,
                 headers: HashMap::new(),
                 headers_from_request: HashMap::new(),
+                tool_headers_from_response: ToolHeaderMappings::default(),
             },
         };
         let msg = hitl_timeout_conflict_warning(&hitl, 60).unwrap();
@@ -1116,6 +1120,7 @@ mod tests {
                 timeout_secs: 120,
                 headers: HashMap::new(),
                 headers_from_request: HashMap::new(),
+                tool_headers_from_response: ToolHeaderMappings::default(),
             },
         };
         let msg = hitl_timeout_conflict_warning(&hitl, 60).unwrap();
@@ -1176,13 +1181,96 @@ url = "https://approvals.example.com/decide"
             DecisionRouteConfig::Webhook {
                 headers,
                 headers_from_request,
+                tool_headers_from_response,
                 ..
             } => {
                 assert!(headers.is_empty());
                 assert!(headers_from_request.is_empty());
+                assert!(tool_headers_from_response.is_empty());
             }
             other => panic!("expected Webhook route, got {:?}", other),
         }
+    }
+
+    /// A non-empty `tool_headers_from_response` map is deployable config.
+    /// It is validated at parse, outbound names lowercased, and the binary
+    /// carries it without consuming it.
+    #[test]
+    fn hitl_webhook_tool_headers_from_response_parses_validated() {
+        let toml = r#"
+require_approval = ["kubectl_*"]
+
+[route]
+mode = "webhook"
+url = "https://approvals.example.com/decide"
+tool_headers_from_response = { "Authorization" = "x-approver-token" }
+"#;
+        let hitl: HitlConfig = toml::from_str(toml).unwrap();
+        match hitl.route {
+            DecisionRouteConfig::Webhook {
+                tool_headers_from_response,
+                ..
+            } => {
+                assert_eq!(
+                    tool_headers_from_response.get("authorization"),
+                    Some("x-approver-token"),
+                    "outbound names are lowercased at parse"
+                );
+                assert!(tool_headers_from_response.get("Authorization").is_none());
+            }
+            other => panic!("expected Webhook route, got {:?}", other),
+        }
+    }
+
+    /// Reserved transport-owned names are rejected at parse.
+    #[test]
+    fn hitl_webhook_tool_headers_reserved_name_rejected() {
+        let toml = r#"
+require_approval = ["kubectl_*"]
+
+[route]
+mode = "webhook"
+url = "https://approvals.example.com/decide"
+tool_headers_from_response = { "Content-Type" = "x-anything" }
+"#;
+        let err = toml::from_str::<HitlConfig>(toml).unwrap_err().to_string();
+        assert!(
+            err.contains("reserved transport header"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A syntactically invalid header name on either side is rejected at
+    /// parse.
+    #[test]
+    fn hitl_webhook_tool_headers_invalid_name_rejected() {
+        for bad in [
+            [("bad header".to_string(), "x-ok".to_string())],
+            [("x-ok".to_string(), "bad value name\n".to_string())],
+        ] {
+            let raw: HashMap<String, String> = bad.into_iter().collect();
+            let err = ToolHeaderMappings::try_from(raw).unwrap_err().to_string();
+            assert!(
+                err.contains("not a valid http header name"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    /// Two spellings that collide after lowercasing are rejected at parse.
+    #[test]
+    fn hitl_webhook_tool_headers_duplicate_after_lowercase_rejected() {
+        let raw: HashMap<String, String> = [
+            ("Authorization".to_string(), "x-a".to_string()),
+            ("authorization".to_string(), "x-b".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let err = ToolHeaderMappings::try_from(raw).unwrap_err().to_string();
+        assert!(
+            err.contains("duplicate tool header override"),
+            "unexpected error: {err}"
+        );
     }
 }
 
@@ -1227,7 +1315,100 @@ pub enum DecisionRouteConfig {
         /// Outbound header name → inbound request header name mapping.
         #[serde(default)]
         headers_from_request: HashMap<String, String>,
+        /// Outbound MCP header name → webhook approval-response header name.
+        /// Non-empty opts gated calls into approver identity forwarding.
+        /// Validated at parse (see [`ToolHeaderMappings`]); the validated
+        /// map is carried but not consumed until capture wiring lands.
+        #[serde(default, skip_serializing_if = "ToolHeaderMappings::is_empty")]
+        tool_headers_from_response: ToolHeaderMappings,
     },
+}
+
+/// Transport-owned header names a `tool_headers_from_response` mapping may
+/// never override: corrupting these breaks MCP framing or session routing.
+pub const RESERVED_TOOL_HEADER_NAMES: [&str; 6] = [
+    "content-type",
+    "accept",
+    "mcp-session-id",
+    "host",
+    "content-length",
+    "transfer-encoding",
+];
+
+/// Validated `tool_headers_from_response` mapping: outbound MCP header
+/// name → webhook approval-response header name, both sides lowercased
+/// at parse so an override always replaces the frozen default header.
+/// Syntactically invalid header names, duplicates after lowercasing, and
+/// reserved transport-owned names (see [`RESERVED_TOOL_HEADER_NAMES`])
+/// are rejected at construction, so downstream code never holds an
+/// unvalidated map.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct ToolHeaderMappings(HashMap<String, String>);
+
+impl ToolHeaderMappings {
+    /// True when no mapping is configured (the legacy, feature-off state).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// The response header name mapped to `outbound_name` (lowercased), if
+    /// one is configured.
+    #[must_use]
+    pub fn get(&self, outbound_name: &str) -> Option<&str> {
+        self.0.get(outbound_name).map(String::as_str)
+    }
+
+    /// Iterate `(outbound_name, response_header_name)` pairs; outbound names
+    /// are lowercased.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.0.iter().map(|(k, v)| (k.as_str(), v.as_str()))
+    }
+}
+
+impl TryFrom<HashMap<String, String>> for ToolHeaderMappings {
+    type Error = ConfigError;
+
+    /// The one validation site: lowercase-normalize outbound names, reject
+    /// syntactically invalid header names on either side, reject duplicates
+    /// after normalization, reject reserved transport-owned names.
+    /// Implemented (not a typed hole) because deserialization is reachable
+    /// through deployable config, where a hole would panic.
+    fn try_from(raw: HashMap<String, String>) -> Result<Self, Self::Error> {
+        let mut normalized: HashMap<String, String> = HashMap::with_capacity(raw.len());
+        for (name, response_name) in raw {
+            let lowered = name.to_lowercase();
+            if http::header::HeaderName::from_bytes(lowered.as_bytes()).is_err() {
+                return Err(ConfigError::InvalidToolHeaderName { name: lowered });
+            }
+            let response_lowered = response_name.to_lowercase();
+            if http::header::HeaderName::from_bytes(response_lowered.as_bytes()).is_err() {
+                return Err(ConfigError::InvalidToolHeaderName {
+                    name: response_lowered,
+                });
+            }
+            if RESERVED_TOOL_HEADER_NAMES.contains(&lowered.as_str()) {
+                return Err(ConfigError::ReservedToolHeaderOverride { name: lowered });
+            }
+            if normalized
+                .insert(lowered.clone(), response_lowered)
+                .is_some()
+            {
+                return Err(ConfigError::DuplicateToolHeaderOverride { name: lowered });
+            }
+        }
+        Ok(Self(normalized))
+    }
+}
+
+impl<'de> Deserialize<'de> for ToolHeaderMappings {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = HashMap::<String, String>::deserialize(deserializer)?;
+        Self::try_from(raw).map_err(serde::de::Error::custom)
+    }
 }
 
 fn default_conversational_timeout_secs() -> u64 {
@@ -1240,8 +1421,8 @@ fn default_webhook_timeout_secs() -> u64 {
 
 /// A validated webhook URL.
 ///
-/// NOTE (skeleton): validation is a minimal scheme check; aura-config has no
-/// URL-parsing crate today, so a full parse is a hole-fill decision.
+/// Validation is a minimal scheme check; aura-config has no URL-parsing
+/// crate today, so a full parse is deferred.
 #[derive(Debug, Clone)]
 pub struct WebhookUrl(String);
 

--- a/crates/aura-config/src/error.rs
+++ b/crates/aura-config/src/error.rs
@@ -20,6 +20,15 @@ pub enum ConfigError {
     #[error("Validation error: {0}")]
     Validation(String),
 
+    #[error("duplicate tool header override name after lowercasing: {name}")]
+    DuplicateToolHeaderOverride { name: String },
+
+    #[error("tool header override is not a valid http header name: {name}")]
+    InvalidToolHeaderName { name: String },
+
+    #[error("reserved transport header cannot be overridden: {name}")]
+    ReservedToolHeaderOverride { name: String },
+
     #[error("Rig error: {0}")]
     Rig(String),
 }

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1309,6 +1309,7 @@ mod tests {
             timeout_secs: 300,
             headers: std::collections::HashMap::new(),
             headers_from_request: std::collections::HashMap::new(),
+            tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
         });
         let req = chat_request_with_stream(None);
 

--- a/crates/aura-web-server/tests/mcp_progress_test.rs
+++ b/crates/aura-web-server/tests/mcp_progress_test.rs
@@ -30,7 +30,7 @@ async fn test_mcp_progress_notifications_received() {
     .collect();
 
     let (result, mut progress_rx) = match client
-        .call_tool_with_progress("task_with_progress", args)
+        .call_tool_with_progress("task_with_progress", args, None)
         .await
     {
         Ok(r) => r,
@@ -122,7 +122,7 @@ async fn test_call_tool_without_progress_still_works() {
             .into_iter()
             .collect();
 
-    let result = match client.call_tool("mock_tool", args).await {
+    let result = match client.call_tool("mock_tool", args, None).await {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Tool call failed: {}", e);

--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -1,0 +1,205 @@
+//! Approver identity header overrides for gated MCP tool calls.
+//!
+//! When a HITL-gated tool call is approved over the webhook route, the
+//! approval HTTP response may carry identity headers. This module holds the
+//! types that carry those headers from capture (gate scope, webhook route
+//! only) to application (exactly one outbound MCP request, via the rmcp
+//! request-extension side-channel).
+
+use aura_config::ToolHeaderMappings;
+use reqwest::header::HeaderMap;
+
+/// Validated approver identity headers captured from one approved webhook
+/// response.
+///
+/// A value of this type exists only for an approved webhook decision whose
+/// mapped response headers were all present and valid; a partial capture
+/// is unrepresentable (construction fails closed). Construction is
+/// crate-private: the webhook client's gate-scoped path is the only
+/// producer.
+#[derive(Clone)]
+pub struct ApproverHeaders {
+    /// The validated override pairs, keys lowercased so an override replaces
+    /// the frozen default header rather than coexisting with it. The keys
+    /// are also the audit surface (names only); no separate name list
+    /// exists to fall out of sync.
+    headers: HeaderMap,
+}
+
+impl ApproverHeaders {
+    /// Capture and validate approver headers from an approval response.
+    ///
+    /// Every outbound name in `mapping` must resolve to a present response
+    /// header or the whole capture fails closed; nothing is silently
+    /// dropped.
+    #[expect(
+        unused_variables,
+        reason = "todo!() body; filled when capture wiring lands"
+    )]
+    #[expect(
+        dead_code,
+        reason = "filled when the webhook client's gate path wires capture"
+    )]
+    pub(crate) fn from_captured(
+        mapping: &ToolHeaderMappings,
+        response_headers: &HeaderMap,
+    ) -> Result<Self, CaptureError> {
+        todo!("resolve mapped response headers, fail closed on missing")
+    }
+
+    /// The captured outbound header names (never values), lowercased.
+    pub fn captured_names(&self) -> impl Iterator<Item = &str> {
+        self.headers.keys().map(reqwest::header::HeaderName::as_str)
+    }
+
+    /// Apply the overrides to an outbound request builder as per-request
+    /// headers, which override the client's frozen `default_headers` for
+    /// that one request only.
+    #[expect(
+        unused_variables,
+        reason = "todo!() body; filled when gate-to-wire wiring lands"
+    )]
+    pub(crate) fn apply_to(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        todo!("per-request .header(k, v) for each captured pair")
+    }
+}
+
+impl std::fmt::Debug for ApproverHeaders {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApproverHeaders")
+            .field("captured_names", &self.captured_names().collect::<Vec<_>>())
+            .finish_non_exhaustive()
+    }
+}
+
+// Manual impls rather than derives: `PreCallOutcome` derives `PartialEq, Eq`
+// and must keep doing so; `Eq` is sound here because `HeaderValue` equality
+// is total, and `HeaderMap` equality is order-insensitive.
+impl PartialEq for ApproverHeaders {
+    fn eq(&self, other: &Self) -> bool {
+        self.headers == other.headers
+    }
+}
+
+impl Eq for ApproverHeaders {}
+
+/// Capture-time failures: the approved webhook response could not yield
+/// the configured approver headers (fail closed).
+///
+/// The `names` payload is diagnostic-only text for the error message and
+/// the event-level audit signal: always non-empty by construction (capture
+/// fails only when at least one name is missing), lowercased outbound
+/// header names, never values, and no domain logic branches on it.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CaptureError {
+    /// Mapped response headers absent from the approved response. Invalid
+    /// values cannot occur here: capture reads a parsed `HeaderMap`, whose
+    /// values are already syntactically valid; invalid outbound names are
+    /// rejected earlier, at config parse.
+    #[error("approver identity capture failed: response missing mapped headers {names:?}")]
+    MissingHeaders { names: Vec<String> },
+}
+
+/// Application-time failures at the execution seam (double override,
+/// transport refusal), kept separate from [`CaptureError`] so a
+/// composition layer cannot wrap one as the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum OverrideApplicationError {
+    /// More than one wrapper produced overrides for one call. Identity is
+    /// never chosen by wrapper order; this is an error in release and debug
+    /// alike.
+    #[error("conflicting approver identity overrides from multiple wrappers")]
+    DoubleOverride,
+    /// The tool's transport cannot deliver per-call headers while identity
+    /// was demanded (stdio fails closed).
+    #[error("transport {kind:?} cannot deliver approver identity overrides")]
+    TransportUnsupported { kind: McpTransportKind },
+}
+
+/// Which MCP transport an adaptor was constructed for. Tagged at
+/// construction (the three `add_all_tools` branches) so the override path
+/// can fail closed on transports that cannot deliver per-request headers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpTransportKind {
+    StreamableHttp,
+    Sse,
+    Stdio,
+}
+
+/// Fail closed when `kind` cannot deliver per-call header overrides.
+/// Called at the execution seam only when overrides exist.
+#[expect(
+    unused_variables,
+    reason = "todo!() body; filled when gate-to-wire wiring lands"
+)]
+pub(crate) fn ensure_transport_delivers_overrides(
+    kind: McpTransportKind,
+    overrides: &ApproverHeaders,
+) -> Result<(), OverrideApplicationError> {
+    todo!("stdio rejects overrides; http and sse accept")
+}
+
+/// Extract approver overrides from an outbound client message, if the one
+/// request riding in it carries them as an extension. `None` for every
+/// non-request message and every request without the extension. Shared by
+/// the streamable-HTTP `post_message` and the SSE `Transport::send` read
+/// points.
+#[must_use]
+pub(crate) fn extract_from_client_message(
+    message: &rmcp::model::ClientJsonRpcMessage,
+) -> Option<ApproverHeaders> {
+    use rmcp::model::GetExtensions;
+    match message {
+        rmcp::model::JsonRpcMessage::Request(request) => request
+            .request
+            .extensions()
+            .get::<ApproverHeaders>()
+            .cloned(),
+        _ => None,
+    }
+}
+
+tokio::task_local! {
+    /// Approver header overrides for the current gated tool call. Scoped
+    /// by `WrappedTool::call` inside the inner-call spawn; read by
+    /// `McpToolAdaptor::call` via [`current_approver_overrides`].
+    /// Crate-private so nothing outside the wrapper path can inject
+    /// overrides.
+    pub(crate) static APPROVER_OVERRIDES: Option<ApproverHeaders>;
+}
+
+/// Unscoped-safe read of the current call's approver overrides.
+///
+/// `None` outside any scope. Unscoped reads are a permanent live path, not
+/// an edge case: `McpToolAdaptor` is registered WITHOUT a `WrappedTool`
+/// when no wrapper is configured. A `with`-based read would panic there;
+/// this helper never does.
+#[must_use]
+pub(crate) fn current_approver_overrides() -> Option<ApproverHeaders> {
+    APPROVER_OVERRIDES
+        .try_with(std::clone::Clone::clone)
+        .unwrap_or(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every adaptor call outside a task-local scope (wrapper-less agents)
+    /// must read `None`, never panic.
+    #[tokio::test]
+    async fn unscoped_read_yields_none() {
+        assert_eq!(current_approver_overrides(), None);
+    }
+
+    /// And the scoped read hands the value through unchanged shape-wise
+    /// (a `None` payload scoped explicitly is still `None`).
+    #[tokio::test]
+    async fn scoped_none_reads_none() {
+        APPROVER_OVERRIDES
+            .scope(None, async {
+                assert_eq!(current_approver_overrides(), None);
+            })
+            .await;
+    }
+}

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -861,6 +861,7 @@ impl Agent {
                             mcp_tool.clone(),
                             server_name.clone(),
                             Arc::clone(&client_arc),
+                            crate::approver_headers::McpTransportKind::StreamableHttp,
                         );
 
                         // Wrap with tool_wrapper if configured
@@ -894,6 +895,7 @@ impl Agent {
                             mcp_tool.clone(),
                             server_name.clone(),
                             Arc::clone(&client_arc),
+                            crate::approver_headers::McpTransportKind::Sse,
                         );
 
                         builder_state = Self::add_mcp_tool(builder_state, tool_adaptor, config);
@@ -970,6 +972,7 @@ impl Agent {
                             mcp_tool.clone(),
                             server_name.clone(),
                             Arc::clone(&client_arc),
+                            crate::approver_headers::McpTransportKind::Stdio,
                         );
 
                         builder_state = Self::add_mcp_tool(builder_state, tool_adaptor, config);

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -12,9 +12,9 @@ use aura_config::GlobPattern;
 use rig::tool::ToolError;
 use serde_json::Value;
 
-use super::decision::{AgentScope, ApprovalDecision, ApprovalOrigin, ApprovalOutcome, DecisionId};
+use super::decision::{AgentScope, ApprovalOrigin, DecisionId};
 use super::protocol::{ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
-use super::route::{ApprovalError, DecisionRoute};
+use super::route::{ApprovalError, DecisionRoute, GateDecision};
 use crate::tool_wrapper::{PreCallOutcome, ToolCallContext, ToolWrapper};
 
 /// Gates matching tool calls behind an approval decision.
@@ -71,7 +71,7 @@ impl ToolWrapper for HitlApprovalWrapper {
         ctx: &ToolCallContext,
     ) -> Result<PreCallOutcome, ToolError> {
         let Some(matched) = self.matched_pattern(&ctx.tool_name) else {
-            return Ok(PreCallOutcome::Proceed);
+            return Ok(PreCallOutcome::Proceed { overrides: None });
         };
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
@@ -90,27 +90,26 @@ impl ToolWrapper for HitlApprovalWrapper {
         let cancel =
             crate::request_cancellation::RequestCancellation::token_for_id(&self.request_id)
                 .unwrap_or_else(crate::request_cancellation::RequestCancelToken::unbound);
-        approval_result_to_pre_call(self.route.decide(request, &cancel).await)
+        approval_result_to_pre_call(self.route.decide_for_gate(request, &cancel).await)
     }
 }
 
+/// Map a gate-scoped decision to a pre-call outcome.
 fn approval_result_to_pre_call(
-    result: Result<ApprovalOutcome, ApprovalError>,
+    result: Result<GateDecision, ApprovalError>,
 ) -> Result<PreCallOutcome, ToolError> {
     match result {
-        Ok(ApprovalOutcome::Decided(ApprovalDecision::Approved)) => Ok(PreCallOutcome::Proceed),
-        Ok(ApprovalOutcome::Decided(ApprovalDecision::Denied { reason })) => {
-            Ok(PreCallOutcome::ShortCircuit {
-                output: format!(
-                    "Tool call blocked by human approval denial: {}. Do not execute this action.",
-                    reason.unwrap_or_else(|| "no reason provided".to_string())
-                ),
-            })
-        }
-        Ok(ApprovalOutcome::TimedOut { .. }) => Err(ToolError::ToolCallError(
+        Ok(GateDecision::Approved { overrides }) => Ok(PreCallOutcome::Proceed { overrides }),
+        Ok(GateDecision::Denied { reason }) => Ok(PreCallOutcome::ShortCircuit {
+            output: format!(
+                "Tool call blocked by human approval denial: {}. Do not execute this action.",
+                reason.unwrap_or_else(|| "no reason provided".to_string())
+            ),
+        }),
+        Ok(GateDecision::TimedOut { .. }) => Err(ToolError::ToolCallError(
             "tool call denied: approval timed out".to_string().into(),
         )),
-        Ok(ApprovalOutcome::Cancelled(_)) => Err(ToolError::ToolCallError(
+        Ok(GateDecision::Cancelled(_)) => Err(ToolError::ToolCallError(
             "tool call denied: approval cancelled".to_string().into(),
         )),
         Err(e) => Err(ToolError::ToolCallError(
@@ -185,19 +184,17 @@ mod tests {
     #[test]
     fn approval_result_mapping_proceeds_only_on_approval() {
         assert_eq!(
-            approval_result_to_pre_call(Ok(ApprovalOutcome::Decided(ApprovalDecision::Approved)))
-                .unwrap(),
-            PreCallOutcome::Proceed
+            approval_result_to_pre_call(Ok(GateDecision::Approved { overrides: None })).unwrap(),
+            PreCallOutcome::Proceed { overrides: None }
         );
     }
 
     #[test]
     fn approval_result_mapping_denial_is_feedback_not_error() {
-        let outcome =
-            approval_result_to_pre_call(Ok(ApprovalOutcome::Decided(ApprovalDecision::Denied {
-                reason: Some("too risky".to_string()),
-            })))
-            .unwrap();
+        let outcome = approval_result_to_pre_call(Ok(GateDecision::Denied {
+            reason: Some("too risky".to_string()),
+        }))
+        .unwrap();
 
         assert_eq!(
             outcome,
@@ -210,25 +207,24 @@ mod tests {
 
     #[test]
     fn approval_result_mapping_timeout_cancel_and_channel_fault_are_errors() {
-        let timed_out = approval_result_to_pre_call(Ok(ApprovalOutcome::TimedOut {
+        let timed_out = approval_result_to_pre_call(Ok(GateDecision::TimedOut {
             waited: Duration::from_secs(1),
         }))
         .unwrap_err()
         .to_string();
         assert!(timed_out.contains("approval timed out"));
 
-        let cancelled = approval_result_to_pre_call(Ok(ApprovalOutcome::Cancelled(
+        let cancelled = approval_result_to_pre_call(Ok(GateDecision::Cancelled(
             CancelReason::ClientDisconnected,
         )))
         .unwrap_err()
         .to_string();
         assert!(cancelled.contains("approval cancelled"));
 
-        let sender_dropped = approval_result_to_pre_call(Ok(ApprovalOutcome::Cancelled(
-            CancelReason::SenderDropped,
-        )))
-        .unwrap_err()
-        .to_string();
+        let sender_dropped =
+            approval_result_to_pre_call(Ok(GateDecision::Cancelled(CancelReason::SenderDropped)))
+                .unwrap_err()
+                .to_string();
         assert!(sender_dropped.contains("approval cancelled"));
 
         let channel_fault =

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use aura_config::{DecisionRouteConfig, GlobPattern, HitlConfig, WebhookUrl};
+use aura_config::{DecisionRouteConfig, GlobPattern, HitlConfig, ToolHeaderMappings, WebhookUrl};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
 use super::decision::{ApprovalDecision, ApprovalOutcome};
@@ -61,6 +61,7 @@ impl HitlRuntime {
                 timeout_secs,
                 headers,
                 headers_from_request,
+                tool_headers_from_response,
             } => {
                 let signing = match hmac {
                     None => EgressSigning::Disabled,
@@ -72,6 +73,7 @@ impl HitlRuntime {
                         url.clone(),
                         resolve_webhook_headers(headers, headers_from_request, req_headers),
                         signing,
+                        tool_headers_from_response.clone(),
                     ),
                     timeout: Duration::from_secs(*timeout_secs),
                 }
@@ -112,9 +114,76 @@ pub enum ApprovalError {
     /// ingress). The decision inside is untrusted and discarded.
     #[error("approval webhook response failed signature verification: {0}")]
     ResponseUnverified(String),
+    /// Approver identity capture failed closed: the approved response was
+    /// missing mapped headers. Names only, never values; the message is
+    /// the event-level audit signal. Wraps only the capture kind, so
+    /// application-time failures cannot be mislabeled as capture failures.
+    #[error("{0}")]
+    CaptureFailed(#[from] crate::approver_headers::CaptureError),
+}
+
+/// A decision as seen by the config gate.
+///
+/// An enum, not a product type: only the [`GateDecision::Approved`] variant
+/// can carry approver header overrides, so a denied, timed-out, or
+/// cancelled decision holding credentials is unrepresentable. Only
+/// [`DecisionRoute::decide_for_gate`] produces it, so the route-wide
+/// [`ApprovalOutcome`] consumed by the `request_approval` tool stays
+/// unit-shaped and that surface never holds approver credentials.
+#[derive(Debug)]
+pub enum GateDecision {
+    /// Approved; the only variant that may carry captured overrides.
+    Approved {
+        overrides: Option<crate::approver_headers::ApproverHeaders>,
+    },
+    Denied {
+        reason: Option<String>,
+    },
+    TimedOut {
+        waited: Duration,
+    },
+    Cancelled(super::decision::CancelReason),
+}
+
+impl GateDecision {
+    /// Total mapping from a route outcome, carrying no overrides: the shape
+    /// every conversational decision and every webhook decision without
+    /// captured identity produces.
+    pub(crate) fn without_overrides(outcome: ApprovalOutcome) -> Self {
+        match outcome {
+            ApprovalOutcome::Decided(ApprovalDecision::Approved) => {
+                Self::Approved { overrides: None }
+            }
+            ApprovalOutcome::Decided(ApprovalDecision::Denied { reason }) => {
+                Self::Denied { reason }
+            }
+            ApprovalOutcome::TimedOut { waited } => Self::TimedOut { waited },
+            ApprovalOutcome::Cancelled(reason) => Self::Cancelled(reason),
+        }
+    }
+
+    /// Event-projection of the decision. Identity material never enters
+    /// events; a projection method, unlike a product type, cannot
+    /// construct a denied-with-overrides state.
+    fn to_outcome(&self) -> ApprovalOutcome {
+        match self {
+            Self::Approved { .. } => ApprovalOutcome::Decided(ApprovalDecision::Approved),
+            Self::Denied { reason } => ApprovalOutcome::Decided(ApprovalDecision::Denied {
+                reason: reason.clone(),
+            }),
+            Self::TimedOut { waited } => ApprovalOutcome::TimedOut { waited: *waited },
+            Self::Cancelled(reason) => ApprovalOutcome::Cancelled(*reason),
+        }
+    }
 }
 
 /// Where an approval decision comes from. Fixed per deployment by config.
+#[expect(
+    clippy::large_enum_variant,
+    reason = "built once per request and held behind Arc, never copied; \
+              boxing the webhook client would churn every construction site \
+              for no runtime benefit"
+)]
 pub enum DecisionRoute {
     /// Attended: park in-process, decision returns via `POST /v1/approvals/{id}`.
     Conversational {
@@ -129,6 +198,62 @@ pub enum DecisionRoute {
 }
 
 impl DecisionRoute {
+    /// Obtain a decision for a config-gated call, carrying any captured
+    /// approver header overrides on the approved arm.
+    ///
+    /// The webhook arm goes through the capture-bearing client seam
+    /// ([`WebhookClient::request_approval_for_gate`]), which owns the HTTP
+    /// response, so capture is filled there without signature changes;
+    /// its event choreography mirrors [`Self::decide`]'s webhook arm. The
+    /// conversational arm delegates to [`Self::decide`]: that route has no
+    /// distinct identity source and never captures.
+    pub async fn decide_for_gate(
+        &self,
+        request: ApprovalRequest,
+        cancel: &crate::request_cancellation::RequestCancelToken,
+    ) -> Result<GateDecision, ApprovalError> {
+        match self {
+            Self::Conversational { .. } => {
+                let outcome = self.decide(request, cancel).await?;
+                Ok(GateDecision::without_overrides(outcome))
+            }
+            Self::Webhook { client, timeout } => {
+                let started = Instant::now();
+                let request_id = request.request_id.clone();
+                let decision_id = request.decision_id;
+                let scope = request.scope.clone();
+
+                approval_event_broker::publish(
+                    &request_id,
+                    ApprovalLifecycleEvent::Requested((&request).into()),
+                )
+                .await;
+
+                let result = client.request_approval_for_gate(&request, *timeout).await;
+                let completed = match &result {
+                    Ok(decision) => events::completed(
+                        decision_id,
+                        &decision.to_outcome(),
+                        &scope,
+                        started.elapsed(),
+                    ),
+                    Err(err) => events::completed_error(
+                        decision_id,
+                        err.to_string(),
+                        &scope,
+                        started.elapsed(),
+                    ),
+                };
+                approval_event_broker::publish(
+                    &request_id,
+                    ApprovalLifecycleEvent::Completed(completed),
+                )
+                .await;
+                result
+            }
+        }
+    }
+
     /// Obtain a decision for `request`, applying the shared semantics (deadline,
     /// fail-closed mapping, event emission) in one place.
     pub async fn decide(
@@ -295,6 +420,13 @@ pub struct WebhookClient {
     /// Resolved webhook headers.
     headers: HeaderMap,
     signing: EgressSigning,
+    /// Validated `tool_headers_from_response` mappings. Read only by the
+    /// gate-scoped path; empty means no capture is configured.
+    #[expect(
+        dead_code,
+        reason = "request_approval_for_gate reads this when capture wiring lands"
+    )]
+    tool_header_mappings: ToolHeaderMappings,
 }
 
 impl WebhookClient {
@@ -304,14 +436,26 @@ impl WebhookClient {
     /// which receives the startup-loaded HMAC and calls `with_signing`.
     #[must_use]
     pub fn new(client: reqwest::Client, url: WebhookUrl) -> Self {
-        Self::with_headers_and_signing(client, url, HeaderMap::new(), EgressSigning::Disabled)
+        Self::with_headers_and_signing(
+            client,
+            url,
+            HeaderMap::new(),
+            EgressSigning::Disabled,
+            ToolHeaderMappings::default(),
+        )
     }
 
     /// Create a webhook client with resolved operator-configured headers
     /// applied to every approval POST.
     #[must_use]
     pub fn new_with_headers(client: reqwest::Client, url: WebhookUrl, headers: HeaderMap) -> Self {
-        Self::with_headers_and_signing(client, url, headers, EgressSigning::Disabled)
+        Self::with_headers_and_signing(
+            client,
+            url,
+            headers,
+            EgressSigning::Disabled,
+            ToolHeaderMappings::default(),
+        )
     }
 
     fn with_headers_and_signing(
@@ -319,6 +463,7 @@ impl WebhookClient {
         url: WebhookUrl,
         headers: HeaderMap,
         signing: EgressSigning,
+        tool_header_mappings: ToolHeaderMappings,
     ) -> Self {
         // A plaintext response channel would defeat response-leg verification,
         // so http:// with a secret configured is itself a misconfiguration
@@ -345,7 +490,24 @@ impl WebhookClient {
             url,
             headers,
             signing,
+            tool_header_mappings,
         }
+    }
+
+    /// Gate-scoped approval request: the config-gate path through the
+    /// webhook. This method owns the HTTP response, so capture is filled
+    /// here — mapped approval-response headers resolved per
+    /// `tool_header_mappings`, fail closed on missing — with no further
+    /// signature change. Until capture wiring lands, every decision
+    /// carries no overrides. The route-wide [`Self::request_approval`]
+    /// path serves `request_approval` and never captures.
+    pub(crate) async fn request_approval_for_gate(
+        &self,
+        request: &ApprovalRequest,
+        timeout: Duration,
+    ) -> Result<GateDecision, ApprovalError> {
+        let outcome = self.request_approval(request, timeout).await?;
+        Ok(GateDecision::without_overrides(outcome))
     }
 
     /// Apply operator-configured headers to a request builder. Called before
@@ -1106,6 +1268,7 @@ mod tests {
                 url: aura_config::WebhookUrl::new(url).unwrap(),
                 headers: HeaderMap::new(),
                 signing: EgressSigning::Enabled(hmac),
+                tool_header_mappings: aura_config::ToolHeaderMappings::default(),
             }
         }
 
@@ -1208,6 +1371,7 @@ mod tests {
                 aura_config::WebhookUrl::new("http://approvals.example.com/aura").unwrap(),
                 HeaderMap::new(),
                 EgressSigning::Enabled(test_hmac()),
+                aura_config::ToolHeaderMappings::default(),
             );
             let err = client
                 .request_approval(
@@ -1233,6 +1397,7 @@ mod tests {
                     timeout_secs: 300,
                     headers: HashMap::new(),
                     headers_from_request: HashMap::new(),
+                    tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
                 },
             };
             let hmac = test_hmac();
@@ -1275,6 +1440,7 @@ mod tests {
                     timeout_secs: 300,
                     headers: HashMap::new(),
                     headers_from_request: HashMap::new(),
+                    tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
                 },
             };
             let pending = crate::hitl::PendingApprovals::new();
@@ -1332,6 +1498,7 @@ mod tests {
                 aura_config::WebhookUrl::new(&url).unwrap(),
                 HeaderMap::new(),
                 EgressSigning::Disabled,
+                aura_config::ToolHeaderMappings::default(),
             );
             let outcome = client
                 .request_approval(&test_request(decision_id), Duration::from_secs(5))

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -6,6 +6,7 @@
 //! programmatically.
 
 pub mod approval_event_broker;
+pub mod approver_headers;
 pub mod bedrock_embedding;
 pub mod builder;
 pub mod config;

--- a/crates/aura/src/mcp.rs
+++ b/crates/aura/src/mcp.rs
@@ -183,6 +183,12 @@ impl StreamableHttpClient for CustomHttpClient {
     > {
         use rmcp::transport::common::http_header::{HEADER_SESSION_ID, JSON_MIME_TYPE};
 
+        // Approver header overrides ride the request's extensions: present
+        // only on the one gated call whose approval captured them, and
+        // never serialized into the JSON body below (the rmcp serializer
+        // emits only `_meta`).
+        let approver_overrides = crate::approver_headers::extract_from_client_message(&message);
+
         let mut request_builder = self
             .client
             .post(uri.as_ref())
@@ -201,8 +207,17 @@ impl StreamableHttpClient for CustomHttpClient {
             request_builder = request_builder.header(HEADER_SESSION_ID, session_id.as_ref());
         }
 
+        // Per-request override headers beat the client's frozen
+        // `default_headers` for exactly this request. Applied last, after
+        // every transport-owned header above; reserved names are
+        // additionally rejected at config parse, so framing and session
+        // routing stay intact.
+        let mut request_builder = request_builder.json(&message);
+        if let Some(overrides) = approver_overrides {
+            request_builder = overrides.apply_to(request_builder);
+        }
+
         let response = request_builder
-            .json(&message)
             .send()
             .await
             .map_err(rmcp::transport::streamable_http_client::StreamableHttpError::Client)?;
@@ -1189,7 +1204,7 @@ impl McpManager {
                     tool_name
                 );
                 return client
-                    .call_tool(tool_name, args_map)
+                    .call_tool(tool_name, args_map, None)
                     .await
                     .map_err(|e| format!("Tool execution failed: {}", e));
             }
@@ -1202,7 +1217,7 @@ impl McpManager {
             {
                 info!("Executing fallback tool '{}' via SSE", tool_name);
                 return client
-                    .call_tool(tool_name, args_map)
+                    .call_tool(tool_name, args_map, None)
                     .await
                     .map_err(|e| format!("Tool execution failed: {}", e));
             }
@@ -1215,7 +1230,7 @@ impl McpManager {
             {
                 info!("Executing fallback tool '{}' via STDIO", tool_name);
                 return client
-                    .call_tool(tool_name, args_map)
+                    .call_tool(tool_name, args_map, None)
                     .await
                     .map_err(|e| format!("Tool execution failed: {}", e));
             }
@@ -1297,7 +1312,11 @@ macro_rules! create_mcp_tool_struct {
 
                 debug!("  Arguments: {:?}", arguments);
 
-                match self.client.call_tool(&self.tool_name, arguments).await {
+                match self
+                    .client
+                    .call_tool(&self.tool_name, arguments, None)
+                    .await
+                {
                     Ok(response) => {
                         debug!("  Response: {}", response);
                         let response_summary = if response.len() > 200 {
@@ -1398,7 +1417,11 @@ impl RigTool for StreamableHttpMcpTool {
         debug!("  Arguments: {:?}", arguments);
 
         // Call the streamable HTTP client
-        match self.client.call_tool(&self.tool_name, arguments).await {
+        match self
+            .client
+            .call_tool(&self.tool_name, arguments, None)
+            .await
+        {
             Ok(result) => {
                 debug!("  Tool execution successful");
                 let response_summary = if result.len() > 200 {
@@ -1556,7 +1579,7 @@ impl RigTool for FallbackHttpMcpTool {
         // Call the streamable HTTP client using the original tool name
         match self
             .client
-            .call_tool(&self.original_tool_name, arguments)
+            .call_tool(&self.original_tool_name, arguments, None)
             .await
         {
             Ok(result) => {

--- a/crates/aura/src/mcp_dynamic.rs
+++ b/crates/aura/src/mcp_dynamic.rs
@@ -6,6 +6,9 @@ use rig::tool::{Tool as RigTool, ToolError};
 use rmcp::model::Tool as McpTool;
 use serde_json::Value;
 
+use crate::approver_headers::{
+    McpTransportKind, current_approver_overrides, ensure_transport_delivers_overrides,
+};
 use crate::mcp_streamable_http::McpClient;
 use crate::mcp_tool_execution::execute_mcp_tool;
 
@@ -16,14 +19,29 @@ pub struct McpToolAdaptor {
     #[allow(dead_code)]
     server_name: String,
     client: Arc<McpClient>,
+    /// Which transport this adaptor fronts, tagged at construction. The
+    /// approver-override path fails closed on transports that cannot
+    /// deliver per-request headers.
+    transport_kind: McpTransportKind,
 }
 
 impl McpToolAdaptor {
-    pub fn new(tool: McpTool, server_name: String, client: Arc<McpClient>) -> Self {
+    /// `transport_kind` must name the transport `client` actually fronts;
+    /// the type cannot enforce it because one `McpClient` serves all three
+    /// transports. Construction sites are the three `add_all_tools`
+    /// branches in `builder.rs`; a mistag bypasses the stdio fail-closed
+    /// check.
+    pub fn new(
+        tool: McpTool,
+        server_name: String,
+        client: Arc<McpClient>,
+        transport_kind: McpTransportKind,
+    ) -> Self {
         Self {
             tool,
             server_name,
             client,
+            transport_kind,
         }
     }
 }
@@ -71,10 +89,22 @@ impl RigTool for McpToolAdaptor {
     ) -> Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send + Sync + '_>> {
         let tool_name = self.tool.name.clone();
         let client = self.client.clone();
+        let transport_kind = self.transport_kind;
 
         Box::pin(async move {
+            // Approver header overrides for this call, if the HITL gate
+            // captured any. Unscoped reads yield `None` (wrapper-less
+            // agents).
+            let approver_overrides = current_approver_overrides();
+            if let Some(overrides) = &approver_overrides {
+                // Fail closed before dispatch when the transport cannot
+                // deliver per-request headers.
+                ensure_transport_delivers_overrides(transport_kind, overrides)
+                    .map_err(|e| ToolError::ToolCallError(Box::new(e)))?;
+            }
+
             // Use shared execution function for consistent logging and error handling
-            execute_mcp_tool(&client, &tool_name, args).await
+            execute_mcp_tool(&client, &tool_name, args, approver_overrides).await
         })
     }
 }

--- a/crates/aura/src/mcp_sse.rs
+++ b/crates/aura/src/mcp_sse.rs
@@ -43,10 +43,18 @@ impl Transport<RoleClient> for SseTransport {
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
         let client = self.http_client.clone();
         let uri = self.message_endpoint.clone();
+        // Approver header overrides ride the request's extensions;
+        // never serialized into the JSON body below.
+        let approver_overrides = crate::approver_headers::extract_from_client_message(&item);
         async move {
-            let response = client
-                .post(uri.as_str())
-                .json(&item)
+            // Per-request override headers beat the client's frozen
+            // `default_headers` for exactly this request. Applied last,
+            // after `.json` sets the transport's content-type.
+            let mut request_builder = client.post(uri.as_str()).json(&item);
+            if let Some(overrides) = approver_overrides {
+                request_builder = overrides.apply_to(request_builder);
+            }
+            let response = request_builder
                 .send()
                 .await
                 .map_err(SseTransportError::Http)?;

--- a/crates/aura/src/mcp_streamable_http.rs
+++ b/crates/aura/src/mcp_streamable_http.rs
@@ -23,9 +23,26 @@ use std::time::Duration;
 use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, error, info, warn};
 
+use crate::approver_headers::ApproverHeaders;
 use crate::mcp_progress::ProgressEnabledHandler;
 use crate::mcp_response::extract_tool_result;
 use crate::tool_event_broker::{peek_tool_call_id, publish_tool_start};
+
+/// Build the CallTool request, attaching approver header overrides as a
+/// request extension when present. The extension rides on this one
+/// request value through the transport worker and is never serialized to
+/// the wire, so one-call scoping is structural. Every `call_tool*` variant
+/// constructs its request here.
+fn call_tool_request(
+    request_param: CallToolRequestParam,
+    approver_overrides: Option<ApproverHeaders>,
+) -> ClientRequest {
+    let mut request = Request::new(request_param);
+    if let Some(overrides) = approver_overrides {
+        request.extensions.insert(overrides);
+    }
+    ClientRequest::CallToolRequest(request)
+}
 
 const CANCEL_NOTIFICATION_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -241,6 +258,7 @@ impl McpClient {
         &self,
         tool_name: &str,
         arguments: HashMap<String, Value>,
+        approver_overrides: Option<ApproverHeaders>,
     ) -> Result<String> {
         if let Some(http_request_id) = self.get_current_request().await {
             info!(
@@ -248,7 +266,7 @@ impl McpClient {
                 tool_name, http_request_id
             );
             return self
-                .call_tool_tracked(tool_name, arguments, &http_request_id)
+                .call_tool_tracked(tool_name, arguments, &http_request_id, approver_overrides)
                 .await;
         }
 
@@ -264,11 +282,25 @@ impl McpClient {
             arguments: Some(args_map),
         };
 
-        match self.client.call_tool(request_param).await {
-            Ok(result) => {
+        // Constructed explicitly (not rmcp's convenience `call_tool`) so
+        // this branch shares the one request-construction site that
+        // accepts the override extension; same shape as the tracked
+        // branch, minus tracking.
+        let handle = self
+            .client
+            .send_cancellable_request(
+                call_tool_request(request_param, approver_overrides),
+                PeerRequestOptions::no_options(),
+            )
+            .await
+            .context("Failed to send tool call request")?;
+
+        match handle.await_response().await {
+            Ok(rmcp::model::ServerResult::CallToolResult(result)) => {
                 debug!("Tool '{}' executed successfully", tool_name);
                 extract_tool_result(result, tool_name).map(|outcome| outcome.into_prefixed_string())
             }
+            Ok(_) => Err(anyhow::anyhow!("Unexpected response type for tool call")),
             Err(err) => {
                 error!("Failed to execute tool '{}': {}", tool_name, err);
                 Err(anyhow::anyhow!("Tool execution failed: {}", err))
@@ -281,6 +313,7 @@ impl McpClient {
         &self,
         tool_name: &str,
         arguments: HashMap<String, Value>,
+        approver_overrides: Option<ApproverHeaders>,
     ) -> Result<(String, mpsc::Receiver<ProgressNotificationParam>)> {
         debug!(
             "Calling tool '{}' with progress tracking, args: {:?}",
@@ -296,7 +329,7 @@ impl McpClient {
         let handle = self
             .client
             .send_cancellable_request(
-                ClientRequest::CallToolRequest(Request::new(request_param)),
+                call_tool_request(request_param, approver_overrides),
                 PeerRequestOptions::no_options(),
             )
             .await
@@ -356,6 +389,7 @@ impl McpClient {
         tool_name: &str,
         arguments: HashMap<String, Value>,
         cancel_token: tokio_util::sync::CancellationToken,
+        approver_overrides: Option<ApproverHeaders>,
     ) -> Result<String> {
         use rmcp::model::{CancelledNotification, CancelledNotificationParam};
 
@@ -373,7 +407,7 @@ impl McpClient {
         let handle = self
             .client
             .send_cancellable_request(
-                ClientRequest::CallToolRequest(Request::new(request_param)),
+                call_tool_request(request_param, approver_overrides),
                 PeerRequestOptions::no_options(),
             )
             .await
@@ -431,6 +465,7 @@ impl McpClient {
         tool_name: &str,
         arguments: HashMap<String, Value>,
         http_request_id: &str,
+        approver_overrides: Option<ApproverHeaders>,
     ) -> Result<String> {
         debug!(
             "Calling tool '{}' with tracking (http_request_id={})",
@@ -445,7 +480,7 @@ impl McpClient {
         let handle = self
             .client
             .send_cancellable_request(
-                ClientRequest::CallToolRequest(Request::new(request_param)),
+                call_tool_request(request_param, approver_overrides),
                 PeerRequestOptions::no_options(),
             )
             .await

--- a/crates/aura/src/mcp_tool_execution.rs
+++ b/crates/aura/src/mcp_tool_execution.rs
@@ -95,11 +95,12 @@ fn record_tool_call_result(span: &tracing::Span, result: &Result<String, anyhow:
 /// 2. Response preview for large outputs
 /// 3. Standardized error handling
 /// 4. Per-request cancellation support (when executed within a cancellation context)
-#[tracing::instrument(name = "mcp.tool_call", skip(client, args), fields(tool.name = %tool_name, server.url = %client.server_url()))]
+#[tracing::instrument(name = "mcp.tool_call", skip(client, args, approver_overrides), fields(tool.name = %tool_name, server.url = %client.server_url()))]
 pub async fn execute_mcp_tool(
     client: &McpClient,
     tool_name: &str,
     args: Value,
+    approver_overrides: Option<crate::approver_headers::ApproverHeaders>,
 ) -> Result<String, ToolError> {
     let span = tracing::Span::current();
 
@@ -127,7 +128,7 @@ pub async fn execute_mcp_tool(
         _ => HashMap::new(),
     };
 
-    let result = call_http_tool_cancellable(client, tool_name, args_map).await;
+    let result = call_http_tool_cancellable(client, tool_name, args_map, approver_overrides).await;
 
     // OTel: record result attributes
     record_tool_call_result(&span, &result);

--- a/crates/aura/src/orchestration/tools/wait_for.rs
+++ b/crates/aura/src/orchestration/tools/wait_for.rs
@@ -518,7 +518,8 @@ impl ProbeDispatcher for McpProbeDispatcher {
             .resolve(tool_name)
             .ok_or(ProbeSampleError::UnknownTool)?;
         let args = serde_json::Value::Object(probe.args().clone());
-        Ok(execute_mcp_tool(client, tool_name, args).await?)
+        // Probes are liveness checks and never carry approver identity.
+        Ok(execute_mcp_tool(client, tool_name, args, None).await?)
     }
 }
 

--- a/crates/aura/src/request_cancellation.rs
+++ b/crates/aura/src/request_cancellation.rs
@@ -138,8 +138,9 @@ pub async fn call_http_tool_cancellable(
     client: &McpClient,
     tool_name: &str,
     args: HashMap<String, Value>,
+    approver_overrides: Option<crate::approver_headers::ApproverHeaders>,
 ) -> Result<String> {
-    client.call_tool(tool_name, args).await
+    client.call_tool(tool_name, args, approver_overrides).await
 }
 
 #[cfg(test)]

--- a/crates/aura/src/tool_wrapper.rs
+++ b/crates/aura/src/tool_wrapper.rs
@@ -158,8 +158,13 @@ pub struct TransformOutputResult {
 /// Result of an async pre-call gate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PreCallOutcome {
-    /// Continue to the wrapped tool.
-    Proceed,
+    /// Continue to the wrapped tool, optionally carrying approver header
+    /// overrides captured at approval. `None` everywhere except an approved
+    /// config-gated call whose webhook response carried the configured
+    /// identity headers.
+    Proceed {
+        overrides: Option<crate::approver_headers::ApproverHeaders>,
+    },
     /// Skip the wrapped tool and return this output as a successful tool result.
     ShortCircuit { output: String },
 }
@@ -327,7 +332,7 @@ pub trait ToolWrapper: Send + Sync {
         _args: &Value,
         _ctx: &ToolCallContext,
     ) -> Result<PreCallOutcome, ToolError> {
-        Ok(PreCallOutcome::Proceed)
+        Ok(PreCallOutcome::Proceed { overrides: None })
     }
 
     /// Async hook called after tool completion (success or failure).
@@ -505,8 +510,13 @@ where
                 Ok(r) => r,
                 Err(join_error) => Err(ToolError::ToolCallError(join_error.into())),
             };
-            match pre_call_result {
-                Ok(PreCallOutcome::Proceed) => {}
+            let approver_overrides = match pre_call_result {
+                // Approver overrides are scoped into the task-local inside
+                // the inner-call spawn below — task-locals do not cross a
+                // spawn, the value is known here after pre_call, and a
+                // demanded override silently degrading to None would
+                // proceed under cached identity, which is fail-open.
+                Ok(PreCallOutcome::Proceed { overrides }) => overrides,
                 Ok(PreCallOutcome::ShortCircuit { output }) => {
                     let duration_ms = start.elapsed().as_millis() as u64;
 
@@ -547,7 +557,7 @@ where
 
                     return Err(pre_call_error);
                 }
-            }
+            };
 
             // Call inner tool (spawn to handle non-Sync futures).
             // Propagate the current span so mcp.tool_call nests under execute_tool.
@@ -555,7 +565,9 @@ where
             let args_clone = clean_args.clone();
             let tool_span = tracing::Span::current();
             let result_handle = tokio::spawn(tracing::Instrument::instrument(
-                async move { inner_clone.call(args_clone).await },
+                crate::approver_headers::APPROVER_OVERRIDES.scope(approver_overrides, async move {
+                    inner_clone.call(args_clone).await
+                }),
                 tool_span,
             ));
 
@@ -705,13 +717,28 @@ impl ToolWrapper for ComposedWrapper {
         // Forward to each wrapper in order, short-circuiting on the first
         // non-proceed outcome. Without this, a composed gate (e.g. HITL) would
         // silently inherit the no-op default and never run.
+        //
+        // At most one wrapper may produce approver overrides. Identity is
+        // never chosen by wrapper order, so a second producer is a
+        // deterministic error in release and debug alike, not last-wins.
+        let mut overrides: Option<crate::approver_headers::ApproverHeaders> = None;
         for wrapper in &self.wrappers {
             match wrapper.pre_call(args, ctx).await? {
-                PreCallOutcome::Proceed => {}
+                PreCallOutcome::Proceed {
+                    overrides: produced,
+                } => match (overrides.is_some(), produced) {
+                    (true, Some(_)) => {
+                        return Err(ToolError::ToolCallError(Box::new(
+                            crate::approver_headers::OverrideApplicationError::DoubleOverride,
+                        )));
+                    }
+                    (false, Some(produced)) => overrides = Some(produced),
+                    (_, None) => {}
+                },
                 outcome @ PreCallOutcome::ShortCircuit { .. } => return Ok(outcome),
             }
         }
-        Ok(PreCallOutcome::Proceed)
+        Ok(PreCallOutcome::Proceed { overrides })
     }
 
     fn transform_output(
@@ -1041,7 +1068,7 @@ mod tests {
                 _c: &ToolCallContext,
             ) -> Result<PreCallOutcome, ToolError> {
                 self.0.store(true, Ordering::SeqCst);
-                Ok(PreCallOutcome::Proceed)
+                Ok(PreCallOutcome::Proceed { overrides: None })
             }
         }
 


### PR DESCRIPTION
Enable HITL webhook approvals to forward approver headers to downstream MCP calls.

## Problem
Currently, MCP calls from approved tools use the original requester's identity headers, not the approver's. This prevents forwarding approver authentication or authorization tokens to backend services.

## Solution
Add `tool_headers_from_response` configuration to map headers from webhook approval responses to MCP tool calls. The feature:

- Forwards configured headers from webhook responses to approved MCP calls
- Validates header names and rejects invalid configurations
- Fails closed if mapped headers are missing from webhook responses
- Works with HTTP and SSE MCP transports
- Redacts header values from logs for security

## Configuration
```toml
[hitl.route]
mode = "webhook"
url = "https://approvals.example.com/hook"
# Map: webhook response header → MCP call header
tool_headers_from_response = { "authorization" = "x-approver-token" }
```

Security
- Fail-closed design: Missing mapped headers cause approval failure
- Header validation: Invalid header names rejected at config parse
- Value redaction: Header values never appear in logs
- Transport limits: Stdio transport fails if headers would be required

Implementation notes
- Uses rmcp request extensions (no wire protocol changes)
- Applies headers after transport-owned headers
- Validates duplicates and reserved header names
- Unit and integration tested

Refs #496