### PR TITLE
ci(packaging): publish deb and rpm packages to cloudsmith

### DIFF
--- a/.makefiles/rust.mk
+++ b/.makefiles/rust.mk
@@ -234,9 +234,15 @@ build-checksums: ## Write sha256 checksums for the release artifacts (binaries +
 		[ -n "$$files" ] || { echo "error: no release artifacts found in $(DIST_DIR)" >&2; exit 1; }; \
 		printf '%s\n' "$$files" | xargs sha256sum > checksums.txt
 
+# ARCHS and PACKAGERS reach the script through env, which $(RUN) does not carry
+# into the container on its own.
 .PHONY: build-packages
 build-packages: $(DIST_DIR) $(DOCKER_ENV) ## Build .deb/.rpm packages from the linux binaries in dist (PACKAGE_VERSION overrides the version)
-	$(RUN) ./scripts/build-packages.sh $(PACKAGE_VERSION)
+	$(RUN) env ARCHS="$(ARCHS)" PACKAGERS="$(PACKAGERS)" ./scripts/build-packages.sh $(PACKAGE_VERSION)
+
+.PHONY: publish-packages
+publish-packages: $(DOCKER_ENV) ## Publish the .deb/.rpm packages in dist to Cloudsmith (requires CLOUDSMITH_API_KEY)
+	$(RUN) env PACKAGERS="$(PACKAGERS)" ./scripts/publish-packages.sh
 
 # Every binary a complete release must contain, across all platforms.
 EXPECTED_BINARIES := \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ ARG NFPM_VERSION=2.47.0
 ARG NFPM_SHA256_AMD64=0660ca602b2d2d2ae4781a06c692b3eeb9d437ffea05b831d76e41f4a3188783
 ARG NFPM_SHA256_ARM64=1c0f5f2999b9a974bfb04fdb0cc3306096de530ac5dbb25d739cc5f5219c919c
 
+# The cloudsmith CLI publishes the .deb/.rpm packages.
+ARG CLOUDSMITH_VERSION=1.21.0
+ARG CLOUDSMITH_SHA256_AMD64=e3729f8fc58e44ae9f7f50af197ab9d99b4b70551b7cbe83cf423d58aadc390b
+ARG CLOUDSMITH_SHA256_ARM64=50c3fd0d7486eb9577bd713240c04f3d9d75a9da424ea944a51b105e13e15901
+
 ### 000 Chef
 FROM lukemathwalker/cargo-chef:latest-rust-1.95@sha256:00c3c07c51d092325df88f0df2d626cd4302e12933f179ba154509cc314d6c2a AS chef
 
@@ -158,6 +163,28 @@ RUN <<EOR
   tar -xzf /tmp/nfpm.tar.gz -C /usr/local/bin nfpm
   rm /tmp/nfpm.tar.gz /tmp/nfpm.tar.gz.sha256
   nfpm --version
+EOR
+
+# A PyInstaller bundle: the executable resolves its payload beside its real
+# path, so the directory is unpacked whole and only the entrypoint linked.
+ARG CLOUDSMITH_VERSION
+ARG CLOUDSMITH_SHA256_AMD64
+ARG CLOUDSMITH_SHA256_ARM64
+RUN <<EOR
+  set -e
+  case "$(uname -m)" in
+    x86_64)  cs_arch=x86_64;  cs_sha=${CLOUDSMITH_SHA256_AMD64};;
+    aarch64) cs_arch=aarch64; cs_sha=${CLOUDSMITH_SHA256_ARM64};;
+    *) echo "unsupported build arch: $(uname -m)" >&2; exit 1;;
+  esac
+  curl -fsSL -o /tmp/cloudsmith.tar.gz "https://github.com/cloudsmith-io/cloudsmith-cli/releases/download/v${CLOUDSMITH_VERSION}/cloudsmith-${CLOUDSMITH_VERSION}-linux-${cs_arch}-gnu.tar.gz"
+  printf '%s  /tmp/cloudsmith.tar.gz\n' "${cs_sha}" > /tmp/cloudsmith.tar.gz.sha256
+  sha256sum -c /tmp/cloudsmith.tar.gz.sha256
+  mkdir -p /opt/cloudsmith
+  tar -xzf /tmp/cloudsmith.tar.gz --strip-components=1 -C /opt/cloudsmith
+  ln -s /opt/cloudsmith/cloudsmith /usr/local/bin/cloudsmith
+  rm /tmp/cloudsmith.tar.gz /tmp/cloudsmith.tar.gz.sha256
+  cloudsmith --version
 EOR
 
 COPY --from=sccache-dl /usr/local/bin/sccache /usr/local/bin/sccache

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,10 @@ def RELEASE_CREDENTIALS = [
      credentialsId: 'github-app-key-mezmo-aura',
      passwordVariable: 'GITHUB_TOKEN',
      usernameVariable: 'GITHUB_APP'
+   ),
+   string(
+     credentialsId: 'cloudsmith-api-key',
+     variable: 'CLOUDSMITH_API_KEY'
    )
 ]
 
@@ -319,46 +323,82 @@ pipeline {
           }
         }
 
-        // Cheap release preview: confirms commits parse and a version
-        // computes, with no image build (that happens at main Release).
-        stage('Release Dry Run') {
-          when {
-            beforeAgent true
-            not {
-              expression { CURRENT_BRANCH == DEFAULT_BRANCH }
-            }
-          }
-
-          agent {
-            node {
-              label 'ec2-fleet-oss'
-              customWorkspace("/tmp/workspace/${BUILD_SLUG}-dryrun")
-            }
-          }
-
-          tools {
-            nodejs 'NodeJS 24'
-          }
-
-          environment {
-            GIT_BRANCH = "${CURRENT_BRANCH}"
-            BRANCH_NAME = "${CURRENT_BRANCH}"
-            CHANGE_ID = ''
-            ENABLE_DOCKER = 'false'
-          }
-
-          steps {
-            // package-lock=false in .npmrc means npm ci cannot be used.
-            sh 'npm install'
-            sh "git checkout -B ${CURRENT_BRANCH}"
-            withReport('Release Test', "npm run release:dry -- --repository-url=file://${env.WORKSPACE} --plugins @semantic-release/commit-analyzer")
-          }
-        }
       }
 
       post {
         always {
           sh 'make test-integration-down'
+        }
+      }
+    }
+
+    // Release preview: confirms commits parse, a version computes, and the
+    // package publish authenticates. Sequential, because it rewrites crate
+    // versions in the workspace the test lane also builds in.
+    stage('Release Dry Run') {
+      when {
+        beforeAgent true
+        not {
+          anyOf {
+            changelog '\\[skip ci\\]'
+            expression { CURRENT_BRANCH == DEFAULT_BRANCH }
+          }
+        }
+      }
+
+      environment {
+        GIT_BRANCH = "${CURRENT_BRANCH}"
+        BRANCH_NAME = "${CURRENT_BRANCH}"
+        SCCACHE_BUCKET = "${BUILD_CACHE_BUCKET}"
+        SCCACHE_REGION = "${BUILD_CACHE_REGION}"
+        SCCACHE_S3_KEY_PREFIX = 'aura/sccache/'
+      }
+
+      steps {
+        script {
+          // This stage commits and rewrites crate versions in the workspace
+          // that later stages build from, so the tree is restored once the dry
+          // run is done with it.
+          def startSha = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
+          try {
+            sh "git checkout -B ${CURRENT_BRANCH}"
+
+            // A breaking empty commit guarantees a version is computed, so the
+            // verify path runs on every change request.
+            sh "git commit --allow-empty -m 'feat!: exercise the release dry run' -m 'BREAKING CHANGE: forced bump'"
+
+            def nextVersion = sh(
+              script: "npm run --silent release:version 'file://${env.WORKSPACE}'",
+              returnStdout: true
+            ).trim()
+            if (!nextVersion) {
+              error('Release dry run computed no version')
+            }
+            echo "Release dry run version: ${nextVersion}"
+
+            sh "./scripts/set-version.sh ${nextVersion}"
+
+            // One arch, so verifyReleaseCmd has a real package to dry-run push.
+            withCredentials([
+              aws(
+                credentialsId: 'oss-aws-build-cache',
+                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+              )
+            ]) {
+              withEnv(['AURA_RUSTC_WRAPPER=sccache']) {
+                sh 'make build-binary-linux-amd64'
+              }
+            }
+
+            sh "ARCHS=amd64 make build-packages"
+
+            withCredentials(RELEASE_CREDENTIALS) {
+              withReport('Release Test', "npm run release:dry -- --repository-url=file://${env.WORKSPACE} --plugins @semantic-release/commit-analyzer @semantic-release/exec")
+            }
+          } finally {
+            sh "git reset --hard ${startSha}"
+          }
         }
       }
     }
@@ -411,16 +451,12 @@ pipeline {
       stages {
         stage('Compute Release Version') {
           steps {
-            withCredentials(RELEASE_CREDENTIALS) {
-              script {
-                try {
-                  sh 'npm run release:dry -- --plugins @semantic-release/commit-analyzer @semantic-release/exec'
-                  env.NEXT_RELEASE_VERSION = fileExists('.next-release-version') ? readFile('.next-release-version').trim() : ''
-                } finally {
-                  sh 'rm -f .next-release-version'
-                }
-                echo env.NEXT_RELEASE_VERSION ? "Release version: ${env.NEXT_RELEASE_VERSION}" : 'No release version determined; skipping build'
-              }
+            script {
+              env.NEXT_RELEASE_VERSION = sh(
+                script: 'npm run --silent release:version',
+                returnStdout: true
+              ).trim()
+              echo env.NEXT_RELEASE_VERSION ? "Release version: ${env.NEXT_RELEASE_VERSION}" : 'No release version determined; skipping build'
             }
           }
         }

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ RUNNER_TOOLCHAIN_ENV := -e CARGO_HOME=/home/aura/.cargo -e RUSTUP_HOME=/home/aur
 # Compiler-cache passthrough, gated on the CI toggle so local $(RUN) is
 # unchanged. Bare -e copies AWS values from the host environment.
 SCCACHE_RUN_ENV = $(if $(AURA_RUSTC_WRAPPER),-e RUSTC_WRAPPER=$(AURA_RUSTC_WRAPPER) -e SCCACHE_BUCKET -e SCCACHE_REGION -e SCCACHE_S3_KEY_PREFIX -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY,)
+# Cloudsmith values for publish-packages, gated on the key so local $(RUN) is
+# unchanged. Bare -e copies them from the host environment.
+CLOUDSMITH_RUN_ENV = $(if $(CLOUDSMITH_API_KEY),-e CLOUDSMITH_API_KEY -e CLOUDSMITH_REPO -e CLOUDSMITH_DISTRO,) $(if $(DRY_RUN),-e DRY_RUN,)
 # Native (non-Docker) builds run cargo directly in this process's environment,
 # so translate the AURA_RUSTC_WRAPPER toggle into the RUSTC_WRAPPER cargo reads.
 # The SCCACHE_* and AWS values are inherited from the host env alongside it.
@@ -50,7 +53,7 @@ ifneq ($(AURA_RUSTC_WRAPPER),)
 RUSTC_WRAPPER := $(AURA_RUSTC_WRAPPER)
 endif
 endif
-RUNNER_CMD = $(DOCKER_RUN) --env-file=$(DOCKER_ENV) $(RUNNER_TOOLCHAIN_ENV) $(SCCACHE_RUN_ENV) $(if $(filter true, $(IS_CI)), ,-t) -v $(PWD):/home/aura $(AURA_RUNNER_IMAGE)
+RUNNER_CMD = $(DOCKER_RUN) --env-file=$(DOCKER_ENV) $(RUNNER_TOOLCHAIN_ENV) $(SCCACHE_RUN_ENV) $(CLOUDSMITH_RUN_ENV) $(if $(filter true, $(IS_CI)), ,-t) -v $(PWD):/home/aura $(AURA_RUNNER_IMAGE)
 RUNNER_NO_ENV_CMD = $(DOCKER_RUN) $(if $(filter true, $(IS_CI)),,-t) -v $(PWD):/home/aura $(AURA_RUNNER_IMAGE)
 DOCKER_RUN_BUILD_ENV := $(RUNNER_CMD)
 BUILD_SLUG := $(call slugify, $(BUILD_TAG))

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue" alt="Apache License, Version 2.0"></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-compatible-green" alt="Model Context Protocol compatible"></a>
+  <a href="https://cloudsmith.com"><img src="https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith" alt="OSS hosting by Cloudsmith"></a>
 </div>
 
 Connect your stack through guided setup, and AURA's preconfigured team of agents starts investigating incidents using the models you already rely on. From there, customize existing agents or add new ones to fit your infrastructure and SRE workflows.
@@ -118,6 +119,10 @@ Through compatible [MCP](https://modelcontextprotocol.io) servers, AURA agents c
 ## Community
 
 Join the [AURA Slack community](https://mezmo.com/r/slack-aura) to ask questions, share what you are building, and help shape the roadmap.
+
+## Package Hosting
+
+Package repository hosting is graciously provided by [Cloudsmith](https://cloudsmith.com), the only fully hosted, cloud-native, universal package management solution — letting your organization create, store, and share packages in any format, to any place, with total confidence.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "commitlint": "commitlint-mzm --format=pretty",
     "release": "semantic-release",
-    "release:dry": "semantic-release --no-ci --dry-run --branches=${BRANCH_NAME:-main}"
+    "release:dry": "semantic-release --no-ci --dry-run --branches=${BRANCH_NAME:-main}",
+    "release:version": "node scripts/next-version.mjs"
   },
   "repository": {
     "type": "git",

--- a/release.config.js
+++ b/release.config.js
@@ -45,8 +45,10 @@ module.exports = {
   dockerTags,
   // https://github.com/semantic-release/exec
   prepareCmd: `./scripts/set-version.sh \${nextRelease.version}`,
-  verifyReleaseCmd: `echo \${nextRelease.version} > .next-release-version && ./scripts/bump-homebrew-tap.sh --dry-run \${nextRelease.version}`,
-  successCmd: `./scripts/bump-homebrew-tap.sh \${nextRelease.version}`,
+  // The dry-run push needs the packages already in dist/, so a release dry run
+  // has to be preceded by `make build-packages`.
+  verifyReleaseCmd: `./scripts/bump-homebrew-tap.sh --dry-run \${nextRelease.version} && DRY_RUN=1 make publish-packages`,
+  successCmd: `./scripts/bump-homebrew-tap.sh \${nextRelease.version} && make publish-packages`,
   // https://github.com/esatterwhite/semantic-release-docker
   dockerProject: 'mezmo',
   dockerImage: 'aura',
@@ -63,4 +65,5 @@ module.exports = {
   plugins: plugins
 }
 
-console.dir(module.exports, {depth: 10})
+// stderr, so a caller reading a version off stdout is not fed the config.
+console.error(require('node:util').inspect(module.exports, {depth: 10}))

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,9 +4,12 @@ Release and install helpers.
 
 | Script | Purpose |
 | --- | --- |
-| [`install.sh`](install.sh) | Install AURA binaries from GitHub Releases |
+| [`install.sh`](install.sh) | Install AURA from the Cloudsmith package repository or GitHub Releases |
+| [`build-packages.sh`](build-packages.sh) | Build `.deb`/`.rpm` packages from the Linux release binaries |
+| [`publish-packages.sh`](publish-packages.sh) | Publish the built `.deb`/`.rpm` packages to Cloudsmith |
 | [`bump-homebrew-tap.sh`](bump-homebrew-tap.sh) | Bump `mezmo/homebrew-tap` formulae to a released version |
 | [`set-version.sh`](set-version.sh) | Set the workspace and crate versions in `Cargo.toml` |
+| [`next-version.mjs`](next-version.mjs) | Print the version semantic-release would release next |
 
 ## `install.sh`
 
@@ -27,12 +30,12 @@ curl -fsSL .../install.sh | AURA_COMPONENT=cli AURA_VERSION=0.1.3 bash
 
 | Variable | Default | Effect |
 | --- | --- | --- |
-| `AURA_VERSION` | `latest` | Release tag to install. A leading `v` is optional (`0.1.3` and `v0.1.3` both work). `latest` is resolved by following the `releases/latest` redirect. |
+| `AURA_VERSION` | `latest` | Version to install. A leading `v` is optional (`0.1.3` and `v0.1.3` both work). For `direct`, `latest` follows the `releases/latest` redirect; for `deb`/`rpm` it pins the package version, and `latest` lets the package manager pick. |
 | `AURA_INSTALL_METHOD` | `auto` | How to install: `auto`, `homebrew`, `direct`, `deb`, or `rpm`. See below. Any other value is an error. |
 | `AURA_INSTALL_PATH` | `~/.local/bin` | Install directory for the `direct` method. Created if missing. The `homebrew`, `deb`, and `rpm` methods install to their own prefixes and ignore it. |
 | `AURA_COMPONENT` | `all` | Which binaries to install: `all`, `server` (`aura-web-server` only), or `cli` (`aura` only). Any other value is an error. |
-| `AURA_REQUIRE_CHECKSUM` | `1` | `0` downgrades a missing `checksums.txt`, or a missing entry for an asset, to a warning instead of a fatal error. A checksum *mismatch* is always fatal. |
-| `AURA_CHECKSUMS` | unset | Path to a local `checksums.txt` to verify against, instead of downloading one from the release. |
+| `AURA_REQUIRE_CHECKSUM` | `1` | `direct` only. `0` downgrades a missing `checksums.txt`, or a missing entry for an asset, to a warning instead of a fatal error. A checksum *mismatch* is always fatal. |
+| `AURA_CHECKSUMS` | unset | `direct` only. Path to a local `checksums.txt` to verify against, instead of downloading one from the release. |
 
 ### Install methods
 
@@ -49,23 +52,60 @@ every method.
   moves on.
 - `homebrew` installs from the `mezmo/tap` tap. It cannot pin `AURA_VERSION` or
   honor `AURA_INSTALL_PATH`.
-- `direct` downloads the release binaries into `AURA_INSTALL_PATH`.
-- `deb` / `rpm` download the release's system packages and install them to
-  `/usr/bin`, escalating with `sudo` if not already root. Linux only; they
-  cannot honor `AURA_INSTALL_PATH`.
+- `direct` downloads the release binaries into `AURA_INSTALL_PATH` and verifies
+  them against the release `checksums.txt`.
+- `deb` / `rpm` register the [Cloudsmith](https://cloudsmith.com) package
+  repository and install through the system package manager, escalating with
+  `sudo` if not already root, so later upgrades arrive with `apt upgrade` /
+  `dnf update`. Packages are verified by the repository's GPG signatures. Linux
+  only; they cannot honor `AURA_INSTALL_PATH`.
 
 Requesting an explicit method whose requirements are unmet (e.g. `deb` off
 Linux, `homebrew` without `brew`) or that conflicts with a set option (e.g.
 `homebrew` with `AURA_VERSION`, or `deb` with `AURA_INSTALL_PATH`) is an error —
 only `auto` falls back.
 
+### Repository layout
+
+Packages are published to `any-distro/any-version`. The RPM side serves that
+path directly; the Debian side indexes per distribution, so an apt source names
+a concrete distro and codename.
+
 ### Requirements
 
 - `curl` or `wget` for downloads
-- `sha256sum`, `shasum`, or `openssl` for checksum verification. If none is
-  installed, verification is skipped with a warning, or fails when
+- `sha256sum`, `shasum`, or `openssl` for `direct` checksum verification. If
+  none is installed, verification is skipped with a warning, or fails when
   `AURA_REQUIRE_CHECKSUM=1`.
-- For `deb`/`rpm`: `dpkg` (deb) or `dnf`/`yum`/`rpm` (rpm), plus root or `sudo`.
+- For `deb`: `apt-get`, plus root or `sudo`. `gpg` dearmors the signing key
+  when present; otherwise the armored key is installed, which `apt` also
+  accepts. `ca-certificates`, and `apt-transport-https` on apt older than 1.5,
+  are installed first when missing.
+- For `rpm`: `dnf`, `microdnf`, `yum`, or `zypper`, plus root or `sudo`.
+
+## `publish-packages.sh`
+
+```
+publish-packages.sh [--dry-run]
+```
+
+Uploads every `.deb` and `.rpm` in `dist/` to a Cloudsmith repository with the
+`cloudsmith` CLI, one package at a time. Uploads wait for server-side
+synchronisation, so a package Cloudsmith rejects fails the script.
+
+`--dry-run` sends the same push but uploads nothing. The server still
+authenticates it, so it verifies the API key and the target repository.
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `DRY_RUN` | `0` | `1` is the same as `--dry-run`. |
+| `CLOUDSMITH_API_KEY` | unset | API key with write access to the repository. Required. |
+| `CLOUDSMITH_REPO` | `mezmo/aura` | `owner/repository` to publish to. |
+| `CLOUDSMITH_DISTRO` | `any-distro/any-version` | Distribution/version coordinates the packages are filed under. |
+| `DIST_DIR` | `dist` | Directory holding the packages. |
+| `PACKAGERS` | `deb rpm` | Space-separated formats to publish. |
+| `CLOUDSMITH` | `cloudsmith` | `cloudsmith` executable to use. |
+
 
 ## `bump-homebrew-tap.sh`
 
@@ -78,11 +118,23 @@ Rewrites the `version` and `sha256` fields in each `Formula/*.rb` of
 
 | Switch | Default | Effect |
 | --- | --- | --- |
-| `--dry-run` / `DRY_RUN=1` | off | Print the proposed commit and test the push with `git push --dry-run` without updating any refs. Tolerates a missing checksums file, validating the version bump only. |
+| `--dry-run` / `DRY_RUN=1` | off | Print the proposed commit and test the push with `git push --dry-run` without updating any refs. Tolerates a missing or incomplete checksums file, leaving any hash it cannot resolve untouched. |
 | `CHECKSUMS_FILE` | `dist/checksums.txt` | Release checksums to source each `sha256` from. |
 | `GH_TOKEN` / `GITHUB_TOKEN` | unset | Token used to clone and push the tap. Required unless `--dry-run`. |
 
 Exits 0 without committing when the formulae already sit at the target version.
+
+## `next-version.mjs`
+
+```
+npm run --silent release:version [repository-url]
+```
+
+Prints the version semantic-release would release next, or nothing when no
+change is releasable. Loads only `commit-analyzer`, so no release lifecycle
+command runs; semantic-release's logging goes to stderr, leaving stdout as the
+version alone. `BRANCH_NAME` selects the branch to analyse, matching
+`release:dry`.
 
 ## `set-version.sh`
 

--- a/scripts/bump-homebrew-tap.sh
+++ b/scripts/bump-homebrew-tap.sh
@@ -53,7 +53,7 @@ git clone --depth 1 "${CLONE_URL}" "${WORKDIR}/tap"
 cd "${WORKDIR}/tap"
 
 for f in Formula/*.rb; do
-  awk -v ver="${VERSION}" -v ck="${CHECKSUMS}" -v have="${HAVE_CHECKSUMS}" '
+  awk -v ver="${VERSION}" -v ck="${CHECKSUMS}" -v have="${HAVE_CHECKSUMS}" -v dry="${DRY_RUN}" '
     BEGIN { if (have) while ((getline l < ck) > 0) { n = split(l, a, /  +/); sums[a[2]] = a[1] } }
     /^[[:space:]]*version "/ { sub(/"[^"]+"/, "\"" ver "\""); print; next }
     /^[[:space:]]*url "/ {
@@ -61,7 +61,10 @@ for f in Formula/*.rb; do
     }
     pend != "" && /sha256 "/ {
       if (!have) { pend = ""; print; next }
-      if (!(pend in sums)) { print "error: no checksum for " pend > "/dev/stderr"; exit 2 }
+      if (!(pend in sums)) {
+        if (dry) { print "warning: no checksum for " pend " (dry run — leaving hash)" > "/dev/stderr"; pend = ""; print; next }
+        print "error: no checksum for " pend > "/dev/stderr"; exit 2
+      }
       sub(/"[0-9a-f]+"/, "\"" sums[pend] "\""); pend = ""; print; next
     }
     { print }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Install AURA binaries from GitHub Releases.
+# Install AURA from the package repository or from GitHub Releases.
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/mezmo/aura/main/scripts/install.sh | bash
@@ -15,8 +15,12 @@
 # "auto" prefers a native package (deb, then rpm) when the matching package
 # manager is present and it can install as root without an interactive prompt
 # (already root, or passwordless sudo); otherwise it falls back to Homebrew and
-# finally a direct binary download. "deb" and "rpm" force a system package and
-# install to /usr/bin, escalating with sudo if needed.
+# finally a direct binary download. "deb" and "rpm" register the AURA package
+# repository and install through apt/dnf/yum/zypper, escalating with sudo if
+# needed, so later upgrades come from the package manager.
+#
+# AURA_REQUIRE_CHECKSUM and AURA_CHECKSUMS apply to the "direct" method only;
+# package installs are verified by the repository's GPG signatures instead.
 
 set -euo pipefail
 
@@ -30,9 +34,17 @@ REQUIRE_CHECKSUM="${AURA_REQUIRE_CHECKSUM:-1}"
 INSTALL_METHOD="${AURA_INSTALL_METHOD:-auto}"
 BASE_URL="https://github.com/${REPO}/releases"
 
-# RPM release field baked into the package asset names; mirrors nfpm's default
-# in scripts/build-packages.sh (which does not set `release`).
-RPM_RELEASE=1
+# Package repository, and the fingerprint-named URL of its signing key.
+PACKAGE_REPO_URL="https://dl.cloudsmith.io/public/${REPO}"
+PACKAGE_KEY_URL="${PACKAGE_REPO_URL}/gpg.05C8AD333177EB1F.key"
+APT_SOURCE_FILE="/etc/apt/sources.list.d/mezmo-aura.list"
+APT_KEYRING_DIR="/usr/share/keyrings"
+YUM_REPO_FILE="/etc/yum.repos.d/mezmo-aura.repo"
+ZYPP_REPO_FILE="/etc/zypp/repos.d/mezmo-aura.repo"
+
+# Apt source suite used when the host's own is not indexed.
+DEB_FALLBACK_DISTRO="debian"
+DEB_FALLBACK_CODENAME="bookworm"
 
 case "${COMPONENT}" in
     all|server|cli) ;;
@@ -100,11 +112,23 @@ hard_available() {
     esac
 }
 
+# A repository install needs a resolving package manager, not bare dpkg or rpm.
 package_manager_present() {
     case "$1" in
-        deb) command -v dpkg >/dev/null 2>&1 ;;
-        rpm) command -v rpm >/dev/null 2>&1 || command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1 ;;
+        deb) command -v apt-get >/dev/null 2>&1 ;;
+        rpm) [[ -n "$(rpm_manager)" ]] ;;
     esac
+}
+
+# The RPM-family package manager to drive, preferring the distribution's native tool.
+rpm_manager() {
+    local manager
+    for manager in zypper dnf microdnf yum; do
+        if command -v "${manager}" >/dev/null 2>&1; then
+            printf '%s' "${manager}"
+            return
+        fi
+    done
 }
 
 # Whether we can run an install command as root non-interactively.
@@ -201,70 +225,189 @@ install_via_package() {
     fi
 
     detect_downloader
-    resolve_version
 
-    echo "Installing AURA ${VERSION} (${OS}/${ARCH}) via ${format} package(s)"
+    local pin=""
+    [[ "${VERSION}" != latest ]] && pin=" ${VERSION}"
+    echo "Installing AURA${pin} (${OS}/${ARCH}) from the ${format} package repository"
 
-    tmpdir=$(mktemp -d)
-    trap 'rm -rf "${tmpdir}"' EXIT
+    case "${format}" in
+        deb) register_deb_repo "${sudo}" || return 1 ;;
+        rpm) register_rpm_repo "${sudo}" || return 1 ;;
+    esac
 
-    fetch_checksums "${tmpdir}"
-
-    # Download and verify every package before installing any, so a mid-way
-    # failure leaves nothing installed.
-    local target asset paths=()
-    for target in $(targets); do
-        asset="$(package_asset "${format}" "${target}")"
-        fetch_asset "${tmpdir}" "${asset}" || return 1
-        paths+=("${tmpdir}/${asset}")
-    done
-
-    install_packages "${format}" "${sudo}" "${paths[@]}"
+    install_from_repo "${format}" "${sudo}" || return 1
 
     echo ""
-    echo "Installed AURA ${VERSION} to /usr/bin"
+    echo "Installed AURA to /usr/bin"
+    echo "Upgrades now come from your package manager."
 }
 
-# Release asset filename for one package, mirroring nfpm's output names in
-# scripts/build-packages.sh (deb uses the Debian arch, rpm the RPM arch).
-package_asset() {
-    local format="$1" name="$2"
-    case "${format}" in
-        deb) printf '%s_%s_%s.deb' "${name}" "${VERSION}" "${ARCH}" ;;
-        rpm) printf '%s-%s-%s.%s.rpm' "${name}" "${VERSION}" "${RPM_RELEASE}" "$(rpm_arch)" ;;
+# Installs the signing key and echoes its path for signed-by, which accepts
+# either a dearmored keyring or an ASCII-armored key.
+install_apt_key() {
+    local sudo="$1" armored keyring
+    armored="$(mktemp)"
+    if ! fetch "${armored}" "${PACKAGE_KEY_URL}"; then
+        rm -f "${armored}"
+        echo "Error: failed to fetch the repository signing key from ${PACKAGE_KEY_URL}" >&2
+        return 1
+    fi
+
+    ${sudo} mkdir -p "${APT_KEYRING_DIR}"
+    if command -v gpg >/dev/null 2>&1; then
+        keyring="${APT_KEYRING_DIR}/mezmo-aura-archive-keyring.gpg"
+        gpg --dearmor <"${armored}" | ${sudo} tee "${keyring}" >/dev/null
+    else
+        keyring="${APT_KEYRING_DIR}/mezmo-aura-archive-keyring.asc"
+        ${sudo} tee "${keyring}" <"${armored}" >/dev/null
+    fi
+    rm -f "${armored}"
+    ${sudo} chmod 0644 "${keyring}"
+
+    printf '%s' "${keyring}"
+}
+
+# HTTPS needs TLS trust and, on apt older than 1.5, a separate transport.
+ensure_apt_transport() {
+    local sudo="$1" missing=()
+    [[ -e /etc/ssl/certs/ca-certificates.crt ]] || missing+=("ca-certificates")
+    [[ -e /usr/lib/apt/methods/https ]] || missing+=("apt-transport-https")
+    [[ ${#missing[@]} -eq 0 ]] && return 0
+
+    echo "  Installing apt prerequisites: ${missing[*]}"
+    # Unscoped: these come from the distribution's own repositories.
+    ${sudo} apt-get update -qq || true
+    if ! ${sudo} apt-get install -y "${missing[@]}"; then
+        echo "Error: could not install ${missing[*]}; install them and re-run." >&2
+        return 1
+    fi
+}
+
+register_deb_repo() {
+    local sudo="$1" distro codename keyring
+    ensure_apt_transport "${sudo}" || return 1
+
+    read -r distro codename <<<"$(deb_suite)"
+
+    keyring="$(install_apt_key "${sudo}")" || return 1
+
+    echo "  Configuring ${APT_SOURCE_FILE} for ${distro} ${codename}"
+    printf 'deb [signed-by=%s] %s/deb/%s %s main\n' \
+        "${keyring}" "${PACKAGE_REPO_URL}" "${distro}" "${codename}" \
+        | ${sudo} tee "${APT_SOURCE_FILE}" >/dev/null
+    ${sudo} chmod 0644 "${APT_SOURCE_FILE}"
+
+    # Refresh only this source, so an unrelated broken entry cannot fail the install.
+    ${sudo} apt-get update \
+        -o Dir::Etc::sourcelist="${APT_SOURCE_FILE}" \
+        -o Dir::Etc::sourceparts="-" \
+        -o APT::Get::List-Cleanup="0"
+}
+
+# The distro and codename for the apt source, derived from /etc/os-release.
+deb_suite() {
+    local id="" codename="" ubuntu_codename="" id_like=""
+    if [[ -r /etc/os-release ]]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        id="${ID:-}"
+        codename="${VERSION_CODENAME:-}"
+        ubuntu_codename="${UBUNTU_CODENAME:-}"
+        id_like="${ID_LIKE:-}"
+    fi
+
+    local distro="" suite=""
+    if [[ "${id}" == debian || "${id}" == ubuntu ]] && [[ -n "${codename}" ]]; then
+        distro="${id}"
+        suite="${codename}"
+    elif [[ -n "${ubuntu_codename}" ]]; then
+        distro="ubuntu"
+        suite="${ubuntu_codename}"
+    elif [[ -n "${codename}" && "${id_like}" == *ubuntu* ]]; then
+        distro="ubuntu"
+        suite="${codename}"
+    elif [[ -n "${codename}" && "${id_like}" == *debian* ]]; then
+        distro="debian"
+        suite="${codename}"
+    fi
+
+    if [[ -z "${distro}" ]]; then
+        echo "Note: could not detect the distribution; using ${DEB_FALLBACK_DISTRO} ${DEB_FALLBACK_CODENAME} (packages are identical)." >&2
+        printf '%s %s' "${DEB_FALLBACK_DISTRO}" "${DEB_FALLBACK_CODENAME}"
+        return
+    fi
+
+    if url_missing "${PACKAGE_REPO_URL}/deb/${distro}/dists/${suite}/Release"; then
+        echo "Note: ${distro} ${suite} is not indexed; using ${DEB_FALLBACK_DISTRO} ${DEB_FALLBACK_CODENAME} (packages are identical)." >&2
+        printf '%s %s' "${DEB_FALLBACK_DISTRO}" "${DEB_FALLBACK_CODENAME}"
+        return
+    fi
+
+    printf '%s %s' "${distro}" "${suite}"
+}
+
+register_rpm_repo() {
+    local sudo="$1" manager repo_file
+    manager="$(rpm_manager)"
+    repo_file="$(rpm_repo_file "${manager}")"
+
+    echo "  Configuring ${repo_file} for ${manager}"
+    ${sudo} mkdir -p "$(dirname "${repo_file}")"
+    ${sudo} tee "${repo_file}" >/dev/null <<EOF
+[mezmo-aura]
+name=mezmo-aura
+baseurl=${PACKAGE_REPO_URL}/rpm/any-distro/any-version/\$basearch
+repo_gpgcheck=1
+gpgcheck=1
+enabled=1
+autorefresh=1
+gpgkey=${PACKAGE_KEY_URL}
+sslverify=1
+metadata_expire=300
+type=rpm-md
+EOF
+    ${sudo} chmod 0644 "${repo_file}"
+
+    # zypper would otherwise prompt to trust the key and hang a piped install.
+    if [[ "${manager}" == zypper ]]; then
+        ${sudo} zypper --gpg-auto-import-keys --non-interactive refresh mezmo-aura
+    fi
+}
+
+# zypper keeps its repositories outside the yum tree.
+rpm_repo_file() {
+    case "$1" in
+        zypper) printf '%s' "${ZYPP_REPO_FILE}" ;;
+        *)      printf '%s' "${YUM_REPO_FILE}" ;;
     esac
 }
 
-rpm_arch() {
-    case "${ARCH}" in
-        amd64) echo "x86_64" ;;
-        arm64) echo "aarch64" ;;
+install_from_repo() {
+    local format="$1" sudo="$2" manager target
+    case "${format}" in
+        deb) manager="apt-get" ;;
+        rpm) manager="$(rpm_manager)" ;;
+    esac
+
+    local packages=()
+    for target in $(targets); do
+        packages+=("$(package_spec "${manager}" "${target}")")
+    done
+
+    case "${manager}" in
+        apt-get) ${sudo} apt-get install -y "${packages[@]}" ;;
+        zypper)  ${sudo} zypper --non-interactive install "${packages[@]}" ;;
+        *)       ${sudo} "${manager}" install -y "${packages[@]}" ;;
     esac
 }
 
-install_packages() {
-    local format="$1" sudo="$2"
-    shift 2
-    case "${format}" in
-        deb)
-            if ! command -v dpkg >/dev/null 2>&1; then
-                echo "Error: dpkg not found; cannot install .deb packages." >&2
-                exit 1
-            fi
-            ${sudo} dpkg -i "$@"
-            ;;
-        rpm)
-            if command -v dnf >/dev/null 2>&1; then
-                ${sudo} dnf install -y "$@"
-            elif command -v yum >/dev/null 2>&1; then
-                ${sudo} yum install -y "$@"
-            elif command -v rpm >/dev/null 2>&1; then
-                ${sudo} rpm -Uvh "$@"
-            else
-                echo "Error: need dnf, yum, or rpm to install .rpm packages." >&2
-                exit 1
-            fi
-            ;;
+# Version-pinned package name: apt and zypper take name=version, dnf name-version.
+package_spec() {
+    local manager="$1" name="$2"
+    [[ "${VERSION}" == latest ]] && { printf '%s' "${name}"; return; }
+    case "${manager}" in
+        apt-get|zypper) printf '%s=%s' "${name}" "${VERSION}" ;;
+        *)              printf '%s-%s' "${name}" "${VERSION}" ;;
     esac
 }
 
@@ -320,6 +463,23 @@ fetch() {
     case "${DOWNLOADER}" in
         curl) curl -fsSL --connect-timeout 10 --retry 3 -o "${dest}" "${url}" ;;
         wget) wget -q --timeout=10 --tries=3 -O "${dest}" "${url}" ;;
+    esac
+}
+
+# True only when the server reports the URL absent; a transport failure is not
+# a negative answer.
+url_missing() {
+    local url="$1" status rc=0
+    case "${DOWNLOADER}" in
+        curl)
+            status="$(curl -sIL --connect-timeout 10 -o /dev/null -w '%{http_code}' "${url}" 2>/dev/null)"
+            [[ "${status}" == 404 ]]
+            ;;
+        wget)
+            # wget exits 8 when the server answered with an error status.
+            wget -q --spider --timeout=10 --tries=1 "${url}" 2>/dev/null || rc=$?
+            [[ "${rc}" -eq 8 ]]
+            ;;
     esac
 }
 

--- a/scripts/next-version.mjs
+++ b/scripts/next-version.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Print the version semantic-release would release next, or nothing when there
+// is no releasable change.
+//
+// Only commit-analyzer is loaded, so no release lifecycle command runs.
+// semantic-release's logging goes to stderr, leaving stdout as the version.
+//
+// Usage: next-version.mjs [repository-url]
+
+import semanticRelease from 'semantic-release'
+
+const [repositoryUrl] = process.argv.slice(2)
+
+// Mirrors the release:dry script: no CI detection, and the branch under test
+// is the one that releases.
+const options = {
+  dryRun: true,
+  ci: false,
+  branches: [process.env.BRANCH_NAME || 'main'],
+  plugins: ['@semantic-release/commit-analyzer'],
+}
+if (repositoryUrl) {
+  options.repositoryUrl = repositoryUrl
+}
+
+const result = await semanticRelease(options, {
+  stdout: process.stderr,
+  stderr: process.stderr,
+})
+
+if (result) {
+  console.log(result.nextRelease.version)
+}

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Publish the Debian (.deb) and RPM (.rpm) packages in dist/ to Cloudsmith.
+#
+# Uploads wait for server-side synchronisation, so a package Cloudsmith rejects
+# fails this script. --dry-run uploads nothing; the server still authenticates,
+# so it verifies the key and the target repository.
+#
+# Usage: publish-packages.sh [--dry-run]
+#   DRY_RUN=1          - same as --dry-run
+#
+# Environment:
+#   CLOUDSMITH_API_KEY - API key with write access to the repository (required)
+#   CLOUDSMITH_REPO    - owner/repository to publish to (default: mezmo/aura)
+#   CLOUDSMITH_DISTRO  - distribution/version coordinates (default: any-distro/any-version)
+#   DIST_DIR           - directory holding the packages (default: dist)
+#   PACKAGERS          - space-separated formats to publish (default: "deb rpm")
+#   CLOUDSMITH         - cloudsmith executable to use (default: cloudsmith on PATH)
+set -euo pipefail
+
+USAGE="usage: $0 [--dry-run]"
+
+DRY_RUN="${DRY_RUN:-0}"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) echo "${USAGE}" >&2; exit 0 ;;
+        *) echo "${USAGE}" >&2; exit 1 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+DIST_DIR="${DIST_DIR:-${PROJECT_ROOT}/dist}"
+PACKAGERS="${PACKAGERS:-deb rpm}"
+CLOUDSMITH="${CLOUDSMITH:-cloudsmith}"
+CLOUDSMITH_REPO="${CLOUDSMITH_REPO:-mezmo/aura}"
+CLOUDSMITH_DISTRO="${CLOUDSMITH_DISTRO:-any-distro/any-version}"
+
+require_cloudsmith() {
+    if ! command -v "${CLOUDSMITH}" >/dev/null 2>&1; then
+        echo "error: cloudsmith not found (set CLOUDSMITH or install from https://docs.cloudsmith.com/developer/cli)" >&2
+        exit 1
+    fi
+    if [ -z "${CLOUDSMITH_API_KEY:-}" ]; then
+        echo "error: CLOUDSMITH_API_KEY is required" >&2
+        exit 1
+    fi
+}
+
+main() {
+    local target="${CLOUDSMITH_REPO}/${CLOUDSMITH_DISTRO}"
+
+    shopt -s nullglob
+    local packager packages=()
+    for packager in ${PACKAGERS}; do
+        packages+=("${DIST_DIR}"/*."${packager}")
+    done
+
+    if [ "${#packages[@]}" -eq 0 ]; then
+        echo "error: no packages found in ${DIST_DIR}" >&2
+        exit 1
+    fi
+
+    require_cloudsmith
+
+    if [ "${DRY_RUN}" = 1 ]; then
+        echo "Validating ${#packages[@]} package(s) against ${target} (dry run)"
+    else
+        echo "Publishing ${#packages[@]} package(s) from ${DIST_DIR} to ${target}"
+    fi
+
+    local file
+    for file in "${packages[@]}"; do
+        packager="${file##*.}"
+        echo "  ${packager} $(basename "${file}")"
+        if [ "${DRY_RUN}" = 1 ]; then
+            "${CLOUDSMITH}" push "${packager}" --dry-run "${target}" "${file}"
+        else
+            "${CLOUDSMITH}" push "${packager}" "${target}" "${file}"
+        fi
+    done
+
+    echo ""
+    if [ "${DRY_RUN}" = 1 ]; then
+        echo "Validated ${#packages[@]} package(s) against ${target}"
+    else
+        echo "Published ${#packages[@]} package(s) to ${target}"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Packages were only attached to GitHub releases, so installing one meant downloading a file by hand and upgrades were manual.

- Add the cloudsmith CLI to the runner image and publish-packages.sh, which pushes every dist/*.deb and *.rpm to mezmo/aura/any-distro/any-version.
- Drive both halves from release.config.js: verifyReleaseCmd packages a single arch and dry-run pushes it, and successCmd publishes once the release lands. Cloudsmith authenticates a --dry-run push, so it doubles as a credential check that fails before anything is published.
- Build one linux/amd64 target in the release dry run so verifyReleaseCmd has a package to push on pull requests.
- Register the Cloudsmith repository from install.sh instead of downloading a single package, so deb/rpm installs upgrade through apt/dnf/microdnf/yum/zypper and verify against the repository GPG key. A resolver is now required, so bare dpkg or rpm no longer qualifies.
- Credit Cloudsmith for the OSS package hosting in the README.