### PR TITLE
fix(ci): compute the release version without a remote

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -450,10 +450,15 @@ pipeline {
 
       stages {
         stage('Compute Release Version') {
+          environment {
+            GIT_BRANCH = "${CURRENT_BRANCH}"
+            BRANCH_NAME = "${CURRENT_BRANCH}"
+          }
+
           steps {
             script {
               env.NEXT_RELEASE_VERSION = sh(
-                script: 'npm run --silent release:version',
+                script: "npm run --silent release:version 'file://${env.WORKSPACE}'",
                 returnStdout: true
               ).trim()
               echo env.NEXT_RELEASE_VERSION ? "Release version: ${env.NEXT_RELEASE_VERSION}" : 'No release version determined; skipping build'


### PR DESCRIPTION
The Compute Release Version stage ran semantic-release with no repository URL and no credentials bound, so it fell back to the SSH URL in package.json and died in branch expansion: the OSS agent has no deploy key, and git ls-remote failed with Permission denied (publickey).

Point the version computation at the workspace instead, so it needs neither the network nor a token. Branch expansion on a local repository lists local branches, and the checkout is detached, so the branch is created as a local ref first.