### PR TITLE
fix(telemetry): add system prompt attribute to spans

### DIFF
--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -553,6 +553,7 @@ pub async fn execute_completion(
         message_count: config.message_count,
         usage_state: usage_state.clone(),
         response_content: config.response_content,
+        system_prompt: streaming_agent.system_prompt().map(str::to_string),
         is_orchestration: streaming_agent.is_orchestration(),
     };
     otel_ctx.record_input();

--- a/crates/aura-web-server/src/streaming/otel.rs
+++ b/crates/aura-web-server/src/streaming/otel.rs
@@ -30,6 +30,8 @@ pub struct StreamOtelContext {
     pub message_count: usize,
     pub usage_state: UsageState,
     pub response_content: ResponseContent,
+    /// Assembled system prompt sent to the provider.
+    pub system_prompt: Option<String>,
     /// True when the streaming agent is an orchestrator. Orchestration emits
     /// per-phase LLM spans (`orchestration.planning`, `orchestration.worker`,
     /// `orchestration.synthesis`, `orchestration.evaluation`) that each carry
@@ -46,6 +48,9 @@ impl StreamOtelContext {
         let span = tracing::Span::current();
         aura::logging::set_llm_identifiers(&span, &self.provider, &self.model);
         aura::logging::set_input_attributes(&span, &self.query);
+        if let Some(system_prompt) = &self.system_prompt {
+            aura::logging::set_system_prompt_attribute(&span, system_prompt);
+        }
         aura::logging::set_span_attribute(&span, "http.request_id", self.request_id.clone());
         aura::logging::set_span_attribute(&span, "session.id", self.session_id.clone());
         if !self.identity_id.is_empty() {

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -148,6 +148,9 @@ pub struct Agent {
     pub(crate) client_tool_names: HashSet<String>,
     /// Turn-limit nudge state shared with this agent's `TurnNudgeWrapper`.
     pub(crate) turn_nudge: Option<Arc<crate::turn_nudge::TurnNudgeState>>,
+    /// Assembled system prompt handed to the provider builder
+    /// (preamble + skill catalog, etc.).
+    pub(crate) system_prompt: String,
 }
 
 impl Agent {
@@ -783,6 +786,7 @@ impl Agent {
             scratchpad_budget: agent_scratchpad_budget,
             client_tool_names,
             turn_nudge,
+            system_prompt,
         })
     }
 
@@ -1133,7 +1137,13 @@ impl Agent {
     ) -> Result<crate::provider_agent::CompletionResponse, Box<dyn std::error::Error + Send + Sync>>
     {
         let span = tracing::Span::current();
-        record_input_attributes(&span, self.inner.provider_name(), &self.model, query);
+        record_input_attributes(
+            &span,
+            self.inner.provider_name(),
+            &self.model,
+            query,
+            &self.system_prompt,
+        );
 
         let stream = self.stream_prompt(query).await;
         let result = self.collect_stream_response(stream).await;
@@ -1152,7 +1162,13 @@ impl Agent {
     ) -> Result<crate::provider_agent::CompletionResponse, Box<dyn std::error::Error + Send + Sync>>
     {
         let span = tracing::Span::current();
-        record_input_attributes(&span, self.inner.provider_name(), &self.model, query);
+        record_input_attributes(
+            &span,
+            self.inner.provider_name(),
+            &self.model,
+            query,
+            &self.system_prompt,
+        );
 
         let stream = self.stream_chat(query, chat_history).await;
         let result = self.collect_stream_response(stream).await;
@@ -1526,9 +1542,11 @@ impl Agent {
 //   The stream is returned to the HTTP handler which sends it back as SSE.
 //   The LLM output is not available until the stream is fully consumed
 //   inside a `tokio::spawn` block, so these helpers are NOT used. Instead,
-//   input/output attributes are recorded in the web server's spawned task
-//   via `StreamOtelContext::record_input()` / `StreamOtelContext::record_output()`
-//   on the `agent.stream` span (see `aura-web-server/src/handlers.rs`).
+//   input/output attributes (including the system prompt, sourced from
+//   `StreamingAgent::system_prompt()`) are recorded in the web server's
+//   spawned task via `StreamOtelContext::record_input()` /
+//   `StreamOtelContext::record_output()` on the `agent.stream` span (see
+//   `aura-web-server/src/handlers.rs`).
 //
 // If you change attribute names here, update the streaming path too.
 // Canonical attribute name constants live in `logging.rs`.
@@ -1538,9 +1556,16 @@ impl Agent {
 ///
 /// Uses `OpenTelemetrySpanExt::set_attribute` to bypass the tracing
 /// `Filtered::on_record` path which doesn't propagate to the OTel layer.
-fn record_input_attributes(span: &tracing::Span, provider_name: &str, model: &str, query: &str) {
+fn record_input_attributes(
+    span: &tracing::Span,
+    provider_name: &str,
+    model: &str,
+    query: &str,
+    system_prompt: &str,
+) {
     crate::logging::set_llm_identifiers(span, provider_name, model);
     crate::logging::set_input_attributes(span, query);
+    crate::logging::set_system_prompt_attribute(span, system_prompt);
 }
 
 /// Record completion result fields (usage, content, status) on the span via OTel API.
@@ -1641,6 +1666,10 @@ impl StreamingAgent for Agent {
             .as_ref()
             .map(|m| m.server_status_snapshot())
             .unwrap_or_default()
+    }
+
+    fn system_prompt(&self) -> Option<&str> {
+        Some(&self.system_prompt)
     }
 }
 

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -115,6 +115,9 @@ pub const ATTR_LLM_TOKEN_COMPLETION: &str = "llm.token_count.completion";
 pub const ATTR_LLM_TOKEN_TOTAL: &str = "llm.token_count.total";
 /// Completion tokens spent generating tool call JSON (subset of completion).
 pub const ATTR_LLM_TOKEN_TOOL_COMPLETION: &str = "llm.token_count.tool_completion";
+/// Assembled system prompt sent to the provider (preamble + skill catalog,
+/// etc.), as an OTel GenAI array of typed parts.
+pub const ATTR_GEN_AI_SYSTEM_INSTRUCTIONS: &str = "gen_ai.system_instructions";
 
 pub const ATTR_INPUT_MIME_TYPE: &str = "input.mime_type";
 pub const ATTR_INPUT_LENGTH: &str = "input.length";
@@ -147,6 +150,13 @@ static CONTENT_MAX_LENGTH: AtomicUsize = AtomicUsize::new(1000);
 /// Controlled by `OTEL_RECORD_CONTENT` env var (default `false`).
 pub fn should_record_content() -> bool {
     RECORD_CONTENT.load(Ordering::Relaxed)
+}
+
+/// Force content recording on/off for a test, returning the previous value
+/// so the test can restore it.
+#[cfg(test)]
+pub(crate) fn set_record_content_for_tests(v: bool) -> bool {
+    RECORD_CONTENT.swap(v, Ordering::Relaxed)
 }
 
 /// Maximum byte length for content span attributes.
@@ -524,6 +534,36 @@ pub fn set_output_attributes(span: &tracing::Span, _text: &str) {
     let _ = span;
 }
 
+/// Serialize a system prompt as a single-part OTel GenAI system-instructions
+/// array.
+///
+/// Truncation applies to the prompt text *before* serialization: truncating
+/// the finished JSON would cut mid-string and leave a value the exporter
+/// cannot parse back into a message.
+#[cfg(any(feature = "otel", test))]
+fn system_instructions_json(text: &str) -> String {
+    serde_json::json!([{ "type": "text", "content": truncate_for_otel(text) }]).to_string()
+}
+
+/// Record the assembled system prompt on a span as an OTel GenAI
+/// system-instructions parts array, subject to the same content gate and
+/// truncation as every other captured content attribute.
+#[cfg(feature = "otel")]
+pub fn set_system_prompt_attribute(span: &tracing::Span, text: &str) {
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    if should_record_content() {
+        span.set_attribute(
+            ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
+            system_instructions_json(text),
+        );
+    }
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn set_system_prompt_attribute(span: &tracing::Span, _text: &str) {
+    let _ = span;
+}
+
 /// Force-flush all pending spans to the OTLP exporter.
 ///
 /// The `BatchSpanProcessor` buffers spans and exports on a timer (default 5 s)
@@ -591,3 +631,39 @@ pub async fn shutdown_tracer() {
 
 #[cfg(not(feature = "otel"))]
 pub async fn shutdown_tracer() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A prompt longer than `OTEL_CONTENT_MAX_LENGTH` must still serialize to
+    /// valid JSON — truncating the finished JSON instead of the content would
+    /// cut mid-string and leave the exporter unable to parse it back.
+    #[test]
+    fn system_instructions_json_stays_valid_when_truncated() {
+        let long_prompt = "x".repeat(content_max_length() * 2);
+        let json = system_instructions_json(&long_prompt);
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("truncated system instructions must be valid JSON");
+
+        let parts = parsed.as_array().expect("expected a parts array");
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0]["type"], "text");
+
+        let content = parts[0]["content"].as_str().unwrap();
+        assert!(
+            content.len() < long_prompt.len(),
+            "content was not truncated"
+        );
+        assert!(content.starts_with("xxx"));
+    }
+
+    /// Content shorter than the limit round-trips unchanged.
+    #[test]
+    fn system_instructions_json_preserves_short_content() {
+        let json = system_instructions_json("You are a helpful assistant.");
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed[0]["content"], "You are a helpful assistant.");
+    }
+}

--- a/crates/aura/src/openinference_exporter.rs
+++ b/crates/aura/src/openinference_exporter.rs
@@ -20,8 +20,9 @@
 //! [OpenInference]: https://github.com/Arize-ai/openinference/tree/main/spec
 
 use crate::logging::{
-    ATTR_INPUT_VALUE, ATTR_LLM_MODEL_NAME, ATTR_LLM_SYSTEM, ATTR_LLM_TOKEN_COMPLETION,
-    ATTR_LLM_TOKEN_PROMPT, ATTR_OUTPUT_VALUE, ATTR_TOOL_NAME, ATTR_TOOL_PARAMETERS,
+    ATTR_GEN_AI_SYSTEM_INSTRUCTIONS, ATTR_INPUT_VALUE, ATTR_LLM_MODEL_NAME, ATTR_LLM_SYSTEM,
+    ATTR_LLM_TOKEN_COMPLETION, ATTR_LLM_TOKEN_PROMPT, ATTR_OUTPUT_VALUE, ATTR_TOOL_NAME,
+    ATTR_TOOL_PARAMETERS,
 };
 use futures::future::BoxFuture;
 use opentelemetry::{KeyValue, StringValue, Value};
@@ -141,7 +142,11 @@ fn transform_span(mut span: SpanData) -> SpanData {
     let mut deferred_turn_prompt: Option<String> = None;
     let mut deferred_response: Option<String> = None;
     let mut deferred_reasoning: Option<String> = None;
-    let mut has_input_messages = false;
+    // Input messages are assembled after the loop so system instructions can
+    // lead them; span attributes iterate in arbitrary order, so emitting any
+    // of them inline would fix indices before the rest are known.
+    let mut deferred_system_instructions: Vec<String> = Vec::new();
+    let mut deferred_input_messages: Vec<ParsedMessage> = Vec::new();
 
     for kv in &span.attributes {
         let key = kv.key.as_str();
@@ -174,15 +179,19 @@ fn transform_span(mut span: SpanData) -> SpanData {
             "gen_ai.turn.response" if kind == "CHAIN" || kind == "LLM" => {
                 deferred_response = Some(kv.value.to_string());
             }
+            // The system prompt has no OpenInference attribute of its own, so
+            // it becomes leading `system` entries in `llm.input_messages`.
+            // Ungated by span kind: Aura records it on `agent.stream` (AGENT)
+            // and the `orchestration.*` (CHAIN/AGENT) spans, never on an LLM one.
+            ATTR_GEN_AI_SYSTEM_INSTRUCTIONS => {
+                deferred_system_instructions = parse_system_instructions(&kv.value.to_string());
+            }
             // Expand structured messages for LLM spans
             "gen_ai.input.messages" if kind == "LLM" => {
-                let before = extra_attrs.len();
-                expand_messages(
-                    &kv.value.to_string(),
-                    "llm.input_messages",
-                    &mut extra_attrs,
-                );
-                has_input_messages = extra_attrs.len() > before;
+                deferred_input_messages = parse_json_value(&kv.value.to_string())
+                    .as_ref()
+                    .and_then(parse_messages)
+                    .unwrap_or_default();
             }
             "gen_ai.output.messages" if kind == "LLM" => {
                 expand_messages(
@@ -219,12 +228,28 @@ fn transform_span(mut span: SpanData) -> SpanData {
         }
     }
 
+    // `gen_ai.input.messages` wins over the `gen_ai.turn.prompt` backfill;
+    // either way the system instructions lead.
+    let mut input_messages: Vec<ParsedMessage> = deferred_system_instructions
+        .into_iter()
+        .map(|content| ParsedMessage {
+            role: "system".to_owned(),
+            content,
+        })
+        .collect();
+    let has_system_messages = !input_messages.is_empty();
+
     if let Some(prompt) = deferred_turn_prompt {
         let normalized = normalize_turn_prompt(&prompt);
         extra_attrs.push(KeyValue::new(ATTR_INPUT_VALUE, normalized.input_value));
-        if kind == "LLM" && !has_input_messages {
-            emit_messages("llm.input_messages", &normalized.messages, &mut extra_attrs);
+        if kind == "LLM" && deferred_input_messages.is_empty() {
+            deferred_input_messages = normalized.messages;
         }
+    }
+    input_messages.append(&mut deferred_input_messages);
+
+    if kind == "LLM" || has_system_messages {
+        emit_messages("llm.input_messages", &input_messages, &mut extra_attrs);
     }
 
     // For LLM spans: emit structured llm.output_messages (Phoenix Output Messages tab)
@@ -412,6 +437,46 @@ fn parse_messages(value: &serde_json::Value) -> Option<Vec<ParsedMessage>> {
         serde_json::Value::Object(_) => parse_message(value).map(|message| vec![message]),
         _ => None,
     }
+}
+
+/// Decode a `gen_ai.system_instructions` value into one string per part.
+///
+/// The OTel GenAI shape is an array of typed parts
+/// (`[{"type":"text","content":"..."}]`). Rig instead records the preamble as
+/// a bare string, so that form is accepted as a single part. Unparseable
+/// values yield no parts rather than a malformed message.
+///
+/// Note these parts key their text on `content`, unlike the `text` key that
+/// [`parse_message_content`] handles for `gen_ai.input.messages` parts.
+fn parse_system_instructions(raw: &str) -> Vec<String> {
+    let Some(value) = parse_json_value(raw) else {
+        // Not JSON at all — a bare, unquoted preamble.
+        return vec![raw.to_owned()];
+    };
+    match value {
+        serde_json::Value::Array(parts) => {
+            parts.iter().filter_map(parse_instruction_part).collect()
+        }
+        serde_json::Value::Object(_) => parse_instruction_part(&value).into_iter().collect(),
+        serde_json::Value::String(text) => vec![text],
+        _ => Vec::new(),
+    }
+}
+
+/// Extract the text of a single system-instruction part, accepting both the
+/// GenAI `content` key and a `text` key, or a bare string element.
+fn parse_instruction_part(value: &serde_json::Value) -> Option<String> {
+    if let serde_json::Value::String(text) = value {
+        return Some(text.clone());
+    }
+    if value.get("type").and_then(serde_json::Value::as_str) != Some("text") {
+        return None;
+    }
+    value
+        .get("content")
+        .or_else(|| value.get("text"))
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
 }
 
 /// Extract role and content from a single `{"role":"...","content":"..."}` object.
@@ -871,6 +936,197 @@ mod tests {
                 .map(|kv| kv.key.as_str())
                 .collect::<Vec<_>>()
         );
+    }
+
+    /// Build a GenAI system-instructions parts array from the given texts.
+    fn system_instructions(parts: &[&str]) -> String {
+        let parts: Vec<_> = parts
+            .iter()
+            .map(|content| serde_json::json!({ "type": "text", "content": content }))
+            .collect();
+        serde_json::Value::Array(parts).to_string()
+    }
+
+    /// A single instruction part becomes a leading `system` message, and the
+    /// raw GenAI key is stripped like every other translated `gen_ai.*` key.
+    /// AGENT kind matters: Aura records the prompt on non-LLM spans.
+    #[test]
+    fn test_system_instructions_translate_to_input_messages() {
+        let span = make_span(
+            "agent.stream",
+            vec![
+                KeyValue::new("gen_ai.system", "openai"),
+                KeyValue::new(
+                    ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
+                    system_instructions(&["You are a helpful assistant."]),
+                ),
+            ],
+        );
+        let result = transform_span(span);
+
+        assert_eq!(
+            find_attr(&result, "llm.input_messages.0.message.role")
+                .unwrap()
+                .to_string(),
+            "system"
+        );
+        assert_eq!(
+            find_attr(&result, "llm.input_messages.0.message.content")
+                .unwrap()
+                .to_string(),
+            "You are a helpful assistant."
+        );
+        assert!(
+            find_attr(&result, ATTR_GEN_AI_SYSTEM_INSTRUCTIONS).is_none(),
+            "the raw GenAI key must be stripped after translation"
+        );
+    }
+
+    /// Each part becomes its own `system` message rather than being joined.
+    #[test]
+    fn test_system_instructions_emit_one_message_per_part() {
+        let span = make_span(
+            "agent.stream",
+            vec![KeyValue::new(
+                ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
+                system_instructions(&[
+                    "You are a language translator.",
+                    "Your mission is to translate text in English to French.",
+                ]),
+            )],
+        );
+        let result = transform_span(span);
+
+        assert_eq!(
+            find_attr(&result, "llm.input_messages.0.message.content")
+                .unwrap()
+                .to_string(),
+            "You are a language translator."
+        );
+        assert_eq!(
+            find_attr(&result, "llm.input_messages.1.message.role")
+                .unwrap()
+                .to_string(),
+            "system"
+        );
+        assert_eq!(
+            find_attr(&result, "llm.input_messages.1.message.content")
+                .unwrap()
+                .to_string(),
+            "Your mission is to translate text in English to French."
+        );
+    }
+
+    /// System instructions lead; existing `gen_ai.input.messages` entries keep
+    /// their order and content, shifted after them.
+    #[test]
+    fn test_system_instructions_prepend_without_erasing_input_messages() {
+        let messages = r#"[{"role":"user","content":"hello"},{"role":"assistant","content":"hi"}]"#;
+        let span = make_span(
+            "chat",
+            vec![
+                KeyValue::new(
+                    ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
+                    system_instructions(&["You are terse."]),
+                ),
+                KeyValue::new("gen_ai.input.messages", messages),
+            ],
+        );
+        let result = transform_span(span);
+
+        let roles_and_contents: Vec<(String, String)> = (0..3)
+            .map(|i| {
+                (
+                    find_attr(&result, &format!("llm.input_messages.{i}.message.role"))
+                        .unwrap()
+                        .to_string(),
+                    find_attr(&result, &format!("llm.input_messages.{i}.message.content"))
+                        .unwrap()
+                        .to_string(),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            roles_and_contents,
+            vec![
+                ("system".to_owned(), "You are terse.".to_owned()),
+                ("user".to_owned(), "hello".to_owned()),
+                ("assistant".to_owned(), "hi".to_owned()),
+            ]
+        );
+    }
+
+    /// The `gen_ai.turn.prompt` backfill still applies when structured input
+    /// messages are absent, with the system instructions ahead of it.
+    #[test]
+    fn test_system_instructions_precede_turn_prompt_backfill() {
+        let prompt = r#"[{"role":"user","content":"what is 23 times 87"}]"#;
+        let span = make_span(
+            "agent.turn",
+            vec![
+                KeyValue::new(
+                    ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
+                    system_instructions(&["You are a calculator."]),
+                ),
+                KeyValue::new("gen_ai.turn.prompt", prompt),
+            ],
+        );
+        let result = transform_span(span);
+
+        assert_eq!(
+            find_attr(&result, "llm.input_messages.0.message.role")
+                .unwrap()
+                .to_string(),
+            "system"
+        );
+        assert_eq!(
+            find_attr(&result, "llm.input_messages.1.message.content")
+                .unwrap()
+                .to_string(),
+            "what is 23 times 87"
+        );
+        // input.value stays the user prompt, not the system instructions.
+        assert_eq!(
+            find_attr(&result, ATTR_INPUT_VALUE).unwrap().to_string(),
+            "what is 23 times 87"
+        );
+    }
+
+    /// Rig records the preamble as a bare string rather than a parts array.
+    #[test]
+    fn test_system_instructions_accept_bare_string() {
+        let span = make_span(
+            "agent.stream",
+            vec![KeyValue::new(
+                ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
+                "You are a helpful assistant.",
+            )],
+        );
+        let result = transform_span(span);
+
+        assert_eq!(
+            find_attr(&result, "llm.input_messages.0.message.content")
+                .unwrap()
+                .to_string(),
+            "You are a helpful assistant."
+        );
+    }
+
+    /// A parts array carrying no usable text yields no messages.
+    #[test]
+    fn test_system_instructions_unusable_parts_emit_nothing() {
+        let span = make_span(
+            "agent.stream",
+            vec![KeyValue::new(
+                ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
+                r#"[{"type":"image","url":"http://example.com/x.png"}]"#,
+            )],
+        );
+        let result = transform_span(span);
+
+        assert!(find_attr(&result, "llm.input_messages.0.message.role").is_none());
+        assert!(find_attr(&result, ATTR_GEN_AI_SYSTEM_INSTRUCTIONS).is_none());
     }
 
     #[test]
@@ -1511,5 +1767,59 @@ mod pipeline_tests {
             find_attr(chat, "llm.token_count.completion").is_none(),
             "llm.token_count.completion should NOT be present (field was Empty and never recorded)"
         );
+    }
+
+    // -- Pipeline test: system prompt attribute recording + content gating -
+
+    /// `set_system_prompt_attribute` toggles on `crate::logging::RECORD_CONTENT`,
+    /// a process-global flag — both branches run sequentially in one test
+    /// (rather than two `#[test]` fns) so concurrently-run tests can't race
+    /// on the shared flag.
+    #[test]
+    fn test_pipeline_system_prompt_attribute() {
+        let previous = crate::logging::set_record_content_for_tests(true);
+
+        let (subscriber, memory) = build_pipeline();
+        let system_prompt = "You are a helpful assistant with access to tools.";
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("agent.stream");
+            let _guard = span.enter();
+            crate::logging::set_system_prompt_attribute(&tracing::Span::current(), system_prompt);
+        });
+        let spans = collect_spans(&memory);
+        let recorded = find_span_by_name(&spans, "agent.stream");
+        assert_eq!(
+            find_attr(recorded, "llm.input_messages.0.message.role")
+                .unwrap()
+                .to_string(),
+            "system"
+        );
+        assert_eq!(
+            find_attr(recorded, "llm.input_messages.0.message.content")
+                .unwrap()
+                .to_string(),
+            system_prompt
+        );
+        assert!(
+            find_attr(recorded, ATTR_GEN_AI_SYSTEM_INSTRUCTIONS).is_none(),
+            "the raw GenAI key must be stripped after translation"
+        );
+
+        crate::logging::set_record_content_for_tests(false);
+
+        let (subscriber, memory) = build_pipeline();
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("agent.stream");
+            let _guard = span.enter();
+            crate::logging::set_system_prompt_attribute(&tracing::Span::current(), system_prompt);
+        });
+        let spans = collect_spans(&memory);
+        let recorded = find_span_by_name(&spans, "agent.stream");
+        assert!(
+            find_attr(recorded, "llm.input_messages.0.message.role").is_none(),
+            "must not be recorded when content recording is disabled"
+        );
+
+        crate::logging::set_record_content_for_tests(previous);
     }
 }

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -896,15 +896,11 @@ impl Orchestrator {
         );
 
         // Capture preamble before config is consumed by builder
-        let preamble = if self.prompt_journal.is_some() {
-            worker_config
-                .preamble_override
-                .as_deref()
-                .unwrap_or("")
-                .to_string()
-        } else {
-            String::new()
-        };
+        let preamble = worker_config
+            .preamble_override
+            .as_deref()
+            .unwrap_or("")
+            .to_string();
 
         // Build worker agent using shared MCP connections.
         // Client-side tools are not supported in orchestration mode and are
@@ -925,6 +921,7 @@ impl Orchestrator {
                 .map(|sp| sp.budget.clone()),
             client_tool_names: Default::default(),
             turn_nudge,
+            system_prompt: preamble.clone(),
         };
 
         Ok(AgentWithPreamble {
@@ -1467,6 +1464,11 @@ impl Orchestrator {
         let mut final_prompt: Option<String> = None;
         let mut final_response: Option<String> = None;
         let planning_start = Instant::now();
+
+        crate::logging::set_system_prompt_attribute(
+            &tracing::Span::current(),
+            &coordinator_state.preamble,
+        );
 
         for attempt in 1..=max_correction_attempts {
             // Clear any stale routing decision
@@ -2319,6 +2321,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 scratchpad_budget: None,
                 client_tool_names: Default::default(),
                 turn_nudge: None,
+                system_prompt: preamble.clone(),
             },
             preamble,
             escalation_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -3095,6 +3098,15 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 escalation_flag,
                 submit_result_decision,
             } = self.create_worker(task_id, attempt, *worker_name).await?;
+
+            // Retries rebuild the same preamble, and `set_attribute` appends
+            // rather than replaces, so record it once per worker span.
+            if attempt == 1 {
+                crate::logging::set_system_prompt_attribute(
+                    &tracing::Span::current(),
+                    &worker_preamble,
+                );
+            }
 
             // Build prompt for this attempt
             let (prompt, history) = if attempt == 1 {

--- a/crates/aura/src/streaming.rs
+++ b/crates/aura/src/streaming.rs
@@ -152,4 +152,14 @@ pub trait StreamingAgent: Send + Sync {
     fn is_orchestration(&self) -> bool {
         false
     }
+
+    /// The assembled system prompt sent to the provider, if this agent has a
+    /// single static one.
+    ///
+    /// Defaults to `None` for implementors that have no single static prompt:
+    /// the orchestrator builds a distinct preamble per coordinator/worker
+    /// phase, so there is nothing to report at the agent level.
+    fn system_prompt(&self) -> Option<&str> {
+        None
+    }
 }


### PR DESCRIPTION
Records the assembled preamble, which includes the skills catalog and orchestration instructions, on a span each time these system prompt instructions are sent to the LLM. This instrumentation is controlled by the existing OTEL_RECORD_CONTENT and OTEL_CONTENT_MAX_LENGTH config options.

Fixes: #272