### PR TITLE
Approver identity header forwarding to downstream MCP calls

### DIFF
--- a/.makefiles/aura.mk
+++ b/.makefiles/aura.mk
@@ -262,3 +262,29 @@ test-integration-session-store-local: $(REPORT_DIR) ## Start an ephemeral Valkey
 	test_exit=$$?; \
 	docker stop $(VALKEY_TEST_NAME) >/dev/null 2>&1 || true; \
 	exit $$test_exit
+
+# --- HITL header-forwarding integration tests (needs only mock-mcp; each ---
+# --- test case spawns and tears down its own aura-web-server) ---
+
+.PHONY:test-integration-hitl-local
+test-integration-hitl-local: $(REPORT_DIR) ## Start mock-mcp, run HITL header-forwarding integration tests, then cleanup
+	@echo "Starting mock-mcp for HITL header-forwarding testing..."
+	docker compose -f compose/base.yml -f compose/dev.yml up -d --build --force-recreate mock-mcp
+	@echo "Waiting for mock-mcp to be healthy..."
+	@timeout=90; while [ $$timeout -gt 0 ]; do \
+		mcp_status=$$(docker compose -f compose/base.yml -f compose/dev.yml ps mock-mcp --format '{{.Health}}' 2>/dev/null); \
+		if [ "$$mcp_status" = "healthy" ]; then \
+			echo "✅ mock-mcp is healthy"; \
+			break; \
+		fi; \
+		echo "Waiting... mock-mcp: $$mcp_status ($$timeout s remaining)"; \
+		sleep 2; \
+		timeout=$$((timeout - 2)); \
+	done; \
+	if [ "$$mcp_status" != "healthy" ]; then echo "❌ Timeout waiting for mock-mcp"; docker compose -f compose/base.yml -f compose/dev.yml down; exit 1; fi
+	@echo "Running HITL header-forwarding integration tests..."
+	@trap 'docker compose -f compose/base.yml -f compose/dev.yml down; exit 130' INT TERM; \
+	cargo test --package aura-web-server --features integration-hitl-header-forwarding --test hitl_header_forwarding_tests --no-fail-fast -- --test-threads=1; \
+	test_exit=$$?; \
+	docker compose -f compose/base.yml -f compose/dev.yml down; \
+	exit $$test_exit

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -156,7 +156,7 @@ Integration tests run single-threaded (`--test-threads=1`) due to LLM API rate l
 | `integration-orchestration-sre` | SRE orchestration (requires k8s-sre-mcp server config)   |
 | `integration-scratchpad`        | Scratchpad (separate from parent `integration`; requires scratchpad-test-mcp server config) |
 | `integration-session-store`     | Redis/Valkey session store (separate from parent `integration`; requires a live Redis/Valkey via `AURA_TEST_REDIS_URL`) |
-| `integration-hitl-header-forwarding` | HITL approver header forwarding (separate from parent `integration`; a gated `echo_headers` would break the base suite's ungated calls to the same tool, so each test spawns its own aura-web-server) |
+| `integration-hitl-header-forwarding` | HITL approver header forwarding (separate from parent `integration`; spawns a per-case aura-web-server) |
 | `integration-vector`            | Vector store / RAG (requires external Qdrant)            |
 
 Example, run only the streaming tests:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -130,6 +130,12 @@ make test-integration-stdio-local
 # no other infra and no LLM key). To use an existing Redis/Valkey instead,
 # set AURA_TEST_REDIS_URL and run the cargo command directly.
 make test-integration-session-store-local
+
+# HITL header-forwarding tests (local only; needs mock-mcp up, same as the
+# base suite, but each test case spawns and tears down its own
+# aura-web-server against a generated per-case config, so there is no
+# separate -up/-down aura-web-server step).
+make test-integration-hitl-local
 ```
 
 Integration tests run single-threaded (`--test-threads=1`) due to LLM API rate limits.
@@ -150,6 +156,7 @@ Integration tests run single-threaded (`--test-threads=1`) due to LLM API rate l
 | `integration-orchestration-sre` | SRE orchestration (requires k8s-sre-mcp server config)   |
 | `integration-scratchpad`        | Scratchpad (separate from parent `integration`; requires scratchpad-test-mcp server config) |
 | `integration-session-store`     | Redis/Valkey session store (separate from parent `integration`; requires a live Redis/Valkey via `AURA_TEST_REDIS_URL`) |
+| `integration-hitl-header-forwarding` | HITL approver header forwarding (separate from parent `integration`; a gated `echo_headers` would break the base suite's ungated calls to the same tool, so each test spawns its own aura-web-server) |
 | `integration-vector`            | Vector store / RAG (requires external Qdrant)            |
 
 Example, run only the streaming tests:

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -99,6 +99,13 @@ impl DirectBackend {
             if let Some(hitl) = &config.hitl {
                 aura::hitl::validate_webhook_signing_config(hitl, hitl_webhook_hmac.as_ref())
                     .context("Invalid HITL webhook configuration")?;
+                aura::hitl::warn_on_cleartext_capture(hitl);
+                // The CLI's tracing subscriber is a no-op unless `log_file`
+                // is set, so the warning rides stderr as well — silent by
+                // default here would contradict the posture the ADR records.
+                if let Some(warning) = aura::hitl::cleartext_capture_warning(hitl) {
+                    eprintln!("warning: {warning}");
+                }
             }
         }
 

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -1406,8 +1406,7 @@ pub enum DecisionRouteConfig {
         headers_from_request: HashMap<String, String>,
         /// Outbound MCP header name → webhook approval-response header name.
         /// Non-empty opts gated calls into approver identity forwarding.
-        /// Validated at parse (see [`ToolHeaderMappings`]); the validated
-        /// map is carried but not consumed until capture wiring lands.
+        /// Validated at parse; see [`ToolHeaderMappings`].
         #[serde(default, skip_serializing_if = "ToolHeaderMappings::is_empty")]
         tool_headers_from_response: ToolHeaderMappings,
     },

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -1285,9 +1285,7 @@ tool_headers_from_response = {}
         );
     }
 
-    /// Both sides of a mapping are lowercased through the real TOML
-    /// deserialization path, so a config spelled in header case resolves the
-    /// same as one spelled in wire case.
+    /// Both sides of a mapping are lowercased through the real TOML deserialization path, so a config spelled in header case resolves like one spelled in wire case.
     #[test]
     fn hitl_webhook_tool_headers_response_name_lowercased() {
         let toml = r#"

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -1258,6 +1258,59 @@ tool_headers_from_response = { "Authorization" = "x-approver-token" }
         }
     }
 
+    /// An explicitly empty map is the same feature-off state as an absent
+    /// one, and survives a serialize round trip as an absent key.
+    #[test]
+    fn hitl_webhook_tool_headers_empty_map_is_feature_off() {
+        let toml = r#"
+require_approval = ["kubectl_*"]
+
+[route]
+mode = "webhook"
+url = "https://approvals.example.com/decide"
+tool_headers_from_response = {}
+"#;
+        let hitl: HitlConfig = toml::from_str(toml).unwrap();
+        match &hitl.route {
+            DecisionRouteConfig::Webhook {
+                tool_headers_from_response,
+                ..
+            } => assert!(tool_headers_from_response.is_empty()),
+            other => panic!("expected Webhook route, got {:?}", other),
+        }
+        let round_tripped = toml::to_string(&hitl).unwrap();
+        assert!(
+            !round_tripped.contains("tool_headers_from_response"),
+            "an empty map must not be emitted: {round_tripped}"
+        );
+    }
+
+    /// Both sides of a mapping are lowercased through the real TOML
+    /// deserialization path, so a config spelled in header case resolves the
+    /// same as one spelled in wire case.
+    #[test]
+    fn hitl_webhook_tool_headers_response_name_lowercased() {
+        let toml = r#"
+require_approval = ["kubectl_*"]
+
+[route]
+mode = "webhook"
+url = "https://approvals.example.com/decide"
+tool_headers_from_response = { "X-Forwarded-User" = "X-Approver-Id" }
+"#;
+        let hitl: HitlConfig = toml::from_str(toml).unwrap();
+        match hitl.route {
+            DecisionRouteConfig::Webhook {
+                tool_headers_from_response,
+                ..
+            } => assert_eq!(
+                tool_headers_from_response.iter().collect::<Vec<_>>(),
+                vec![("x-forwarded-user", "x-approver-id")]
+            ),
+            other => panic!("expected Webhook route, got {:?}", other),
+        }
+    }
+
     /// Reserved transport-owned names are rejected at parse.
     #[test]
     fn hitl_webhook_tool_headers_reserved_name_rejected() {

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -1405,8 +1405,6 @@ pub enum DecisionRouteConfig {
         #[serde(default)]
         headers_from_request: HashMap<String, String>,
         /// Outbound MCP header name → webhook approval-response header name.
-        /// Non-empty opts gated calls into approver identity forwarding.
-        /// Validated at parse; see [`ToolHeaderMappings`].
         #[serde(default, skip_serializing_if = "ToolHeaderMappings::is_empty")]
         tool_headers_from_response: ToolHeaderMappings,
     },
@@ -1424,8 +1422,7 @@ pub const RESERVED_TOOL_HEADER_NAMES: [&str; 6] = [
 ];
 
 /// Validated `tool_headers_from_response` mapping: outbound MCP header
-/// name → webhook approval-response header name, both sides lowercased
-/// at parse so an override always replaces the frozen default header.
+/// name → webhook approval-response header name, both sides lowercased.
 /// Syntactically invalid header names, duplicates after lowercasing, and
 /// reserved transport-owned names (see [`RESERVED_TOOL_HEADER_NAMES`])
 /// are rejected at construction, so downstream code never holds an
@@ -1434,7 +1431,7 @@ pub const RESERVED_TOOL_HEADER_NAMES: [&str; 6] = [
 pub struct ToolHeaderMappings(HashMap<String, String>);
 
 impl ToolHeaderMappings {
-    /// True when no mapping is configured (the legacy, feature-off state).
+    /// True when no mapping is configured.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()

--- a/crates/aura-web-server/Cargo.toml
+++ b/crates/aura-web-server/Cargo.toml
@@ -81,12 +81,8 @@ integration-scratchpad = []  # scratchpad_test
 # `AURA_TEST_REDIS_URL` in tests/redis_session_store_test.rs)
 integration-session-store = ["session-store-redis"]  # redis_session_store_test
 
-# HITL approver header forwarding (separate - a `require_approval` glob on
-# `echo_headers` would gate every call the base header_forwarding_tests.rs
-# suite makes to the same tool, so this suite builds its own aura-web-server
-# per test case against the shared mock-mcp fixture instead of the one
-# compose/base.yml starts). See hitl_header_forwarding_tests.rs for the run
-# recipe.
+# HITL approver header forwarding (separate per-case server; see
+# hitl_header_forwarding_tests.rs for why and the run recipe)
 integration-hitl-header-forwarding = []  # hitl_header_forwarding_tests
 
 [dev-dependencies]

--- a/crates/aura-web-server/Cargo.toml
+++ b/crates/aura-web-server/Cargo.toml
@@ -81,6 +81,14 @@ integration-scratchpad = []  # scratchpad_test
 # `AURA_TEST_REDIS_URL` in tests/redis_session_store_test.rs)
 integration-session-store = ["session-store-redis"]  # redis_session_store_test
 
+# HITL approver header forwarding (separate - a `require_approval` glob on
+# `echo_headers` would gate every call the base header_forwarding_tests.rs
+# suite makes to the same tool, so this suite builds its own aura-web-server
+# per test case against the shared mock-mcp fixture instead of the one
+# compose/base.yml starts). See hitl_header_forwarding_tests.rs for the run
+# recipe.
+integration-hitl-header-forwarding = []  # hitl_header_forwarding_tests
+
 [dev-dependencies]
 tokio-test = "0.4"
 reqwest = { workspace = true }

--- a/crates/aura-web-server/src/server.rs
+++ b/crates/aura-web-server/src/server.rs
@@ -404,7 +404,10 @@ async fn run(args: ServerArgs) -> std::io::Result<()> {
         )
     })?;
     // With a secret configured, a plaintext webhook URL fails at boot rather
-    // than on the first approval request.
+    // than on the first approval request. Cleartext response-header capture
+    // (a usable, unsigned configuration) warns here too, once per config —
+    // not from `WebhookClient` construction, which runs fresh on every
+    // request that builds an agent.
     for config in configs_arc.iter() {
         if let Some(hitl) = &config.hitl {
             aura::hitl::validate_webhook_signing_config(hitl, ingress_hmac.as_ref()).map_err(
@@ -416,6 +419,7 @@ async fn run(args: ServerArgs) -> std::io::Result<()> {
                     )
                 },
             )?;
+            aura::hitl::warn_on_cleartext_capture(hitl);
         }
     }
 

--- a/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
+++ b/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
@@ -6,33 +6,23 @@
 //! a real gated MCP call, over the actual `/v1/chat/completions` path —
 //! everything the unit suites cover only seam by seam.
 //!
-//! # Why this suite runs its own server
-//!
-//! `header_forwarding_tests.rs` shares one already-running `aura-web-server`
-//! and one `test-config.toml` with every other `integration-*` suite. A
-//! `require_approval` glob on `echo_headers` would gate every call that
-//! shared server makes to the tool, including that suite's — there is no way
-//! to scope `[hitl]` to a subset of calls on one running config. So each
-//! test here builds its own `aura-web-server` child process against its own
-//! generated config, on its own port, and tears it down when the test ends.
-//! All instances share the one `mock-mcp` fixture `header_forwarding_tests.rs`
-//! already depends on.
+//! Each test builds its own `aura-web-server` child process against its own
+//! generated config: the shared server behind `header_forwarding_tests.rs`
+//! cannot carry `[hitl]` gating, because a `require_approval` glob would
+//! gate every suite's calls to the same tool. All instances share the one
+//! `mock-mcp` fixture `header_forwarding_tests.rs` already depends on.
 //!
 //! # Run recipe
 //!
-//! 1. Start the shared MCP fixture (the same one `header_forwarding_tests.rs`
-//!    needs): `docker compose -f compose/base.yml -f compose/dev.yml up -d
-//!    mock-mcp`. Its FastMCP server must be reachable at
-//!    `${MCP_MOCK_HOST:-127.0.0.1}:9999`.
+//! 1. Start the shared MCP fixture: `docker compose -f compose/base.yml -f
+//!    compose/dev.yml up -d mock-mcp` (FastMCP at
+//!    `${MCP_MOCK_HOST:-127.0.0.1}:9999`).
 //! 2. Export `OPENAI_API_KEY` (each generated config resolves
 //!    `{{ env.OPENAI_API_KEY }}`, exactly like `test-config.toml`).
 //! 3. `cargo test -p aura-web-server --features integration-hitl-header-forwarding`.
 //!    Cargo builds `aura-web-server` as a side effect (via
 //!    `CARGO_BIN_EXE_aura-web-server`); each test spawns it fresh, waits on
 //!    `/health`, drives one chat completion, and kills it on drop.
-//!
-//! No docker image, compose overlay, or Makefile target is needed beyond
-//! step 1's existing `mock-mcp` service.
 
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -445,6 +435,14 @@ fn assistant_text(response_json: &Value) -> &str {
         .expect("response carries assistant message content")
 }
 
+/// The `echo_headers` JSON blob out of a chat response's assistant prose,
+/// with `context` naming what the calling test expected, so a miss names
+/// both the expectation and what the assistant actually said.
+fn headers_from_response(response_json: &Value, context: &str) -> Value {
+    let text = assistant_text(response_json);
+    extract_json_object(text).unwrap_or_else(|| panic!("{context}; got: {text:?}"))
+}
+
 /// The first `{...}` JSON object embedded in `text`, if any — mirrors
 /// `header_forwarding_tests.rs`'s extraction of the `echo_headers` JSON blob
 /// out of the model's prose.
@@ -493,12 +491,10 @@ async fn override_forwarded_to_the_gated_call() {
         "Call the echo_headers tool now and reply with only its raw JSON output.",
     )
     .await;
-    let headers = extract_json_object(assistant_text(&response)).unwrap_or_else(|| {
-        panic!(
-            "the assistant relays the echo_headers JSON output; got: {:?}",
-            assistant_text(&response)
-        )
-    });
+    let headers = headers_from_response(
+        &response,
+        "the assistant relays the echo_headers JSON output",
+    );
 
     assert_eq!(
         headers.get("authorization").and_then(Value::as_str),
@@ -601,12 +597,10 @@ async fn approval_with_no_configured_map_proceeds_with_no_override() {
         "Call the echo_headers tool now and reply with only its raw JSON output.",
     )
     .await;
-    let headers = extract_json_object(assistant_text(&response)).unwrap_or_else(|| {
-        panic!(
-            "an approval with no map still proceeds and echoes the real headers; got: {:?}",
-            assistant_text(&response)
-        )
-    });
+    let headers = headers_from_response(
+        &response,
+        "an approval with no map still proceeds and echoes the real headers",
+    );
 
     assert_eq!(
         headers.get("authorization").and_then(Value::as_str),
@@ -639,12 +633,10 @@ async fn a_tool_the_glob_does_not_match_is_unaffected() {
         "Call the echo_headers tool now and reply with only its raw JSON output.",
     )
     .await;
-    let headers = extract_json_object(assistant_text(&response)).unwrap_or_else(|| {
-        panic!(
-            "a tool the glob does not match runs with no approval step at all; got: {:?}",
-            assistant_text(&response)
-        )
-    });
+    let headers = headers_from_response(
+        &response,
+        "a tool the glob does not match runs with no approval step at all",
+    );
 
     assert_eq!(
         headers.get("authorization").and_then(Value::as_str),

--- a/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
+++ b/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
@@ -360,15 +360,11 @@ temperature = 0.0
     )
 }
 
-/// `[hitl]` gating `echo_headers`, routed to `approver_url`.
-/// `tool_headers_from_response` is present when `with_map` is true (cases 1-3)
-/// and absent when false (case 4, legacy behavior).
-fn gated_hitl_toml(approver_url: &str, with_map: bool) -> String {
-    let mapping = if with_map {
-        r#"tool_headers_from_response = { "authorization" = "x-approver-token" }"#
-    } else {
-        ""
-    };
+/// `[hitl]` gating `echo_headers`, routed to `approver_url`, with
+/// `tool_headers_from_response` mapping the approver token onto
+/// `authorization`.
+fn gated_hitl_toml(approver_url: &str) -> String {
+    let mapping = r#"tool_headers_from_response = { "authorization" = "x-approver-token" }"#;
     format!(
         r#"
 [hitl]
@@ -482,7 +478,7 @@ async fn override_forwarded_to_the_gated_call() {
     let server = AuraServer::start(&config_toml(
         &mcp_url(),
         "Bearer legacy-frozen-identity",
-        &gated_hitl_toml(&approver.url, true),
+        &gated_hitl_toml(&approver.url),
     ))
     .await;
 
@@ -517,7 +513,7 @@ async fn missing_mapped_header_fails_the_call_by_name_only() {
     let server = AuraServer::start(&config_toml(
         &mcp_url(),
         "Bearer legacy-frozen-identity",
-        &gated_hitl_toml(&approver.url, true),
+        &gated_hitl_toml(&approver.url),
     ))
     .await;
 
@@ -545,78 +541,7 @@ async fn missing_mapped_header_fails_the_call_by_name_only() {
     server.stop().await;
 }
 
-/// Case 3: a denial short-circuits before the inner tool ever runs — the
-/// assistant sees the denial text, never a real headers echo.
-#[tokio::test]
-async fn denial_short_circuits_before_the_tool_runs() {
-    let approver = MockApprover::start(ApproverReply::Deny).await;
-    let server = AuraServer::start(&config_toml(
-        &mcp_url(),
-        "Bearer legacy-frozen-identity",
-        &gated_hitl_toml(&approver.url, true),
-    ))
-    .await;
-
-    let response = send_chat(
-        &server,
-        "Call the echo_headers tool now and reply with only its exact output.",
-    )
-    .await;
-    let text = assistant_text(&response);
-
-    assert!(
-        text.to_lowercase().contains("denial") || text.to_lowercase().contains("blocked"),
-        "the assistant must relay the denial, got: {text}"
-    );
-    assert!(
-        extract_json_object(text).is_none(),
-        "a denied call must never reach the tool and echo real headers, got: {text}"
-    );
-    assert_eq!(
-        approver.hits(),
-        1,
-        "exactly one decision request for the one gated call"
-    );
-    server.stop().await;
-}
-
-/// Case 4: an approval with no `tool_headers_from_response` configured
-/// proceeds exactly as it did before this feature — no override anywhere.
-#[tokio::test]
-async fn approval_with_no_configured_map_proceeds_with_no_override() {
-    let approver = MockApprover::start(ApproverReply::ApproveBare).await;
-    let server = AuraServer::start(&config_toml(
-        &mcp_url(),
-        "Bearer legacy-frozen-identity",
-        &gated_hitl_toml(&approver.url, false),
-    ))
-    .await;
-
-    let response = send_chat(
-        &server,
-        "Call the echo_headers tool now and reply with only its raw JSON output.",
-    )
-    .await;
-    let headers = headers_from_response(
-        &response,
-        "an approval with no map still proceeds and echoes the real headers",
-    );
-
-    assert_eq!(
-        headers.get("authorization").and_then(Value::as_str),
-        Some("Bearer legacy-frozen-identity"),
-        "with no tool_headers_from_response configured, the call keeps the frozen \
-         identity, got: {headers}"
-    );
-    assert_eq!(
-        approver.hits(),
-        1,
-        "exactly one decision request for the one gated call"
-    );
-    server.stop().await;
-}
-
-/// Case 5: `[hitl]` is configured, but the glob does not match this tool —
+/// Case 3: `[hitl]` is configured, but the glob does not match this tool —
 /// the call never consults the route, so a denying approver never fires.
 #[tokio::test]
 async fn a_tool_the_glob_does_not_match_is_unaffected() {

--- a/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
+++ b/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
@@ -1,0 +1,660 @@
+#![cfg(feature = "integration-hitl-header-forwarding")]
+
+//! Integration tests for HITL approver header forwarding (aura#496).
+//!
+//! Proves the override path end to end, through a real approval webhook and
+//! a real gated MCP call, over the actual `/v1/chat/completions` path —
+//! everything the unit suites cover only seam by seam.
+//!
+//! # Why this suite runs its own server
+//!
+//! `header_forwarding_tests.rs` shares one already-running `aura-web-server`
+//! and one `test-config.toml` with every other `integration-*` suite. A
+//! `require_approval` glob on `echo_headers` would gate every call that
+//! shared server makes to the tool, including that suite's — there is no way
+//! to scope `[hitl]` to a subset of calls on one running config. So each
+//! test here builds its own `aura-web-server` child process against its own
+//! generated config, on its own port, and tears it down when the test ends.
+//! All instances share the one `mock-mcp` fixture `header_forwarding_tests.rs`
+//! already depends on.
+//!
+//! # Run recipe
+//!
+//! 1. Start the shared MCP fixture (the same one `header_forwarding_tests.rs`
+//!    needs): `docker compose -f compose/base.yml -f compose/dev.yml up -d
+//!    mock-mcp`. Its FastMCP server must be reachable at
+//!    `${MCP_MOCK_HOST:-127.0.0.1}:9999`.
+//! 2. Export `OPENAI_API_KEY` (each generated config resolves
+//!    `{{ env.OPENAI_API_KEY }}`, exactly like `test-config.toml`).
+//! 3. `cargo test -p aura-web-server --features integration-hitl-header-forwarding`.
+//!    Cargo builds `aura-web-server` as a side effect (via
+//!    `CARGO_BIN_EXE_aura-web-server`); each test spawns it fresh, waits on
+//!    `/health`, drives one chat completion, and kills it on drop.
+//!
+//! No docker image, compose overlay, or Makefile target is needed beyond
+//! step 1's existing `mock-mcp` service.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::process::{Child, Command};
+
+const CHAT_TIMEOUT: Duration = Duration::from_secs(90);
+const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// A dedicated aura-web-server, spawned fresh per test case
+// ---------------------------------------------------------------------------
+
+/// A freshly spawned `aura-web-server`, bound to its own port and reading a
+/// config generated for exactly one test case. Killed and its config file
+/// removed on drop.
+struct AuraServer {
+    port: u16,
+    child: Child,
+    config_path: PathBuf,
+    /// Accumulated stderr, drained continuously so the child's pipe never
+    /// blocks; read back to explain a health-check timeout.
+    stderr_log: Arc<Mutex<String>>,
+}
+
+impl AuraServer {
+    fn base_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+
+    /// Spawn `aura-web-server` (built as a side effect of this test binary,
+    /// via `CARGO_BIN_EXE_aura-web-server`) against `config_toml`, and wait
+    /// until it answers `/health`. `free_port`'s bind-then-drop leaves a
+    /// window for something else to grab the port before the child binds it;
+    /// one retry on a fresh port covers that without masking a genuine
+    /// startup failure, which still panics on the second attempt.
+    async fn start(config_toml: &str) -> Self {
+        match Self::try_start(config_toml).await {
+            Ok(server) => server,
+            Err(failed) => {
+                let log = failed.stderr_log.lock().expect("stderr log mutex").clone();
+                eprintln!(
+                    "aura-web-server on port {} never answered /health within {HEALTH_TIMEOUT:?}; \
+                     retrying once on a fresh port. stderr:\n{log}",
+                    failed.port
+                );
+                failed.stop().await;
+                match Self::try_start(config_toml).await {
+                    Ok(server) => server,
+                    Err(failed) => {
+                        let log = failed.stderr_log.lock().expect("stderr log mutex").clone();
+                        let port = failed.port;
+                        failed.stop().await;
+                        panic!(
+                            "aura-web-server never answered /health, on a fresh port either; \
+                             last tried port {port}; stderr:\n{log}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// One spawn-and-wait attempt. `Err` carries the (still-running) server
+    /// so the caller can log its stderr and stop it before retrying.
+    async fn try_start(config_toml: &str) -> Result<Self, Self> {
+        let port = free_port();
+        let config_path =
+            std::env::temp_dir().join(format!("aura-hitl-test-{}.toml", uuid::Uuid::new_v4()));
+        std::fs::write(&config_path, config_toml).expect("write generated test config");
+
+        let mut child = Command::new(env!("CARGO_BIN_EXE_aura-web-server"))
+            .env("CONFIG_PATH", &config_path)
+            .env("HOST", "127.0.0.1")
+            .env("PORT", port.to_string())
+            .env("RUST_LOG", "warn")
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn aura-web-server (did `cargo build -p aura-web-server` succeed?)");
+
+        let stderr_log = Arc::new(Mutex::new(String::new()));
+        let stderr = child.stderr.take().expect("stderr was piped");
+        let log_sink = Arc::clone(&stderr_log);
+        tokio::spawn(async move {
+            let mut lines = tokio::io::BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let mut log = log_sink.lock().expect("stderr log mutex");
+                log.push_str(&line);
+                log.push('\n');
+            }
+        });
+
+        let server = Self {
+            port,
+            child,
+            config_path,
+            stderr_log,
+        };
+        if server.is_healthy_within(HEALTH_TIMEOUT).await {
+            Ok(server)
+        } else {
+            Err(server)
+        }
+    }
+
+    async fn is_healthy_within(&self, timeout: Duration) -> bool {
+        let client = reqwest::Client::new();
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Ok(resp) = client
+                .get(format!("{}/health", self.base_url()))
+                .send()
+                .await
+                && resp.status().is_success()
+            {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+
+    /// Kill the child and await its exit, reaping the process, then remove
+    /// its generated config file. Call this explicitly at the end of a
+    /// test; `Drop`'s `start_kill` is only the fallback for a test that
+    /// panics before reaching it, since a non-blocking kill on drop cannot
+    /// await the reap.
+    async fn stop(mut self) {
+        let _ = self.child.kill().await;
+        let _ = std::fs::remove_file(&self.config_path);
+    }
+}
+
+impl Drop for AuraServer {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+        let _ = std::fs::remove_file(&self.config_path);
+    }
+}
+
+/// An OS-assigned free port, read and released before the caller uses it.
+/// The bind-then-drop race is the standard tolerance for test-local ports.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+// ---------------------------------------------------------------------------
+// A hand-rolled mock webhook approver
+// ---------------------------------------------------------------------------
+
+/// How the mock approver answers every decision request it receives for the
+/// life of one test.
+#[derive(Clone, Copy)]
+enum ApproverReply {
+    /// Approve and return one extra response header, for capture.
+    ApproveWithHeader {
+        name: &'static str,
+        value: &'static str,
+    },
+    /// Approve with no extra headers — the mapped header (if any) is missing.
+    ApproveBare,
+    /// Deny every request.
+    Deny,
+}
+
+/// An in-process webhook approver bound to a loopback port, answering every
+/// POST it receives the same way for the life of the test. Mirrors the
+/// one-shot receiver idiom in `hitl::route`'s `webhook_signing` tests, minus
+/// the one-shot restriction: a chat turn may retry or the harness may want
+/// more than one decision, so this loops `accept`.
+struct MockApprover {
+    url: String,
+    hits: Arc<AtomicUsize>,
+}
+
+impl MockApprover {
+    async fn start(reply: ApproverReply) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock approver");
+        let url = format!("http://{}/decision", listener.local_addr().unwrap());
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hit_sink = Arc::clone(&hits);
+        tokio::spawn(async move {
+            while let Ok((socket, _)) = listener.accept().await {
+                // Counted on accept, before the decision is served: a test
+                // asserting `hits() == 0` is asserting the gate never even
+                // opened a connection, not that a slow reply raced the
+                // assertion.
+                hit_sink.fetch_add(1, Ordering::SeqCst);
+                serve_one_decision(socket, reply).await;
+            }
+        });
+        Self { url, hits }
+    }
+
+    /// How many decision requests this approver has accepted so far. The
+    /// direct proof that a call did, or did not, consult the route at all —
+    /// stronger than inferring it from the reply's shape.
+    fn hits(&self) -> usize {
+        self.hits.load(Ordering::SeqCst)
+    }
+}
+
+/// Read one HTTP request off `socket` and answer it per `reply`. Ignores the
+/// request body: which decision to hand back is fixed per test, not derived
+/// from the payload.
+async fn serve_one_decision(mut socket: tokio::net::TcpStream, reply: ApproverReply) {
+    let mut buf = Vec::new();
+    let head_end = loop {
+        let mut chunk = [0u8; 4096];
+        let Ok(n) = socket.read(&mut chunk).await else {
+            return;
+        };
+        if n == 0 {
+            return;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+            break pos;
+        }
+    };
+    let head = String::from_utf8_lossy(&buf[..head_end]).into_owned();
+    let content_length: usize = head
+        .lines()
+        .filter_map(|line| line.split_once(':'))
+        .find(|(name, _)| name.trim().eq_ignore_ascii_case("content-length"))
+        .and_then(|(_, value)| value.trim().parse().ok())
+        .unwrap_or(0);
+    let mut body = buf[head_end + 4..].to_vec();
+    while body.len() < content_length {
+        let mut chunk = [0u8; 4096];
+        let Ok(n) = socket.read(&mut chunk).await else {
+            return;
+        };
+        if n == 0 {
+            return;
+        }
+        body.extend_from_slice(&chunk[..n]);
+    }
+
+    let (payload, extra_header) = match reply {
+        ApproverReply::ApproveWithHeader { name, value } => {
+            (json!({"approved": true}).to_string(), Some((name, value)))
+        }
+        ApproverReply::ApproveBare => (json!({"approved": true}).to_string(), None),
+        ApproverReply::Deny => (
+            json!({"approved": false, "reason": "integration test denial"}).to_string(),
+            None,
+        ),
+    };
+
+    let mut response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n",
+        payload.len()
+    );
+    if let Some((name, value)) = extra_header {
+        response.push_str(&format!("{name}: {value}\r\n"));
+    }
+    response.push_str("\r\n");
+    response.push_str(&payload);
+    socket.write_all(response.as_bytes()).await.ok();
+    socket.shutdown().await.ok();
+}
+
+// ---------------------------------------------------------------------------
+// Generated config
+// ---------------------------------------------------------------------------
+
+/// The shared mock-mcp fixture's URL — the same server
+/// `header_forwarding_tests.rs` depends on, honoring the same `MCP_MOCK_HOST`
+/// override for container-network runs.
+fn mcp_url() -> String {
+    let host = std::env::var("MCP_MOCK_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    format!("http://{host}:9999/mcp")
+}
+
+/// A minimal single-agent config: one MCP server with a frozen static
+/// `Authorization` header (standing in for the pre-approval requester
+/// identity, as `test-config.toml` does for the base suite), plus whatever
+/// `[hitl]` table the caller supplies.
+fn config_toml(mcp_url: &str, frozen_authorization: &str, hitl_toml: &str) -> String {
+    format!(
+        r#"
+[mcp]
+sanitize_schemas = true
+
+[mcp.servers.mock_test_server]
+transport = "http_streamable"
+url = "{mcp_url}"
+description = "Mock MCP server for HITL header-forwarding integration tests"
+
+[mcp.servers.mock_test_server.headers]
+Authorization = "{frozen_authorization}"
+
+[agent]
+name = "HITL Header Forwarding Test Assistant"
+alias = "test-assistant"
+system_prompt = """
+You are a test assistant. Call tools immediately when requested, with no
+explanation, confirmation, or promise to call them later.
+
+If a tool call succeeds, reply with only its raw output - no commentary.
+
+If a tool call returns an error, reply with only the exact error message
+text - no apology, no extra commentary.
+
+AVAILABLE TOOLS (from mock_test_server):
+- echo_headers: Return HTTP headers as JSON (no params)
+"""
+turn_depth = 3
+
+[agent.llm]
+provider = "openai"
+api_key = "{{{{ env.OPENAI_API_KEY }}}}"
+model = "gpt-5.1"
+temperature = 0.0
+
+{hitl_toml}
+"#
+    )
+}
+
+/// `[hitl]` gating `echo_headers`, routed to `approver_url`.
+/// `tool_headers_from_response` is present when `with_map` is true (cases 1-3)
+/// and absent when false (case 4, legacy behavior).
+fn gated_hitl_toml(approver_url: &str, with_map: bool) -> String {
+    let mapping = if with_map {
+        r#"tool_headers_from_response = { "authorization" = "x-approver-token" }"#
+    } else {
+        ""
+    };
+    format!(
+        r#"
+[hitl]
+require_approval = ["echo_headers"]
+
+[hitl.route]
+mode = "webhook"
+url = "{approver_url}"
+{mapping}
+"#
+    )
+}
+
+/// `[hitl]` present and pointed at a real (denying) approver, but its glob
+/// matches no tool this suite calls — proves an unmatched call never
+/// consults the route at all.
+fn ungated_hitl_toml(approver_url: &str) -> String {
+    format!(
+        r#"
+[hitl]
+require_approval = ["not_a_real_tool_*"]
+
+[hitl.route]
+mode = "webhook"
+url = "{approver_url}"
+tool_headers_from_response = {{ "authorization" = "x-approver-token" }}
+"#
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Chat helpers
+// ---------------------------------------------------------------------------
+
+async fn send_chat(server: &AuraServer, prompt: &str) -> Value {
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("{}/v1/chat/completions", server.base_url()))
+        .json(&json!({
+            "model": "test-assistant",
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": false,
+            "metadata": {
+                "account_id": "test-account",
+                "chat_session_id": format!("hitl-test-{}", uuid::Uuid::new_v4())
+            }
+        }))
+        .timeout(CHAT_TIMEOUT)
+        .send()
+        .await
+        .expect("chat completion request reaches the server");
+
+    assert_eq!(
+        response.status(),
+        200,
+        "expected 200 OK from /v1/chat/completions"
+    );
+    response.json().await.expect("response body is valid JSON")
+}
+
+fn assistant_text(response_json: &Value) -> &str {
+    response_json["choices"][0]["message"]["content"]
+        .as_str()
+        .expect("response carries assistant message content")
+}
+
+/// The first `{...}` JSON object embedded in `text`, if any — mirrors
+/// `header_forwarding_tests.rs`'s extraction of the `echo_headers` JSON blob
+/// out of the model's prose.
+fn extract_json_object(text: &str) -> Option<Value> {
+    // The assistant relays the tool output in whatever quoting it fancies:
+    // bare, wrapped as a JSON string literal, or with the headers JSON
+    // stringified inside a `result` field - sometimes several layers deep.
+    // Unwrap until an object with plain fields remains.
+    if let Ok(Value::String(inner)) = serde_json::from_str::<Value>(text.trim()) {
+        return extract_json_object(&inner);
+    }
+    let start = text.find('{')?;
+    let end = text.rfind('}')?;
+    let mut value: Value = serde_json::from_str(&text[start..=end]).ok()?;
+    while let Some(inner) = value.get("result").and_then(Value::as_str) {
+        match serde_json::from_str::<Value>(inner) {
+            Ok(unwrapped) => value = unwrapped,
+            Err(_) => break,
+        }
+    }
+    Some(value)
+}
+
+// ---------------------------------------------------------------------------
+// Cases (spec Phase 3)
+// ---------------------------------------------------------------------------
+
+/// Case 1: an approved decision carrying the mapped header replaces the
+/// frozen requester identity on the one gated call.
+#[tokio::test]
+async fn override_forwarded_to_the_gated_call() {
+    let approver = MockApprover::start(ApproverReply::ApproveWithHeader {
+        name: "x-approver-token",
+        value: "Bearer approver-issued-identity",
+    })
+    .await;
+    let server = AuraServer::start(&config_toml(
+        &mcp_url(),
+        "Bearer legacy-frozen-identity",
+        &gated_hitl_toml(&approver.url, true),
+    ))
+    .await;
+
+    let response = send_chat(
+        &server,
+        "Call the echo_headers tool now and reply with only its raw JSON output.",
+    )
+    .await;
+    let headers = extract_json_object(assistant_text(&response)).unwrap_or_else(|| {
+        panic!(
+            "the assistant relays the echo_headers JSON output; got: {:?}",
+            assistant_text(&response)
+        )
+    });
+
+    assert_eq!(
+        headers.get("authorization").and_then(Value::as_str),
+        Some("Bearer approver-issued-identity"),
+        "the approver's identity must replace the frozen requester identity, got: {headers}"
+    );
+    assert_eq!(
+        approver.hits(),
+        1,
+        "exactly one decision request for the one gated call"
+    );
+    server.stop().await;
+}
+
+/// Case 2: an approved decision missing the mapped header fails the gated
+/// call closed; the error names the header, never any value.
+#[tokio::test]
+async fn missing_mapped_header_fails_the_call_by_name_only() {
+    let approver = MockApprover::start(ApproverReply::ApproveBare).await;
+    let server = AuraServer::start(&config_toml(
+        &mcp_url(),
+        "Bearer legacy-frozen-identity",
+        &gated_hitl_toml(&approver.url, true),
+    ))
+    .await;
+
+    let response = send_chat(
+        &server,
+        "Call the echo_headers tool now. If it returns an error, reply with \
+         only the exact error message text.",
+    )
+    .await;
+    let text = assistant_text(&response);
+
+    assert!(
+        text.to_lowercase().contains("authorization"),
+        "the error must name the missing header, got: {text}"
+    );
+    assert!(
+        !text.contains("legacy-frozen-identity"),
+        "the error must never leak a header value, got: {text}"
+    );
+    assert_eq!(
+        approver.hits(),
+        1,
+        "exactly one decision request for the one gated call"
+    );
+    server.stop().await;
+}
+
+/// Case 3: a denial short-circuits before the inner tool ever runs — the
+/// assistant sees the denial text, never a real headers echo.
+#[tokio::test]
+async fn denial_short_circuits_before_the_tool_runs() {
+    let approver = MockApprover::start(ApproverReply::Deny).await;
+    let server = AuraServer::start(&config_toml(
+        &mcp_url(),
+        "Bearer legacy-frozen-identity",
+        &gated_hitl_toml(&approver.url, true),
+    ))
+    .await;
+
+    let response = send_chat(
+        &server,
+        "Call the echo_headers tool now and reply with only its exact output.",
+    )
+    .await;
+    let text = assistant_text(&response);
+
+    assert!(
+        text.to_lowercase().contains("denial") || text.to_lowercase().contains("blocked"),
+        "the assistant must relay the denial, got: {text}"
+    );
+    assert!(
+        extract_json_object(text).is_none(),
+        "a denied call must never reach the tool and echo real headers, got: {text}"
+    );
+    assert_eq!(
+        approver.hits(),
+        1,
+        "exactly one decision request for the one gated call"
+    );
+    server.stop().await;
+}
+
+/// Case 4: an approval with no `tool_headers_from_response` configured
+/// proceeds exactly as it did before this feature — no override anywhere.
+#[tokio::test]
+async fn approval_with_no_configured_map_proceeds_with_no_override() {
+    let approver = MockApprover::start(ApproverReply::ApproveBare).await;
+    let server = AuraServer::start(&config_toml(
+        &mcp_url(),
+        "Bearer legacy-frozen-identity",
+        &gated_hitl_toml(&approver.url, false),
+    ))
+    .await;
+
+    let response = send_chat(
+        &server,
+        "Call the echo_headers tool now and reply with only its raw JSON output.",
+    )
+    .await;
+    let headers = extract_json_object(assistant_text(&response)).unwrap_or_else(|| {
+        panic!(
+            "an approval with no map still proceeds and echoes the real headers; got: {:?}",
+            assistant_text(&response)
+        )
+    });
+
+    assert_eq!(
+        headers.get("authorization").and_then(Value::as_str),
+        Some("Bearer legacy-frozen-identity"),
+        "with no tool_headers_from_response configured, the call keeps the frozen \
+         identity, got: {headers}"
+    );
+    assert_eq!(
+        approver.hits(),
+        1,
+        "exactly one decision request for the one gated call"
+    );
+    server.stop().await;
+}
+
+/// Case 5: `[hitl]` is configured, but the glob does not match this tool —
+/// the call never consults the route, so a denying approver never fires.
+#[tokio::test]
+async fn a_tool_the_glob_does_not_match_is_unaffected() {
+    let approver = MockApprover::start(ApproverReply::Deny).await;
+    let server = AuraServer::start(&config_toml(
+        &mcp_url(),
+        "Bearer legacy-frozen-identity",
+        &ungated_hitl_toml(&approver.url),
+    ))
+    .await;
+
+    let response = send_chat(
+        &server,
+        "Call the echo_headers tool now and reply with only its raw JSON output.",
+    )
+    .await;
+    let headers = extract_json_object(assistant_text(&response)).unwrap_or_else(|| {
+        panic!(
+            "a tool the glob does not match runs with no approval step at all; got: {:?}",
+            assistant_text(&response)
+        )
+    });
+
+    assert_eq!(
+        headers.get("authorization").and_then(Value::as_str),
+        Some("Bearer legacy-frozen-identity"),
+        "an unmatched call must carry no approver override, got: {headers}"
+    );
+    assert_eq!(
+        approver.hits(),
+        0,
+        "a call the glob does not match must never consult the approver at all"
+    );
+    server.stop().await;
+}

--- a/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
+++ b/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
@@ -38,6 +38,9 @@ use tokio::process::{Child, Command};
 const CHAT_TIMEOUT: Duration = Duration::from_secs(90);
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// The prompt that has the model call `echo_headers` and relay its output.
+const ECHO_PROMPT: &str = "Call the echo_headers tool now and reply with only its raw JSON output.";
+
 // ---------------------------------------------------------------------------
 // A dedicated aura-web-server, spawned fresh per test case
 // ---------------------------------------------------------------------------
@@ -466,27 +469,35 @@ fn extract_json_object(text: &str) -> Option<Value> {
 // Cases (spec Phase 3)
 // ---------------------------------------------------------------------------
 
-/// Case 1: an approved decision carrying the mapped header replaces the
-/// frozen requester identity on the one gated call.
-#[tokio::test]
-async fn override_forwarded_to_the_gated_call() {
-    let approver = MockApprover::start(ApproverReply::ApproveWithHeader {
-        name: "x-approver-token",
-        value: "Bearer approver-issued-identity",
-    })
-    .await;
+/// An approver answering with `reply`, plus a freshly spawned server whose
+/// `[hitl]` route points at it and whose client carries the frozen identity.
+async fn gated_server(reply: ApproverReply) -> (MockApprover, AuraServer) {
+    let approver = MockApprover::start(reply).await;
     let server = AuraServer::start(&config_toml(
         &mcp_url(),
         "Bearer legacy-frozen-identity",
         &gated_hitl_toml(&approver.url),
     ))
     .await;
+    (approver, server)
+}
 
-    let response = send_chat(
-        &server,
-        "Call the echo_headers tool now and reply with only its raw JSON output.",
-    )
+/// The approver saw exactly `expected` decision requests; `context` says why.
+fn assert_hits(approver: &MockApprover, expected: usize, context: &str) {
+    assert_eq!(approver.hits(), expected, "{context}");
+}
+
+/// Case 1: an approved decision carrying the mapped header replaces the
+/// frozen requester identity on the one gated call.
+#[tokio::test]
+async fn override_forwarded_to_the_gated_call() {
+    let (approver, server) = gated_server(ApproverReply::ApproveWithHeader {
+        name: "x-approver-token",
+        value: "Bearer approver-issued-identity",
+    })
     .await;
+
+    let response = send_chat(&server, ECHO_PROMPT).await;
     let headers = headers_from_response(
         &response,
         "the assistant relays the echo_headers JSON output",
@@ -497,10 +508,10 @@ async fn override_forwarded_to_the_gated_call() {
         Some("Bearer approver-issued-identity"),
         "the approver's identity must replace the frozen requester identity, got: {headers}"
     );
-    assert_eq!(
-        approver.hits(),
+    assert_hits(
+        &approver,
         1,
-        "exactly one decision request for the one gated call"
+        "exactly one decision request for the one gated call",
     );
     server.stop().await;
 }
@@ -509,13 +520,7 @@ async fn override_forwarded_to_the_gated_call() {
 /// call closed; the error names the header, never any value.
 #[tokio::test]
 async fn missing_mapped_header_fails_the_call_by_name_only() {
-    let approver = MockApprover::start(ApproverReply::ApproveBare).await;
-    let server = AuraServer::start(&config_toml(
-        &mcp_url(),
-        "Bearer legacy-frozen-identity",
-        &gated_hitl_toml(&approver.url),
-    ))
-    .await;
+    let (approver, server) = gated_server(ApproverReply::ApproveBare).await;
 
     let response = send_chat(
         &server,
@@ -533,10 +538,10 @@ async fn missing_mapped_header_fails_the_call_by_name_only() {
         !text.contains("legacy-frozen-identity"),
         "the error must never leak a header value, got: {text}"
     );
-    assert_eq!(
-        approver.hits(),
+    assert_hits(
+        &approver,
         1,
-        "exactly one decision request for the one gated call"
+        "exactly one decision request for the one gated call",
     );
     server.stop().await;
 }
@@ -553,11 +558,7 @@ async fn a_tool_the_glob_does_not_match_is_unaffected() {
     ))
     .await;
 
-    let response = send_chat(
-        &server,
-        "Call the echo_headers tool now and reply with only its raw JSON output.",
-    )
-    .await;
+    let response = send_chat(&server, ECHO_PROMPT).await;
     let headers = headers_from_response(
         &response,
         "a tool the glob does not match runs with no approval step at all",
@@ -568,10 +569,10 @@ async fn a_tool_the_glob_does_not_match_is_unaffected() {
         Some("Bearer legacy-frozen-identity"),
         "an unmatched call must carry no approver override, got: {headers}"
     );
-    assert_eq!(
-        approver.hits(),
+    assert_hits(
+        &approver,
         0,
-        "a call the glob does not match must never consult the approver at all"
+        "a call the glob does not match must never consult the approver at all",
     );
     server.stop().await;
 }

--- a/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
+++ b/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
@@ -14,15 +14,10 @@
 //!
 //! # Run recipe
 //!
-//! 1. Start the shared MCP fixture: `docker compose -f compose/base.yml -f
-//!    compose/dev.yml up -d mock-mcp` (FastMCP at
-//!    `${MCP_MOCK_HOST:-127.0.0.1}:9999`).
-//! 2. Export `OPENAI_API_KEY` (each generated config resolves
-//!    `{{ env.OPENAI_API_KEY }}`, exactly like `test-config.toml`).
-//! 3. `cargo test -p aura-web-server --features integration-hitl-header-forwarding`.
-//!    Cargo builds `aura-web-server` as a side effect (via
-//!    `CARGO_BIN_EXE_aura-web-server`); each test spawns it fresh, waits on
-//!    `/health`, drives one chat completion, and kills it on drop.
+//! `make test-integration-hitl-local` (`.makefiles/aura.mk`) starts the
+//! shared `mock-mcp` fixture, needs no env beyond `OPENAI_API_KEY`, and runs
+//! this suite. Each test spawns its server fresh, waits on `/health`, drives
+//! one chat completion, and kills it on drop.
 
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -45,9 +40,7 @@ const ECHO_PROMPT: &str = "Call the echo_headers tool now and reply with only it
 // A dedicated aura-web-server, spawned fresh per test case
 // ---------------------------------------------------------------------------
 
-/// A freshly spawned `aura-web-server`, bound to its own port and reading a
-/// config generated for exactly one test case. Killed and its config file
-/// removed on drop.
+/// A freshly spawned `aura-web-server`, bound to its own port and reading a config generated for exactly one test case. Killed and its config file removed on drop.
 struct AuraServer {
     port: u16,
     child: Child,
@@ -62,12 +55,7 @@ impl AuraServer {
         format!("http://127.0.0.1:{}", self.port)
     }
 
-    /// Spawn `aura-web-server` (built as a side effect of this test binary,
-    /// via `CARGO_BIN_EXE_aura-web-server`) against `config_toml`, and wait
-    /// until it answers `/health`. `free_port`'s bind-then-drop leaves a
-    /// window for something else to grab the port before the child binds it;
-    /// one retry on a fresh port covers that without masking a genuine
-    /// startup failure, which still panics on the second attempt.
+    /// Spawn `aura-web-server` against `config_toml`, wait until it answers `/health`. `free_port`'s bind-then-drop leaves a window for another process to grab the port; one retry on a fresh port covers that.
     async fn start(config_toml: &str) -> Self {
         match Self::try_start(config_toml).await {
             Ok(server) => server,
@@ -158,11 +146,7 @@ impl AuraServer {
         }
     }
 
-    /// Kill the child and await its exit, reaping the process, then remove
-    /// its generated config file. Call this explicitly at the end of a
-    /// test; `Drop`'s `start_kill` is only the fallback for a test that
-    /// panics before reaching it, since a non-blocking kill on drop cannot
-    /// await the reap.
+    /// Kill the child and await its exit, reaping the process, then remove its generated config file. Call this explicitly at test end; `Drop`'s `start_kill` is only the fallback for a test that panics.
     async fn stop(mut self) {
         let _ = self.child.kill().await;
         let _ = std::fs::remove_file(&self.config_path);
@@ -205,11 +189,7 @@ enum ApproverReply {
     Deny,
 }
 
-/// An in-process webhook approver bound to a loopback port, answering every
-/// POST it receives the same way for the life of the test. Mirrors the
-/// one-shot receiver idiom in `hitl::route`'s `webhook_signing` tests, minus
-/// the one-shot restriction: a chat turn may retry or the harness may want
-/// more than one decision, so this loops `accept`.
+/// An in-process webhook approver bound to a loopback port, answering every POST it receives the same way for the life of the test. Mirrors the one-shot receiver idiom in `hitl::route`'s `webhook_signing` tests, minus the one-shot restriction.
 struct MockApprover {
     url: String,
     hits: Arc<AtomicUsize>,
@@ -236,17 +216,13 @@ impl MockApprover {
         Self { url, hits }
     }
 
-    /// How many decision requests this approver has accepted so far. The
-    /// direct proof that a call did, or did not, consult the route at all —
-    /// stronger than inferring it from the reply's shape.
+    /// How many decision requests this approver has accepted so far: direct proof that a call did, or did not, consult the route.
     fn hits(&self) -> usize {
         self.hits.load(Ordering::SeqCst)
     }
 }
 
-/// Read one HTTP request off `socket` and answer it per `reply`. Ignores the
-/// request body: which decision to hand back is fixed per test, not derived
-/// from the payload.
+/// Read one HTTP request off `socket` and answer it per `reply`. Ignores the request body: which decision to hand back is fixed per test.
 async fn serve_one_decision(mut socket: tokio::net::TcpStream, reply: ApproverReply) {
     let mut buf = Vec::new();
     let head_end = loop {
@@ -309,18 +285,13 @@ async fn serve_one_decision(mut socket: tokio::net::TcpStream, reply: ApproverRe
 // Generated config
 // ---------------------------------------------------------------------------
 
-/// The shared mock-mcp fixture's URL — the same server
-/// `header_forwarding_tests.rs` depends on, honoring the same `MCP_MOCK_HOST`
-/// override for container-network runs.
+/// The shared mock-mcp fixture's URL, the same server `header_forwarding_tests.rs` depends on, honoring the same `MCP_MOCK_HOST` override.
 fn mcp_url() -> String {
     let host = std::env::var("MCP_MOCK_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
     format!("http://{host}:9999/mcp")
 }
 
-/// A minimal single-agent config: one MCP server with a frozen static
-/// `Authorization` header (standing in for the pre-approval requester
-/// identity, as `test-config.toml` does for the base suite), plus whatever
-/// `[hitl]` table the caller supplies.
+/// A minimal single-agent config: one MCP server with a frozen static `Authorization` header (standing in for pre-approval requester identity), plus whatever `[hitl]` table the caller supplies.
 fn config_toml(mcp_url: &str, frozen_authorization: &str, hitl_toml: &str) -> String {
     format!(
         r#"
@@ -363,9 +334,7 @@ temperature = 0.0
     )
 }
 
-/// `[hitl]` gating `echo_headers`, routed to `approver_url`, with
-/// `tool_headers_from_response` mapping the approver token onto
-/// `authorization`.
+/// `[hitl]` gating `echo_headers`, routed to `approver_url`, with `tool_headers_from_response` mapping the approver token onto `authorization`.
 fn gated_hitl_toml(approver_url: &str) -> String {
     let mapping = r#"tool_headers_from_response = { "authorization" = "x-approver-token" }"#;
     format!(
@@ -381,9 +350,7 @@ url = "{approver_url}"
     )
 }
 
-/// `[hitl]` present and pointed at a real (denying) approver, but its glob
-/// matches no tool this suite calls — proves an unmatched call never
-/// consults the route at all.
+/// `[hitl]` present and pointed at a real (denying) approver, but its glob matches no tool this suite calls, proving an unmatched call never consults the route.
 fn ungated_hitl_toml(approver_url: &str) -> String {
     format!(
         r#"
@@ -434,17 +401,13 @@ fn assistant_text(response_json: &Value) -> &str {
         .expect("response carries assistant message content")
 }
 
-/// The `echo_headers` JSON blob out of a chat response's assistant prose,
-/// with `context` naming what the calling test expected, so a miss names
-/// both the expectation and what the assistant actually said.
+/// Extract the `echo_headers` JSON blob from a chat response's assistant prose, with `context` naming what the test expected, so a miss identifies both expectation and actual assistant output.
 fn headers_from_response(response_json: &Value, context: &str) -> Value {
     let text = assistant_text(response_json);
     extract_json_object(text).unwrap_or_else(|| panic!("{context}; got: {text:?}"))
 }
 
-/// The first `{...}` JSON object embedded in `text`, if any — mirrors
-/// `header_forwarding_tests.rs`'s extraction of the `echo_headers` JSON blob
-/// out of the model's prose.
+/// The first `{...}` JSON object embedded in `text`, if any, mirrors `header_forwarding_tests.rs`'s extraction of the `echo_headers` JSON blob from the model's prose.
 fn extract_json_object(text: &str) -> Option<Value> {
     // The assistant relays the tool output in whatever quoting it fancies:
     // bare, wrapped as a JSON string literal, or with the headers JSON

--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -313,6 +313,17 @@ pub(crate) mod tests {
                 names: vec!["authorization".to_owned(), "x-forwarded-user".to_owned()],
             }
         );
+
+        // The event-level audit signal: the Display text names every missing
+        // header and carries no value, including the one response value that
+        // did arrive (for the header that was present).
+        let message = err.to_string();
+        assert_eq!(
+            message,
+            "approver identity capture failed: response missing mapped headers \
+             [\"authorization\", \"x-forwarded-user\"]"
+        );
+        assert!(!message.contains("acme"), "message was: {message}");
     }
 
     /// Every captured pair lands on the request the builder produces, under

--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -19,9 +19,7 @@ use reqwest::header::{HeaderMap, HeaderName};
 /// producer.
 #[derive(Clone)]
 pub struct ApproverHeaders {
-    /// The validated override pairs, keys lowercased. The keys are also the
-    /// audit surface (names only); no separate name list exists to fall out
-    /// of sync.
+    /// Validated override pairs, keys lowercased. Keys serve as the audit surface (names only); no separate name list exists.
     headers: HeaderMap,
 }
 
@@ -172,9 +170,7 @@ pub(crate) fn extract_from_client_message(
 }
 
 tokio::task_local! {
-    /// Approver header overrides for the current gated tool call. Scoped
-    /// by `WrappedTool::call` inside the inner-call spawn; read by
-    /// `McpToolAdaptor::call` via [`current_approver_overrides`].
+    /// Approver header overrides for the current gated tool call.
     /// Crate-private so nothing outside the wrapper path can inject
     /// overrides.
     pub(crate) static APPROVER_OVERRIDES: Option<ApproverHeaders>;
@@ -201,10 +197,7 @@ pub(crate) mod tests {
 
     use super::*;
 
-    /// One captured override pair, for the seam tests that need a value of
-    /// this type without restating the capture plumbing. Construction goes
-    /// through the real capture path so a test can never hold overrides the
-    /// production path could not have produced.
+    /// One captured override pair for seam tests. Construction uses the real capture path, so a test cannot hold overrides that production could not produce.
     pub(crate) fn captured_overrides(outbound: &str, value: &str) -> ApproverHeaders {
         const RESPONSE_NAME: &str = "x-approver-source";
         ApproverHeaders::from_captured(
@@ -214,11 +207,7 @@ pub(crate) mod tests {
         .expect("the mapped header is present")
     }
 
-    /// Captured overrides for several pairs at once, each mapped from its
-    /// own `x-response-<outbound>` response header, given in whatever order
-    /// the caller likes. Construction goes through the real capture path,
-    /// so a test can never hold overrides the production path could not
-    /// have produced.
+    /// Captured overrides for several pairs. Construction uses the real capture path, so a test cannot hold overrides that production could not produce.
     #[cfg(feature = "otel")]
     pub(crate) fn captured_overrides_multi(pairs: &[(&str, &str)]) -> ApproverHeaders {
         let response_names: Vec<String> = pairs
@@ -258,8 +247,6 @@ pub(crate) mod tests {
         headers
     }
 
-    /// Capture rekeys the response value under the configured outbound name,
-    /// carrying the value through unchanged.
     #[test]
     fn captures_response_value_under_outbound_name() {
         let captured = ApproverHeaders::from_captured(
@@ -276,9 +263,7 @@ pub(crate) mod tests {
         assert!(captured.headers.get("x-approver-id").is_none());
     }
 
-    /// A webhook is free to spell its response header any way, and so is
-    /// the operator configuring the mapping; neither spelling has to match
-    /// the other's case.
+    /// A webhook may spell its response header however it likes, as may the operator configuring the mapping.
     #[test]
     fn response_lookup_is_case_insensitive() {
         let captured = ApproverHeaders::from_captured(
@@ -290,9 +275,7 @@ pub(crate) mod tests {
         assert_eq!(captured.headers.get("x-forwarded-user").unwrap(), "alice");
     }
 
-    /// A response may repeat a header. Capture takes the first value, as the
-    /// route's own header reads do, and exactly one value lands under the
-    /// outbound name — a second approver identity cannot ride along.
+    /// A response may repeat a header. Capture takes the first value, as the route does. Exactly one value lands under the outbound name; a second identity cannot ride along.
     #[test]
     fn repeated_response_header_captures_only_the_first_value() {
         let captured = ApproverHeaders::from_captured(
@@ -329,9 +312,7 @@ pub(crate) mod tests {
             }
         );
 
-        // The event-level audit signal: the Display text names every missing
-        // header and carries no value, including the one response value that
-        // did arrive (for the header that was present).
+        // Event-level audit signal: the Display text names every missing header and carries no value.
         let message = err.to_string();
         assert_eq!(
             message,
@@ -341,8 +322,6 @@ pub(crate) mod tests {
         assert!(!message.contains("acme"), "message was: {message}");
     }
 
-    /// Every captured pair lands on the request the builder produces, under
-    /// the outbound name.
     #[test]
     fn apply_to_sets_every_captured_pair_on_the_request() {
         let captured = ApproverHeaders::from_captured(
@@ -363,11 +342,6 @@ pub(crate) mod tests {
         assert_eq!(request.headers().get("x-tenant").unwrap(), "acme");
     }
 
-    /// The override REPLACES a same-named header already on the builder rather
-    /// than coexisting with it. Two identities on one request is the failure
-    /// mode this guards: `reqwest`'s per-header setter appends, so applying
-    /// pair-by-pair would leave the original value in place beside the
-    /// approver's.
     #[test]
     fn apply_to_replaces_a_header_already_on_the_builder() {
         let captured = ApproverHeaders::from_captured(
@@ -429,8 +403,6 @@ pub(crate) mod tests {
         assert_eq!(current_approver_overrides(), None);
     }
 
-    /// And the scoped read hands the value through unchanged shape-wise
-    /// (a `None` payload scoped explicitly is still `None`).
     #[tokio::test]
     async fn scoped_none_reads_none() {
         APPROVER_OVERRIDES

--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -19,23 +19,18 @@ use reqwest::header::{HeaderMap, HeaderName};
 /// producer.
 #[derive(Clone)]
 pub struct ApproverHeaders {
-    /// The validated override pairs, keys lowercased so an override replaces
-    /// the frozen default header rather than coexisting with it. The keys
-    /// are also the audit surface (names only); no separate name list
-    /// exists to fall out of sync.
+    /// The validated override pairs, keys lowercased. The keys are also the
+    /// audit surface (names only); no separate name list exists to fall out
+    /// of sync.
     headers: HeaderMap,
 }
 
 impl ApproverHeaders {
     /// Capture and validate approver headers from an approval response.
     ///
-    /// Every outbound name in `mapping` must resolve to a present response
-    /// header or the whole capture fails closed; nothing is silently
-    /// dropped. Response lookup is case-insensitive and takes the first
-    /// value of a multi-valued header, matching how the route reads the
-    /// signature headers off the same response. The missing names in the
-    /// error are sorted so a given failure always reports them in one
-    /// order.
+    /// Response lookup is case-insensitive and takes the first value of a
+    /// multi-valued header, matching how the route reads the signature
+    /// headers off the same response.
     pub(crate) fn from_captured(
         mapping: &ToolHeaderMappings,
         response_headers: &HeaderMap,

--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -219,6 +219,31 @@ pub(crate) mod tests {
         .expect("the mapped header is present")
     }
 
+    /// Captured overrides for several pairs at once, each mapped from its
+    /// own `x-response-<outbound>` response header, given in whatever order
+    /// the caller likes. Construction goes through the real capture path,
+    /// so a test can never hold overrides the production path could not
+    /// have produced.
+    #[cfg(feature = "otel")]
+    pub(crate) fn captured_overrides_multi(pairs: &[(&str, &str)]) -> ApproverHeaders {
+        let response_names: Vec<String> = pairs
+            .iter()
+            .map(|(outbound, _)| format!("x-response-{outbound}"))
+            .collect();
+        let mapping: Vec<(&str, &str)> = pairs
+            .iter()
+            .zip(&response_names)
+            .map(|((outbound, _), name)| (*outbound, name.as_str()))
+            .collect();
+        let response_pairs: Vec<(&str, &str)> = pairs
+            .iter()
+            .zip(&response_names)
+            .map(|((_, value), name)| (name.as_str(), *value))
+            .collect();
+        ApproverHeaders::from_captured(&mappings(&mapping), &response(&response_pairs))
+            .expect("every mapped header is present")
+    }
+
     fn mappings(pairs: &[(&str, &str)]) -> ToolHeaderMappings {
         let raw: HashMap<String, String> = pairs
             .iter()

--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -7,7 +7,7 @@
 //! request-extension side-channel).
 
 use aura_config::ToolHeaderMappings;
-use reqwest::header::HeaderMap;
+use reqwest::header::{HeaderMap, HeaderName};
 
 /// Validated approver identity headers captured from one approved webhook
 /// response.
@@ -31,25 +31,39 @@ impl ApproverHeaders {
     ///
     /// Every outbound name in `mapping` must resolve to a present response
     /// header or the whole capture fails closed; nothing is silently
-    /// dropped.
-    #[expect(
-        unused_variables,
-        reason = "todo!() body; filled when capture wiring lands"
-    )]
-    #[expect(
-        dead_code,
-        reason = "filled when the webhook client's gate path wires capture"
-    )]
+    /// dropped. Response lookup is case-insensitive and takes the first
+    /// value of a multi-valued header, matching how the route reads the
+    /// signature headers off the same response. The missing names in the
+    /// error are sorted so a given failure always reports them in one
+    /// order.
     pub(crate) fn from_captured(
         mapping: &ToolHeaderMappings,
         response_headers: &HeaderMap,
     ) -> Result<Self, CaptureError> {
-        todo!("resolve mapped response headers, fail closed on missing")
+        let mut headers = HeaderMap::new();
+        let mut missing = Vec::new();
+        for (outbound, response_name) in mapping.iter() {
+            match response_headers.get(response_name) {
+                Some(value) => {
+                    // The outbound name is a validated lowercase header name
+                    // by construction of `ToolHeaderMappings`.
+                    let name = HeaderName::from_bytes(outbound.as_bytes())
+                        .expect("outbound names validated at config parse");
+                    headers.insert(name, value.clone());
+                }
+                None => missing.push(outbound.to_owned()),
+            }
+        }
+        if !missing.is_empty() {
+            missing.sort_unstable();
+            return Err(CaptureError::MissingHeaders { names: missing });
+        }
+        Ok(Self { headers })
     }
 
     /// The captured outbound header names (never values), lowercased.
     pub fn captured_names(&self) -> impl Iterator<Item = &str> {
-        self.headers.keys().map(reqwest::header::HeaderName::as_str)
+        self.headers.keys().map(HeaderName::as_str)
     }
 
     /// Apply the overrides to an outbound request builder as per-request
@@ -183,7 +197,102 @@ pub(crate) fn current_approver_overrides() -> Option<ApproverHeaders> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use reqwest::header::HeaderValue;
+
     use super::*;
+
+    fn mappings(pairs: &[(&str, &str)]) -> ToolHeaderMappings {
+        let raw: HashMap<String, String> = pairs
+            .iter()
+            .map(|(outbound, response)| ((*outbound).to_owned(), (*response).to_owned()))
+            .collect();
+        ToolHeaderMappings::try_from(raw).expect("test mappings are valid config")
+    }
+
+    fn response(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        for (name, value) in pairs {
+            headers.append(
+                HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                HeaderValue::from_str(value).unwrap(),
+            );
+        }
+        headers
+    }
+
+    /// Capture rekeys the response value under the configured outbound name,
+    /// carrying the value through unchanged.
+    #[test]
+    fn captures_response_value_under_outbound_name() {
+        let captured = ApproverHeaders::from_captured(
+            &mappings(&[("x-forwarded-user", "x-approver-id")]),
+            &response(&[("x-approver-id", "alice")]),
+        )
+        .expect("a present mapped header captures");
+
+        assert_eq!(
+            captured.captured_names().collect::<Vec<_>>(),
+            vec!["x-forwarded-user"]
+        );
+        assert_eq!(captured.headers.get("x-forwarded-user").unwrap(), "alice");
+        assert!(captured.headers.get("x-approver-id").is_none());
+    }
+
+    /// A webhook is free to spell its response header any way, and so is
+    /// the operator configuring the mapping; neither spelling has to match
+    /// the other's case.
+    #[test]
+    fn response_lookup_is_case_insensitive() {
+        let captured = ApproverHeaders::from_captured(
+            &mappings(&[("x-forwarded-user", "X-Approver-Id")]),
+            &response(&[("X-APPROVER-ID", "alice")]),
+        )
+        .expect("response header casing must not defeat capture");
+
+        assert_eq!(captured.headers.get("x-forwarded-user").unwrap(), "alice");
+    }
+
+    /// A response may repeat a header. Capture takes the first value, as the
+    /// route's own header reads do, and exactly one value lands under the
+    /// outbound name — a second approver identity cannot ride along.
+    #[test]
+    fn repeated_response_header_captures_only_the_first_value() {
+        let captured = ApproverHeaders::from_captured(
+            &mappings(&[("x-forwarded-user", "x-approver-id")]),
+            &response(&[("x-approver-id", "alice"), ("x-approver-id", "mallory")]),
+        )
+        .expect("a repeated mapped header still captures");
+
+        assert_eq!(captured.headers.get("x-forwarded-user").unwrap(), "alice");
+        assert_eq!(
+            captured.headers.get_all("x-forwarded-user").iter().count(),
+            1
+        );
+    }
+
+    /// Every missing name is reported at once, sorted, so one failing
+    /// response always produces the same audit string.
+    #[test]
+    fn missing_names_are_all_reported_and_sorted() {
+        let err = ApproverHeaders::from_captured(
+            &mappings(&[
+                ("x-forwarded-user", "x-approver-id"),
+                ("authorization", "x-approver-token"),
+                ("x-tenant", "x-approver-tenant"),
+            ]),
+            &response(&[("x-approver-tenant", "acme")]),
+        )
+        .expect_err("a partial capture must fail closed");
+
+        assert_eq!(
+            err,
+            CaptureError::MissingHeaders {
+                names: vec!["authorization".to_owned(), "x-forwarded-user".to_owned()],
+            }
+        );
+    }
 
     /// Every adaptor call outside a task-local scope (wrapper-less agents)
     /// must read `None`, never panic.

--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -139,15 +139,10 @@ pub enum McpTransportKind {
 }
 
 /// Fail closed when `kind` cannot deliver per-call header overrides.
-/// Called at the execution seam only when overrides exist.
-///
-/// The transport alone decides. An override value carrying no pairs is not
-/// "no override": the caller reached here because identity was demanded, and
-/// a transport with no per-call header channel cannot honor that demand
-/// whatever the configured map turned out to hold.
+/// Called at the execution seam only when overrides exist, so the check
+/// keys off the transport alone.
 pub(crate) fn ensure_transport_delivers_overrides(
     kind: McpTransportKind,
-    _overrides: &ApproverHeaders,
 ) -> Result<(), OverrideApplicationError> {
     match kind {
         // Both HTTP send paths read the extension and apply the overrides.
@@ -401,20 +396,12 @@ pub(crate) mod tests {
         );
     }
 
-    fn any_overrides() -> ApproverHeaders {
-        ApproverHeaders::from_captured(
-            &mappings(&[("x-forwarded-user", "x-approver-id")]),
-            &response(&[("x-approver-id", "alice")]),
-        )
-        .expect("test overrides capture")
-    }
-
     /// Stdio has no per-call header channel, so a call that demands identity
     /// cannot be delivered and must not proceed under the cached one.
     #[test]
     fn stdio_transport_refuses_overrides() {
         assert_eq!(
-            ensure_transport_delivers_overrides(McpTransportKind::Stdio, &any_overrides()),
+            ensure_transport_delivers_overrides(McpTransportKind::Stdio),
             Err(OverrideApplicationError::TransportUnsupported {
                 kind: McpTransportKind::Stdio
             }),
@@ -425,32 +412,13 @@ pub(crate) mod tests {
     /// can deliver.
     #[test]
     fn http_transports_accept_overrides() {
-        let overrides = any_overrides();
         assert_eq!(
-            ensure_transport_delivers_overrides(McpTransportKind::StreamableHttp, &overrides),
+            ensure_transport_delivers_overrides(McpTransportKind::StreamableHttp),
             Ok(()),
         );
         assert_eq!(
-            ensure_transport_delivers_overrides(McpTransportKind::Sse, &overrides),
+            ensure_transport_delivers_overrides(McpTransportKind::Sse),
             Ok(()),
-        );
-    }
-
-    /// The check keys off the transport alone. An override value with no pairs
-    /// is not "no override": identity was demanded, the configured map decided
-    /// what that means, and a transport that cannot carry headers still cannot
-    /// honor the demand.
-    #[test]
-    fn stdio_refuses_even_an_empty_override_set() {
-        let empty = ApproverHeaders::from_captured(&mappings(&[]), &HeaderMap::new())
-            .expect("an empty mapping captures nothing and succeeds");
-        assert_eq!(empty.captured_names().count(), 0);
-
-        assert_eq!(
-            ensure_transport_delivers_overrides(McpTransportKind::Stdio, &empty),
-            Err(OverrideApplicationError::TransportUnsupported {
-                kind: McpTransportKind::Stdio
-            }),
         );
     }
 

--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -239,7 +239,7 @@ pub(crate) mod tests {
             .expect("every mapped header is present")
     }
 
-    fn mappings(pairs: &[(&str, &str)]) -> ToolHeaderMappings {
+    pub(crate) fn mappings(pairs: &[(&str, &str)]) -> ToolHeaderMappings {
         let raw: HashMap<String, String> = pairs
             .iter()
             .map(|(outbound, response)| ((*outbound).to_owned(), (*response).to_owned()))

--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -69,12 +69,15 @@ impl ApproverHeaders {
     /// Apply the overrides to an outbound request builder as per-request
     /// headers, which override the client's frozen `default_headers` for
     /// that one request only.
-    #[expect(
-        unused_variables,
-        reason = "todo!() body; filled when gate-to-wire wiring lands"
-    )]
+    ///
+    /// Whole-map application, not pair-by-pair: `RequestBuilder::header`
+    /// appends, so a name the builder already carries would end up sent
+    /// twice — the approver's identity beside the requester's. Passing the
+    /// map replaces per name, which is the discipline the lowercased keys
+    /// were established for. Default headers need no such care: `reqwest`
+    /// fills them in only where the request left the name vacant.
     pub(crate) fn apply_to(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        todo!("per-request .header(k, v) for each captured pair")
+        builder.headers(self.headers.clone())
     }
 }
 
@@ -142,15 +145,20 @@ pub enum McpTransportKind {
 
 /// Fail closed when `kind` cannot deliver per-call header overrides.
 /// Called at the execution seam only when overrides exist.
-#[expect(
-    unused_variables,
-    reason = "todo!() body; filled when gate-to-wire wiring lands"
-)]
+///
+/// The transport alone decides. An override value carrying no pairs is not
+/// "no override": the caller reached here because identity was demanded, and
+/// a transport with no per-call header channel cannot honor that demand
+/// whatever the configured map turned out to hold.
 pub(crate) fn ensure_transport_delivers_overrides(
     kind: McpTransportKind,
-    overrides: &ApproverHeaders,
+    _overrides: &ApproverHeaders,
 ) -> Result<(), OverrideApplicationError> {
-    todo!("stdio rejects overrides; http and sse accept")
+    match kind {
+        // Both HTTP send paths read the extension and apply the overrides.
+        McpTransportKind::StreamableHttp | McpTransportKind::Sse => Ok(()),
+        McpTransportKind::Stdio => Err(OverrideApplicationError::TransportUnsupported { kind }),
+    }
 }
 
 /// Extract approver overrides from an outbound client message, if the one
@@ -196,12 +204,25 @@ pub(crate) fn current_approver_overrides() -> Option<ApproverHeaders> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::collections::HashMap;
 
     use reqwest::header::HeaderValue;
 
     use super::*;
+
+    /// One captured override pair, for the seam tests that need a value of
+    /// this type without restating the capture plumbing. Construction goes
+    /// through the real capture path so a test can never hold overrides the
+    /// production path could not have produced.
+    pub(crate) fn captured_overrides(outbound: &str, value: &str) -> ApproverHeaders {
+        const RESPONSE_NAME: &str = "x-approver-source";
+        ApproverHeaders::from_captured(
+            &mappings(&[(outbound, RESPONSE_NAME)]),
+            &response(&[(RESPONSE_NAME, value)]),
+        )
+        .expect("the mapped header is present")
+    }
 
     fn mappings(pairs: &[(&str, &str)]) -> ToolHeaderMappings {
         let raw: HashMap<String, String> = pairs
@@ -291,6 +312,114 @@ mod tests {
             CaptureError::MissingHeaders {
                 names: vec!["authorization".to_owned(), "x-forwarded-user".to_owned()],
             }
+        );
+    }
+
+    /// Every captured pair lands on the request the builder produces, under
+    /// the outbound name.
+    #[test]
+    fn apply_to_sets_every_captured_pair_on_the_request() {
+        let captured = ApproverHeaders::from_captured(
+            &mappings(&[
+                ("x-forwarded-user", "x-approver-id"),
+                ("x-tenant", "x-approver-tenant"),
+            ]),
+            &response(&[("x-approver-id", "alice"), ("x-approver-tenant", "acme")]),
+        )
+        .expect("both mapped headers capture");
+
+        let request = captured
+            .apply_to(reqwest::Client::new().post("http://127.0.0.1:9/"))
+            .build()
+            .expect("the override headers are valid");
+
+        assert_eq!(request.headers().get("x-forwarded-user").unwrap(), "alice");
+        assert_eq!(request.headers().get("x-tenant").unwrap(), "acme");
+    }
+
+    /// The override REPLACES a same-named header already on the builder rather
+    /// than coexisting with it. Two identities on one request is the failure
+    /// mode this guards: `reqwest`'s per-header setter appends, so applying
+    /// pair-by-pair would leave the original value in place beside the
+    /// approver's.
+    #[test]
+    fn apply_to_replaces_a_header_already_on_the_builder() {
+        let captured = ApproverHeaders::from_captured(
+            &mappings(&[("authorization", "x-approver-token")]),
+            &response(&[("x-approver-token", "Bearer approver")]),
+        )
+        .expect("the mapped header captures");
+
+        let request = captured
+            .apply_to(
+                reqwest::Client::new()
+                    .post("http://127.0.0.1:9/")
+                    .header("authorization", "Bearer requester"),
+            )
+            .build()
+            .expect("the override headers are valid");
+
+        assert_eq!(
+            request.headers().get_all("authorization").iter().count(),
+            1,
+            "the requester's identity must not ride along beside the approver's",
+        );
+        assert_eq!(
+            request.headers().get("authorization").unwrap(),
+            "Bearer approver",
+        );
+    }
+
+    fn any_overrides() -> ApproverHeaders {
+        ApproverHeaders::from_captured(
+            &mappings(&[("x-forwarded-user", "x-approver-id")]),
+            &response(&[("x-approver-id", "alice")]),
+        )
+        .expect("test overrides capture")
+    }
+
+    /// Stdio has no per-call header channel, so a call that demands identity
+    /// cannot be delivered and must not proceed under the cached one.
+    #[test]
+    fn stdio_transport_refuses_overrides() {
+        assert_eq!(
+            ensure_transport_delivers_overrides(McpTransportKind::Stdio, &any_overrides()),
+            Err(OverrideApplicationError::TransportUnsupported {
+                kind: McpTransportKind::Stdio
+            }),
+        );
+    }
+
+    /// Both HTTP transports read the extension on their send path, so both
+    /// can deliver.
+    #[test]
+    fn http_transports_accept_overrides() {
+        let overrides = any_overrides();
+        assert_eq!(
+            ensure_transport_delivers_overrides(McpTransportKind::StreamableHttp, &overrides),
+            Ok(()),
+        );
+        assert_eq!(
+            ensure_transport_delivers_overrides(McpTransportKind::Sse, &overrides),
+            Ok(()),
+        );
+    }
+
+    /// The check keys off the transport alone. An override value with no pairs
+    /// is not "no override": identity was demanded, the configured map decided
+    /// what that means, and a transport that cannot carry headers still cannot
+    /// honor the demand.
+    #[test]
+    fn stdio_refuses_even_an_empty_override_set() {
+        let empty = ApproverHeaders::from_captured(&mappings(&[]), &HeaderMap::new())
+            .expect("an empty mapping captures nothing and succeeds");
+        assert_eq!(empty.captured_names().count(), 0);
+
+        assert_eq!(
+            ensure_transport_delivers_overrides(McpTransportKind::Stdio, &empty),
+            Err(OverrideApplicationError::TransportUnsupported {
+                kind: McpTransportKind::Stdio
+            }),
         );
     }
 

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -1970,10 +1970,7 @@ mod tests {
         scratchpad::ContextBudget::new(128_000, 0.20, 0, counter)
     }
 
-    /// Tool composition is where each MCP adaptor learns which transport it
-    /// fronts. Both the single-agent path and the orchestration worker path
-    /// reach it through `add_all_tools`, so what that function tags decides
-    /// whether a gated call can deliver approver identity or must refuse.
+    /// Tool composition is where each MCP adaptor learns which transport it fronts. Both the single-agent path and the orchestration worker path reach it through `add_all_tools`, so what that function tags decides whether a gated call can deliver approver identity or must refuse.
     mod transport_tagging {
         use std::collections::HashMap;
 
@@ -2045,9 +2042,7 @@ mod tests {
             )
         }
 
-        /// A manager offering the same tool name on each of the three
-        /// transports, all backed by `server` — so the only thing that can
-        /// distinguish them downstream is the tag composition gives them.
+        /// A manager offering the same tool name on each of the three transports, all backed by `server`, so the tag composition distinguishes them downstream.
         async fn manager_serving_all_transports(server: &RecordingMcpServer) -> McpManager {
             let connect = async || {
                 McpClient::new(server.url.clone(), &HashMap::new())

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -1970,6 +1970,171 @@ mod tests {
         scratchpad::ContextBudget::new(128_000, 0.20, 0, counter)
     }
 
+    /// Tool composition is where each MCP adaptor learns which transport it
+    /// fronts. Both the single-agent path and the orchestration worker path
+    /// reach it through `add_all_tools`, so what that function tags decides
+    /// whether a gated call can deliver approver identity or must refuse.
+    mod transport_tagging {
+        use std::collections::HashMap;
+
+        use rig::completion::{CompletionError, CompletionRequest, CompletionResponse};
+        use serde_json::json;
+
+        use super::*;
+        use crate::approver_headers::tests::captured_overrides;
+        use crate::mcp::McpManager;
+        use crate::mcp_streamable_http::McpClient;
+        use crate::mcp_streamable_http::tests::RecordingMcpServer;
+        use crate::tool_wrapper::{PreCallOutcome, ToolCallContext, ToolWrapper};
+
+        /// A completion model that exists only to satisfy the builder's type
+        /// parameter. Composition never prompts it.
+        #[derive(Clone)]
+        struct UnpromptedModel;
+
+        impl rig::completion::CompletionModel for UnpromptedModel {
+            type Response = ();
+            type StreamingResponse = ();
+            type Client = ();
+
+            fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+                Self
+            }
+
+            async fn completion(
+                &self,
+                _request: CompletionRequest,
+            ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+                unreachable!("tool composition never prompts the model")
+            }
+
+            async fn stream(
+                &self,
+                _request: CompletionRequest,
+            ) -> Result<
+                rig::streaming::StreamingCompletionResponse<Self::StreamingResponse>,
+                CompletionError,
+            > {
+                unreachable!("tool composition never prompts the model")
+            }
+        }
+
+        /// Stands in for the HITL gate: every call it wraps arrives carrying
+        /// approver identity, which is what makes the transport tag decide the
+        /// outcome.
+        struct AlwaysOverrides;
+
+        #[async_trait]
+        impl ToolWrapper for AlwaysOverrides {
+            async fn pre_call(
+                &self,
+                _args: &serde_json::Value,
+                _ctx: &ToolCallContext,
+            ) -> Result<PreCallOutcome, rig::tool::ToolError> {
+                Ok(PreCallOutcome::Proceed {
+                    overrides: Some(captured_overrides("x-forwarded-user", "alice")),
+                })
+            }
+        }
+
+        fn declared_tool(name: &str) -> rmcp::model::Tool {
+            rmcp::model::Tool::new(
+                name.to_owned(),
+                "test tool".to_owned(),
+                Arc::new(serde_json::Map::new()),
+            )
+        }
+
+        /// A manager offering the same tool name on each of the three
+        /// transports, all backed by `server` — so the only thing that can
+        /// distinguish them downstream is the tag composition gives them.
+        async fn manager_serving_all_transports(server: &RecordingMcpServer) -> McpManager {
+            let connect = async || {
+                McpClient::new(server.url.clone(), &HashMap::new())
+                    .await
+                    .expect("the loopback server completes the handshake")
+            };
+            McpManager {
+                server_info: HashMap::new(),
+                streamable_clients: HashMap::from([("http".to_owned(), connect().await)]),
+                streamable_tools: HashMap::from([(
+                    "http".to_owned(),
+                    vec![declared_tool("http_tool")],
+                )]),
+                sse_clients: HashMap::from([("sse".to_owned(), connect().await)]),
+                sse_tools: HashMap::from([("sse".to_owned(), vec![declared_tool("sse_tool")])]),
+                stdio_clients: HashMap::from([("stdio".to_owned(), connect().await)]),
+                stdio_tools: HashMap::from([(
+                    "stdio".to_owned(),
+                    vec![declared_tool("stdio_tool")],
+                )]),
+                sanitize_schemas: false,
+            }
+        }
+
+        /// Compose an agent the way a request does — gate wrapper included —
+        /// over a manager whose tools span all three transports.
+        async fn compose_agent(server: &RecordingMcpServer) -> rig::agent::Agent<UnpromptedModel> {
+            let config = AgentRuntimeConfig {
+                tool_wrapper: Some(Arc::new(AlwaysOverrides)),
+                ..Default::default()
+            };
+            let manager = Some(Arc::new(manager_serving_all_transports(server).await));
+            let state = BuilderState::Initial(rig::agent::AgentBuilder::new(UnpromptedModel));
+            Agent::add_all_tools(state, &config, &manager, Vec::new())
+                .await
+                .expect("composition succeeds")
+                .build()
+        }
+
+        /// The stdio branch must tag its adaptors `Stdio`, or a gated stdio
+        /// call would silently run under the requester's cached identity.
+        #[tokio::test]
+        async fn stdio_tools_are_tagged_so_a_gated_call_fails_closed() {
+            let server = RecordingMcpServer::start().await;
+            let agent = compose_agent(&server).await;
+
+            let error = agent
+                .tool_server_handle
+                .call_tool("stdio_tool", &json!({}).to_string())
+                .await
+                .expect_err("a gated stdio call must fail closed");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("cannot deliver approver identity"),
+                "the error must name the reason, got: {error}",
+            );
+            assert!(
+                server.tool_calls().is_empty(),
+                "the refused call must not reach any server",
+            );
+        }
+
+        /// The two HTTP branches must tag adaptors that can carry identity, so
+        /// the same gated call reaches the wire wearing the approver's header.
+        #[tokio::test]
+        async fn http_and_sse_tools_are_tagged_so_a_gated_call_delivers_identity() {
+            let server = RecordingMcpServer::start().await;
+            let agent = compose_agent(&server).await;
+
+            for tool in ["http_tool", "sse_tool"] {
+                agent
+                    .tool_server_handle
+                    .call_tool(tool, &json!({}).to_string())
+                    .await
+                    .unwrap_or_else(|e| panic!("a gated {tool} call proceeds: {e}"));
+            }
+
+            let calls = server.tool_calls();
+            assert_eq!(calls.len(), 2);
+            for call in calls {
+                assert_eq!(call.header_values("x-forwarded-user"), vec!["alice"]);
+            }
+        }
+    }
+
     #[test]
     fn scratchpad_usage_event_returns_none_when_no_activity() {
         let b = budget();

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -283,12 +283,26 @@ mod tests {
                 self.spans().iter().any(|span| span.name == name)
             }
 
+            /// The single `key` attribute on the span named `name`, or `None`
+            /// if the span carries no such attribute. Panics if the span
+            /// carries more than one — a double-stamp regression would
+            /// otherwise pass unnoticed, since `find` would silently return
+            /// only the first entry.
             fn attribute(&self, name: &str, key: &str) -> Option<String> {
-                self.spans()
+                let spans = self.spans();
+                let span = spans.iter().find(|span| span.name == name)?;
+                let matches: Vec<_> = span
+                    .attributes
                     .iter()
-                    .find(|span| span.name == name)
-                    .and_then(|span| span.attributes.iter().find(|kv| kv.key.as_str() == key))
-                    .map(|kv| kv.value.to_string())
+                    .filter(|kv| kv.key.as_str() == key)
+                    .collect();
+                assert!(
+                    matches.len() <= 1,
+                    "span {name:?} must carry at most one {key} attribute, found {}: \
+                     a regression is double-stamping the same span",
+                    matches.len(),
+                );
+                matches.first().map(|kv| kv.value.to_string())
             }
         }
 

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -285,8 +285,8 @@ mod tests {
     /// Trace correlation: a gated call's `execute_tool` span carries the
     /// `decision_id` of the approval that gated it.
     ///
-    /// Gated on `otel` — without the feature `set_span_attribute` is a
-    /// documented no-op and there is no span data to assert against.
+    /// Gated on `otel`: without the feature there is no span data to
+    /// assert against.
     #[cfg(feature = "otel")]
     mod decision_id_span {
         use std::future::Future;
@@ -327,8 +327,7 @@ mod tests {
             /// The single `key` attribute on the span named `name`, or `None`
             /// if the span carries no such attribute. Panics if the span
             /// carries more than one — a double-stamp regression would
-            /// otherwise pass unnoticed, since `find` would silently return
-            /// only the first entry.
+            /// otherwise pass with only the first entry.
             fn attribute(&self, name: &str, key: &str) -> Option<String> {
                 let spans = self.spans();
                 let span = spans.iter().find(|span| span.name == name)?;

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -214,29 +214,8 @@ mod tests {
         );
     }
 
-    /// No decision other than approval may carry identity forward: a denial,
-    /// a timeout, a cancellation and a channel fault all stop the call, so
-    /// there is nothing to apply.
-    #[test]
-    fn only_an_approval_yields_a_proceed() {
-        for result in [
-            Ok(GateDecision::Denied { reason: None }),
-            Ok(GateDecision::TimedOut {
-                waited: Duration::from_secs(1),
-            }),
-            Ok(GateDecision::Cancelled(CancelReason::ClientDisconnected)),
-            Err(ApprovalError::BadStatus { status: 500 }),
-        ] {
-            assert!(
-                !matches!(
-                    approval_result_to_pre_call(result),
-                    Ok(PreCallOutcome::Proceed { .. })
-                ),
-                "an undecided or refused approval must never proceed",
-            );
-        }
-    }
-
+    /// A denial is feedback the model can act on, not a tool error: the
+    /// mapping short-circuits the call with the denial reason.
     #[test]
     fn approval_result_mapping_denial_is_feedback_not_error() {
         let outcome = approval_result_to_pre_call(Ok(GateDecision::Denied {

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -196,9 +196,7 @@ mod tests {
         );
     }
 
-    /// The mapping is the only path from an approval's captured identity to
-    /// the call it released; a `Proceed` that dropped the overrides would
-    /// send the gated call under the requester's identity instead.
+    /// The mapping is the only path from an approval's captured identity to the call it released; a `Proceed` that dropped the overrides would send the gated call under the requester's identity instead.
     #[test]
     fn approval_result_mapping_carries_captured_overrides_into_the_call() {
         let captured = crate::approver_headers::tests::captured_overrides("authorization", "tok");
@@ -556,8 +554,6 @@ mod tests {
             approval_event_broker::unsubscribe(&request_id).await;
         }
 
-        /// A call no glob matches allocates no decision, so its span must not
-        /// claim one.
         #[tokio::test]
         async fn ungated_call_records_no_decision_id() {
             let (tool, ran) = gated_tool(

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -196,6 +196,47 @@ mod tests {
         );
     }
 
+    /// The mapping is the only path from an approval's captured identity to
+    /// the call it released; a `Proceed` that dropped the overrides would
+    /// send the gated call under the requester's identity instead.
+    #[test]
+    fn approval_result_mapping_carries_captured_overrides_into_the_call() {
+        let captured = crate::approver_headers::tests::captured_overrides("authorization", "tok");
+
+        assert_eq!(
+            approval_result_to_pre_call(Ok(GateDecision::Approved {
+                overrides: Some(captured.clone()),
+            }))
+            .unwrap(),
+            PreCallOutcome::Proceed {
+                overrides: Some(captured)
+            },
+        );
+    }
+
+    /// No decision other than approval may carry identity forward: a denial,
+    /// a timeout, a cancellation and a channel fault all stop the call, so
+    /// there is nothing to apply.
+    #[test]
+    fn only_an_approval_yields_a_proceed() {
+        for result in [
+            Ok(GateDecision::Denied { reason: None }),
+            Ok(GateDecision::TimedOut {
+                waited: Duration::from_secs(1),
+            }),
+            Ok(GateDecision::Cancelled(CancelReason::ClientDisconnected)),
+            Err(ApprovalError::BadStatus { status: 500 }),
+        ] {
+            assert!(
+                !matches!(
+                    approval_result_to_pre_call(result),
+                    Ok(PreCallOutcome::Proceed { .. })
+                ),
+                "an undecided or refused approval must never proceed",
+            );
+        }
+    }
+
     #[test]
     fn approval_result_mapping_denial_is_feedback_not_error() {
         let outcome = approval_result_to_pre_call(Ok(GateDecision::Denied {

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -289,13 +289,12 @@ mod tests {
     /// assert against.
     #[cfg(feature = "otel")]
     mod decision_id_span {
-        use std::future::Future;
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::{Arc, Mutex, MutexGuard};
 
-        use futures::future::BoxFuture;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
         use opentelemetry::trace::TracerProvider as _;
-        use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
+
         use opentelemetry_sdk::trace::TracerProvider;
         use rig::completion::ToolDefinition;
         use rig::tool::Tool as RigTool;
@@ -309,80 +308,8 @@ mod tests {
         use super::*;
         use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
         use crate::logging::ATTR_DECISION_ID;
+        use crate::test_span_capture::{CapturedSpans, traced_as_execute_tool};
         use crate::tool_wrapper::WrappedTool;
-
-        /// Spans the test subscriber has exported.
-        #[derive(Debug, Clone, Default)]
-        struct CapturedSpans(Arc<Mutex<Vec<SpanData>>>);
-
-        impl CapturedSpans {
-            fn spans(&self) -> MutexGuard<'_, Vec<SpanData>> {
-                self.0.lock().expect("captured spans mutex")
-            }
-
-            fn contains(&self, name: &str) -> bool {
-                self.spans().iter().any(|span| span.name == name)
-            }
-
-            /// The single `key` attribute on the span named `name`, or `None`
-            /// if the span carries no such attribute. Panics if the span
-            /// carries more than one — a double-stamp regression would
-            /// otherwise pass with only the first entry.
-            fn attribute(&self, name: &str, key: &str) -> Option<String> {
-                let spans = self.spans();
-                let span = spans.iter().find(|span| span.name == name)?;
-                let matches: Vec<_> = span
-                    .attributes
-                    .iter()
-                    .filter(|kv| kv.key.as_str() == key)
-                    .collect();
-                assert!(
-                    matches.len() <= 1,
-                    "span {name:?} must carry at most one {key} attribute, found {}: \
-                     a regression is double-stamping the same span",
-                    matches.len(),
-                );
-                matches.first().map(|kv| kv.value.to_string())
-            }
-        }
-
-        impl SpanExporter for CapturedSpans {
-            fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
-                self.spans().extend(batch);
-                Box::pin(std::future::ready(Ok(())))
-            }
-        }
-
-        /// Run `body` inside an `execute_tool` span — the span Rig opens around
-        /// a tool call — under a subscriber that exports to memory, returning
-        /// the body's output and the `decision_id` the exported span carries.
-        async fn traced_as_execute_tool<T>(body: impl Future<Output = T>) -> (T, Option<String>) {
-            let captured = CapturedSpans::default();
-            let provider = TracerProvider::builder()
-                .with_simple_exporter(captured.clone())
-                .build();
-            let _guard = tracing::subscriber::set_default(
-                tracing_subscriber::registry()
-                    .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test"))),
-            );
-
-            let output = body.instrument(tracing::info_span!("execute_tool")).await;
-
-            // The registry instruments a parked approval's wake task with the
-            // same span, so the export lands once that task has released it too.
-            for _ in 0..1_000 {
-                if captured.contains("execute_tool") {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-            assert!(
-                captured.contains("execute_tool"),
-                "the execute_tool span was never exported",
-            );
-
-            (output, captured.attribute("execute_tool", ATTR_DECISION_ID))
-        }
 
         /// What a trace backend actually receives, assembled the way the binary
         /// assembles it: the real OTel filter, the OpenInference exporter, and

--- a/crates/aura/src/hitl/mod.rs
+++ b/crates/aura/src/hitl/mod.rs
@@ -46,7 +46,7 @@ pub use protocol::{ApprovalDecisionWire, ApprovalItem, ApprovalRequest, PROTOCOL
 pub use registry::{ParkedApproval, PendingApprovals, ResolveError};
 pub use route::{
     ApprovalError, DecisionRoute, HitlRuntime, PlaintextWebhookUrlError, WebhookClient,
-    validate_webhook_signing_config,
+    validate_webhook_signing_config, warn_on_cleartext_capture,
 };
 pub use signing::{
     SIGNATURE_HEADER, SignedHeaders, SigningContext, TIMESTAMP_HEADER, VerificationError,

--- a/crates/aura/src/hitl/mod.rs
+++ b/crates/aura/src/hitl/mod.rs
@@ -46,7 +46,7 @@ pub use protocol::{ApprovalDecisionWire, ApprovalItem, ApprovalRequest, PROTOCOL
 pub use registry::{ParkedApproval, PendingApprovals, ResolveError};
 pub use route::{
     ApprovalError, DecisionRoute, HitlRuntime, PlaintextWebhookUrlError, WebhookClient,
-    validate_webhook_signing_config, warn_on_cleartext_capture,
+    cleartext_capture_warning, validate_webhook_signing_config, warn_on_cleartext_capture,
 };
 pub use signing::{
     SIGNATURE_HEADER, SignedHeaders, SigningContext, TIMESTAMP_HEADER, VerificationError,

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -494,14 +494,13 @@ fn resolve_webhook_headers(
     header_map
 }
 
-/// The webhook route's egress signing state, plus the fail-closed state an
-/// unusable route configuration lands in.
+/// HMAC signing state for the webhook route.
 enum EgressSigning {
     /// Unsigned egress.
     Disabled,
     /// Signed egress under the configured HMAC secret.
     Enabled(WebhookHmac),
-    /// An unusable route configuration, with the reason.
+    /// An unusable signing configuration, with the reason.
     Misconfigured(String),
 }
 
@@ -579,36 +578,36 @@ impl WebhookClient {
         signing: EgressSigning,
         tool_header_mappings: ToolHeaderMappings,
     ) -> Self {
-        // Two ways a plaintext url makes the route unusable, both fail closed
-        // for the life of the client. A plaintext response channel defeats
-        // response-leg verification, so http:// with a secret configured is
-        // itself a misconfiguration (DESIGN.md §4, Route A). Captured
-        // approver headers are credentials the gated call then presents as
-        // identity, so carrying them back over cleartext exposes them to the
-        // network whether or not the decision itself is signed. Neither check
-        // exempts loopback: the url is operator config, not a test fixture.
-        let signing = if url.as_str().starts_with("http://") {
-            match signing {
-                EgressSigning::Enabled(_) => EgressSigning::Misconfigured(format!(
+        // A plaintext response channel would defeat response-leg verification,
+        // so http:// with a secret configured is itself a misconfiguration
+        // (DESIGN.md §4, Route A).
+        let signing = match signing {
+            EgressSigning::Enabled(_) if url.as_str().starts_with("http://") => {
+                EgressSigning::Misconfigured(format!(
                     "webhook url {} uses plaintext http:// while an HMAC secret is configured; \
                      use https://",
                     url.as_str()
-                )),
-                _ if !tool_header_mappings.is_empty() => EgressSigning::Misconfigured(format!(
-                    "webhook url {} uses plaintext http:// while tool_headers_from_response is \
-                     configured; use https://",
-                    url.as_str()
-                )),
-                other => other,
+                ))
             }
-        } else {
-            signing
+            other => other,
         };
         if let EgressSigning::Misconfigured(reason) = &signing {
             tracing::error!(
                 reason,
-                "HITL webhook route misconfigured; every approval request on this route \
+                "HITL webhook HMAC misconfigured; every approval request on this route \
                  will fail closed"
+            );
+        }
+        // Capture over cleartext stays usable — TLS is often terminated ahead
+        // of this process (trusted gateway, service-to-service), which the url
+        // alone cannot distinguish from an exposed hop — but it is never
+        // silent.
+        if !tool_header_mappings.is_empty() && !url.as_str().starts_with("https://") {
+            tracing::warn!(
+                url = url.as_str(),
+                "HITL webhook route captures approver response headers over cleartext http, so \
+                 this route's tool_headers_from_response values are readable by any network \
+                 observer; intended for trusted-gateway or service-to-service deployments"
             );
         }
         Self {
@@ -1785,11 +1784,12 @@ mod tests {
             );
         }
 
-        /// Captured approver headers are credentials travelling back from the
-        /// approver, so a cleartext approval channel must fail closed for
-        /// them on its own — with no HMAC secret anywhere in the config.
+        /// Capture does not require https: TLS may be terminated ahead of the
+        /// process (trusted gateway, service-to-service), so a cleartext url
+        /// with mappings builds a usable unsigned route. Only the HMAC-secret
+        /// rule rejects plaintext, and it is unchanged by capture.
         #[test]
-        fn from_config_rejects_capture_over_plaintext_url() {
+        fn from_config_allows_capture_over_plaintext_url() {
             use super::super::HitlRuntime;
 
             let pending = crate::hitl::PendingApprovals::new();
@@ -1800,13 +1800,10 @@ mod tests {
                 None,
                 None,
             );
-            match signing_of(&plaintext) {
-                EgressSigning::Misconfigured(reason) => assert!(
-                    reason.contains("tool_headers_from_response"),
-                    "the reason must name the capture config: {reason}"
-                ),
-                _ => panic!("plaintext http:// with capture must fail closed"),
-            }
+            assert!(
+                matches!(signing_of(&plaintext), EgressSigning::Disabled),
+                "plaintext http:// with capture and no secret must stay usable"
+            );
 
             let secure = HitlRuntime::from_config(
                 &webhook_config("https://approvals.example.com/aura", user_mapping()),
@@ -1819,8 +1816,6 @@ mod tests {
                 "https:// with capture and no secret is a usable unsigned route"
             );
 
-            // Without capture configured, plaintext stays allowed for an
-            // unsigned route — this guard adds no new restriction there.
             let legacy = HitlRuntime::from_config(
                 &webhook_config(
                     "http://approvals.example.com/aura",
@@ -1830,7 +1825,72 @@ mod tests {
                 None,
                 None,
             );
-            assert!(matches!(signing_of(&legacy), EgressSigning::Disabled));
+            assert!(
+                matches!(signing_of(&legacy), EgressSigning::Disabled),
+                "plaintext http:// without capture is unchanged"
+            );
+
+            // The HMAC-secret rule is the one that still rejects plaintext,
+            // and capture being configured does not soften it.
+            let signed_plaintext = HitlRuntime::from_config(
+                &webhook_config("http://approvals.example.com/aura", user_mapping()),
+                &pending,
+                Some(&test_hmac()),
+                None,
+            );
+            assert!(
+                matches!(
+                    signing_of(&signed_plaintext),
+                    EgressSigning::Misconfigured(_)
+                ),
+                "plaintext http:// with a secret must still fail closed"
+            );
+        }
+
+        /// Cleartext capture is allowed but never silent: constructing the
+        /// route warns, naming the risk and the url.
+        #[test]
+        fn capture_over_plaintext_url_warns_at_construction() {
+            use std::sync::Arc;
+
+            let buf = Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(buf.clone())
+                .with_max_level(tracing::Level::WARN)
+                .with_ansi(false)
+                .finish();
+
+            let pending = crate::hitl::PendingApprovals::new();
+            tracing::subscriber::with_default(subscriber, || {
+                let _ = super::super::HitlRuntime::from_config(
+                    &webhook_config("http://approvals.example.com/aura", user_mapping()),
+                    &pending,
+                    None,
+                    None,
+                );
+                // An https route with the same mappings must stay quiet, so
+                // the warning is attributable to the cleartext url alone.
+                let _ = super::super::HitlRuntime::from_config(
+                    &webhook_config("https://approvals.example.com/aura", user_mapping()),
+                    &pending,
+                    None,
+                    None,
+                );
+            });
+
+            let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
+            assert!(
+                log.contains("cleartext http"),
+                "the warning must name the risk, got log: {log}"
+            );
+            assert!(
+                log.contains("http://approvals.example.com/aura"),
+                "the warning must name the url, got log: {log}"
+            );
+            assert!(
+                !log.contains("https://approvals.example.com/aura"),
+                "an https route must not warn, got log: {log}"
+            );
         }
 
         #[tokio::test]

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -2041,6 +2041,35 @@ mod tests {
             );
         }
 
+        /// The route-wide `request_approval` surface — what the
+        /// agent-callable tool uses — never captures identity, whatever the
+        /// mapping says: an approved, identity-bearing response resolves to
+        /// a plain decision, and the outcome type has no override channel
+        /// that could carry the headers anywhere.
+        #[tokio::test]
+        async fn route_wide_approval_discards_identity_headers() {
+            let (url, _received) = one_shot_receiver(
+                vec![("x-approver-id".to_owned(), "alice".to_owned())],
+                r#"{"approved":true}"#.to_owned(),
+            )
+            .await;
+
+            let client = loopback_client(&url, EgressSigning::Disabled, user_mapping());
+            let outcome = client
+                .request_approval(
+                    &test_request(DecisionId::generate()),
+                    Duration::from_secs(5),
+                )
+                .await
+                .expect("the route-wide round trip succeeds");
+
+            assert_eq!(
+                outcome,
+                ApprovalOutcome::Decided(ApprovalDecision::Approved),
+                "the identity headers must be discarded, not captured"
+            );
+        }
+
         /// The gate path's response matrix, one loopback receiver per row:
         /// identity exists only on an approved response whose mapped headers
         /// are all present. Every other row — a denial, a missing mapped

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -1,9 +1,8 @@
 //! The approval decision route: how a gated call gets its decision.
 //!
-//! A closed two-variant enum chosen by the `[hitl.route]` config table. Replaces
-//! the spike's `ApprovalDispatch` trait: the variant set is known, and
-//! [`DecisionRoute::decide`] holds the shared semantics (deadline, fail-closed
-//! mapping, event emission) in one place instead of per-impl.
+//! A closed two-variant enum chosen by the `[hitl.route]` config table;
+//! [`DecisionRoute::decide`] holds the shared semantics (deadline,
+//! fail-closed mapping, event emission) in one place.
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -200,10 +199,7 @@ pub enum DecisionRoute {
 
 /// Stamp `decision_id` on the current tracing span.
 ///
-/// `set_span_attribute` appends rather than overwrites by key, so one span
-/// stamped twice would carry a duplicate attribute entry. The entry points
-/// stamp once each and delegate through the unstamped
-/// [`DecisionRoute::decide_inner`].
+/// `set_span_attribute` appends rather than overwrites, so a span stamped twice would carry duplicate attribute entries. Entry points stamp once each, delegating through the unstamped [`DecisionRoute::decide_inner`].
 fn stamp_decision_id(decision_id: DecisionId) {
     crate::logging::set_span_attribute(
         &tracing::Span::current(),
@@ -212,15 +208,9 @@ fn stamp_decision_id(decision_id: DecisionId) {
     );
 }
 
-/// Run one webhook approval round trip behind the choreography both webhook
-/// arms share: publish `Requested`, race the round trip against the cancel
-/// token, then publish `Completed`.
+/// Run one webhook approval round trip behind the choreography both arms share: publish `Requested`, race against cancellation, then publish `Completed`.
 ///
-/// Two phases, both failing closed: the race is `biased` so a pending
-/// cancellation wins, and the result is rechecked against the token before
-/// it becomes the decision, so a disconnect landing just as the decision
-/// arrives is caught too. The arms differ only in the round trip itself and
-/// in how their decision shape projects into the completed event.
+/// Two phases, both failing closed: the race is `biased` so pending cancellation wins, and the result is rechecked against the token before becoming the decision. The arms differ only in the round trip itself and how their decision shape projects into the completed event.
 async fn webhook_round_trip<T>(
     request: &ApprovalRequest,
     cancel: &crate::request_cancellation::RequestCancelToken,
@@ -309,10 +299,7 @@ impl DecisionRoute {
         self.decide_inner(request, cancel).await
     }
 
-    /// Obtain a decision for `request`, applying the shared semantics
-    /// (deadline, fail-closed mapping, event emission) in one place.
-    ///
-    /// Does not stamp: both callers stamp on their own entry.
+    /// Obtain a decision for `request`, applying the shared semantics (deadline, fail-closed mapping, event emission) in one place. Does not stamp: both callers stamp on their own entry.
     async fn decide_inner(
         &self,
         request: ApprovalRequest,
@@ -548,8 +535,6 @@ impl WebhookClient {
                  will fail closed"
             );
         }
-        // The cleartext-capture warning lives at the boot-time seam, not
-        // here: see [`warn_on_cleartext_capture`].
         Self {
             client,
             url,
@@ -773,23 +758,14 @@ pub fn validate_webhook_signing_config(
     }
 }
 
-/// Boot-time warning for a webhook route that captures approver response
-/// headers over plain `http://`. Call this once per `[hitl]` config at
-/// startup, alongside `validate_webhook_signing_config`. Do not call from
-/// [`WebhookClient`] construction: that runs fresh per request via
-/// `HitlRuntime::from_config` and would turn one misconfiguration into a
-/// warning per chat request.
+/// Boot-time warning for a webhook route capturing approver response headers over `http://`. Call once per `[hitl]` config at startup, alongside `validate_webhook_signing_config`. Do not call from [`WebhookClient`] construction: that would turn one misconfiguration into a warning per chat request.
 pub fn warn_on_cleartext_capture(config: &HitlConfig) {
     if let Some(warning) = cleartext_capture_warning(config) {
         tracing::warn!("{warning}");
     }
 }
 
-/// The cleartext-capture warning for `config`, rendered as a message so a
-/// binary whose default tracing subscriber is silent (aura-cli without
-/// `log_file`) can print it on a channel it actually owns, such as stderr.
-/// `None` for every configuration [`warn_on_cleartext_capture`] stays quiet
-/// for; the message carries the redacted origin, never the full URL.
+/// The cleartext-capture warning for `config`, rendered as a message so a binary with silent default tracing (aura-cli without `log_file`) can print it on a channel it owns, such as stderr. `None` for every configuration [`warn_on_cleartext_capture`] stays quiet for; the message carries the redacted origin, never the full URL.
 pub fn cleartext_capture_warning(config: &HitlConfig) -> Option<String> {
     let DecisionRouteConfig::Webhook {
         url,
@@ -810,9 +786,7 @@ pub fn cleartext_capture_warning(config: &HitlConfig) -> Option<String> {
     ))
 }
 
-/// `scheme://host[:port]` of `url`, dropping userinfo, path, query, and
-/// fragment — the parts of a webhook URL a log line must never carry,
-/// since a webhook URL may embed a token in any of them.
+/// `scheme://host[:port]` of `url`, dropping userinfo, path, query, and fragment. These are parts a log line must never carry, since a webhook URL may embed a token in any of them.
 fn redact_to_origin(url: &str) -> String {
     let (scheme, rest) = url.split_once("://").unwrap_or(("", url));
     let authority = &rest[..rest.find(['/', '?', '#']).unwrap_or(rest.len())];
@@ -1394,10 +1368,7 @@ mod tests {
                 .await
         }
 
-        /// [`one_shot_receiver`] that fires `cancel_after_read` once it has
-        /// the whole request and before it writes a byte of the response, so
-        /// the caller meets a cancelled token and an arriving approval at the
-        /// same time.
+        /// [`one_shot_receiver`] that fires `cancel_after_read` once it has the whole request and before writing any response, so the caller meets cancellation and an arriving approval simultaneously.
         async fn cancelling_receiver(
             cancel: crate::request_cancellation::RequestCancelToken,
             response_headers: Vec<(String, String)>,
@@ -1467,9 +1438,7 @@ mod tests {
                 }
                 response.push_str("\r\n");
                 response.push_str(&response_body);
-                // A cancelling caller may already have dropped the connection,
-                // so a failed reply is not a test failure; every test that
-                // cares asserts on what the client resolved to.
+                // A cancelling caller may already have dropped the connection, so a failed reply is not a test failure; every test that cares asserts on what the client resolved to.
                 socket.write_all(response.as_bytes()).await.ok();
                 socket.shutdown().await.ok();
                 tx.send(ReceivedRequest { headers, body }).ok();
@@ -1477,12 +1446,7 @@ mod tests {
             (url, rx)
         }
 
-        /// A receiver that accepts one connection, signals over the returned
-        /// channel that it has, and then never answers — so the caller's own
-        /// timeout or cancellation is what resolves the round trip. Awaiting
-        /// the signal before acting proves the round trip is in flight. The
-        /// spawned task holds the accepted socket open for the life of the
-        /// test; closing it would surface as a transport error instead.
+        /// A receiver that accepts one connection, signals over the returned channel, and never answers, so the caller's own timeout or cancellation resolves the round trip. Awaiting the signal before acting proves the round trip is in flight. The spawned task holds the accepted socket open for the life of the test.
         async fn stalled_receiver() -> (String, tokio::sync::oneshot::Receiver<()>) {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             let url = format!("http://{}", listener.local_addr().unwrap());
@@ -1495,9 +1459,7 @@ mod tests {
             (url, accepted_rx)
         }
 
-        /// Builds a client directly against a loopback `http://` receiver.
-        /// Bypasses the https-only policy deliberately: the policy is
-        /// exercised by `http_url_with_secret_fails_closed`.
+        /// Builds a client directly against a loopback `http://` receiver, bypassing the https-only policy deliberately. The policy is exercised by `http_url_with_secret_fails_closed`.
         fn loopback_client(
             url: &str,
             signing: EgressSigning,
@@ -1757,10 +1719,7 @@ mod tests {
             );
         }
 
-        /// Capture does not require https: TLS may be terminated ahead of the
-        /// process (trusted gateway, service-to-service), so a cleartext url
-        /// with mappings builds a usable unsigned route. Only the HMAC-secret
-        /// rule rejects plaintext, and it is unchanged by capture.
+        /// Capture does not require https: TLS may be terminated ahead of the process (trusted gateway, service-to-service), so a cleartext url with mappings builds a usable unsigned route. Only the HMAC-secret rule rejects plaintext, unchanged by capture.
         #[test]
         fn from_config_allows_capture_over_plaintext_url() {
             use super::super::HitlRuntime;
@@ -1832,11 +1791,7 @@ mod tests {
             String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string()
         }
 
-        /// Construction (`HitlRuntime::from_config`, and so `WebhookClient`
-        /// construction) runs once per chat request, not once at startup —
-        /// so it must never warn on cleartext capture itself, or every
-        /// request on the route would repeat the warning.
-        /// [`warn_on_cleartext_capture`] is the boot-time seam for it.
+        /// Construction (`HitlRuntime::from_config`, and so `WebhookClient` construction) runs once per chat request, not once at startup, so it must never warn on cleartext capture itself, or every request on the route would repeat the warning. [`warn_on_cleartext_capture`] is the boot-time seam for it.
         #[test]
         fn capture_over_plaintext_url_stays_silent_at_construction() {
             let pending = crate::hitl::PendingApprovals::new();
@@ -1851,11 +1806,7 @@ mod tests {
             assert!(log.is_empty(), "construction must not log, got: {log}");
         }
 
-        /// The boot-time warning names the risk and the webhook's origin,
-        /// but never the userinfo, path, or query a webhook URL may carry —
-        /// any of which can hold a secret. An https route with the same
-        /// mappings stays quiet, so the warning is attributable to the
-        /// cleartext scheme alone.
+        /// The boot-time warning names the risk and the webhook's origin, but never the userinfo, path, or query. The warning is attributable to the cleartext scheme alone.
         #[test]
         fn warn_on_cleartext_capture_warns_once_and_redacts_the_url() {
             let log = captured_warn_log(|| {
@@ -1888,10 +1839,7 @@ mod tests {
             );
         }
 
-        /// The rendered warning carries the redacted origin so a binary can
-        /// print it on a channel tracing does not reach, and it keeps the
-        /// same redaction the traced event holds: userinfo, path, and query
-        /// never appear.
+        /// The rendered warning carries the redacted origin so a binary can print it on a channel tracing does not reach, keeping the same redaction the traced event holds.
         #[test]
         fn cleartext_capture_warning_redacts_the_url() {
             let warning = super::super::cleartext_capture_warning(&webhook_config(
@@ -1912,10 +1860,7 @@ mod tests {
             }
         }
 
-        /// The quiet cases match [`warn_on_cleartext_capture`]: an https
-        /// route and an empty (legacy) mapping both return `None`, so the
-        /// stderr channel a binary opens stays silent exactly when the
-        /// traced one does.
+        /// The quiet cases match [`warn_on_cleartext_capture`]: an https route and an empty (legacy) mapping both return `None`.
         #[test]
         fn cleartext_capture_warning_is_none_when_quiet() {
             assert!(
@@ -1936,9 +1881,7 @@ mod tests {
             );
         }
 
-        /// An absent or empty `tool_headers_from_response` map captures
-        /// nothing, so there is no exposure to warn about, over either
-        /// scheme.
+        /// An absent or empty `tool_headers_from_response` map captures nothing, so there is no exposure to warn about over either scheme.
         #[test]
         fn warn_on_cleartext_capture_is_quiet_with_no_map() {
             let log = captured_warn_log(|| {
@@ -2018,11 +1961,7 @@ mod tests {
             );
         }
 
-        /// The route-wide `request_approval` surface — what the
-        /// agent-callable tool uses — never captures identity, whatever the
-        /// mapping says: an approved, identity-bearing response resolves to
-        /// a plain decision, and the outcome type has no override channel
-        /// that could carry the headers anywhere.
+        /// The route-wide `request_approval` surface (what the agent-callable tool uses) never captures identity, whatever the mapping says. An approved, identity-bearing response resolves to a plain decision, and the outcome type has no override channel to carry headers anywhere.
         #[tokio::test]
         async fn route_wide_approval_discards_identity_headers() {
             let (url, _received) = one_shot_receiver(
@@ -2047,12 +1986,7 @@ mod tests {
             );
         }
 
-        /// The gate path's response matrix, one loopback receiver per row:
-        /// identity exists only on an approved response whose mapped headers
-        /// are all present. Every other row — a denial, a missing mapped
-        /// header, an empty mapping, a non-2xx status, a malformed body, an
-        /// unverified response, a timeout — yields no override object, each
-        /// asserted at its own shape rather than by omission.
+        /// The gate path's response matrix: identity exists only on an approved response whose mapped headers are all present. Every other row (denial, missing header, empty mapping, non-2xx status, malformed body, unverified response, timeout) yields no override, each asserted at its own shape.
         #[tokio::test]
         async fn gate_response_matrix_yields_overrides_only_on_a_complete_approval() {
             enum Reply {
@@ -2234,10 +2168,7 @@ mod tests {
             }
         }
 
-        /// Cancelling a round trip the receiver has already accepted — so it
-        /// is provably in flight — resolves the cancelled decision without
-        /// waiting out the timeout. Both entrypoints honour the same token:
-        /// `decide_for_gate` and the route-wide `decide`.
+        /// Cancelling a round trip the receiver has already accepted resolves the cancelled decision without waiting out the timeout. Both entrypoints honour the same token: `decide_for_gate` and the route-wide `decide`.
         #[tokio::test]
         async fn webhook_cancellation_short_circuits_the_round_trip_on_both_paths() {
             for route_wide in [false, true] {
@@ -2275,11 +2206,7 @@ mod tests {
             }
         }
 
-        /// Cancellation beats an approval that is already on the wire: the
-        /// receiver cancels the token before writing an approved,
-        /// identity-bearing response, so the decision and the disconnect are
-        /// both live. Whichever the race sees first, the recheck makes
-        /// `Cancelled` the answer and no override object is produced.
+        /// Cancellation beats an approval already on the wire: the receiver cancels before writing an approved response, so whichever the race sees first, the recheck makes `Cancelled` the answer and no override object is produced.
         #[tokio::test]
         async fn webhook_gate_cancellation_beats_a_ready_approval() {
             let cancel = crate::request_cancellation::RequestCancelToken::unbound();

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -6,6 +6,7 @@
 //! mapping, event emission) in one place instead of per-impl.
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -211,6 +212,60 @@ fn stamp_decision_id(decision_id: DecisionId) {
     );
 }
 
+/// Run one webhook approval round trip behind the choreography both webhook
+/// arms share: publish `Requested`, race the round trip against the cancel
+/// token, then publish `Completed`.
+///
+/// Two phases, both failing closed: the race is `biased` so a pending
+/// cancellation wins, and the result is rechecked against the token before
+/// it becomes the decision, so a disconnect landing just as the decision
+/// arrives is caught too. The arms differ only in the round trip itself and
+/// in how their decision shape projects into the completed event.
+async fn webhook_round_trip<T>(
+    request: &ApprovalRequest,
+    cancel: &crate::request_cancellation::RequestCancelToken,
+    round_trip: impl Future<Output = Result<T, ApprovalError>>,
+    cancelled: impl FnOnce() -> T,
+    event_outcome: impl FnOnce(&T) -> ApprovalOutcome,
+) -> Result<T, ApprovalError> {
+    let started = Instant::now();
+    let request_id = request.request_id.clone();
+    let decision_id = request.decision_id;
+    let scope = request.scope.clone();
+
+    approval_event_broker::publish(
+        &request_id,
+        ApprovalLifecycleEvent::Requested(request.into()),
+    )
+    .await;
+
+    let raced = tokio::select! {
+        biased;
+        () = cancel.cancelled() => None,
+        decision = round_trip => Some(decision),
+    };
+    let result = match raced {
+        Some(decision) if !cancel.is_cancelled() => decision,
+        _ => {
+            tracing::warn!(%decision_id, "approval cancelled: client disconnected");
+            Ok(cancelled())
+        }
+    };
+    let completed = match &result {
+        Ok(decision) => events::completed(
+            decision_id,
+            &event_outcome(decision),
+            &scope,
+            started.elapsed(),
+        ),
+        Err(err) => {
+            events::completed_error(decision_id, err.to_string(), &scope, started.elapsed())
+        }
+    };
+    approval_event_broker::publish(&request_id, ApprovalLifecycleEvent::Completed(completed)).await;
+    result
+}
+
 impl DecisionRoute {
     /// Obtain a decision for a config-gated call, carrying any captured
     /// approver header overrides on the approved arm.
@@ -232,55 +287,14 @@ impl DecisionRoute {
                 Ok(GateDecision::without_overrides(outcome))
             }
             Self::Webhook { client, timeout } => {
-                let started = Instant::now();
-                let request_id = request.request_id.clone();
-                let decision_id = request.decision_id;
-                let scope = request.scope.clone();
-
-                approval_event_broker::publish(
-                    &request_id,
-                    ApprovalLifecycleEvent::Requested((&request).into()),
+                webhook_round_trip(
+                    &request,
+                    cancel,
+                    client.request_approval_for_gate(&request, *timeout),
+                    || GateDecision::Cancelled(super::decision::CancelReason::ClientDisconnected),
+                    GateDecision::to_outcome,
                 )
-                .await;
-
-                // Two phases, both failing closed: the round trip races the
-                // cancel token, and the result is rechecked against the token
-                // before it becomes this arm's decision, so a disconnect
-                // landing just as the decision arrives is caught too.
-                let raced = tokio::select! {
-                    biased;
-                    () = cancel.cancelled() => None,
-                    decision = client.request_approval_for_gate(&request, *timeout) => Some(decision),
-                };
-                let result = match raced {
-                    Some(decision) if !cancel.is_cancelled() => decision,
-                    _ => {
-                        tracing::warn!(%decision_id, "approval cancelled: client disconnected");
-                        Ok(GateDecision::Cancelled(
-                            super::decision::CancelReason::ClientDisconnected,
-                        ))
-                    }
-                };
-                let completed = match &result {
-                    Ok(decision) => events::completed(
-                        decision_id,
-                        &decision.to_outcome(),
-                        &scope,
-                        started.elapsed(),
-                    ),
-                    Err(err) => events::completed_error(
-                        decision_id,
-                        err.to_string(),
-                        &scope,
-                        started.elapsed(),
-                    ),
-                };
-                approval_event_broker::publish(
-                    &request_id,
-                    ApprovalLifecycleEvent::Completed(completed),
-                )
-                .await;
-                result
+                .await
             }
         }
     }
@@ -359,44 +373,18 @@ impl DecisionRoute {
                 Ok(outcome)
             }
             Self::Webhook { client, timeout } => {
-                approval_event_broker::publish(
-                    &request_id,
-                    ApprovalLifecycleEvent::Requested((&request).into()),
-                )
-                .await;
-
-                // Two-phase, as on the gate path.
-                let raced = tokio::select! {
-                    biased;
-                    () = cancel.cancelled() => None,
-                    outcome = client.request_approval(&request, *timeout) => Some(outcome),
-                };
-                let result = match raced {
-                    Some(outcome) if !cancel.is_cancelled() => outcome,
-                    _ => {
-                        tracing::warn!(%decision_id, "approval cancelled: client disconnected");
-                        Ok(ApprovalOutcome::Cancelled(
+                webhook_round_trip(
+                    &request,
+                    cancel,
+                    client.request_approval(&request, *timeout),
+                    || {
+                        ApprovalOutcome::Cancelled(
                             super::decision::CancelReason::ClientDisconnected,
-                        ))
-                    }
-                };
-                let completed = match &result {
-                    Ok(outcome) => {
-                        events::completed(decision_id, outcome, &scope, started.elapsed())
-                    }
-                    Err(err) => events::completed_error(
-                        decision_id,
-                        err.to_string(),
-                        &scope,
-                        started.elapsed(),
-                    ),
-                };
-                approval_event_broker::publish(
-                    &request_id,
-                    ApprovalLifecycleEvent::Completed(completed),
+                        )
+                    },
+                    |outcome| outcome.clone(),
                 )
-                .await;
-                result
+                .await
             }
         }
     }
@@ -484,9 +472,6 @@ pub struct WebhookClient {
 
 /// One webhook round trip's answer, with the HTTP response headers it
 /// arrived alongside.
-///
-/// Only the decided arm carries headers, so headers-without-a-decision is
-/// unrepresentable.
 enum WebhookReply {
     Decided {
         decision: ApprovalDecision,

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -1520,17 +1520,9 @@ mod tests {
             )
         }
 
-        fn mappings(pairs: &[(&str, &str)]) -> aura_config::ToolHeaderMappings {
-            let raw: HashMap<String, String> = pairs
-                .iter()
-                .map(|(outbound, response)| ((*outbound).to_owned(), (*response).to_owned()))
-                .collect();
-            aura_config::ToolHeaderMappings::try_from(raw).expect("test mappings are valid config")
-        }
-
         /// The one mapping every gate test below configures.
         fn user_mapping() -> aura_config::ToolHeaderMappings {
-            mappings(&[("x-forwarded-user", "x-approver-id")])
+            crate::approver_headers::tests::mappings(&[("x-forwarded-user", "x-approver-id")])
         }
 
         /// Sign `body` under the approval-decision context for `decision_id`,

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -224,11 +224,11 @@ fn stamp_decision_id(decision_id: DecisionId) {
 async fn webhook_round_trip<T>(
     request: &ApprovalRequest,
     cancel: &crate::request_cancellation::RequestCancelToken,
+    started: Instant,
     round_trip: impl Future<Output = Result<T, ApprovalError>>,
     cancelled: impl FnOnce() -> T,
     event_outcome: impl FnOnce(&T) -> ApprovalOutcome,
 ) -> Result<T, ApprovalError> {
-    let started = Instant::now();
     let request_id = request.request_id.clone();
     let decision_id = request.decision_id;
     let scope = request.scope.clone();
@@ -252,12 +252,10 @@ async fn webhook_round_trip<T>(
         }
     };
     let completed = match &result {
-        Ok(decision) => events::completed(
-            decision_id,
-            &event_outcome(decision),
-            &scope,
-            started.elapsed(),
-        ),
+        Ok(decision) => {
+            let elapsed = started.elapsed();
+            events::completed(decision_id, &event_outcome(decision), &scope, elapsed)
+        }
         Err(err) => {
             events::completed_error(decision_id, err.to_string(), &scope, started.elapsed())
         }
@@ -290,6 +288,7 @@ impl DecisionRoute {
                 webhook_round_trip(
                     &request,
                     cancel,
+                    Instant::now(),
                     client.request_approval_for_gate(&request, *timeout),
                     || GateDecision::Cancelled(super::decision::CancelReason::ClientDisconnected),
                     GateDecision::to_outcome,
@@ -376,6 +375,7 @@ impl DecisionRoute {
                 webhook_round_trip(
                     &request,
                     cancel,
+                    started,
                     client.request_approval(&request, *timeout),
                     || {
                         ApprovalOutcome::Cancelled(

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -598,18 +598,9 @@ impl WebhookClient {
                  will fail closed"
             );
         }
-        // Capture over cleartext stays usable — TLS is often terminated ahead
-        // of this process (trusted gateway, service-to-service), which the url
-        // alone cannot distinguish from an exposed hop — but it is never
-        // silent.
-        if !tool_header_mappings.is_empty() && !url.as_str().starts_with("https://") {
-            tracing::warn!(
-                url = url.as_str(),
-                "HITL webhook route captures approver response headers over cleartext http, so \
-                 this route's tool_headers_from_response values are readable by any network \
-                 observer; intended for trusted-gateway or service-to-service deployments"
-            );
-        }
+        // The cleartext-capture warning does not live here: `HitlRuntime::from_config`
+        // (and so this constructor) runs once per request, not once at startup.
+        // `warn_on_cleartext_capture` below is the boot-time seam for it.
         Self {
             client,
             url,
@@ -842,6 +833,51 @@ pub fn validate_webhook_signing_config(
             })
         }
         DecisionRouteConfig::Webhook { .. } | DecisionRouteConfig::Conversational { .. } => Ok(()),
+    }
+}
+
+/// Boot-time warning: a webhook route with `tool_headers_from_response`
+/// configured over plain `http://` is usable (`validate_webhook_signing_config`
+/// above covers the one case that still fails closed, an HMAC secret over
+/// plaintext) but exposes captured approver credentials to any network
+/// observer between here and the webhook. Call this once per `[hitl]`
+/// config at startup, alongside `validate_webhook_signing_config` — never
+/// from [`WebhookClient`] construction, which runs fresh per request via
+/// `HitlRuntime::from_config` and would turn one misconfiguration into a
+/// warning per chat request.
+pub fn warn_on_cleartext_capture(config: &HitlConfig) {
+    let DecisionRouteConfig::Webhook {
+        url,
+        tool_headers_from_response,
+        ..
+    } = &config.route
+    else {
+        return;
+    };
+    if tool_headers_from_response.is_empty() || url.as_str().starts_with("https://") {
+        return;
+    }
+    tracing::warn!(
+        origin = %redact_to_origin(url.as_str()),
+        "HITL webhook route captures approver response headers over cleartext http, so \
+         this route's tool_headers_from_response values are readable by any network \
+         observer; intended for trusted-gateway or service-to-service deployments"
+    );
+}
+
+/// `scheme://host[:port]` of `url`, dropping userinfo, path, query, and
+/// fragment — the parts of a webhook URL a log line must never carry,
+/// since a webhook URL may embed a token in any of them.
+fn redact_to_origin(url: &str) -> String {
+    let (scheme, rest) = url.split_once("://").unwrap_or(("", url));
+    let authority = &rest[..rest.find(['/', '?', '#']).unwrap_or(rest.len())];
+    let host_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if scheme.is_empty() {
+        host_port.to_string()
+    } else {
+        format!("{scheme}://{host_port}")
     }
 }
 
@@ -1847,10 +1883,13 @@ mod tests {
             );
         }
 
-        /// Cleartext capture is allowed but never silent: constructing the
-        /// route warns, naming the risk and the url.
+        /// Construction (`HitlRuntime::from_config`, and so `WebhookClient`
+        /// construction) runs once per chat request, not once at startup —
+        /// so it must never warn on cleartext capture itself, or every
+        /// request on the route would repeat the warning.
+        /// [`warn_on_cleartext_capture`] is the boot-time seam for it.
         #[test]
-        fn capture_over_plaintext_url_warns_at_construction() {
+        fn capture_over_plaintext_url_stays_silent_at_construction() {
             use std::sync::Arc;
 
             let buf = Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
@@ -1868,14 +1907,37 @@ mod tests {
                     None,
                     None,
                 );
-                // An https route with the same mappings must stay quiet, so
-                // the warning is attributable to the cleartext url alone.
-                let _ = super::super::HitlRuntime::from_config(
-                    &webhook_config("https://approvals.example.com/aura", user_mapping()),
-                    &pending,
-                    None,
-                    None,
-                );
+            });
+
+            let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
+            assert!(log.is_empty(), "construction must not log, got: {log}");
+        }
+
+        /// The boot-time warning names the risk and the webhook's origin,
+        /// but never the userinfo, path, or query a webhook URL may carry —
+        /// any of which can hold a secret. An https route with the same
+        /// mappings stays quiet, so the warning is attributable to the
+        /// cleartext scheme alone.
+        #[test]
+        fn warn_on_cleartext_capture_warns_once_and_redacts_the_url() {
+            use std::sync::Arc;
+
+            let buf = Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(buf.clone())
+                .with_max_level(tracing::Level::WARN)
+                .with_ansi(false)
+                .finish();
+
+            tracing::subscriber::with_default(subscriber, || {
+                super::super::warn_on_cleartext_capture(&webhook_config(
+                    "http://token:secret@approvals.example.com:8443/aura/hook?key=shh",
+                    user_mapping(),
+                ));
+                super::super::warn_on_cleartext_capture(&webhook_config(
+                    "https://approvals.example.com/aura",
+                    user_mapping(),
+                ));
             });
 
             let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
@@ -1884,12 +1946,46 @@ mod tests {
                 "the warning must name the risk, got log: {log}"
             );
             assert!(
-                log.contains("http://approvals.example.com/aura"),
-                "the warning must name the url, got log: {log}"
+                log.contains("http://approvals.example.com:8443"),
+                "the warning must name the origin, got log: {log}"
             );
+            for secret in ["token", "secret", "aura/hook", "key=shh"] {
+                assert!(
+                    !log.contains(secret),
+                    "the warning must never carry userinfo, path, or query, got: {log}"
+                );
+            }
             assert!(
-                !log.contains("https://approvals.example.com/aura"),
+                !log.contains("https://approvals.example.com"),
                 "an https route must not warn, got log: {log}"
+            );
+        }
+
+        /// An absent or empty `tool_headers_from_response` map is the
+        /// legacy path: no capture, so no exposure to warn about, over
+        /// either scheme.
+        #[test]
+        fn warn_on_cleartext_capture_is_quiet_with_no_map() {
+            use std::sync::Arc;
+
+            let buf = Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(buf.clone())
+                .with_max_level(tracing::Level::WARN)
+                .with_ansi(false)
+                .finish();
+
+            tracing::subscriber::with_default(subscriber, || {
+                super::super::warn_on_cleartext_capture(&webhook_config(
+                    "http://approvals.example.com/aura",
+                    aura_config::ToolHeaderMappings::default(),
+                ));
+            });
+
+            let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
+            assert!(
+                log.is_empty(),
+                "no map means nothing to warn about, got: {log}"
             );
         }
 

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -1843,6 +1843,18 @@ mod tests {
             );
         }
 
+        /// Capture what `body` logs at WARN and above, as text.
+        fn captured_warn_log(body: impl FnOnce()) -> String {
+            let buf = std::sync::Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(buf.clone())
+                .with_max_level(tracing::Level::WARN)
+                .with_ansi(false)
+                .finish();
+            tracing::subscriber::with_default(subscriber, body);
+            String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string()
+        }
+
         /// Construction (`HitlRuntime::from_config`, and so `WebhookClient`
         /// construction) runs once per chat request, not once at startup —
         /// so it must never warn on cleartext capture itself, or every
@@ -1850,17 +1862,8 @@ mod tests {
         /// [`warn_on_cleartext_capture`] is the boot-time seam for it.
         #[test]
         fn capture_over_plaintext_url_stays_silent_at_construction() {
-            use std::sync::Arc;
-
-            let buf = Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
-            let subscriber = tracing_subscriber::fmt()
-                .with_writer(buf.clone())
-                .with_max_level(tracing::Level::WARN)
-                .with_ansi(false)
-                .finish();
-
             let pending = crate::hitl::PendingApprovals::new();
-            tracing::subscriber::with_default(subscriber, || {
+            let log = captured_warn_log(|| {
                 let _ = super::super::HitlRuntime::from_config(
                     &webhook_config("http://approvals.example.com/aura", user_mapping()),
                     &pending,
@@ -1868,8 +1871,6 @@ mod tests {
                     None,
                 );
             });
-
-            let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
             assert!(log.is_empty(), "construction must not log, got: {log}");
         }
 
@@ -1880,16 +1881,7 @@ mod tests {
         /// cleartext scheme alone.
         #[test]
         fn warn_on_cleartext_capture_warns_once_and_redacts_the_url() {
-            use std::sync::Arc;
-
-            let buf = Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
-            let subscriber = tracing_subscriber::fmt()
-                .with_writer(buf.clone())
-                .with_max_level(tracing::Level::WARN)
-                .with_ansi(false)
-                .finish();
-
-            tracing::subscriber::with_default(subscriber, || {
+            let log = captured_warn_log(|| {
                 super::super::warn_on_cleartext_capture(&webhook_config(
                     "http://token:secret@approvals.example.com:8443/aura/hook?key=shh",
                     user_mapping(),
@@ -1899,8 +1891,6 @@ mod tests {
                     user_mapping(),
                 ));
             });
-
-            let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
             assert!(
                 log.contains("cleartext http"),
                 "the warning must name the risk, got log: {log}"
@@ -1974,23 +1964,12 @@ mod tests {
         /// either scheme.
         #[test]
         fn warn_on_cleartext_capture_is_quiet_with_no_map() {
-            use std::sync::Arc;
-
-            let buf = Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
-            let subscriber = tracing_subscriber::fmt()
-                .with_writer(buf.clone())
-                .with_max_level(tracing::Level::WARN)
-                .with_ansi(false)
-                .finish();
-
-            tracing::subscriber::with_default(subscriber, || {
+            let log = captured_warn_log(|| {
                 super::super::warn_on_cleartext_capture(&webhook_config(
                     "http://approvals.example.com/aura",
                     aura_config::ToolHeaderMappings::default(),
                 ));
             });
-
-            let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
             assert!(
                 log.is_empty(),
                 "no map means nothing to warn about, got: {log}"
@@ -2025,34 +2004,6 @@ mod tests {
                 "no secret configured must mean no signature header"
             );
             assert!(received.header(TIMESTAMP_HEADER).is_none());
-        }
-
-        #[tokio::test]
-        async fn unsigned_gate_approved_captures_mapped_headers() {
-            let (url, _received) = one_shot_receiver(
-                vec![("x-approver-id".to_owned(), "alice".to_owned())],
-                r#"{"approved":true}"#.to_owned(),
-            )
-            .await;
-
-            let client = loopback_client(&url, EgressSigning::Disabled, user_mapping());
-            let decision = client
-                .request_approval_for_gate(
-                    &test_request(DecisionId::generate()),
-                    Duration::from_secs(5),
-                )
-                .await
-                .expect("unsigned gate round trip succeeds");
-
-            match decision {
-                GateDecision::Approved {
-                    overrides: Some(overrides),
-                } => assert_eq!(
-                    overrides.captured_names().collect::<Vec<_>>(),
-                    vec!["x-forwarded-user"]
-                ),
-                other => panic!("expected Approved carrying overrides, got {other:?}"),
-            }
         }
 
         /// Capture composes with the response-leg signature check: the same
@@ -2090,223 +2041,232 @@ mod tests {
             );
         }
 
-        /// An approval that does not carry the demanded identity is not an
-        /// approval: no partial override survives.
+        /// The gate path's response matrix, one loopback receiver per row:
+        /// identity exists only on an approved response whose mapped headers
+        /// are all present. Every other row — a denial, a missing mapped
+        /// header, an empty mapping, a non-2xx status, a malformed body, an
+        /// unverified response, a timeout — yields no override object, each
+        /// asserted at its own shape rather than by omission.
         #[tokio::test]
-        async fn gate_approved_missing_mapped_header_fails_closed() {
-            let (url, _received) =
-                one_shot_receiver(vec![], r#"{"approved":true}"#.to_owned()).await;
-
-            let client = loopback_client(&url, EgressSigning::Disabled, user_mapping());
-            let err = client
-                .request_approval_for_gate(
-                    &test_request(DecisionId::generate()),
-                    Duration::from_secs(5),
-                )
-                .await
-                .expect_err("a missing mapped header must fail the approval closed");
-
-            match &err {
-                ApprovalError::CaptureFailed(CaptureError::MissingHeaders { names }) => {
-                    assert_eq!(names, &["x-forwarded-user".to_owned()]);
-                }
-                other => panic!("expected CaptureFailed, got {other:?}"),
+        async fn gate_response_matrix_yields_overrides_only_on_a_complete_approval() {
+            enum Reply {
+                Respond {
+                    status: &'static str,
+                    headers: Vec<(String, String)>,
+                    body: String,
+                },
+                Stall,
             }
-            assert!(
-                err.to_string().contains("x-forwarded-user"),
-                "the audit message must name the missing header: {err}"
-            );
-        }
+            enum Expected {
+                ApprovedWithOverrides,
+                ApprovedWithoutOverrides,
+                Denied(&'static str),
+                TimedOut,
+                BadStatus(u16),
+                Parse,
+                Unverified,
+                CaptureFailed(&'static str),
+            }
 
-        /// A denial short-circuits before capture, so the same response that
-        /// would fail an approval closed is a clean `Denied` here.
-        #[tokio::test]
-        async fn gate_denied_response_ignores_missing_mapped_header() {
-            let (url, _received) = one_shot_receiver(
-                vec![],
-                r#"{"approved":false,"reason":"not today"}"#.to_owned(),
-            )
-            .await;
+            let identity = || ("x-approver-id".to_owned(), "alice".to_owned());
+            let approved = || r#"{"approved":true}"#.to_owned();
+            let cases: Vec<(&str, Reply, EgressSigning, bool, Expected)> = vec![
+                (
+                    "an unsigned approval carrying the mapped header",
+                    Reply::Respond {
+                        status: "200 OK",
+                        headers: vec![identity()],
+                        body: approved(),
+                    },
+                    EgressSigning::Disabled,
+                    true,
+                    Expected::ApprovedWithOverrides,
+                ),
+                (
+                    "an approval missing the mapped header fails closed",
+                    Reply::Respond {
+                        status: "200 OK",
+                        headers: vec![],
+                        body: approved(),
+                    },
+                    EgressSigning::Disabled,
+                    true,
+                    Expected::CaptureFailed("x-forwarded-user"),
+                ),
+                (
+                    "a denial short-circuits before capture",
+                    Reply::Respond {
+                        status: "200 OK",
+                        headers: vec![],
+                        body: r#"{"approved":false,"reason":"not today"}"#.to_owned(),
+                    },
+                    EgressSigning::Disabled,
+                    true,
+                    Expected::Denied("not today"),
+                ),
+                (
+                    "an empty mapping yields no override object at all",
+                    Reply::Respond {
+                        status: "200 OK",
+                        headers: vec![identity()],
+                        body: approved(),
+                    },
+                    EgressSigning::Disabled,
+                    false,
+                    Expected::ApprovedWithoutOverrides,
+                ),
+                (
+                    "a non-2xx status is a channel fault",
+                    Reply::Respond {
+                        status: "503 Service Unavailable",
+                        headers: vec![identity()],
+                        body: approved(),
+                    },
+                    EgressSigning::Disabled,
+                    true,
+                    Expected::BadStatus(503),
+                ),
+                (
+                    "a malformed body is a channel fault",
+                    Reply::Respond {
+                        status: "200 OK",
+                        headers: vec![identity()],
+                        body: "not json".to_owned(),
+                    },
+                    EgressSigning::Disabled,
+                    true,
+                    Expected::Parse,
+                ),
+                (
+                    "an unsigned response under a configured HMAC is rejected",
+                    Reply::Respond {
+                        status: "200 OK",
+                        headers: vec![identity()],
+                        body: approved(),
+                    },
+                    EgressSigning::Enabled(test_hmac()),
+                    true,
+                    Expected::Unverified,
+                ),
+                (
+                    "a webhook that never answers times out",
+                    Reply::Stall,
+                    EgressSigning::Disabled,
+                    true,
+                    Expected::TimedOut,
+                ),
+            ];
 
-            let client = loopback_client(&url, EgressSigning::Disabled, user_mapping());
-            let decision = client
-                .request_approval_for_gate(
-                    &test_request(DecisionId::generate()),
-                    Duration::from_secs(5),
-                )
-                .await
-                .expect("a denial is a decision, not a capture failure");
+            for (case, reply, signing, mapped, expected) in cases {
+                let (url, timeout) = match reply {
+                    Reply::Respond {
+                        status,
+                        headers,
+                        body,
+                    } => {
+                        let (url, _received) =
+                            one_shot_receiver_with_status(status, headers, body).await;
+                        (url, Duration::from_secs(5))
+                    }
+                    Reply::Stall => {
+                        let (url, _accepted) = stalled_receiver().await;
+                        (url, Duration::from_millis(200))
+                    }
+                };
+                let mapping = if mapped {
+                    user_mapping()
+                } else {
+                    aura_config::ToolHeaderMappings::default()
+                };
+                let decision = loopback_client(&url, signing, mapping)
+                    .request_approval_for_gate(&test_request(DecisionId::generate()), timeout)
+                    .await;
 
-            assert!(
-                matches!(decision, GateDecision::Denied { reason } if reason.as_deref() == Some("not today")),
-                "expected Denied"
-            );
-        }
-
-        /// With no mapping configured, a response header that happens to
-        /// match one is not identity: `Approved` carries no override object
-        /// at all rather than an empty one.
-        #[tokio::test]
-        async fn gate_empty_mapping_yields_no_overrides() {
-            let (url, _received) = one_shot_receiver(
-                vec![("x-approver-id".to_owned(), "alice".to_owned())],
-                r#"{"approved":true}"#.to_owned(),
-            )
-            .await;
-
-            let client = loopback_client(
-                &url,
-                EgressSigning::Disabled,
-                aura_config::ToolHeaderMappings::default(),
-            );
-            let decision = client
-                .request_approval_for_gate(
-                    &test_request(DecisionId::generate()),
-                    Duration::from_secs(5),
-                )
-                .await
-                .expect("unsigned gate round trip succeeds");
-
-            assert!(
-                matches!(decision, GateDecision::Approved { overrides: None }),
-                "expected Approved without overrides, got {decision:?}"
-            );
-        }
-
-        /// The remaining loopback-matrix rows on the gate path: with capture
-        /// configured, none of them reaches an `Approved` decision, so no
-        /// override object can exist.
-        #[tokio::test]
-        async fn gate_non_happy_responses_yield_no_overrides() {
-            // Non-2xx.
-            let (url, _received) = one_shot_receiver_with_status(
-                "503 Service Unavailable",
-                vec![("x-approver-id".to_owned(), "alice".to_owned())],
-                r#"{"approved":true}"#.to_owned(),
-            )
-            .await;
-            let err = loopback_client(&url, EgressSigning::Disabled, user_mapping())
-                .request_approval_for_gate(
-                    &test_request(DecisionId::generate()),
-                    Duration::from_secs(5),
-                )
-                .await
-                .expect_err("a non-2xx response is a channel fault");
-            assert!(matches!(err, ApprovalError::BadStatus { status: 503 }));
-
-            // Malformed body.
-            let (url, _received) = one_shot_receiver(
-                vec![("x-approver-id".to_owned(), "alice".to_owned())],
-                "not json".to_owned(),
-            )
-            .await;
-            let err = loopback_client(&url, EgressSigning::Disabled, user_mapping())
-                .request_approval_for_gate(
-                    &test_request(DecisionId::generate()),
-                    Duration::from_secs(5),
-                )
-                .await
-                .expect_err("an unparsable body is a channel fault");
-            assert!(matches!(err, ApprovalError::Parse(_)));
-
-            // Response-leg HMAC failure: an approved, identity-bearing body
-            // that is not signed must not become an approval.
-            let (url, _received) = one_shot_receiver(
-                vec![("x-approver-id".to_owned(), "alice".to_owned())],
-                r#"{"approved":true}"#.to_owned(),
-            )
-            .await;
-            let err = loopback_client(&url, EgressSigning::Enabled(test_hmac()), user_mapping())
-                .request_approval_for_gate(
-                    &test_request(DecisionId::generate()),
-                    Duration::from_secs(5),
-                )
-                .await
-                .expect_err("an unverified response must not become an approval");
-            assert!(matches!(err, ApprovalError::ResponseUnverified(_)));
-        }
-
-        /// A round trip the webhook never answers times out, and a timeout
-        /// is not an approval.
-        #[tokio::test]
-        async fn gate_timeout_yields_no_overrides() {
-            let (url, _accepted) = stalled_receiver().await;
-
-            let decision = loopback_client(&url, EgressSigning::Disabled, user_mapping())
-                .request_approval_for_gate(
-                    &test_request(DecisionId::generate()),
-                    Duration::from_millis(200),
-                )
-                .await
-                .expect("a timeout is an outcome, not a channel fault");
-
-            assert!(
-                matches!(decision, GateDecision::TimedOut { .. }),
-                "expected TimedOut, got {decision:?}"
-            );
+                match (expected, decision) {
+                    (
+                        Expected::ApprovedWithOverrides,
+                        Ok(GateDecision::Approved {
+                            overrides: Some(overrides),
+                        }),
+                    ) => assert_eq!(
+                        overrides.captured_names().collect::<Vec<_>>(),
+                        vec!["x-forwarded-user"],
+                        "{case}"
+                    ),
+                    (
+                        Expected::ApprovedWithoutOverrides,
+                        Ok(GateDecision::Approved { overrides: None }),
+                    ) => {}
+                    (Expected::Denied(reason), Ok(GateDecision::Denied { reason: got })) => {
+                        assert_eq!(got.as_deref(), Some(reason), "{case}")
+                    }
+                    (Expected::TimedOut, Ok(GateDecision::TimedOut { .. })) => {}
+                    (
+                        Expected::BadStatus(status),
+                        Err(ApprovalError::BadStatus { status: got }),
+                    ) => {
+                        assert_eq!(got, status, "{case}")
+                    }
+                    (Expected::Parse, Err(ApprovalError::Parse(_))) => {}
+                    (Expected::Unverified, Err(ApprovalError::ResponseUnverified(_))) => {}
+                    (
+                        Expected::CaptureFailed(name),
+                        Err(
+                            ref err @ ApprovalError::CaptureFailed(CaptureError::MissingHeaders {
+                                ref names,
+                            }),
+                        ),
+                    ) => {
+                        assert_eq!(names, &[name.to_owned()], "{case}");
+                        assert!(
+                            err.to_string().contains(name),
+                            "{case}: the audit message must name the missing header: {err}"
+                        );
+                    }
+                    (_, got) => panic!("{case}: unexpected gate outcome {got:?}"),
+                }
+            }
         }
 
         /// Cancelling a round trip the receiver has already accepted — so it
-        /// is provably in flight — resolves the gate's webhook arm without
-        /// waiting out its timeout, and the cancelled decision carries no
-        /// override.
+        /// is provably in flight — resolves the cancelled decision without
+        /// waiting out the timeout. Both entrypoints honour the same token:
+        /// `decide_for_gate` and the route-wide `decide`.
         #[tokio::test]
-        async fn webhook_gate_cancellation_short_circuits_the_round_trip() {
-            let (url, accepted) = stalled_receiver().await;
-            let route = super::super::DecisionRoute::Webhook {
-                client: loopback_client(&url, EgressSigning::Disabled, user_mapping()),
-                timeout: Duration::from_secs(300),
-            };
-            let cancel = crate::request_cancellation::RequestCancelToken::unbound();
+        async fn webhook_cancellation_short_circuits_the_round_trip_on_both_paths() {
+            for route_wide in [false, true] {
+                let (url, accepted) = stalled_receiver().await;
+                let route = super::super::DecisionRoute::Webhook {
+                    client: loopback_client(&url, EgressSigning::Disabled, user_mapping()),
+                    timeout: Duration::from_secs(300),
+                };
+                let cancel = crate::request_cancellation::RequestCancelToken::unbound();
+                let request = test_request(DecisionId::generate());
 
-            let (decision, ()) = tokio::join!(
-                route.decide_for_gate(test_request(DecisionId::generate()), &cancel),
-                async {
+                let cancelled = async {
+                    if route_wide {
+                        match route.decide(request, &cancel).await {
+                            Ok(ApprovalOutcome::Cancelled(CancelReason::ClientDisconnected)) => {}
+                            other => {
+                                panic!("route_wide={route_wide}: expected Cancelled, got {other:?}")
+                            }
+                        }
+                    } else {
+                        match route.decide_for_gate(request, &cancel).await {
+                            Ok(GateDecision::Cancelled(CancelReason::ClientDisconnected)) => {}
+                            other => {
+                                panic!("route_wide={route_wide}: expected Cancelled, got {other:?}")
+                            }
+                        }
+                    }
+                };
+                let ((), ()) = tokio::join!(cancelled, async {
                     accepted
                         .await
                         .expect("the round trip must reach the receiver first");
                     cancel.cancel();
-                }
-            );
-
-            let decision = decision.expect("cancellation is an outcome, not a channel fault");
-            assert!(
-                matches!(
-                    decision,
-                    GateDecision::Cancelled(CancelReason::ClientDisconnected)
-                ),
-                "expected Cancelled, got {decision:?}"
-            );
-        }
-
-        /// The route-wide path honours the same token.
-        #[tokio::test]
-        async fn webhook_route_cancellation_short_circuits_the_round_trip() {
-            let (url, accepted) = stalled_receiver().await;
-            let route = super::super::DecisionRoute::Webhook {
-                client: loopback_client(
-                    &url,
-                    EgressSigning::Disabled,
-                    aura_config::ToolHeaderMappings::default(),
-                ),
-                timeout: Duration::from_secs(300),
-            };
-            let cancel = crate::request_cancellation::RequestCancelToken::unbound();
-
-            let (outcome, ()) = tokio::join!(
-                route.decide(test_request(DecisionId::generate()), &cancel),
-                async {
-                    accepted
-                        .await
-                        .expect("the round trip must reach the receiver first");
-                    cancel.cancel();
-                }
-            );
-
-            assert_eq!(
-                outcome.expect("cancellation is an outcome, not a channel fault"),
-                ApprovalOutcome::Cancelled(CancelReason::ClientDisconnected)
-            );
+                });
+            }
         }
 
         /// Cancellation beats an approval that is already on the wire: the

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 use aura_config::{DecisionRouteConfig, GlobPattern, HitlConfig, ToolHeaderMappings, WebhookUrl};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
-use super::decision::{ApprovalDecision, ApprovalOutcome};
+use super::decision::{ApprovalDecision, ApprovalOutcome, DecisionId};
 use super::events;
 use super::protocol::{ApprovalDecisionWire, ApprovalRequest, ApprovalRequestWire};
 use super::registry::PendingApprovals;
@@ -197,24 +197,56 @@ pub enum DecisionRoute {
     },
 }
 
+/// Stamp `decision_id` on the current tracing span
+/// (`crate::logging::set_span_attribute`, a documented no-op without the
+/// `otel` feature).
+///
+/// Called from both [`DecisionRoute::decide_for_gate`] and
+/// [`DecisionRoute::decide`] — the two public entry points, since neither
+/// reaches the other on every path: the gate's webhook arm resolves through
+/// the client seam without ever calling `decide`, and the agent-callable
+/// `request_approval` tool calls `decide` directly, bypassing the gate
+/// entirely. Each entry point stamps exactly once: `decide_for_gate`'s
+/// conversational arm reaches the shared decision logic through the
+/// unstamped [`DecisionRoute::decide_inner`] rather than through `decide`,
+/// so nesting never produces a second stamp on the same span.
+/// `set_span_attribute` appends rather than overwrites by key, so a second
+/// stamp would add a duplicate attribute entry rather than update the
+/// existing one — this is the failure mode the single-stamp invariant
+/// avoids.
+fn stamp_decision_id(decision_id: DecisionId) {
+    crate::logging::set_span_attribute(
+        &tracing::Span::current(),
+        crate::logging::ATTR_DECISION_ID,
+        decision_id.to_string(),
+    );
+}
+
 impl DecisionRoute {
     /// Obtain a decision for a config-gated call, carrying any captured
     /// approver header overrides on the approved arm.
+    ///
+    /// The gate awaits this inline from the gated call's `execute_tool`
+    /// span, so stamping the decision id here — ahead of the route split
+    /// and of any outcome — correlates the approval with the execution it
+    /// gates on either route, decided or not.
     ///
     /// The webhook arm goes through the capture-bearing client seam
     /// ([`WebhookClient::request_approval_for_gate`]), which owns the HTTP
     /// response, so capture is filled there without signature changes;
     /// its event choreography mirrors [`Self::decide`]'s webhook arm. The
-    /// conversational arm delegates to [`Self::decide`]: that route has no
-    /// distinct identity source and never captures.
+    /// conversational arm delegates to the unstamped [`Self::decide_inner`]
+    /// (not [`Self::decide`], which would stamp a second time on this span):
+    /// that route has no distinct identity source and never captures.
     pub async fn decide_for_gate(
         &self,
         request: ApprovalRequest,
         cancel: &crate::request_cancellation::RequestCancelToken,
     ) -> Result<GateDecision, ApprovalError> {
+        stamp_decision_id(request.decision_id);
         match self {
             Self::Conversational { .. } => {
-                let outcome = self.decide(request, cancel).await?;
+                let outcome = self.decide_inner(request, cancel).await?;
                 Ok(GateDecision::without_overrides(outcome))
             }
             Self::Webhook { client, timeout } => {
@@ -222,14 +254,6 @@ impl DecisionRoute {
                 let request_id = request.request_id.clone();
                 let decision_id = request.decision_id;
                 let scope = request.scope.clone();
-
-                // Mirrors the stamp at the top of `decide`: ahead of any
-                // outcome, so the correlation holds on either route.
-                crate::logging::set_span_attribute(
-                    &tracing::Span::current(),
-                    crate::logging::ATTR_DECISION_ID,
-                    decision_id.to_string(),
-                );
 
                 approval_event_broker::publish(
                     &request_id,
@@ -262,14 +286,30 @@ impl DecisionRoute {
         }
     }
 
-    /// Obtain a decision for `request`, applying the shared semantics (deadline,
-    /// fail-closed mapping, event emission) in one place.
+    /// Obtain a decision for `request`.
     ///
-    /// Both surfaces await this inline from the gated call's `execute_tool`
-    /// span, so stamping the decision id on the current span here — ahead of
-    /// the route split and of any outcome — correlates the approval with the
-    /// execution it gates on either route, decided or not.
+    /// The agent-callable `request_approval` tool awaits this directly on
+    /// its own `execute_tool` span, never through [`Self::decide_for_gate`],
+    /// so this entry point stamps the decision id on the current span
+    /// before delegating to [`Self::decide_inner`] for the shared decision
+    /// logic (deadline, fail-closed mapping, event emission).
     pub async fn decide(
+        &self,
+        request: ApprovalRequest,
+        cancel: &crate::request_cancellation::RequestCancelToken,
+    ) -> Result<ApprovalOutcome, ApprovalError> {
+        stamp_decision_id(request.decision_id);
+        self.decide_inner(request, cancel).await
+    }
+
+    /// Obtain a decision for `request`, applying the shared semantics
+    /// (deadline, fail-closed mapping, event emission) in one place.
+    ///
+    /// Does not stamp the current span: both callers — [`Self::decide`] and
+    /// the conversational arm of [`Self::decide_for_gate`] — have already
+    /// stamped it on their own entry, so stamping here too would duplicate
+    /// the attribute on the same span.
+    async fn decide_inner(
         &self,
         request: ApprovalRequest,
         cancel: &crate::request_cancellation::RequestCancelToken,
@@ -278,12 +318,6 @@ impl DecisionRoute {
         let request_id = request.request_id.clone();
         let decision_id = request.decision_id;
         let scope = request.scope.clone();
-
-        crate::logging::set_span_attribute(
-            &tracing::Span::current(),
-            crate::logging::ATTR_DECISION_ID,
-            decision_id.to_string(),
-        );
 
         match self {
             Self::Conversational { registry, timeout } => {

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -197,23 +197,12 @@ pub enum DecisionRoute {
     },
 }
 
-/// Stamp `decision_id` on the current tracing span
-/// (`crate::logging::set_span_attribute`, a documented no-op without the
-/// `otel` feature).
+/// Stamp `decision_id` on the current tracing span.
 ///
-/// Called from both [`DecisionRoute::decide_for_gate`] and
-/// [`DecisionRoute::decide`] — the two public entry points, since neither
-/// reaches the other on every path: the gate's webhook arm resolves through
-/// the client seam without ever calling `decide`, and the agent-callable
-/// `request_approval` tool calls `decide` directly, bypassing the gate
-/// entirely. Each entry point stamps exactly once: `decide_for_gate`'s
-/// conversational arm reaches the shared decision logic through the
-/// unstamped [`DecisionRoute::decide_inner`] rather than through `decide`,
-/// so nesting never produces a second stamp on the same span.
-/// `set_span_attribute` appends rather than overwrites by key, so a second
-/// stamp would add a duplicate attribute entry rather than update the
-/// existing one — this is the failure mode the single-stamp invariant
-/// avoids.
+/// `set_span_attribute` appends rather than overwrites by key, so one span
+/// stamped twice would carry a duplicate attribute entry. The entry points
+/// stamp once each and delegate through the unstamped
+/// [`DecisionRoute::decide_inner`].
 fn stamp_decision_id(decision_id: DecisionId) {
     crate::logging::set_span_attribute(
         &tracing::Span::current(),
@@ -226,18 +215,11 @@ impl DecisionRoute {
     /// Obtain a decision for a config-gated call, carrying any captured
     /// approver header overrides on the approved arm.
     ///
-    /// The gate awaits this inline from the gated call's `execute_tool`
-    /// span, so stamping the decision id here — ahead of the route split
-    /// and of any outcome — correlates the approval with the execution it
-    /// gates on either route, decided or not.
-    ///
     /// The webhook arm goes through the capture-bearing client seam
     /// ([`WebhookClient::request_approval_for_gate`]), the only path that
-    /// reads approver identity off an approval response; its event
-    /// choreography mirrors [`Self::decide`]'s webhook arm. The
-    /// conversational arm delegates to the unstamped [`Self::decide_inner`]
-    /// (not [`Self::decide`], which would stamp a second time on this span):
-    /// that route has no distinct identity source and never captures.
+    /// reads approver identity off an approval response. The conversational
+    /// arm delegates to the unstamped [`Self::decide_inner`]: that route has
+    /// no distinct identity source and never captures.
     pub async fn decide_for_gate(
         &self,
         request: ApprovalRequest,
@@ -261,13 +243,10 @@ impl DecisionRoute {
                 )
                 .await;
 
-                // Cancellation is checked in two phases, both failing closed:
-                // the round trip races the cancel token, and whatever the
-                // race returns is rechecked against the token before it
-                // becomes this arm's decision — so a disconnect landing just
-                // as the decision arrives is caught too, and a cancelled call
-                // captures nothing. The completed event is derived after both
-                // phases, so the event and the returned decision always agree.
+                // Two phases, both failing closed: the round trip races the
+                // cancel token, and the result is rechecked against the token
+                // before it becomes this arm's decision, so a disconnect
+                // landing just as the decision arrives is caught too.
                 let raced = tokio::select! {
                     biased;
                     () = cancel.cancelled() => None,
@@ -306,13 +285,8 @@ impl DecisionRoute {
         }
     }
 
-    /// Obtain a decision for `request`.
-    ///
-    /// The agent-callable `request_approval` tool awaits this directly on
-    /// its own `execute_tool` span, never through [`Self::decide_for_gate`],
-    /// so this entry point stamps the decision id on the current span
-    /// before delegating to [`Self::decide_inner`] for the shared decision
-    /// logic (deadline, fail-closed mapping, event emission).
+    /// Obtain a decision for `request`, stamping the decision id on the
+    /// current span before delegating to [`Self::decide_inner`].
     pub async fn decide(
         &self,
         request: ApprovalRequest,
@@ -325,10 +299,7 @@ impl DecisionRoute {
     /// Obtain a decision for `request`, applying the shared semantics
     /// (deadline, fail-closed mapping, event emission) in one place.
     ///
-    /// Does not stamp the current span: both callers — [`Self::decide`] and
-    /// the conversational arm of [`Self::decide_for_gate`] — have already
-    /// stamped it on their own entry, so stamping here too would duplicate
-    /// the attribute on the same span.
+    /// Does not stamp: both callers stamp on their own entry.
     async fn decide_inner(
         &self,
         request: ApprovalRequest,
@@ -394,11 +365,7 @@ impl DecisionRoute {
                 )
                 .await;
 
-                // Two-phase, as on the gate path: race the round trip against
-                // the cancel token, then recheck the token before the raced
-                // outcome becomes this arm's outcome. The completed event is
-                // derived after both phases, so the event and the returned
-                // outcome always agree.
+                // Two-phase, as on the gate path.
                 let raced = tokio::select! {
                     biased;
                     () = cancel.cancelled() => None,
@@ -511,16 +478,14 @@ pub struct WebhookClient {
     /// Resolved webhook headers.
     headers: HeaderMap,
     signing: EgressSigning,
-    /// Validated `tool_headers_from_response` mappings; empty means approver
-    /// identity capture is not configured.
+    /// Validated `tool_headers_from_response` mappings.
     tool_header_mappings: ToolHeaderMappings,
 }
 
 /// One webhook round trip's answer, with the HTTP response headers it
 /// arrived alongside.
 ///
-/// Only the decided arm carries headers: a timed-out round trip has no
-/// response to read them from, so headers-without-a-decision is
+/// Only the decided arm carries headers, so headers-without-a-decision is
 /// unrepresentable.
 enum WebhookReply {
     Decided {
@@ -598,9 +563,8 @@ impl WebhookClient {
                  will fail closed"
             );
         }
-        // The cleartext-capture warning does not live here: `HitlRuntime::from_config`
-        // (and so this constructor) runs once per request, not once at startup.
-        // `warn_on_cleartext_capture` below is the boot-time seam for it.
+        // The cleartext-capture warning lives at the boot-time seam, not
+        // here: see [`warn_on_cleartext_capture`].
         Self {
             client,
             url,
@@ -611,19 +575,8 @@ impl WebhookClient {
     }
 
     /// Gate-scoped approval request: the config-gate path through the
-    /// webhook.
-    ///
-    /// Runs the round trip through [`Self::request_approval_with_headers`]
-    /// and captures approver identity from the reply's response headers on
-    /// the approved arm only, and only when `tool_header_mappings` is
-    /// non-empty — so overrides are `Some` exactly when capture is
-    /// configured and every mapped header resolved, and `None` otherwise.
-    /// A capture that cannot complete fails closed as
-    /// [`ApprovalError::CaptureFailed`] rather than approving without the
-    /// identity the operator demanded. Every other reply projects through
-    /// [`GateDecision::without_overrides`]. The route-wide
-    /// [`Self::request_approval`] path serves the agent-callable approval
-    /// tool and never captures.
+    /// webhook, capturing approver identity from the reply's response
+    /// headers on the approved arm only.
     pub(crate) async fn request_approval_for_gate(
         &self,
         request: &ApprovalRequest,
@@ -735,8 +688,7 @@ impl WebhookClient {
                 // ingress before any parse.
                 let signature = header_value(resp.headers(), super::signing::SIGNATURE_HEADER);
                 let timestamp = header_value(resp.headers(), super::signing::TIMESTAMP_HEADER);
-                // Cloned here because `bytes()` consumes the response; the
-                // clone is inert until a verified parse builds `Decided`.
+                // Cloned here because `bytes()` consumes the response.
                 let response_headers = resp.headers().clone();
                 let body = match resp.bytes().await {
                     Ok(body) => body,
@@ -836,13 +788,10 @@ pub fn validate_webhook_signing_config(
     }
 }
 
-/// Boot-time warning: a webhook route with `tool_headers_from_response`
-/// configured over plain `http://` is usable (`validate_webhook_signing_config`
-/// above covers the one case that still fails closed, an HMAC secret over
-/// plaintext) but exposes captured approver credentials to any network
-/// observer between here and the webhook. Call this once per `[hitl]`
-/// config at startup, alongside `validate_webhook_signing_config` — never
-/// from [`WebhookClient`] construction, which runs fresh per request via
+/// Boot-time warning for a webhook route that captures approver response
+/// headers over plain `http://`. Call this once per `[hitl]` config at
+/// startup, alongside `validate_webhook_signing_config`. Do not call from
+/// [`WebhookClient`] construction: that runs fresh per request via
 /// `HitlRuntime::from_config` and would turn one misconfiguration into a
 /// warning per chat request.
 pub fn warn_on_cleartext_capture(config: &HitlConfig) {

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -846,23 +846,34 @@ pub fn validate_webhook_signing_config(
 /// `HitlRuntime::from_config` and would turn one misconfiguration into a
 /// warning per chat request.
 pub fn warn_on_cleartext_capture(config: &HitlConfig) {
+    if let Some(warning) = cleartext_capture_warning(config) {
+        tracing::warn!("{warning}");
+    }
+}
+
+/// The cleartext-capture warning for `config`, rendered as a message so a
+/// binary whose default tracing subscriber is silent (aura-cli without
+/// `log_file`) can print it on a channel it actually owns, such as stderr.
+/// `None` for every configuration [`warn_on_cleartext_capture`] stays quiet
+/// for; the message carries the redacted origin, never the full URL.
+pub fn cleartext_capture_warning(config: &HitlConfig) -> Option<String> {
     let DecisionRouteConfig::Webhook {
         url,
         tool_headers_from_response,
         ..
     } = &config.route
     else {
-        return;
+        return None;
     };
     if tool_headers_from_response.is_empty() || url.as_str().starts_with("https://") {
-        return;
+        return None;
     }
-    tracing::warn!(
-        origin = %redact_to_origin(url.as_str()),
-        "HITL webhook route captures approver response headers over cleartext http, so \
+    Some(format!(
+        "HITL webhook route {} captures approver response headers over cleartext http, so \
          this route's tool_headers_from_response values are readable by any network \
-         observer; intended for trusted-gateway or service-to-service deployments"
-    );
+         observer; intended for trusted-gateway or service-to-service deployments",
+        redact_to_origin(url.as_str())
+    ))
 }
 
 /// `scheme://host[:port]` of `url`, dropping userinfo, path, query, and
@@ -1958,6 +1969,54 @@ mod tests {
             assert!(
                 !log.contains("https://approvals.example.com"),
                 "an https route must not warn, got log: {log}"
+            );
+        }
+
+        /// The rendered warning carries the redacted origin so a binary can
+        /// print it on a channel tracing does not reach, and it keeps the
+        /// same redaction the traced event holds: userinfo, path, and query
+        /// never appear.
+        #[test]
+        fn cleartext_capture_warning_redacts_the_url() {
+            let warning = super::super::cleartext_capture_warning(&webhook_config(
+                "http://token:secret@approvals.example.com:8443/aura/hook?key=shh",
+                user_mapping(),
+            ))
+            .expect("a mapped cleartext route must warn");
+
+            assert!(
+                warning.contains("http://approvals.example.com:8443"),
+                "the warning must name the origin, got: {warning}"
+            );
+            for secret in ["token", "secret", "aura/hook", "key=shh"] {
+                assert!(
+                    !warning.contains(secret),
+                    "the warning must never carry userinfo, path, or query, got: {warning}"
+                );
+            }
+        }
+
+        /// The quiet cases match [`warn_on_cleartext_capture`]: an https
+        /// route and an empty (legacy) mapping both return `None`, so the
+        /// stderr channel a binary opens stays silent exactly when the
+        /// traced one does.
+        #[test]
+        fn cleartext_capture_warning_is_none_when_quiet() {
+            assert!(
+                super::super::cleartext_capture_warning(&webhook_config(
+                    "https://approvals.example.com/aura",
+                    user_mapping(),
+                ))
+                .is_none(),
+                "an https route must not warn"
+            );
+            assert!(
+                super::super::cleartext_capture_warning(&webhook_config(
+                    "http://approvals.example.com/aura",
+                    aura_config::ToolHeaderMappings::default(),
+                ))
+                .is_none(),
+                "an empty mapping is the legacy path and must not warn"
             );
         }
 

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -232,9 +232,9 @@ impl DecisionRoute {
     /// gates on either route, decided or not.
     ///
     /// The webhook arm goes through the capture-bearing client seam
-    /// ([`WebhookClient::request_approval_for_gate`]), which owns the HTTP
-    /// response, so capture is filled there without signature changes;
-    /// its event choreography mirrors [`Self::decide`]'s webhook arm. The
+    /// ([`WebhookClient::request_approval_for_gate`]), the only path that
+    /// reads approver identity off an approval response; its event
+    /// choreography mirrors [`Self::decide`]'s webhook arm. The
     /// conversational arm delegates to the unstamped [`Self::decide_inner`]
     /// (not [`Self::decide`], which would stamp a second time on this span):
     /// that route has no distinct identity source and never captures.
@@ -261,7 +261,27 @@ impl DecisionRoute {
                 )
                 .await;
 
-                let result = client.request_approval_for_gate(&request, *timeout).await;
+                // Cancellation is checked in two phases, both failing closed:
+                // the round trip races the cancel token, and whatever the
+                // race returns is rechecked against the token before it
+                // becomes this arm's decision — so a disconnect landing just
+                // as the decision arrives is caught too, and a cancelled call
+                // captures nothing. The completed event is derived after both
+                // phases, so the event and the returned decision always agree.
+                let raced = tokio::select! {
+                    biased;
+                    () = cancel.cancelled() => None,
+                    decision = client.request_approval_for_gate(&request, *timeout) => Some(decision),
+                };
+                let result = match raced {
+                    Some(decision) if !cancel.is_cancelled() => decision,
+                    _ => {
+                        tracing::warn!(%decision_id, "approval cancelled: client disconnected");
+                        Ok(GateDecision::Cancelled(
+                            super::decision::CancelReason::ClientDisconnected,
+                        ))
+                    }
+                };
                 let completed = match &result {
                     Ok(decision) => events::completed(
                         decision_id,
@@ -374,7 +394,25 @@ impl DecisionRoute {
                 )
                 .await;
 
-                let result = client.request_approval(&request, *timeout).await;
+                // Two-phase, as on the gate path: race the round trip against
+                // the cancel token, then recheck the token before the raced
+                // outcome becomes this arm's outcome. The completed event is
+                // derived after both phases, so the event and the returned
+                // outcome always agree.
+                let raced = tokio::select! {
+                    biased;
+                    () = cancel.cancelled() => None,
+                    outcome = client.request_approval(&request, *timeout) => Some(outcome),
+                };
+                let result = match raced {
+                    Some(outcome) if !cancel.is_cancelled() => outcome,
+                    _ => {
+                        tracing::warn!(%decision_id, "approval cancelled: client disconnected");
+                        Ok(ApprovalOutcome::Cancelled(
+                            super::decision::CancelReason::ClientDisconnected,
+                        ))
+                    }
+                };
                 let completed = match &result {
                     Ok(outcome) => {
                         events::completed(decision_id, outcome, &scope, started.elapsed())
@@ -456,13 +494,14 @@ fn resolve_webhook_headers(
     header_map
 }
 
-/// HMAC signing state for the webhook route.
+/// The webhook route's egress signing state, plus the fail-closed state an
+/// unusable route configuration lands in.
 enum EgressSigning {
     /// Unsigned egress.
     Disabled,
     /// Signed egress under the configured HMAC secret.
     Enabled(WebhookHmac),
-    /// An unusable signing configuration, with the reason.
+    /// An unusable route configuration, with the reason.
     Misconfigured(String),
 }
 
@@ -473,13 +512,35 @@ pub struct WebhookClient {
     /// Resolved webhook headers.
     headers: HeaderMap,
     signing: EgressSigning,
-    /// Validated `tool_headers_from_response` mappings. Read only by the
-    /// gate-scoped path; empty means no capture is configured.
-    #[expect(
-        dead_code,
-        reason = "request_approval_for_gate reads this when capture wiring lands"
-    )]
+    /// Validated `tool_headers_from_response` mappings; empty means approver
+    /// identity capture is not configured.
     tool_header_mappings: ToolHeaderMappings,
+}
+
+/// One webhook round trip's answer, with the HTTP response headers it
+/// arrived alongside.
+///
+/// Only the decided arm carries headers: a timed-out round trip has no
+/// response to read them from, so headers-without-a-decision is
+/// unrepresentable.
+enum WebhookReply {
+    Decided {
+        decision: ApprovalDecision,
+        response_headers: HeaderMap,
+    },
+    TimedOut {
+        waited: Duration,
+    },
+}
+
+impl WebhookReply {
+    /// Project to the route-wide outcome, dropping the response headers.
+    fn into_outcome(self) -> ApprovalOutcome {
+        match self {
+            Self::Decided { decision, .. } => ApprovalOutcome::Decided(decision),
+            Self::TimedOut { waited } => ApprovalOutcome::TimedOut { waited },
+        }
+    }
 }
 
 impl WebhookClient {
@@ -518,23 +579,35 @@ impl WebhookClient {
         signing: EgressSigning,
         tool_header_mappings: ToolHeaderMappings,
     ) -> Self {
-        // A plaintext response channel would defeat response-leg verification,
-        // so http:// with a secret configured is itself a misconfiguration
-        // (DESIGN.md §4, Route A).
-        let signing = match signing {
-            EgressSigning::Enabled(_) if url.as_str().starts_with("http://") => {
-                EgressSigning::Misconfigured(format!(
+        // Two ways a plaintext url makes the route unusable, both fail closed
+        // for the life of the client. A plaintext response channel defeats
+        // response-leg verification, so http:// with a secret configured is
+        // itself a misconfiguration (DESIGN.md §4, Route A). Captured
+        // approver headers are credentials the gated call then presents as
+        // identity, so carrying them back over cleartext exposes them to the
+        // network whether or not the decision itself is signed. Neither check
+        // exempts loopback: the url is operator config, not a test fixture.
+        let signing = if url.as_str().starts_with("http://") {
+            match signing {
+                EgressSigning::Enabled(_) => EgressSigning::Misconfigured(format!(
                     "webhook url {} uses plaintext http:// while an HMAC secret is configured; \
                      use https://",
                     url.as_str()
-                ))
+                )),
+                _ if !tool_header_mappings.is_empty() => EgressSigning::Misconfigured(format!(
+                    "webhook url {} uses plaintext http:// while tool_headers_from_response is \
+                     configured; use https://",
+                    url.as_str()
+                )),
+                other => other,
             }
-            other => other,
+        } else {
+            signing
         };
         if let EgressSigning::Misconfigured(reason) = &signing {
             tracing::error!(
                 reason,
-                "HITL webhook HMAC misconfigured; every approval request on this route \
+                "HITL webhook route misconfigured; every approval request on this route \
                  will fail closed"
             );
         }
@@ -548,19 +621,41 @@ impl WebhookClient {
     }
 
     /// Gate-scoped approval request: the config-gate path through the
-    /// webhook. This method owns the HTTP response, so capture is filled
-    /// here — mapped approval-response headers resolved per
-    /// `tool_header_mappings`, fail closed on missing — with no further
-    /// signature change. Until capture wiring lands, every decision
-    /// carries no overrides. The route-wide [`Self::request_approval`]
-    /// path serves `request_approval` and never captures.
+    /// webhook.
+    ///
+    /// Runs the round trip through [`Self::request_approval_with_headers`]
+    /// and captures approver identity from the reply's response headers on
+    /// the approved arm only, and only when `tool_header_mappings` is
+    /// non-empty — so overrides are `Some` exactly when capture is
+    /// configured and every mapped header resolved, and `None` otherwise.
+    /// A capture that cannot complete fails closed as
+    /// [`ApprovalError::CaptureFailed`] rather than approving without the
+    /// identity the operator demanded. Every other reply projects through
+    /// [`GateDecision::without_overrides`]. The route-wide
+    /// [`Self::request_approval`] path serves the agent-callable approval
+    /// tool and never captures.
     pub(crate) async fn request_approval_for_gate(
         &self,
         request: &ApprovalRequest,
         timeout: Duration,
     ) -> Result<GateDecision, ApprovalError> {
-        let outcome = self.request_approval(request, timeout).await?;
-        Ok(GateDecision::without_overrides(outcome))
+        match self.request_approval_with_headers(request, timeout).await? {
+            WebhookReply::Decided {
+                decision: ApprovalDecision::Approved,
+                response_headers,
+            } => {
+                let overrides = if self.tool_header_mappings.is_empty() {
+                    None
+                } else {
+                    Some(crate::approver_headers::ApproverHeaders::from_captured(
+                        &self.tool_header_mappings,
+                        &response_headers,
+                    )?)
+                };
+                Ok(GateDecision::Approved { overrides })
+            }
+            other => Ok(GateDecision::without_overrides(other.into_outcome())),
+        }
     }
 
     /// Apply operator-configured headers to a request builder. Called before
@@ -575,16 +670,34 @@ impl WebhookClient {
         builder
     }
 
-    /// POST the request and resolve a decision, failing closed on timeout or
-    /// transport/parse error. With a secret configured the POST carries the
-    /// `X-Aura-*` signature headers (context `approval-request:{decision_id}`)
-    /// and the HTTP response must verify under
-    /// `approval-decision:{decision_id}` before its body is parsed.
+    /// Resolve a decision without its response headers: the route-wide path,
+    /// which never captures approver identity.
     async fn request_approval(
         &self,
         request: &ApprovalRequest,
         timeout: Duration,
     ) -> Result<ApprovalOutcome, ApprovalError> {
+        Ok(self
+            .request_approval_with_headers(request, timeout)
+            .await?
+            .into_outcome())
+    }
+
+    /// POST the request and resolve a decision, failing closed on timeout or
+    /// transport/parse error. With a secret configured the POST carries the
+    /// `X-Aura-*` signature headers (context `approval-request:{decision_id}`)
+    /// and the HTTP response must verify under
+    /// `approval-decision:{decision_id}` before its body is parsed.
+    ///
+    /// The reply carries the response headers, cloned off the response
+    /// before its body is consumed. On the signed path they reach a caller
+    /// only inside a [`WebhookReply::Decided`], which is built after
+    /// verification and parse both succeed.
+    async fn request_approval_with_headers(
+        &self,
+        request: &ApprovalRequest,
+        timeout: Duration,
+    ) -> Result<WebhookReply, ApprovalError> {
         let hmac = match &self.signing {
             EgressSigning::Misconfigured(reason) => {
                 return Err(ApprovalError::Misconfigured(reason.clone()));
@@ -618,7 +731,7 @@ impl WebhookClient {
             post = post.header(name, value);
         }
         match post.body(body).timeout(timeout).send().await {
-            Err(e) if e.is_timeout() => Ok(ApprovalOutcome::TimedOut { waited: timeout }),
+            Err(e) if e.is_timeout() => Ok(WebhookReply::TimedOut { waited: timeout }),
             Err(e) => Err(ApprovalError::Transport(e.to_string())),
             Ok(resp) => {
                 let status = resp.status();
@@ -632,12 +745,15 @@ impl WebhookClient {
                 // ingress before any parse.
                 let signature = header_value(resp.headers(), super::signing::SIGNATURE_HEADER);
                 let timestamp = header_value(resp.headers(), super::signing::TIMESTAMP_HEADER);
+                // Cloned here because `bytes()` consumes the response; the
+                // clone is inert until a verified parse builds `Decided`.
+                let response_headers = resp.headers().clone();
                 let body = match resp.bytes().await {
                     Ok(body) => body,
                     // A timeout firing mid-body download is still a timeout, not
                     // a transport fault — keep the classification honest.
                     Err(e) if e.is_timeout() => {
-                        return Ok(ApprovalOutcome::TimedOut { waited: timeout });
+                        return Ok(WebhookReply::TimedOut { waited: timeout });
                     }
                     Err(e) => return Err(ApprovalError::Transport(e.to_string())),
                 };
@@ -653,7 +769,10 @@ impl WebhookClient {
                 )
                 .map_err(|e| ApprovalError::ResponseUnverified(e.to_string()))?;
                 match serde_json::from_slice::<ApprovalDecisionWire>(verified.as_ref()) {
-                    Ok(wire) => Ok(ApprovalOutcome::Decided(ApprovalDecision::from(wire))),
+                    Ok(wire) => Ok(WebhookReply::Decided {
+                        decision: ApprovalDecision::from(wire),
+                        response_headers,
+                    }),
                     Err(e) => Err(ApprovalError::Parse(e.to_string())),
                 }
             }
@@ -665,12 +784,12 @@ impl WebhookClient {
         &self,
         wire: &ApprovalRequestWire<'_>,
         timeout: Duration,
-    ) -> Result<ApprovalOutcome, ApprovalError> {
+    ) -> Result<WebhookReply, ApprovalError> {
         let builder = self
             .apply_operator_headers(self.client.post(self.url.as_str()).json(wire))
             .timeout(timeout);
         match builder.send().await {
-            Err(e) if e.is_timeout() => Ok(ApprovalOutcome::TimedOut { waited: timeout }),
+            Err(e) if e.is_timeout() => Ok(WebhookReply::TimedOut { waited: timeout }),
             Err(e) => Err(ApprovalError::Transport(e.to_string())),
             Ok(resp) => {
                 let status = resp.status();
@@ -679,11 +798,16 @@ impl WebhookClient {
                         status: status.as_u16(),
                     });
                 }
+                // Cloned here because `json()` consumes the response.
+                let response_headers = resp.headers().clone();
                 match resp.json::<ApprovalDecisionWire>().await {
-                    Ok(wire) => Ok(ApprovalOutcome::Decided(ApprovalDecision::from(wire))),
+                    Ok(wire) => Ok(WebhookReply::Decided {
+                        decision: ApprovalDecision::from(wire),
+                        response_headers,
+                    }),
                     // A timeout firing mid-body download is still a timeout, not a
                     // parse fault — keep the error-vs-decision classification honest.
-                    Err(e) if e.is_timeout() => Ok(ApprovalOutcome::TimedOut { waited: timeout }),
+                    Err(e) if e.is_timeout() => Ok(WebhookReply::TimedOut { waited: timeout }),
                     Err(e) => Err(ApprovalError::Parse(e.to_string())),
                 }
             }
@@ -1219,7 +1343,7 @@ mod tests {
         use tokio::net::TcpListener;
 
         use super::super::super::decision::{
-            AgentScope, ApprovalDecision, ApprovalOrigin, DecisionId,
+            AgentScope, ApprovalDecision, ApprovalOrigin, CancelReason, DecisionId,
         };
         use super::super::super::protocol::{ApprovalRequest, PROTOCOL_VERSION};
         use super::super::super::signing::{
@@ -1227,8 +1351,10 @@ mod tests {
             WebhookHmac, authorize_ingress,
         };
         use super::super::{
-            ApprovalError, ApprovalOutcome, EgressSigning, WebhookClient, build_webhook_client,
+            ApprovalError, ApprovalOutcome, EgressSigning, GateDecision, WebhookClient,
+            build_webhook_client,
         };
+        use crate::approver_headers::CaptureError;
 
         fn test_hmac() -> WebhookHmac {
             WebhookHmac::new(
@@ -1274,6 +1400,44 @@ mod tests {
             response_headers: Vec<(String, String)>,
             response_body: String,
         ) -> (String, tokio::sync::oneshot::Receiver<ReceivedRequest>) {
+            one_shot_receiver_with_status("200 OK", response_headers, response_body).await
+        }
+
+        /// [`one_shot_receiver`] with the response status line chosen by the
+        /// caller, for the non-2xx path.
+        async fn one_shot_receiver_with_status(
+            status: &'static str,
+            response_headers: Vec<(String, String)>,
+            response_body: String,
+        ) -> (String, tokio::sync::oneshot::Receiver<ReceivedRequest>) {
+            one_shot_receiver_cancelling_after_read(status, response_headers, response_body, None)
+                .await
+        }
+
+        /// [`one_shot_receiver`] that fires `cancel_after_read` once it has
+        /// the whole request and before it writes a byte of the response, so
+        /// the caller meets a cancelled token and an arriving approval at the
+        /// same time.
+        async fn cancelling_receiver(
+            cancel: crate::request_cancellation::RequestCancelToken,
+            response_headers: Vec<(String, String)>,
+            response_body: String,
+        ) -> (String, tokio::sync::oneshot::Receiver<ReceivedRequest>) {
+            one_shot_receiver_cancelling_after_read(
+                "200 OK",
+                response_headers,
+                response_body,
+                Some(cancel),
+            )
+            .await
+        }
+
+        async fn one_shot_receiver_cancelling_after_read(
+            status: &'static str,
+            response_headers: Vec<(String, String)>,
+            response_body: String,
+            cancel_after_read: Option<crate::request_cancellation::RequestCancelToken>,
+        ) -> (String, tokio::sync::oneshot::Receiver<ReceivedRequest>) {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             let url = format!("http://{}", listener.local_addr().unwrap());
             let (tx, rx) = tokio::sync::oneshot::channel();
@@ -1309,8 +1473,12 @@ mod tests {
                     body.extend_from_slice(&chunk[..n]);
                 }
 
+                if let Some(cancel) = cancel_after_read {
+                    cancel.cancel();
+                }
+
                 let mut response = format!(
-                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                    "HTTP/1.1 {status}\r\ncontent-type: application/json\r\n\
                      content-length: {}\r\nconnection: close\r\n",
                     response_body.len()
                 );
@@ -1319,24 +1487,85 @@ mod tests {
                 }
                 response.push_str("\r\n");
                 response.push_str(&response_body);
-                socket.write_all(response.as_bytes()).await.unwrap();
+                // A cancelling caller may already have dropped the connection,
+                // so a failed reply is not a test failure; every test that
+                // cares asserts on what the client resolved to.
+                socket.write_all(response.as_bytes()).await.ok();
                 socket.shutdown().await.ok();
                 tx.send(ReceivedRequest { headers, body }).ok();
             });
             (url, rx)
         }
 
-        /// Builds a signing-enabled client directly against a loopback
-        /// `http://` receiver. Bypasses the https-only policy deliberately:
-        /// the policy is exercised by `http_url_with_secret_fails_closed`.
-        fn loopback_signed_client(url: &str, hmac: WebhookHmac) -> WebhookClient {
+        /// A receiver that accepts one connection, signals over the returned
+        /// channel that it has, and then never answers — so the caller's own
+        /// timeout or cancellation is what resolves the round trip. Awaiting
+        /// the signal before acting proves the round trip is in flight. The
+        /// spawned task holds the accepted socket open for the life of the
+        /// test; closing it would surface as a transport error instead.
+        async fn stalled_receiver() -> (String, tokio::sync::oneshot::Receiver<()>) {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let url = format!("http://{}", listener.local_addr().unwrap());
+            let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+            tokio::spawn(async move {
+                let _socket = listener.accept().await.unwrap();
+                accepted_tx.send(()).ok();
+                std::future::pending::<()>().await;
+            });
+            (url, accepted_rx)
+        }
+
+        /// Builds a client directly against a loopback `http://` receiver.
+        /// Bypasses the https-only policy deliberately: the policy is
+        /// exercised by `http_url_with_secret_fails_closed`.
+        fn loopback_client(
+            url: &str,
+            signing: EgressSigning,
+            tool_header_mappings: aura_config::ToolHeaderMappings,
+        ) -> WebhookClient {
             WebhookClient {
                 client: build_webhook_client(),
                 url: aura_config::WebhookUrl::new(url).unwrap(),
                 headers: HeaderMap::new(),
-                signing: EgressSigning::Enabled(hmac),
-                tool_header_mappings: aura_config::ToolHeaderMappings::default(),
+                signing,
+                tool_header_mappings,
             }
+        }
+
+        fn loopback_signed_client(url: &str, hmac: WebhookHmac) -> WebhookClient {
+            loopback_client(
+                url,
+                EgressSigning::Enabled(hmac),
+                aura_config::ToolHeaderMappings::default(),
+            )
+        }
+
+        fn mappings(pairs: &[(&str, &str)]) -> aura_config::ToolHeaderMappings {
+            let raw: HashMap<String, String> = pairs
+                .iter()
+                .map(|(outbound, response)| ((*outbound).to_owned(), (*response).to_owned()))
+                .collect();
+            aura_config::ToolHeaderMappings::try_from(raw).expect("test mappings are valid config")
+        }
+
+        /// The one mapping every gate test below configures.
+        fn user_mapping() -> aura_config::ToolHeaderMappings {
+            mappings(&[("x-forwarded-user", "x-approver-id")])
+        }
+
+        /// Sign `body` under the approval-decision context for `decision_id`,
+        /// as a webhook answering that decision must.
+        fn signed_response_headers(
+            hmac: &WebhookHmac,
+            decision_id: DecisionId,
+            body: &str,
+        ) -> Vec<(String, String)> {
+            let context = SigningContext::new(&format!("approval-decision:{decision_id}")).unwrap();
+            hmac.sign(&context, body.as_bytes())
+                .unwrap()
+                .into_pairs()
+                .map(|(name, value)| (name.to_string(), value))
+                .to_vec()
         }
 
         #[tokio::test]
@@ -1457,16 +1686,8 @@ mod tests {
         fn boot_validation_rejects_plaintext_url_only_with_secret() {
             use super::super::validate_webhook_signing_config;
 
-            let webhook = |url: &str| aura_config::HitlConfig {
-                require_approval: vec![],
-                route: aura_config::DecisionRouteConfig::Webhook {
-                    url: aura_config::WebhookUrl::new(url).unwrap(),
-                    timeout_secs: 300,
-                    headers: HashMap::new(),
-                    headers_from_request: HashMap::new(),
-                    tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
-                },
-            };
+            let webhook =
+                |url: &str| webhook_config(url, aura_config::ToolHeaderMappings::default());
             let hmac = test_hmac();
 
             // Secret + http:// fails at boot.
@@ -1496,29 +1717,39 @@ mod tests {
             validate_webhook_signing_config(&conversational, Some(&hmac)).unwrap();
         }
 
-        #[test]
-        fn from_config_threads_hmac_into_webhook_route() {
-            use super::super::{DecisionRoute, HitlRuntime};
-
-            let config = |url: &str| aura_config::HitlConfig {
+        fn webhook_config(
+            url: &str,
+            tool_headers_from_response: aura_config::ToolHeaderMappings,
+        ) -> aura_config::HitlConfig {
+            aura_config::HitlConfig {
                 require_approval: vec![],
                 route: aura_config::DecisionRouteConfig::Webhook {
                     url: aura_config::WebhookUrl::new(url).unwrap(),
                     timeout_secs: 300,
                     headers: HashMap::new(),
                     headers_from_request: HashMap::new(),
-                    tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
+                    tool_headers_from_response,
                 },
-            };
-            let pending = crate::hitl::PendingApprovals::new();
-            let hmac = test_hmac();
+            }
+        }
 
-            fn signing_of(runtime: &HitlRuntime) -> &EgressSigning {
-                match &*runtime.route {
-                    DecisionRoute::Webhook { client, .. } => &client.signing,
-                    DecisionRoute::Conversational { .. } => panic!("expected webhook route"),
+        fn signing_of(runtime: &super::super::HitlRuntime) -> &EgressSigning {
+            match &*runtime.route {
+                super::super::DecisionRoute::Webhook { client, .. } => &client.signing,
+                super::super::DecisionRoute::Conversational { .. } => {
+                    panic!("expected webhook route")
                 }
             }
+        }
+
+        #[test]
+        fn from_config_threads_hmac_into_webhook_route() {
+            use super::super::HitlRuntime;
+
+            let config =
+                |url: &str| webhook_config(url, aura_config::ToolHeaderMappings::default());
+            let pending = crate::hitl::PendingApprovals::new();
+            let hmac = test_hmac();
 
             let signed = HitlRuntime::from_config(
                 &config("https://approvals.example.com/aura"),
@@ -1554,6 +1785,54 @@ mod tests {
             );
         }
 
+        /// Captured approver headers are credentials travelling back from the
+        /// approver, so a cleartext approval channel must fail closed for
+        /// them on its own — with no HMAC secret anywhere in the config.
+        #[test]
+        fn from_config_rejects_capture_over_plaintext_url() {
+            use super::super::HitlRuntime;
+
+            let pending = crate::hitl::PendingApprovals::new();
+
+            let plaintext = HitlRuntime::from_config(
+                &webhook_config("http://approvals.example.com/aura", user_mapping()),
+                &pending,
+                None,
+                None,
+            );
+            match signing_of(&plaintext) {
+                EgressSigning::Misconfigured(reason) => assert!(
+                    reason.contains("tool_headers_from_response"),
+                    "the reason must name the capture config: {reason}"
+                ),
+                _ => panic!("plaintext http:// with capture must fail closed"),
+            }
+
+            let secure = HitlRuntime::from_config(
+                &webhook_config("https://approvals.example.com/aura", user_mapping()),
+                &pending,
+                None,
+                None,
+            );
+            assert!(
+                matches!(signing_of(&secure), EgressSigning::Disabled),
+                "https:// with capture and no secret is a usable unsigned route"
+            );
+
+            // Without capture configured, plaintext stays allowed for an
+            // unsigned route — this guard adds no new restriction there.
+            let legacy = HitlRuntime::from_config(
+                &webhook_config(
+                    "http://approvals.example.com/aura",
+                    aura_config::ToolHeaderMappings::default(),
+                ),
+                &pending,
+                None,
+                None,
+            );
+            assert!(matches!(signing_of(&legacy), EgressSigning::Disabled));
+        }
+
         #[tokio::test]
         async fn no_secret_sends_unsigned_and_trusts_response() {
             let decision_id = DecisionId::generate();
@@ -1582,6 +1861,321 @@ mod tests {
                 "no secret configured must mean no signature header"
             );
             assert!(received.header(TIMESTAMP_HEADER).is_none());
+        }
+
+        #[tokio::test]
+        async fn unsigned_gate_approved_captures_mapped_headers() {
+            let (url, _received) = one_shot_receiver(
+                vec![("x-approver-id".to_owned(), "alice".to_owned())],
+                r#"{"approved":true}"#.to_owned(),
+            )
+            .await;
+
+            let client = loopback_client(&url, EgressSigning::Disabled, user_mapping());
+            let decision = client
+                .request_approval_for_gate(
+                    &test_request(DecisionId::generate()),
+                    Duration::from_secs(5),
+                )
+                .await
+                .expect("unsigned gate round trip succeeds");
+
+            match decision {
+                GateDecision::Approved {
+                    overrides: Some(overrides),
+                } => assert_eq!(
+                    overrides.captured_names().collect::<Vec<_>>(),
+                    vec!["x-forwarded-user"]
+                ),
+                other => panic!("expected Approved carrying overrides, got {other:?}"),
+            }
+        }
+
+        /// Capture composes with the response-leg signature check: the same
+        /// response both verifies and yields identity.
+        #[tokio::test]
+        async fn signed_gate_approved_captures_mapped_headers() {
+            let hmac = test_hmac();
+            let decision_id = DecisionId::generate();
+            let response_body = r#"{"approved":true}"#.to_owned();
+
+            let mut response_headers = signed_response_headers(&hmac, decision_id, &response_body);
+            response_headers.push(("x-approver-id".to_owned(), "alice".to_owned()));
+            let (url, received) = one_shot_receiver(response_headers, response_body).await;
+
+            let client = loopback_client(&url, EgressSigning::Enabled(hmac), user_mapping());
+            let decision = client
+                .request_approval_for_gate(&test_request(decision_id), Duration::from_secs(5))
+                .await
+                .expect("signed gate round trip succeeds");
+
+            match decision {
+                GateDecision::Approved {
+                    overrides: Some(overrides),
+                } => assert_eq!(
+                    overrides.captured_names().collect::<Vec<_>>(),
+                    vec!["x-forwarded-user"]
+                ),
+                other => panic!("expected Approved carrying overrides, got {other:?}"),
+            }
+
+            let received = received.await.unwrap();
+            assert!(
+                received.header(SIGNATURE_HEADER).is_some(),
+                "the gate path must still sign its egress POST"
+            );
+        }
+
+        /// An approval that does not carry the demanded identity is not an
+        /// approval: no partial override survives.
+        #[tokio::test]
+        async fn gate_approved_missing_mapped_header_fails_closed() {
+            let (url, _received) =
+                one_shot_receiver(vec![], r#"{"approved":true}"#.to_owned()).await;
+
+            let client = loopback_client(&url, EgressSigning::Disabled, user_mapping());
+            let err = client
+                .request_approval_for_gate(
+                    &test_request(DecisionId::generate()),
+                    Duration::from_secs(5),
+                )
+                .await
+                .expect_err("a missing mapped header must fail the approval closed");
+
+            match &err {
+                ApprovalError::CaptureFailed(CaptureError::MissingHeaders { names }) => {
+                    assert_eq!(names, &["x-forwarded-user".to_owned()]);
+                }
+                other => panic!("expected CaptureFailed, got {other:?}"),
+            }
+            assert!(
+                err.to_string().contains("x-forwarded-user"),
+                "the audit message must name the missing header: {err}"
+            );
+        }
+
+        /// A denial short-circuits before capture, so the same response that
+        /// would fail an approval closed is a clean `Denied` here.
+        #[tokio::test]
+        async fn gate_denied_response_ignores_missing_mapped_header() {
+            let (url, _received) = one_shot_receiver(
+                vec![],
+                r#"{"approved":false,"reason":"not today"}"#.to_owned(),
+            )
+            .await;
+
+            let client = loopback_client(&url, EgressSigning::Disabled, user_mapping());
+            let decision = client
+                .request_approval_for_gate(
+                    &test_request(DecisionId::generate()),
+                    Duration::from_secs(5),
+                )
+                .await
+                .expect("a denial is a decision, not a capture failure");
+
+            assert!(
+                matches!(decision, GateDecision::Denied { reason } if reason.as_deref() == Some("not today")),
+                "expected Denied"
+            );
+        }
+
+        /// With no mapping configured, a response header that happens to
+        /// match one is not identity: `Approved` carries no override object
+        /// at all rather than an empty one.
+        #[tokio::test]
+        async fn gate_empty_mapping_yields_no_overrides() {
+            let (url, _received) = one_shot_receiver(
+                vec![("x-approver-id".to_owned(), "alice".to_owned())],
+                r#"{"approved":true}"#.to_owned(),
+            )
+            .await;
+
+            let client = loopback_client(
+                &url,
+                EgressSigning::Disabled,
+                aura_config::ToolHeaderMappings::default(),
+            );
+            let decision = client
+                .request_approval_for_gate(
+                    &test_request(DecisionId::generate()),
+                    Duration::from_secs(5),
+                )
+                .await
+                .expect("unsigned gate round trip succeeds");
+
+            assert!(
+                matches!(decision, GateDecision::Approved { overrides: None }),
+                "expected Approved without overrides, got {decision:?}"
+            );
+        }
+
+        /// The remaining loopback-matrix rows on the gate path: with capture
+        /// configured, none of them reaches an `Approved` decision, so no
+        /// override object can exist.
+        #[tokio::test]
+        async fn gate_non_happy_responses_yield_no_overrides() {
+            // Non-2xx.
+            let (url, _received) = one_shot_receiver_with_status(
+                "503 Service Unavailable",
+                vec![("x-approver-id".to_owned(), "alice".to_owned())],
+                r#"{"approved":true}"#.to_owned(),
+            )
+            .await;
+            let err = loopback_client(&url, EgressSigning::Disabled, user_mapping())
+                .request_approval_for_gate(
+                    &test_request(DecisionId::generate()),
+                    Duration::from_secs(5),
+                )
+                .await
+                .expect_err("a non-2xx response is a channel fault");
+            assert!(matches!(err, ApprovalError::BadStatus { status: 503 }));
+
+            // Malformed body.
+            let (url, _received) = one_shot_receiver(
+                vec![("x-approver-id".to_owned(), "alice".to_owned())],
+                "not json".to_owned(),
+            )
+            .await;
+            let err = loopback_client(&url, EgressSigning::Disabled, user_mapping())
+                .request_approval_for_gate(
+                    &test_request(DecisionId::generate()),
+                    Duration::from_secs(5),
+                )
+                .await
+                .expect_err("an unparsable body is a channel fault");
+            assert!(matches!(err, ApprovalError::Parse(_)));
+
+            // Response-leg HMAC failure: an approved, identity-bearing body
+            // that is not signed must not become an approval.
+            let (url, _received) = one_shot_receiver(
+                vec![("x-approver-id".to_owned(), "alice".to_owned())],
+                r#"{"approved":true}"#.to_owned(),
+            )
+            .await;
+            let err = loopback_client(&url, EgressSigning::Enabled(test_hmac()), user_mapping())
+                .request_approval_for_gate(
+                    &test_request(DecisionId::generate()),
+                    Duration::from_secs(5),
+                )
+                .await
+                .expect_err("an unverified response must not become an approval");
+            assert!(matches!(err, ApprovalError::ResponseUnverified(_)));
+        }
+
+        /// A round trip the webhook never answers times out, and a timeout
+        /// is not an approval.
+        #[tokio::test]
+        async fn gate_timeout_yields_no_overrides() {
+            let (url, _accepted) = stalled_receiver().await;
+
+            let decision = loopback_client(&url, EgressSigning::Disabled, user_mapping())
+                .request_approval_for_gate(
+                    &test_request(DecisionId::generate()),
+                    Duration::from_millis(200),
+                )
+                .await
+                .expect("a timeout is an outcome, not a channel fault");
+
+            assert!(
+                matches!(decision, GateDecision::TimedOut { .. }),
+                "expected TimedOut, got {decision:?}"
+            );
+        }
+
+        /// Cancelling a round trip the receiver has already accepted — so it
+        /// is provably in flight — resolves the gate's webhook arm without
+        /// waiting out its timeout, and the cancelled decision carries no
+        /// override.
+        #[tokio::test]
+        async fn webhook_gate_cancellation_short_circuits_the_round_trip() {
+            let (url, accepted) = stalled_receiver().await;
+            let route = super::super::DecisionRoute::Webhook {
+                client: loopback_client(&url, EgressSigning::Disabled, user_mapping()),
+                timeout: Duration::from_secs(300),
+            };
+            let cancel = crate::request_cancellation::RequestCancelToken::unbound();
+
+            let (decision, ()) = tokio::join!(
+                route.decide_for_gate(test_request(DecisionId::generate()), &cancel),
+                async {
+                    accepted
+                        .await
+                        .expect("the round trip must reach the receiver first");
+                    cancel.cancel();
+                }
+            );
+
+            let decision = decision.expect("cancellation is an outcome, not a channel fault");
+            assert!(
+                matches!(
+                    decision,
+                    GateDecision::Cancelled(CancelReason::ClientDisconnected)
+                ),
+                "expected Cancelled, got {decision:?}"
+            );
+        }
+
+        /// The route-wide path honours the same token.
+        #[tokio::test]
+        async fn webhook_route_cancellation_short_circuits_the_round_trip() {
+            let (url, accepted) = stalled_receiver().await;
+            let route = super::super::DecisionRoute::Webhook {
+                client: loopback_client(
+                    &url,
+                    EgressSigning::Disabled,
+                    aura_config::ToolHeaderMappings::default(),
+                ),
+                timeout: Duration::from_secs(300),
+            };
+            let cancel = crate::request_cancellation::RequestCancelToken::unbound();
+
+            let (outcome, ()) = tokio::join!(
+                route.decide(test_request(DecisionId::generate()), &cancel),
+                async {
+                    accepted
+                        .await
+                        .expect("the round trip must reach the receiver first");
+                    cancel.cancel();
+                }
+            );
+
+            assert_eq!(
+                outcome.expect("cancellation is an outcome, not a channel fault"),
+                ApprovalOutcome::Cancelled(CancelReason::ClientDisconnected)
+            );
+        }
+
+        /// Cancellation beats an approval that is already on the wire: the
+        /// receiver cancels the token before writing an approved,
+        /// identity-bearing response, so the decision and the disconnect are
+        /// both live. Whichever the race sees first, the recheck makes
+        /// `Cancelled` the answer and no override object is produced.
+        #[tokio::test]
+        async fn webhook_gate_cancellation_beats_a_ready_approval() {
+            let cancel = crate::request_cancellation::RequestCancelToken::unbound();
+            let (url, _received) = cancelling_receiver(
+                cancel.clone(),
+                vec![("x-approver-id".to_owned(), "alice".to_owned())],
+                r#"{"approved":true}"#.to_owned(),
+            )
+            .await;
+            let route = super::super::DecisionRoute::Webhook {
+                client: loopback_client(&url, EgressSigning::Disabled, user_mapping()),
+                timeout: Duration::from_secs(300),
+            };
+
+            let decision = route
+                .decide_for_gate(test_request(DecisionId::generate()), &cancel)
+                .await
+                .expect("cancellation is an outcome, not a channel fault");
+
+            assert!(
+                matches!(
+                    decision,
+                    GateDecision::Cancelled(CancelReason::ClientDisconnected)
+                ),
+                "expected Cancelled to win over the ready approval, got {decision:?}"
+            );
         }
     }
 

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -1936,9 +1936,9 @@ mod tests {
             );
         }
 
-        /// An absent or empty `tool_headers_from_response` map is the
-        /// legacy path: no capture, so no exposure to warn about, over
-        /// either scheme.
+        /// An absent or empty `tool_headers_from_response` map captures
+        /// nothing, so there is no exposure to warn about, over either
+        /// scheme.
         #[test]
         fn warn_on_cleartext_capture_is_quiet_with_no_map() {
             let log = captured_warn_log(|| {

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -449,4 +449,161 @@ mod tests {
             item.arguments,
         );
     }
+
+    /// Trace correlation for the agent-callable surface: `request_approval`
+    /// dispatches through [`DecisionRoute::decide`] directly, never through
+    /// the config gate's `decide_for_gate`, so this surface must stamp the
+    /// decision id on its own execution span rather than inherit one from
+    /// the gate. Mirrors the equivalent coverage for the config-gate surface
+    /// in `gate.rs`'s `decision_id_span` tests.
+    ///
+    /// Gated on `otel` — without the feature `set_span_attribute` is a
+    /// documented no-op and there is no span data to assert against.
+    #[cfg(feature = "otel")]
+    mod decision_id_span {
+        use std::future::Future;
+        use std::sync::{Arc, Mutex, MutexGuard};
+
+        use futures::future::BoxFuture;
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
+        use opentelemetry_sdk::trace::TracerProvider;
+        use tracing::Instrument;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        use super::*;
+        use crate::logging::ATTR_DECISION_ID;
+
+        /// Spans the test subscriber has exported.
+        #[derive(Debug, Clone, Default)]
+        struct CapturedSpans(Arc<Mutex<Vec<SpanData>>>);
+
+        impl CapturedSpans {
+            fn spans(&self) -> MutexGuard<'_, Vec<SpanData>> {
+                self.0.lock().expect("captured spans mutex")
+            }
+
+            fn contains(&self, name: &str) -> bool {
+                self.spans().iter().any(|span| span.name == name)
+            }
+
+            /// The single `key` attribute on the span named `name`, or `None`
+            /// if the span carries no such attribute. Panics if the span
+            /// carries more than one — a double-stamp regression would
+            /// otherwise pass unnoticed, since `find` would silently return
+            /// only the first entry.
+            fn attribute(&self, name: &str, key: &str) -> Option<String> {
+                let spans = self.spans();
+                let span = spans.iter().find(|span| span.name == name)?;
+                let matches: Vec<_> = span
+                    .attributes
+                    .iter()
+                    .filter(|kv| kv.key.as_str() == key)
+                    .collect();
+                assert!(
+                    matches.len() <= 1,
+                    "span {name:?} must carry at most one {key} attribute, found {}: \
+                     a regression is double-stamping the same span",
+                    matches.len(),
+                );
+                matches.first().map(|kv| kv.value.to_string())
+            }
+        }
+
+        impl SpanExporter for CapturedSpans {
+            fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+                self.spans().extend(batch);
+                Box::pin(std::future::ready(Ok(())))
+            }
+        }
+
+        /// Run `body` inside an `execute_tool` span — the span Rig opens
+        /// around a tool call — under a subscriber that exports to memory,
+        /// returning the body's output and the `decision_id` the exported
+        /// span carries.
+        async fn traced_as_execute_tool<T>(body: impl Future<Output = T>) -> (T, Option<String>) {
+            let captured = CapturedSpans::default();
+            let provider = TracerProvider::builder()
+                .with_simple_exporter(captured.clone())
+                .build();
+            let _guard = tracing::subscriber::set_default(
+                tracing_subscriber::registry()
+                    .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test"))),
+            );
+
+            let output = body.instrument(tracing::info_span!("execute_tool")).await;
+
+            // The registry instruments a parked approval's wake task with the
+            // same span, so the export lands once that task has released it too.
+            for _ in 0..1_000 {
+                if captured.contains("execute_tool") {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            assert!(
+                captured.contains("execute_tool"),
+                "the execute_tool span was never exported",
+            );
+
+            (output, captured.attribute("execute_tool", ATTR_DECISION_ID))
+        }
+
+        #[tokio::test]
+        async fn request_approval_tool_stamps_the_decision_id_on_the_execution_span() {
+            let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+            let bus: Arc<dyn EventBus> = Arc::new(InMemoryEventBus::new());
+            let registry = PendingApprovals::with_backend(store, bus);
+            let route = Arc::new(DecisionRoute::Conversational {
+                registry: registry.clone(),
+                timeout: std::time::Duration::from_secs(60),
+            });
+
+            let request_id = format!("req_tool_span_{}", uuid::Uuid::new_v4().simple());
+            let mut events = approval_event_broker::subscribe(&request_id).await;
+            let tool = RequestApprovalTool::new(
+                route,
+                AgentScope::Single { session_id: None },
+                request_id.clone(),
+                "test-agent".to_string(),
+            );
+            let args = RequestApprovalArgs {
+                action_description: "delete namespace".to_string(),
+                risk_rationale: "touches prod".to_string(),
+                context: None,
+                tool_call_intent: None,
+            };
+
+            let ((result, payload_id), span_id) = traced_as_execute_tool(async {
+                tokio::join!(tool.call(args), async {
+                    let event = events.recv().await.expect("requested event arrives");
+                    let id = match event {
+                        ApprovalLifecycleEvent::Requested(req) => {
+                            DecisionId::parse(&req.decision_id).expect("valid decision id")
+                        }
+                        other => panic!("expected Requested event, got {:?}", other),
+                    };
+                    registry
+                        .resolve(&id, ApprovalDecision::Approved)
+                        .await
+                        .expect("parked approval resolves");
+                    id
+                })
+            })
+            .await;
+
+            assert!(
+                result.is_ok(),
+                "an approved call must succeed: {:?}",
+                result
+            );
+            assert_eq!(
+                span_id.as_deref(),
+                Some(payload_id.to_string().as_str()),
+                "the execution span must carry the request_approval tool's decision id",
+            );
+
+            approval_event_broker::unsubscribe(&request_id).await;
+        }
+    }
 }

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -450,15 +450,13 @@ mod tests {
         );
     }
 
-    /// Trace correlation for the agent-callable surface: `request_approval`
-    /// dispatches through [`DecisionRoute::decide`] directly, never through
-    /// the config gate's `decide_for_gate`, so this surface must stamp the
-    /// decision id on its own execution span rather than inherit one from
-    /// the gate. Mirrors the equivalent coverage for the config-gate surface
-    /// in `gate.rs`'s `decision_id_span` tests.
+    /// Trace correlation for the agent-callable surface: the decision id
+    /// must land on the tool's own execution span. Mirrors the equivalent
+    /// coverage for the config-gate surface in `gate.rs`'s `decision_id_span`
+    /// tests.
     ///
-    /// Gated on `otel` — without the feature `set_span_attribute` is a
-    /// documented no-op and there is no span data to assert against.
+    /// Gated on `otel`: without the feature there is no span data to
+    /// assert against.
     #[cfg(feature = "otel")]
     mod decision_id_span {
         use std::future::Future;
@@ -490,8 +488,7 @@ mod tests {
             /// The single `key` attribute on the span named `name`, or `None`
             /// if the span carries no such attribute. Panics if the span
             /// carries more than one — a double-stamp regression would
-            /// otherwise pass unnoticed, since `find` would silently return
-            /// only the first entry.
+            /// otherwise pass with only the first entry.
             fn attribute(&self, name: &str, key: &str) -> Option<String> {
                 let spans = self.spans();
                 let span = spans.iter().find(|span| span.name == name)?;

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -459,92 +459,12 @@ mod tests {
     /// assert against.
     #[cfg(feature = "otel")]
     mod decision_id_span {
-        use std::future::Future;
-        use std::sync::{Arc, Mutex, MutexGuard};
 
-        use futures::future::BoxFuture;
-        use opentelemetry::trace::TracerProvider as _;
-        use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
-        use opentelemetry_sdk::trace::TracerProvider;
-        use tracing::Instrument;
-        use tracing_subscriber::layer::SubscriberExt;
+        use std::sync::Arc;
 
         use super::*;
-        use crate::logging::ATTR_DECISION_ID;
 
-        /// Spans the test subscriber has exported.
-        #[derive(Debug, Clone, Default)]
-        struct CapturedSpans(Arc<Mutex<Vec<SpanData>>>);
-
-        impl CapturedSpans {
-            fn spans(&self) -> MutexGuard<'_, Vec<SpanData>> {
-                self.0.lock().expect("captured spans mutex")
-            }
-
-            fn contains(&self, name: &str) -> bool {
-                self.spans().iter().any(|span| span.name == name)
-            }
-
-            /// The single `key` attribute on the span named `name`, or `None`
-            /// if the span carries no such attribute. Panics if the span
-            /// carries more than one — a double-stamp regression would
-            /// otherwise pass with only the first entry.
-            fn attribute(&self, name: &str, key: &str) -> Option<String> {
-                let spans = self.spans();
-                let span = spans.iter().find(|span| span.name == name)?;
-                let matches: Vec<_> = span
-                    .attributes
-                    .iter()
-                    .filter(|kv| kv.key.as_str() == key)
-                    .collect();
-                assert!(
-                    matches.len() <= 1,
-                    "span {name:?} must carry at most one {key} attribute, found {}: \
-                     a regression is double-stamping the same span",
-                    matches.len(),
-                );
-                matches.first().map(|kv| kv.value.to_string())
-            }
-        }
-
-        impl SpanExporter for CapturedSpans {
-            fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
-                self.spans().extend(batch);
-                Box::pin(std::future::ready(Ok(())))
-            }
-        }
-
-        /// Run `body` inside an `execute_tool` span — the span Rig opens
-        /// around a tool call — under a subscriber that exports to memory,
-        /// returning the body's output and the `decision_id` the exported
-        /// span carries.
-        async fn traced_as_execute_tool<T>(body: impl Future<Output = T>) -> (T, Option<String>) {
-            let captured = CapturedSpans::default();
-            let provider = TracerProvider::builder()
-                .with_simple_exporter(captured.clone())
-                .build();
-            let _guard = tracing::subscriber::set_default(
-                tracing_subscriber::registry()
-                    .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test"))),
-            );
-
-            let output = body.instrument(tracing::info_span!("execute_tool")).await;
-
-            // The registry instruments a parked approval's wake task with the
-            // same span, so the export lands once that task has released it too.
-            for _ in 0..1_000 {
-                if captured.contains("execute_tool") {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-            assert!(
-                captured.contains("execute_tool"),
-                "the execute_tool span was never exported",
-            );
-
-            (output, captured.attribute("execute_tool", ATTR_DECISION_ID))
-        }
+        use crate::test_span_capture::traced_as_execute_tool;
 
         #[tokio::test]
         async fn request_approval_tool_stamps_the_decision_id_on_the_execution_span() {

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -450,13 +450,7 @@ mod tests {
         );
     }
 
-    /// Trace correlation for the agent-callable surface: the decision id
-    /// must land on the tool's own execution span. Mirrors the equivalent
-    /// coverage for the config-gate surface in `gate.rs`'s `decision_id_span`
-    /// tests.
-    ///
-    /// Gated on `otel`: without the feature there is no span data to
-    /// assert against.
+    /// Trace correlation for the agent-callable surface: the decision id must land on the tool's own execution span. Mirrors the equivalent coverage in `gate.rs`'s `decision_id_span` tests. Gated on `otel`: without the feature there is no span data to assert against.
     #[cfg(feature = "otel")]
     mod decision_id_span {
 

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -42,6 +42,8 @@ pub mod stream_events;
 pub mod streaming;
 pub mod streaming_request_hook;
 pub(crate) mod string_utils;
+#[cfg(all(test, feature = "otel"))]
+pub(crate) mod test_span_capture;
 pub mod tool_call_observer;
 pub mod tool_error_detection;
 pub mod tool_event_broker;

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -267,12 +267,16 @@ where
     }
 }
 
-/// Ensure aura_config warnings are always visible regardless of RUST_LOG setting.
+/// Keep operational warnings visible regardless of RUST_LOG setting.
 ///
-/// This is important for operational warnings like duplicate skill detection
-/// that should never be silently filtered.
-fn ensure_aura_config_warnings(filter: EnvFilter) -> EnvFilter {
-    filter.add_directive("aura_config=warn".parse().unwrap())
+/// This is important for warnings that must never be silently filtered:
+/// `aura_config` (duplicate skill detection) and `aura::hitl` (the
+/// cleartext-capture exposure warning), both of which the default
+/// per-binary `info` filter would otherwise drop.
+fn ensure_operational_warnings(filter: EnvFilter) -> EnvFilter {
+    filter
+        .add_directive("aura_config=warn".parse().unwrap())
+        .add_directive("aura::hitl=warn".parse().unwrap())
 }
 
 // ---------------------------------------------------------------------------
@@ -523,7 +527,7 @@ pub fn init_logging(debug: bool, verbose: bool, binary_name: &str) {
         // Default: Only binary-specific info level logging on console
         let console_filter = EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| format!("{binary_name}=info").into());
-        let console_filter = ensure_aura_config_warnings(console_filter);
+        let console_filter = ensure_operational_warnings(console_filter);
 
         let registry =
             tracing_subscriber::registry().with(fmt::layer().with_filter(console_filter));
@@ -857,6 +861,60 @@ pub async fn shutdown_tracer() {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Minimal tracing-capture facility (same shape as the one in
+    /// `hitl::route` tests): a shared buffer that implements `io::Write` by
+    /// reference, so `Arc<CapturedLog>` satisfies `tracing_subscriber`'s
+    /// `MakeWriter`, and a filter's real select/not-select behavior is
+    /// observable without touching the global subscriber.
+    struct CapturedLog(std::sync::Mutex<Vec<u8>>);
+
+    impl std::io::Write for &CapturedLog {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// The default console filter is `{binary}=info` plus the operational
+    /// directives; under EnvFilter semantics an unmatched target is silent,
+    /// so without the `aura::hitl=warn` directive the cleartext-capture
+    /// warning would never reach a default-mode console. Warn-level events
+    /// from that subtree must pass while its info-level noise stays dropped.
+    #[test]
+    fn default_console_filter_still_shows_hitl_warnings() {
+        use std::sync::Arc;
+
+        let buf = Arc::new(CapturedLog(std::sync::Mutex::new(Vec::new())));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(buf.clone())
+            .with_env_filter(ensure_operational_warnings(EnvFilter::new(
+                "aura-web-server=info",
+            )))
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::warn!(
+                target: "aura::hitl::route",
+                "cleartext capture warning under a default filter"
+            );
+            tracing::info!(target: "aura::hitl::route", "info noise stays filtered");
+        });
+
+        let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
+        assert!(
+            log.contains("cleartext capture warning under a default filter"),
+            "the hitl warning must survive the default filter, got log: {log}"
+        );
+        assert!(
+            !log.contains("info noise stays filtered"),
+            "the directive is warn-level, not a blanket enable, got log: {log}"
+        );
+    }
 
     /// A prompt longer than `OTEL_CONTENT_MAX_LENGTH` must still serialize to
     /// valid JSON — truncating the finished JSON instead of the content would

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -154,11 +154,15 @@ pub const ATTR_TOOL_RESULT: &str = "tool.result";
 pub const ATTR_TOOL_RESULT_LENGTH: &str = "tool.result.length";
 pub const ATTR_TOOL_CANCELLED: &str = "tool.cancelled";
 
-// HITL attribute (used by `hitl::route`)
+// HITL attributes (used by `hitl::route` and `mcp_tool_execution`)
 
 /// Handle of the human approval decision gating a tool call — the same
 /// `decision_id` the approval payload and lifecycle events carry.
 pub const ATTR_DECISION_ID: &str = "decision_id";
+
+/// Comma-separated, sorted outbound header NAMES an approver override
+/// applied to a gated MCP call — never their values.
+pub const ATTR_APPLIED_HEADERS: &str = "applied_headers";
 
 // --- Content recording configuration ---
 

--- a/crates/aura/src/mcp_dynamic.rs
+++ b/crates/aura/src/mcp_dynamic.rs
@@ -114,7 +114,6 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::approver_headers::{APPROVER_OVERRIDES, tests::captured_overrides};
     use crate::mcp_streamable_http::tests::RecordingMcpServer;
 
     /// An adaptor for `tool_name`, fronting `server`, tagged as `kind`.
@@ -135,55 +134,6 @@ mod tests {
             std::sync::Arc::new(serde_json::Map::new()),
         );
         McpToolAdaptor::new(tool, "test-server".to_owned(), Arc::new(client), kind)
-    }
-
-    /// Identity was demanded and stdio has no way to carry it, so the call
-    /// must not run — and must not run *at all*: the refusal comes before
-    /// anything reaches the server, not after.
-    #[tokio::test]
-    async fn stdio_adaptor_refuses_a_gated_call_before_dispatch() {
-        let server = RecordingMcpServer::start().await;
-        let adaptor = adaptor_for(&server, "gated", McpTransportKind::Stdio).await;
-
-        let error = APPROVER_OVERRIDES
-            .scope(
-                Some(captured_overrides("x-forwarded-user", "alice")),
-                adaptor.call(json!({})),
-            )
-            .await
-            .expect_err("a stdio tool call carrying overrides must fail closed");
-
-        assert!(
-            error
-                .to_string()
-                .contains("cannot deliver approver identity"),
-            "the error must name the reason, got: {error}",
-        );
-        assert!(
-            server.tool_calls().is_empty(),
-            "the call must not reach the server",
-        );
-    }
-
-    /// The same adaptor over a transport that can carry headers reads the
-    /// task-local and threads it all the way to the wire.
-    #[tokio::test]
-    async fn http_adaptor_forwards_the_scoped_override() {
-        let server = RecordingMcpServer::start().await;
-        let adaptor = adaptor_for(&server, "gated", McpTransportKind::StreamableHttp).await;
-
-        APPROVER_OVERRIDES
-            .scope(
-                Some(captured_overrides("x-forwarded-user", "alice")),
-                adaptor.call(json!({})),
-            )
-            .await
-            .expect("an http-backed gated call proceeds");
-
-        assert_eq!(
-            server.tool_calls()[0].header_values("x-forwarded-user"),
-            vec!["alice"],
-        );
     }
 
     /// A stdio tool that no approval gated is untouched by any of this.

--- a/crates/aura/src/mcp_dynamic.rs
+++ b/crates/aura/src/mcp_dynamic.rs
@@ -108,3 +108,95 @@ impl RigTool for McpToolAdaptor {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::approver_headers::{APPROVER_OVERRIDES, tests::captured_overrides};
+    use crate::mcp_streamable_http::tests::RecordingMcpServer;
+
+    /// An adaptor for `tool_name`, fronting `server`, tagged as `kind`.
+    /// The client is always a streamable-HTTP one: the tag, not the wire, is
+    /// what the override path consults, so a stdio-tagged adaptor over a
+    /// reachable server is exactly the case that must still refuse.
+    async fn adaptor_for(
+        server: &RecordingMcpServer,
+        tool_name: &str,
+        kind: McpTransportKind,
+    ) -> McpToolAdaptor {
+        let client = McpClient::new(server.url.clone(), &std::collections::HashMap::new())
+            .await
+            .expect("the loopback server completes the handshake");
+        let tool = rmcp::model::Tool::new(
+            tool_name.to_owned(),
+            "test tool".to_owned(),
+            std::sync::Arc::new(serde_json::Map::new()),
+        );
+        McpToolAdaptor::new(tool, "test-server".to_owned(), Arc::new(client), kind)
+    }
+
+    /// Identity was demanded and stdio has no way to carry it, so the call
+    /// must not run — and must not run *at all*: the refusal comes before
+    /// anything reaches the server, not after.
+    #[tokio::test]
+    async fn stdio_adaptor_refuses_a_gated_call_before_dispatch() {
+        let server = RecordingMcpServer::start().await;
+        let adaptor = adaptor_for(&server, "gated", McpTransportKind::Stdio).await;
+
+        let error = APPROVER_OVERRIDES
+            .scope(
+                Some(captured_overrides("x-forwarded-user", "alice")),
+                adaptor.call(json!({})),
+            )
+            .await
+            .expect_err("a stdio tool call carrying overrides must fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("cannot deliver approver identity"),
+            "the error must name the reason, got: {error}",
+        );
+        assert!(
+            server.tool_calls().is_empty(),
+            "the call must not reach the server",
+        );
+    }
+
+    /// The same adaptor over a transport that can carry headers reads the
+    /// task-local and threads it all the way to the wire.
+    #[tokio::test]
+    async fn http_adaptor_forwards_the_scoped_override() {
+        let server = RecordingMcpServer::start().await;
+        let adaptor = adaptor_for(&server, "gated", McpTransportKind::StreamableHttp).await;
+
+        APPROVER_OVERRIDES
+            .scope(
+                Some(captured_overrides("x-forwarded-user", "alice")),
+                adaptor.call(json!({})),
+            )
+            .await
+            .expect("an http-backed gated call proceeds");
+
+        assert_eq!(
+            server.tool_calls()[0].header_values("x-forwarded-user"),
+            vec!["alice"],
+        );
+    }
+
+    /// A stdio tool that no approval gated is untouched by any of this.
+    #[tokio::test]
+    async fn stdio_adaptor_runs_an_ungated_call() {
+        let server = RecordingMcpServer::start().await;
+        let adaptor = adaptor_for(&server, "ungated", McpTransportKind::Stdio).await;
+
+        adaptor
+            .call(json!({}))
+            .await
+            .expect("an ungated stdio call proceeds");
+
+        assert_eq!(server.tool_calls().len(), 1);
+    }
+}

--- a/crates/aura/src/mcp_dynamic.rs
+++ b/crates/aura/src/mcp_dynamic.rs
@@ -114,10 +114,7 @@ mod tests {
     use super::*;
     use crate::mcp_streamable_http::tests::client_and_server;
 
-    /// An adaptor for `tool_name`, fronting `client`, tagged as `kind`.
-    /// The client is always a streamable-HTTP one: the tag, not the wire, is
-    /// what the override path consults, so a stdio-tagged adaptor over a
-    /// reachable server is exactly the case that must still refuse.
+    /// An adaptor for `tool_name`, fronting `client`, tagged as `kind`. The client is always streamable-HTTP: the tag, not the wire, is what the override path consults.
     async fn adaptor_for(
         client: McpClient,
         tool_name: &str,
@@ -131,7 +128,6 @@ mod tests {
         McpToolAdaptor::new(tool, "test-server".to_owned(), Arc::new(client), kind)
     }
 
-    /// A stdio tool that no approval gated is untouched by any of this.
     #[tokio::test]
     async fn stdio_adaptor_runs_an_ungated_call() {
         let (server, client) = client_and_server(&std::collections::HashMap::new()).await;

--- a/crates/aura/src/mcp_dynamic.rs
+++ b/crates/aura/src/mcp_dynamic.rs
@@ -112,20 +112,17 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::mcp_streamable_http::tests::RecordingMcpServer;
+    use crate::mcp_streamable_http::tests::client_and_server;
 
-    /// An adaptor for `tool_name`, fronting `server`, tagged as `kind`.
+    /// An adaptor for `tool_name`, fronting `client`, tagged as `kind`.
     /// The client is always a streamable-HTTP one: the tag, not the wire, is
     /// what the override path consults, so a stdio-tagged adaptor over a
     /// reachable server is exactly the case that must still refuse.
     async fn adaptor_for(
-        server: &RecordingMcpServer,
+        client: McpClient,
         tool_name: &str,
         kind: McpTransportKind,
     ) -> McpToolAdaptor {
-        let client = McpClient::new(server.url.clone(), &std::collections::HashMap::new())
-            .await
-            .expect("the loopback server completes the handshake");
         let tool = rmcp::model::Tool::new(
             tool_name.to_owned(),
             "test tool".to_owned(),
@@ -137,8 +134,8 @@ mod tests {
     /// A stdio tool that no approval gated is untouched by any of this.
     #[tokio::test]
     async fn stdio_adaptor_runs_an_ungated_call() {
-        let server = RecordingMcpServer::start().await;
-        let adaptor = adaptor_for(&server, "ungated", McpTransportKind::Stdio).await;
+        let (server, client) = client_and_server(&std::collections::HashMap::new()).await;
+        let adaptor = adaptor_for(client, "ungated", McpTransportKind::Stdio).await;
 
         adaptor
             .call(json!({}))

--- a/crates/aura/src/mcp_dynamic.rs
+++ b/crates/aura/src/mcp_dynamic.rs
@@ -19,9 +19,7 @@ pub struct McpToolAdaptor {
     #[allow(dead_code)]
     server_name: String,
     client: Arc<McpClient>,
-    /// Which transport this adaptor fronts, tagged at construction. The
-    /// approver-override path fails closed on transports that cannot
-    /// deliver per-request headers.
+    /// Which transport this adaptor fronts, tagged at construction.
     transport_kind: McpTransportKind,
 }
 
@@ -96,10 +94,10 @@ impl RigTool for McpToolAdaptor {
             // captured any. Unscoped reads yield `None` (wrapper-less
             // agents).
             let approver_overrides = current_approver_overrides();
-            if let Some(overrides) = &approver_overrides {
+            if approver_overrides.is_some() {
                 // Fail closed before dispatch when the transport cannot
                 // deliver per-request headers.
-                ensure_transport_delivers_overrides(transport_kind, overrides)
+                ensure_transport_delivers_overrides(transport_kind)
                     .map_err(|e| ToolError::ToolCallError(Box::new(e)))?;
             }
 

--- a/crates/aura/src/mcp_sse.rs
+++ b/crates/aura/src/mcp_sse.rs
@@ -191,6 +191,94 @@ fn resolve_message_endpoint(
 mod tests {
     use super::*;
 
+    mod approver_overrides {
+        use rmcp::model::{CallToolRequestParam, ClientJsonRpcMessage, RequestId};
+
+        use super::*;
+        use crate::approver_headers::{ApproverHeaders, tests::captured_overrides};
+        use crate::mcp_streamable_http::call_tool_request;
+        use crate::mcp_streamable_http::tests::RecordingMcpServer;
+
+        /// An SSE transport aimed at `endpoint`, carrying the same frozen
+        /// identity a configured client would hold. Built by hand because
+        /// `connect` needs a live SSE stream and the send path is what is
+        /// under test.
+        fn transport_to(endpoint: &str) -> SseTransport {
+            let mut frozen = HeaderMap::new();
+            frozen.insert(
+                "authorization",
+                HeaderValue::from_static("Bearer requester"),
+            );
+            SseTransport {
+                http_client: reqwest::Client::builder()
+                    .default_headers(frozen)
+                    .build()
+                    .unwrap(),
+                message_endpoint: url::Url::parse(endpoint).unwrap(),
+                stream: None,
+            }
+        }
+
+        fn call_message(tool: &str, overrides: Option<ApproverHeaders>) -> ClientJsonRpcMessage {
+            ClientJsonRpcMessage::request(
+                call_tool_request(
+                    CallToolRequestParam {
+                        name: tool.to_owned().into(),
+                        arguments: None,
+                    },
+                    overrides,
+                ),
+                RequestId::Number(1),
+            )
+        }
+
+        /// The SSE send path reads the same extension the streamable-HTTP path
+        /// does: the override replaces the frozen identity on that one POST,
+        /// arrives once, and never appears in the JSON body.
+        #[tokio::test]
+        async fn send_applies_the_override_to_the_post_and_not_the_body() {
+            let server = RecordingMcpServer::start().await;
+            let mut transport = transport_to(&server.url);
+
+            transport
+                .send(call_message(
+                    "gated",
+                    Some(captured_overrides("authorization", "Bearer approver")),
+                ))
+                .await
+                .expect("the loopback server accepts the post");
+
+            let calls = server.tool_calls();
+            assert_eq!(calls.len(), 1);
+            assert_eq!(
+                calls[0].header_values("authorization"),
+                vec!["Bearer approver"],
+                "the requester's identity must be replaced, not joined",
+            );
+            let body = calls[0].body_text();
+            assert!(!body.contains("authorization"), "body was: {body}");
+            assert!(!body.contains("approver"), "body was: {body}");
+        }
+
+        /// A message with no extension leaves the client's own identity in
+        /// place, so an ungated call on an SSE server is unaffected.
+        #[tokio::test]
+        async fn send_without_an_extension_keeps_the_frozen_identity() {
+            let server = RecordingMcpServer::start().await;
+            let mut transport = transport_to(&server.url);
+
+            transport
+                .send(call_message("ungated", None))
+                .await
+                .expect("the loopback server accepts the post");
+
+            assert_eq!(
+                server.tool_calls()[0].header_values("authorization"),
+                vec!["Bearer requester"],
+            );
+        }
+    }
+
     #[test]
     fn test_resolve_message_endpoint_query_only() {
         let base = url::Url::parse("https://localhost/sse").unwrap();

--- a/crates/aura/src/mcp_sse.rs
+++ b/crates/aura/src/mcp_sse.rs
@@ -212,10 +212,7 @@ mod tests {
             )
         }
 
-        /// The SSE send path reads the same extension the streamable-HTTP path
-        /// does: an override replaces the frozen identity on exactly that one
-        /// POST, arrives once, and never appears in the JSON body — and a
-        /// message with no extension leaves the client's identity in place.
+        /// The SSE send path reads the same extension the streamable-HTTP path does: an override replaces the frozen identity on exactly that one POST, arrives once, and never appears in the JSON body.
         #[tokio::test]
         async fn send_applies_the_override_to_that_post_alone() {
             let server = RecordingMcpServer::start().await;

--- a/crates/aura/src/mcp_sse.rs
+++ b/crates/aura/src/mcp_sse.rs
@@ -233,10 +233,11 @@ mod tests {
         }
 
         /// The SSE send path reads the same extension the streamable-HTTP path
-        /// does: the override replaces the frozen identity on that one POST,
-        /// arrives once, and never appears in the JSON body.
+        /// does: an override replaces the frozen identity on exactly that one
+        /// POST, arrives once, and never appears in the JSON body — and a
+        /// message with no extension leaves the client's identity in place.
         #[tokio::test]
-        async fn send_applies_the_override_to_the_post_and_not_the_body() {
+        async fn send_applies_the_override_to_that_post_alone() {
             let server = RecordingMcpServer::start().await;
             let mut transport = transport_to(&server.url);
 
@@ -248,33 +249,26 @@ mod tests {
                 .await
                 .expect("the loopback server accepts the post");
 
-            let calls = server.tool_calls();
-            assert_eq!(calls.len(), 1);
+            let gated = &server.tool_calls()[0];
             assert_eq!(
-                calls[0].header_values("authorization"),
+                gated.header_values("authorization"),
                 vec!["Bearer approver"],
                 "the requester's identity must be replaced, not joined",
             );
-            let body = calls[0].body_text();
+            let body = gated.body_text();
             assert!(!body.contains("authorization"), "body was: {body}");
             assert!(!body.contains("approver"), "body was: {body}");
-        }
-
-        /// A message with no extension leaves the client's own identity in
-        /// place, so an ungated call on an SSE server is unaffected.
-        #[tokio::test]
-        async fn send_without_an_extension_keeps_the_frozen_identity() {
-            let server = RecordingMcpServer::start().await;
-            let mut transport = transport_to(&server.url);
 
             transport
                 .send(call_message("ungated", None))
                 .await
-                .expect("the loopback server accepts the post");
+                .expect("the loopback server accepts the second post");
 
+            let ungated = &server.tool_calls()[1];
             assert_eq!(
-                server.tool_calls()[0].header_values("authorization"),
+                ungated.header_values("authorization"),
                 vec!["Bearer requester"],
+                "the next ungated message keeps the frozen identity",
             );
         }
     }

--- a/crates/aura/src/mcp_sse.rs
+++ b/crates/aura/src/mcp_sse.rs
@@ -264,6 +264,11 @@ mod tests {
                 .await
                 .expect("the loopback server accepts the second post");
 
+            assert_eq!(
+                server.tool_calls().len(),
+                2,
+                "exactly one POST per message, nothing duplicated"
+            );
             let ungated = &server.tool_calls()[1];
             assert_eq!(
                 ungated.header_values("authorization"),

--- a/crates/aura/src/mcp_sse.rs
+++ b/crates/aura/src/mcp_sse.rs
@@ -199,26 +199,6 @@ mod tests {
         use crate::mcp_streamable_http::call_tool_request;
         use crate::mcp_streamable_http::tests::RecordingMcpServer;
 
-        /// An SSE transport aimed at `endpoint`, carrying the same frozen
-        /// identity a configured client would hold. Built by hand because
-        /// `connect` needs a live SSE stream and the send path is what is
-        /// under test.
-        fn transport_to(endpoint: &str) -> SseTransport {
-            let mut frozen = HeaderMap::new();
-            frozen.insert(
-                "authorization",
-                HeaderValue::from_static("Bearer requester"),
-            );
-            SseTransport {
-                http_client: reqwest::Client::builder()
-                    .default_headers(frozen)
-                    .build()
-                    .unwrap(),
-                message_endpoint: url::Url::parse(endpoint).unwrap(),
-                stream: None,
-            }
-        }
-
         fn call_message(tool: &str, overrides: Option<ApproverHeaders>) -> ClientJsonRpcMessage {
             ClientJsonRpcMessage::request(
                 call_tool_request(
@@ -239,7 +219,22 @@ mod tests {
         #[tokio::test]
         async fn send_applies_the_override_to_that_post_alone() {
             let server = RecordingMcpServer::start().await;
-            let mut transport = transport_to(&server.url);
+            // Built by hand because `connect` needs a live SSE stream and the
+            // send path is what is under test. The frozen header stands in
+            // for the identity a configured client would hold.
+            let mut frozen = HeaderMap::new();
+            frozen.insert(
+                "authorization",
+                HeaderValue::from_static("Bearer requester"),
+            );
+            let mut transport = SseTransport {
+                http_client: reqwest::Client::builder()
+                    .default_headers(frozen)
+                    .build()
+                    .unwrap(),
+                message_endpoint: url::Url::parse(&server.url).unwrap(),
+                stream: None,
+            };
 
             transport
                 .send(call_message(

--- a/crates/aura/src/mcp_streamable_http.rs
+++ b/crates/aura/src/mcp_streamable_http.rs
@@ -33,7 +33,7 @@ use crate::tool_event_broker::{peek_tool_call_id, publish_tool_start};
 /// request value through the transport worker and is never serialized to
 /// the wire, so one-call scoping is structural. Every `call_tool*` variant
 /// constructs its request here.
-fn call_tool_request(
+pub(crate) fn call_tool_request(
     request_param: CallToolRequestParam,
     approver_overrides: Option<ApproverHeaders>,
 ) -> ClientRequest {
@@ -635,8 +635,14 @@ impl McpClient {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
+    use std::sync::Mutex;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
     use super::*;
+    use crate::approver_headers::tests::captured_overrides;
 
     #[tokio::test]
     async fn test_in_flight_requests_tracking() {
@@ -649,5 +655,438 @@ mod tests {
 
         tracker.remove(http_id, &mcp_id).await;
         assert_eq!(tracker.get_all(http_id).await.len(), 0);
+    }
+
+    /// One HTTP request the server received, kept whole so a test can ask
+    /// both what rode in the headers and what rode in the body.
+    #[derive(Clone)]
+    pub(crate) struct RecordedRequest {
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+    }
+
+    impl RecordedRequest {
+        /// Every value sent under `name`, in arrival order. A test that asks
+        /// for the count is asking whether an override replaced a header or
+        /// merely joined it.
+        pub(crate) fn header_values(&self, name: &str) -> Vec<&str> {
+            self.headers
+                .iter()
+                .filter(|(k, _)| k.eq_ignore_ascii_case(name))
+                .map(|(_, v)| v.as_str())
+                .collect()
+        }
+
+        pub(crate) fn body_text(&self) -> String {
+            String::from_utf8_lossy(&self.body).into_owned()
+        }
+
+        /// The JSON-RPC method this request carried, or `None` for a body
+        /// that is not a JSON-RPC message.
+        fn rpc_method(&self) -> Option<String> {
+            serde_json::from_slice::<Value>(&self.body)
+                .ok()?
+                .get("method")?
+                .as_str()
+                .map(str::to_owned)
+        }
+
+        /// The tool this request asked the server to run, for correlating a
+        /// recorded request back to the call that produced it.
+        pub(crate) fn called_tool(&self) -> Option<String> {
+            serde_json::from_slice::<Value>(&self.body)
+                .ok()?
+                .get("params")?
+                .get("name")?
+                .as_str()
+                .map(str::to_owned)
+        }
+    }
+
+    /// A loopback MCP server over streamable HTTP that answers the handshake
+    /// and every tool call, and keeps each request it received.
+    ///
+    /// It exists so a test can watch what actually reaches the wire: the
+    /// approver override is applied deep inside the transport, after rmcp's
+    /// worker has taken the request value, so nothing short of the received
+    /// request proves it arrived — or, for the calls that must not carry it,
+    /// that it did not.
+    pub(crate) struct RecordingMcpServer {
+        pub(crate) url: String,
+        received: Arc<Mutex<Vec<RecordedRequest>>>,
+    }
+
+    impl RecordingMcpServer {
+        pub(crate) async fn start() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let url = format!("http://{}/mcp", listener.local_addr().unwrap());
+            let received = Arc::new(Mutex::new(Vec::new()));
+            let sink = Arc::clone(&received);
+            tokio::spawn(async move {
+                while let Ok((socket, _)) = listener.accept().await {
+                    let sink = Arc::clone(&sink);
+                    tokio::spawn(serve_one_request(socket, sink));
+                }
+            });
+            Self { url, received }
+        }
+
+        /// Snapshot of every `tools/call` the server received, oldest first.
+        pub(crate) fn tool_calls(&self) -> Vec<RecordedRequest> {
+            self.received
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|r| r.rpc_method().as_deref() == Some("tools/call"))
+                .cloned()
+                .collect()
+        }
+
+        /// The handshake request, which no approval has gated and which must
+        /// therefore carry only the identity the client was built with.
+        pub(crate) fn initialize(&self) -> RecordedRequest {
+            self.received
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|r| r.rpc_method().as_deref() == Some("initialize"))
+                .cloned()
+                .expect("the client completed a handshake")
+        }
+    }
+
+    /// The session id the handshake hands back, echoed by the client on every
+    /// later request.
+    const SESSION_ID: &str = "recording-session";
+
+    /// Read one HTTP request off `socket`, record it, answer it, and close.
+    /// Answering `connection: close` keeps the framing to one request per
+    /// connection, so the reader never has to unpick a keep-alive stream.
+    async fn serve_one_request(mut socket: TcpStream, sink: Arc<Mutex<Vec<RecordedRequest>>>) {
+        let mut buf = Vec::new();
+        let head_end = loop {
+            let mut chunk = [0u8; 4096];
+            let Ok(n) = socket.read(&mut chunk).await else {
+                return;
+            };
+            if n == 0 {
+                return;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..head_end]).into_owned();
+        let mut lines = head.lines();
+        let request_line = lines.next().unwrap_or_default().to_owned();
+        let headers: Vec<(String, String)> = lines
+            .filter_map(|line| line.split_once(':'))
+            .map(|(k, v)| (k.trim().to_owned(), v.trim().to_owned()))
+            .collect();
+        let content_length: usize = headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+            .and_then(|(_, v)| v.parse().ok())
+            .unwrap_or(0);
+        let mut body = buf[head_end + 4..].to_vec();
+        while body.len() < content_length {
+            let mut chunk = [0u8; 4096];
+            let Ok(n) = socket.read(&mut chunk).await else {
+                return;
+            };
+            if n == 0 {
+                return;
+            }
+            body.extend_from_slice(&chunk[..n]);
+        }
+
+        let http_method = request_line.split_whitespace().next().unwrap_or_default();
+        let (status, extra_headers, payload) = match http_method {
+            // rmcp opens a server-to-client stream once it has a session; 405
+            // is the documented "this server has none", which the worker
+            // absorbs instead of failing the connection.
+            "GET" => ("405 Method Not Allowed", Vec::new(), String::new()),
+            "DELETE" => ("202 Accepted", Vec::new(), String::new()),
+            _ => reply_to_rpc(&body),
+        };
+
+        sink.lock().unwrap().push(RecordedRequest { headers, body });
+
+        let mut response = format!(
+            "HTTP/1.1 {status}\r\ncontent-length: {}\r\nconnection: close\r\n",
+            payload.len()
+        );
+        if !payload.is_empty() {
+            response.push_str("content-type: application/json\r\n");
+        }
+        for (name, value) in extra_headers {
+            response.push_str(&format!("{name}: {value}\r\n"));
+        }
+        response.push_str("\r\n");
+        response.push_str(&payload);
+        socket.write_all(response.as_bytes()).await.ok();
+        socket.shutdown().await.ok();
+    }
+
+    /// Answer a JSON-RPC POST: a result for a request, a bare ack for a
+    /// notification.
+    fn reply_to_rpc(body: &[u8]) -> (&'static str, Vec<(String, String)>, String) {
+        let Ok(message) = serde_json::from_slice::<Value>(body) else {
+            return ("400 Bad Request", Vec::new(), String::new());
+        };
+        let method = message
+            .get("method")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        let Some(id) = message
+            .get("id")
+            .cloned()
+            .and_then(|id| serde_json::from_value::<RequestId>(id).ok())
+        else {
+            return ("202 Accepted", Vec::new(), String::new());
+        };
+
+        let result = match method.as_str() {
+            "initialize" => {
+                rmcp::model::ServerResult::InitializeResult(rmcp::model::InitializeResult::default())
+            }
+            "tools/call" => rmcp::model::ServerResult::CallToolResult(
+                rmcp::model::CallToolResult::success(vec![rmcp::model::Content::text("ok")]),
+            ),
+            _ => rmcp::model::ServerResult::empty(()),
+        };
+        let payload =
+            serde_json::to_string(&rmcp::model::ServerJsonRpcMessage::response(result, id))
+                .expect("server result serializes");
+        let extra_headers = if method == "initialize" {
+            vec![("mcp-session-id".to_owned(), SESSION_ID.to_owned())]
+        } else {
+            Vec::new()
+        };
+        ("200 OK", extra_headers, payload)
+    }
+
+    /// The identity frozen into the client at build time, standing in for the
+    /// original requester's forwarded headers.
+    fn requester_headers() -> HashMap<String, String> {
+        HashMap::from([("authorization".to_owned(), "Bearer requester".to_owned())])
+    }
+
+    fn no_args() -> HashMap<String, Value> {
+        HashMap::new()
+    }
+
+    /// The override rides exactly the call it was captured for: the gated
+    /// call carries it, and the very next call on the same client — the one
+    /// no approval unblocked — is back to the client's own identity.
+    #[tokio::test]
+    async fn override_rides_one_call_and_no_later_one() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        client
+            .call_tool(
+                "gated",
+                no_args(),
+                Some(captured_overrides("x-forwarded-user", "alice")),
+            )
+            .await
+            .expect("the gated call succeeds");
+        client
+            .call_tool("ungated", no_args(), None)
+            .await
+            .expect("the ungated call succeeds");
+
+        let calls = server.tool_calls();
+        assert_eq!(calls.len(), 2, "both calls reached the server");
+        assert_eq!(calls[0].header_values("x-forwarded-user"), vec!["alice"]);
+        assert!(
+            calls[1].header_values("x-forwarded-user").is_empty(),
+            "the approver's identity must not persist onto the next call",
+        );
+    }
+
+    /// The override never becomes part of the message: it rides the request
+    /// value as an extension, and the serializer emits no trace of it.
+    #[tokio::test]
+    async fn override_never_reaches_the_json_body() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        client
+            .call_tool(
+                "gated",
+                no_args(),
+                Some(captured_overrides("x-forwarded-user", "alice")),
+            )
+            .await
+            .expect("the gated call succeeds");
+
+        let body = server.tool_calls()[0].body_text();
+        assert!(!body.contains("x-forwarded-user"), "body was: {body}");
+        assert!(!body.contains("alice"), "body was: {body}");
+    }
+
+    /// The whole point of the frozen-header problem: the approver's value must
+    /// stand in place of the requester's on the gated call, not beside it.
+    #[tokio::test]
+    async fn override_replaces_the_clients_frozen_identity_for_that_call_only() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        client
+            .call_tool(
+                "gated",
+                no_args(),
+                Some(captured_overrides("authorization", "Bearer approver")),
+            )
+            .await
+            .expect("the gated call succeeds");
+        client
+            .call_tool("ungated", no_args(), None)
+            .await
+            .expect("the ungated call succeeds");
+
+        let calls = server.tool_calls();
+        assert_eq!(
+            calls[0].header_values("authorization"),
+            vec!["Bearer approver"],
+            "the requester's identity must be replaced, not joined",
+        );
+        assert_eq!(
+            calls[1].header_values("authorization"),
+            vec!["Bearer requester"],
+        );
+        assert_eq!(
+            server.initialize().header_values("authorization"),
+            vec!["Bearer requester"],
+            "the handshake predates any approval",
+        );
+    }
+
+    /// Two gated calls in flight on one client keep their own identities.
+    /// Scoping is structural — each override rides its own request value —
+    /// and this is the test that would catch a regression to shared state.
+    #[tokio::test]
+    async fn concurrent_gated_calls_keep_their_own_identity() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        let (first, second) = tokio::join!(
+            client.call_tool(
+                "for_alice",
+                no_args(),
+                Some(captured_overrides("x-forwarded-user", "alice")),
+            ),
+            client.call_tool(
+                "for_bob",
+                no_args(),
+                Some(captured_overrides("x-forwarded-user", "bob")),
+            ),
+        );
+        first.expect("alice's call succeeds");
+        second.expect("bob's call succeeds");
+
+        let calls = server.tool_calls();
+        assert_eq!(calls.len(), 2);
+        for call in calls {
+            let expected = match call.called_tool().as_deref() {
+                Some("for_alice") => "alice",
+                Some("for_bob") => "bob",
+                other => panic!("unexpected tool call {other:?}"),
+            };
+            assert_eq!(call.header_values("x-forwarded-user"), vec![expected]);
+        }
+    }
+
+    /// The tracked branch is the one production takes under the web server;
+    /// it must deliver identity the same way the untracked branch does.
+    #[tokio::test]
+    async fn tracked_call_carries_the_override_like_the_untracked_one() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        client
+            .call_tool_tracked(
+                "gated",
+                no_args(),
+                "http-req-1",
+                Some(captured_overrides("x-forwarded-user", "alice")),
+            )
+            .await
+            .expect("the tracked gated call succeeds");
+
+        assert_eq!(
+            server.tool_calls()[0].header_values("x-forwarded-user"),
+            vec!["alice"],
+        );
+    }
+
+    /// `set_current_request` selects the tracked branch, so this is the same
+    /// entry point a gated call takes in the server and the branch choice must
+    /// not decide whether identity is delivered.
+    #[tokio::test]
+    async fn call_tool_delivers_the_override_on_either_branch() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        client
+            .call_tool(
+                "untracked",
+                no_args(),
+                Some(captured_overrides("x-forwarded-user", "alice")),
+            )
+            .await
+            .expect("the untracked call succeeds");
+
+        client.set_current_request("http-req-1").await;
+        client
+            .call_tool(
+                "tracked",
+                no_args(),
+                Some(captured_overrides("x-forwarded-user", "bob")),
+            )
+            .await
+            .expect("the tracked call succeeds");
+
+        let calls = server.tool_calls();
+        assert_eq!(calls[0].header_values("x-forwarded-user"), vec!["alice"]);
+        assert_eq!(calls[1].header_values("x-forwarded-user"), vec!["bob"]);
+    }
+
+    /// A call no approval gated must reach the server carrying nothing extra —
+    /// neither an override header nor a stale one from an earlier call.
+    #[tokio::test]
+    async fn ungated_call_carries_no_override() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        client
+            .call_tool("ungated", no_args(), None)
+            .await
+            .expect("the ungated call succeeds");
+
+        let call = &server.tool_calls()[0];
+        assert!(call.header_values("x-forwarded-user").is_empty());
+        assert_eq!(
+            call.header_values("authorization"),
+            vec!["Bearer requester"]
+        );
     }
 }

--- a/crates/aura/src/mcp_streamable_http.rs
+++ b/crates/aura/src/mcp_streamable_http.rs
@@ -872,6 +872,18 @@ pub(crate) mod tests {
         HashMap::from([("authorization".to_owned(), "Bearer requester".to_owned())])
     }
 
+    /// A running recording server and a client connected to it, frozen with
+    /// `headers` as its request-time identity.
+    pub(crate) async fn client_and_server(
+        headers: &HashMap<String, String>,
+    ) -> (RecordingMcpServer, McpClient) {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), headers)
+            .await
+            .expect("the loopback server completes the handshake");
+        (server, client)
+    }
+
     fn no_args() -> HashMap<String, Value> {
         HashMap::new()
     }
@@ -881,10 +893,7 @@ pub(crate) mod tests {
     /// no approval unblocked — is back to the client's own identity.
     #[tokio::test]
     async fn override_rides_one_call_and_no_later_one() {
-        let server = RecordingMcpServer::start().await;
-        let client = McpClient::new(server.url.clone(), &requester_headers())
-            .await
-            .expect("the loopback server completes the handshake");
+        let (server, client) = client_and_server(&requester_headers()).await;
 
         client
             .call_tool(
@@ -912,10 +921,7 @@ pub(crate) mod tests {
     /// value as an extension, and the serializer emits no trace of it.
     #[tokio::test]
     async fn override_never_reaches_the_json_body() {
-        let server = RecordingMcpServer::start().await;
-        let client = McpClient::new(server.url.clone(), &requester_headers())
-            .await
-            .expect("the loopback server completes the handshake");
+        let (server, client) = client_and_server(&requester_headers()).await;
 
         client
             .call_tool(
@@ -935,10 +941,7 @@ pub(crate) mod tests {
     /// stand in place of the requester's on the gated call, not beside it.
     #[tokio::test]
     async fn override_replaces_the_clients_frozen_identity_for_that_call_only() {
-        let server = RecordingMcpServer::start().await;
-        let client = McpClient::new(server.url.clone(), &requester_headers())
-            .await
-            .expect("the loopback server completes the handshake");
+        let (server, client) = client_and_server(&requester_headers()).await;
 
         client
             .call_tool(
@@ -975,10 +978,7 @@ pub(crate) mod tests {
     /// and this is the test that would catch a regression to shared state.
     #[tokio::test]
     async fn concurrent_gated_calls_keep_their_own_identity() {
-        let server = RecordingMcpServer::start().await;
-        let client = McpClient::new(server.url.clone(), &requester_headers())
-            .await
-            .expect("the loopback server completes the handshake");
+        let (server, client) = client_and_server(&requester_headers()).await;
 
         let (first, second) = tokio::join!(
             client.call_tool(
@@ -1012,10 +1012,7 @@ pub(crate) mod tests {
     /// not decide whether identity is delivered.
     #[tokio::test]
     async fn call_tool_delivers_the_override_on_either_branch() {
-        let server = RecordingMcpServer::start().await;
-        let client = McpClient::new(server.url.clone(), &requester_headers())
-            .await
-            .expect("the loopback server completes the handshake");
+        let (server, client) = client_and_server(&requester_headers()).await;
 
         client
             .call_tool(

--- a/crates/aura/src/mcp_streamable_http.rs
+++ b/crates/aura/src/mcp_streamable_http.rs
@@ -832,9 +832,7 @@ pub(crate) mod tests {
     /// Answer a JSON-RPC POST: a result for a request, a bare ack for a
     /// notification.
     fn reply_to_rpc(body: &[u8]) -> (&'static str, Vec<(String, String)>, String) {
-        let Ok(message) = serde_json::from_slice::<Value>(body) else {
-            return ("400 Bad Request", Vec::new(), String::new());
-        };
+        let message = serde_json::from_slice::<Value>(body).expect("client sends valid JSON-RPC");
         let method = message
             .get("method")
             .and_then(Value::as_str)
@@ -855,7 +853,7 @@ pub(crate) mod tests {
             "tools/call" => rmcp::model::ServerResult::CallToolResult(
                 rmcp::model::CallToolResult::success(vec![rmcp::model::Content::text("ok")]),
             ),
-            _ => rmcp::model::ServerResult::empty(()),
+            other => panic!("unexpected rpc method {other:?}"),
         };
         let payload =
             serde_json::to_string(&rmcp::model::ServerJsonRpcMessage::response(result, id))
@@ -1009,31 +1007,6 @@ pub(crate) mod tests {
         }
     }
 
-    /// The tracked branch is the one production takes under the web server;
-    /// it must deliver identity the same way the untracked branch does.
-    #[tokio::test]
-    async fn tracked_call_carries_the_override_like_the_untracked_one() {
-        let server = RecordingMcpServer::start().await;
-        let client = McpClient::new(server.url.clone(), &requester_headers())
-            .await
-            .expect("the loopback server completes the handshake");
-
-        client
-            .call_tool_tracked(
-                "gated",
-                no_args(),
-                "http-req-1",
-                Some(captured_overrides("x-forwarded-user", "alice")),
-            )
-            .await
-            .expect("the tracked gated call succeeds");
-
-        assert_eq!(
-            server.tool_calls()[0].header_values("x-forwarded-user"),
-            vec!["alice"],
-        );
-    }
-
     /// `set_current_request` selects the tracked branch, so this is the same
     /// entry point a gated call takes in the server and the branch choice must
     /// not decide whether identity is delivered.
@@ -1066,27 +1039,5 @@ pub(crate) mod tests {
         let calls = server.tool_calls();
         assert_eq!(calls[0].header_values("x-forwarded-user"), vec!["alice"]);
         assert_eq!(calls[1].header_values("x-forwarded-user"), vec!["bob"]);
-    }
-
-    /// A call no approval gated must reach the server carrying nothing extra —
-    /// neither an override header nor a stale one from an earlier call.
-    #[tokio::test]
-    async fn ungated_call_carries_no_override() {
-        let server = RecordingMcpServer::start().await;
-        let client = McpClient::new(server.url.clone(), &requester_headers())
-            .await
-            .expect("the loopback server completes the handshake");
-
-        client
-            .call_tool("ungated", no_args(), None)
-            .await
-            .expect("the ungated call succeeds");
-
-        let call = &server.tool_calls()[0];
-        assert!(call.header_values("x-forwarded-user").is_empty());
-        assert_eq!(
-            call.header_values("authorization"),
-            vec!["Bearer requester"]
-        );
     }
 }

--- a/crates/aura/src/mcp_streamable_http.rs
+++ b/crates/aura/src/mcp_streamable_http.rs
@@ -666,9 +666,7 @@ pub(crate) mod tests {
     }
 
     impl RecordedRequest {
-        /// Every value sent under `name`, in arrival order. A test that asks
-        /// for the count is asking whether an override replaced a header or
-        /// merely joined it.
+        /// Every value sent under `name`, in arrival order. A test counting values asks whether an override replaced a header or merely joined it.
         pub(crate) fn header_values(&self, name: &str) -> Vec<&str> {
             self.headers
                 .iter()
@@ -681,8 +679,7 @@ pub(crate) mod tests {
             String::from_utf8_lossy(&self.body).into_owned()
         }
 
-        /// The JSON-RPC method this request carried, or `None` for a body
-        /// that is not a JSON-RPC message.
+        /// The JSON-RPC method this request carried.
         fn rpc_method(&self) -> Option<String> {
             serde_json::from_slice::<Value>(&self.body)
                 .ok()?
@@ -703,14 +700,7 @@ pub(crate) mod tests {
         }
     }
 
-    /// A loopback MCP server over streamable HTTP that answers the handshake
-    /// and every tool call, and keeps each request it received.
-    ///
-    /// It exists so a test can watch what actually reaches the wire: the
-    /// approver override is applied deep inside the transport, after rmcp's
-    /// worker has taken the request value, so nothing short of the received
-    /// request proves it arrived — or, for the calls that must not carry it,
-    /// that it did not.
+    /// A loopback MCP server over streamable HTTP that answers the handshake and every tool call, keeping each request it receives. It exists so a test can watch what actually reaches the wire: the approver override is applied deep inside the transport, after rmcp's worker has taken the request value.
     pub(crate) struct RecordingMcpServer {
         pub(crate) url: String,
         received: Arc<Mutex<Vec<RecordedRequest>>>,
@@ -759,9 +749,7 @@ pub(crate) mod tests {
     /// later request.
     const SESSION_ID: &str = "recording-session";
 
-    /// Read one HTTP request off `socket`, record it, answer it, and close.
-    /// Answering `connection: close` keeps the framing to one request per
-    /// connection, so the reader never has to unpick a keep-alive stream.
+    /// Read one HTTP request off `socket`, record it, answer it, and close. Answering `connection: close` keeps the framing to one request per connection.
     async fn serve_one_request(mut socket: TcpStream, sink: Arc<Mutex<Vec<RecordedRequest>>>) {
         let mut buf = Vec::new();
         let head_end = loop {
@@ -803,9 +791,7 @@ pub(crate) mod tests {
 
         let http_method = request_line.split_whitespace().next().unwrap_or_default();
         let (status, extra_headers, payload) = match http_method {
-            // rmcp opens a server-to-client stream once it has a session; 405
-            // is the documented "this server has none", which the worker
-            // absorbs instead of failing the connection.
+            // rmcp opens a server-to-client stream once it has a session; 405 is the documented "this server has none", which the worker absorbs instead of failing the connection.
             "GET" => ("405 Method Not Allowed", Vec::new(), String::new()),
             "DELETE" => ("202 Accepted", Vec::new(), String::new()),
             _ => reply_to_rpc(&body),
@@ -888,9 +874,7 @@ pub(crate) mod tests {
         HashMap::new()
     }
 
-    /// The override rides exactly the call it was captured for: the gated
-    /// call carries it, and the very next call on the same client — the one
-    /// no approval unblocked — is back to the client's own identity.
+    /// The override rides exactly the call it was captured for: the gated call carries it, and the very next call on the same client (the one no approval unblocked) reverts to the client's own identity.
     #[tokio::test]
     async fn override_rides_one_call_and_no_later_one() {
         let (server, client) = client_and_server(&requester_headers()).await;
@@ -973,9 +957,7 @@ pub(crate) mod tests {
         );
     }
 
-    /// Two gated calls in flight on one client keep their own identities.
-    /// Scoping is structural — each override rides its own request value —
-    /// and this is the test that would catch a regression to shared state.
+    /// Two gated calls in flight on one client keep their own identities. Scoping is structural; each override rides its own request value. This test catches a regression to shared state.
     #[tokio::test]
     async fn concurrent_gated_calls_keep_their_own_identity() {
         let (server, client) = client_and_server(&requester_headers()).await;
@@ -1007,9 +989,7 @@ pub(crate) mod tests {
         }
     }
 
-    /// `set_current_request` selects the tracked branch, so this is the same
-    /// entry point a gated call takes in the server and the branch choice must
-    /// not decide whether identity is delivered.
+    /// `set_current_request` selects the tracked branch, so this is the same entry point a gated call takes in the server and the branch choice must not decide whether identity is delivered.
     #[tokio::test]
     async fn call_tool_delivers_the_override_on_either_branch() {
         let (server, client) = client_and_server(&requester_headers()).await;

--- a/crates/aura/src/mcp_tool_execution.rs
+++ b/crates/aura/src/mcp_tool_execution.rs
@@ -44,8 +44,7 @@ fn record_tool_call_input(span: &tracing::Span, args: &Value) {
 }
 
 /// Record the outbound header NAMES an approver override applies to this
-/// call, sorted and comma-joined, never the values. Absent from the span
-/// when the call carries no override.
+/// call, sorted and comma-joined, never the values.
 fn record_applied_headers(
     span: &tracing::Span,
     overrides: &crate::approver_headers::ApproverHeaders,
@@ -290,8 +289,8 @@ mod tests {
     /// captured override's header NAMES, never their values, and an
     /// ungated call's span carries neither.
     ///
-    /// Gated on `otel` — without the feature `set_span_attribute` is a
-    /// documented no-op and there is no span data to assert against.
+    /// Gated on `otel`: without the feature there is no span data to
+    /// assert against.
     #[cfg(feature = "otel")]
     mod applied_headers_span {
         use std::sync::{Arc, Mutex, MutexGuard};
@@ -352,8 +351,7 @@ mod tests {
             /// The single `key` attribute on the span named `name`, or `None`
             /// if the span carries no such attribute. Panics if the span
             /// carries more than one — a double-stamp regression would
-            /// otherwise pass unnoticed, since `find` would silently return
-            /// only the first entry.
+            /// otherwise pass with only the first entry.
             fn attribute(&self, name: &str, key: &str) -> Option<String> {
                 let spans = self.spans();
                 let span = spans.iter().find(|span| span.name == name)?;

--- a/crates/aura/src/mcp_tool_execution.rs
+++ b/crates/aura/src/mcp_tool_execution.rs
@@ -43,6 +43,18 @@ fn record_tool_call_input(span: &tracing::Span, args: &Value) {
     }
 }
 
+/// Record the outbound header NAMES an approver override applies to this
+/// call, sorted and comma-joined, never the values. Absent from the span
+/// when the call carries no override.
+fn record_applied_headers(
+    span: &tracing::Span,
+    overrides: &crate::approver_headers::ApproverHeaders,
+) {
+    let mut names: Vec<&str> = overrides.captured_names().collect();
+    names.sort_unstable();
+    crate::logging::set_span_attribute(span, crate::logging::ATTR_APPLIED_HEADERS, names.join(","));
+}
+
 /// Record tool call result attributes on the current span.
 ///
 /// On success: result length, status OK, and (when content recording is
@@ -106,6 +118,9 @@ pub async fn execute_mcp_tool(
 
     // OTel: record input attributes
     record_tool_call_input(&span, &args);
+    if let Some(overrides) = approver_overrides.as_ref() {
+        record_applied_headers(&span, overrides);
+    }
 
     // Log tool call initiation
     info!(
@@ -269,5 +284,172 @@ mod tests {
         assert!(bounded.contains("[tool error truncated:"));
         // The leading context (where categorization keywords live) survives.
         assert!(bounded.starts_with("Tool execution failed:"));
+    }
+
+    /// Trace correlation: a gated call's `mcp.tool_call` span carries the
+    /// captured override's header NAMES, never their values, and an
+    /// ungated call's span carries neither.
+    ///
+    /// Gated on `otel` — without the feature `set_span_attribute` is a
+    /// documented no-op and there is no span data to assert against.
+    #[cfg(feature = "otel")]
+    mod applied_headers_span {
+        use std::sync::{Arc, Mutex, MutexGuard};
+
+        use futures::future::BoxFuture;
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
+        use opentelemetry_sdk::trace::TracerProvider;
+        use serde_json::json;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        use aura_config::ToolHeaderMappings;
+        use reqwest::header::{HeaderMap as ReqwestHeaderMap, HeaderName, HeaderValue};
+
+        use super::*;
+        use crate::logging::ATTR_APPLIED_HEADERS;
+        use crate::mcp_streamable_http::tests::RecordingMcpServer;
+
+        /// Captured overrides for `pairs`, given in whatever order the
+        /// caller likes — the loopback response headers are keyed
+        /// `x-response-<outbound>` so the capture step (case-insensitive
+        /// lookup by mapped name) is exercised the same way production
+        /// capture is, rather than hand-building the type directly.
+        fn captured_overrides_for(
+            pairs: &[(&str, &str)],
+        ) -> crate::approver_headers::ApproverHeaders {
+            let mapping: std::collections::HashMap<String, String> = pairs
+                .iter()
+                .map(|(outbound, _)| (outbound.to_string(), format!("x-response-{outbound}")))
+                .collect();
+            let mut response = ReqwestHeaderMap::new();
+            for (outbound, value) in pairs {
+                response.insert(
+                    HeaderName::from_bytes(format!("x-response-{outbound}").as_bytes()).unwrap(),
+                    HeaderValue::from_str(value).unwrap(),
+                );
+            }
+            crate::approver_headers::ApproverHeaders::from_captured(
+                &ToolHeaderMappings::try_from(mapping).expect("test mapping is valid config"),
+                &response,
+            )
+            .expect("every mapped header is present")
+        }
+
+        /// Spans the test subscriber has exported.
+        #[derive(Debug, Clone, Default)]
+        struct CapturedSpans(Arc<Mutex<Vec<SpanData>>>);
+
+        impl CapturedSpans {
+            fn spans(&self) -> MutexGuard<'_, Vec<SpanData>> {
+                self.0.lock().expect("captured spans mutex")
+            }
+
+            fn contains(&self, name: &str) -> bool {
+                self.spans().iter().any(|span| span.name == name)
+            }
+
+            /// The single `key` attribute on the span named `name`, or `None`
+            /// if the span carries no such attribute. Panics if the span
+            /// carries more than one — a double-stamp regression would
+            /// otherwise pass unnoticed, since `find` would silently return
+            /// only the first entry.
+            fn attribute(&self, name: &str, key: &str) -> Option<String> {
+                let spans = self.spans();
+                let span = spans.iter().find(|span| span.name == name)?;
+                let matches: Vec<_> = span
+                    .attributes
+                    .iter()
+                    .filter(|kv| kv.key.as_str() == key)
+                    .collect();
+                assert!(
+                    matches.len() <= 1,
+                    "span {name:?} must carry at most one {key} attribute, found {}: \
+                     a regression is double-stamping the same span",
+                    matches.len(),
+                );
+                matches.first().map(|kv| kv.value.to_string())
+            }
+        }
+
+        impl SpanExporter for CapturedSpans {
+            fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+                self.spans().extend(batch);
+                Box::pin(std::future::ready(Ok(())))
+            }
+        }
+
+        /// Run `execute_mcp_tool` under a subscriber that exports to memory,
+        /// returning the `applied_headers` attribute its `mcp.tool_call`
+        /// span carries. `#[tracing::instrument]` on `execute_mcp_tool`
+        /// opens the span itself, so no outer instrumentation is needed.
+        async fn applied_headers_on_call(
+            client: &McpClient,
+            overrides: Option<crate::approver_headers::ApproverHeaders>,
+        ) -> Option<String> {
+            let captured = CapturedSpans::default();
+            let provider = TracerProvider::builder()
+                .with_simple_exporter(captured.clone())
+                .build();
+            let _guard = tracing::subscriber::set_default(
+                tracing_subscriber::registry()
+                    .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test"))),
+            );
+
+            execute_mcp_tool(client, "gated", json!({}), overrides)
+                .await
+                .expect("the call succeeds");
+
+            assert!(
+                captured.contains("mcp.tool_call"),
+                "the mcp.tool_call span was never exported",
+            );
+            captured.attribute("mcp.tool_call", ATTR_APPLIED_HEADERS)
+        }
+
+        /// A gated call carrying an override stamps its captured names,
+        /// sorted and comma-joined, on the execution span — never a value.
+        /// Configured out of alphabetical order (`x-tenant` before
+        /// `authorization`), so a joined-but-unsorted regression would
+        /// produce `"x-tenant,authorization"` and this test would catch it.
+        #[tokio::test]
+        async fn gated_call_stamps_the_applied_header_names_never_values() {
+            let server = RecordingMcpServer::start().await;
+            let client = McpClient::new(server.url.clone(), &HashMap::new())
+                .await
+                .expect("the loopback server completes the handshake");
+
+            let overrides = captured_overrides_for(&[
+                ("x-tenant", "acme"),
+                ("authorization", "Bearer approver-secret"),
+            ]);
+            let attribute = applied_headers_on_call(&client, Some(overrides)).await;
+
+            assert_eq!(
+                attribute.as_deref(),
+                Some("authorization,x-tenant"),
+                "the span must name every applied header, sorted",
+            );
+            for value in ["acme", "Bearer approver-secret", "approver-secret"] {
+                assert!(
+                    !attribute.as_deref().unwrap().contains(value),
+                    "the span must never carry a header value, got: {attribute:?}",
+                );
+            }
+        }
+
+        /// A call no approval gated carries no override, so its span records
+        /// no `applied_headers` attribute at all.
+        #[tokio::test]
+        async fn ungated_call_records_no_applied_headers() {
+            let server = RecordingMcpServer::start().await;
+            let client = McpClient::new(server.url.clone(), &HashMap::new())
+                .await
+                .expect("the loopback server completes the handshake");
+
+            let attribute = applied_headers_on_call(&client, None).await;
+
+            assert_eq!(attribute, None);
+        }
     }
 }

--- a/crates/aura/src/mcp_tool_execution.rs
+++ b/crates/aura/src/mcp_tool_execution.rs
@@ -293,89 +293,17 @@ mod tests {
     /// assert against.
     #[cfg(feature = "otel")]
     mod applied_headers_span {
-        use std::sync::{Arc, Mutex, MutexGuard};
 
-        use futures::future::BoxFuture;
         use opentelemetry::trace::TracerProvider as _;
-        use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
+
         use opentelemetry_sdk::trace::TracerProvider;
         use serde_json::json;
         use tracing_subscriber::layer::SubscriberExt;
 
-        use aura_config::ToolHeaderMappings;
-        use reqwest::header::{HeaderMap as ReqwestHeaderMap, HeaderName, HeaderValue};
-
         use super::*;
         use crate::logging::ATTR_APPLIED_HEADERS;
         use crate::mcp_streamable_http::tests::RecordingMcpServer;
-
-        /// Captured overrides for `pairs`, given in whatever order the
-        /// caller likes — the loopback response headers are keyed
-        /// `x-response-<outbound>` so the capture step (case-insensitive
-        /// lookup by mapped name) is exercised the same way production
-        /// capture is, rather than hand-building the type directly.
-        fn captured_overrides_for(
-            pairs: &[(&str, &str)],
-        ) -> crate::approver_headers::ApproverHeaders {
-            let mapping: std::collections::HashMap<String, String> = pairs
-                .iter()
-                .map(|(outbound, _)| (outbound.to_string(), format!("x-response-{outbound}")))
-                .collect();
-            let mut response = ReqwestHeaderMap::new();
-            for (outbound, value) in pairs {
-                response.insert(
-                    HeaderName::from_bytes(format!("x-response-{outbound}").as_bytes()).unwrap(),
-                    HeaderValue::from_str(value).unwrap(),
-                );
-            }
-            crate::approver_headers::ApproverHeaders::from_captured(
-                &ToolHeaderMappings::try_from(mapping).expect("test mapping is valid config"),
-                &response,
-            )
-            .expect("every mapped header is present")
-        }
-
-        /// Spans the test subscriber has exported.
-        #[derive(Debug, Clone, Default)]
-        struct CapturedSpans(Arc<Mutex<Vec<SpanData>>>);
-
-        impl CapturedSpans {
-            fn spans(&self) -> MutexGuard<'_, Vec<SpanData>> {
-                self.0.lock().expect("captured spans mutex")
-            }
-
-            fn contains(&self, name: &str) -> bool {
-                self.spans().iter().any(|span| span.name == name)
-            }
-
-            /// The single `key` attribute on the span named `name`, or `None`
-            /// if the span carries no such attribute. Panics if the span
-            /// carries more than one — a double-stamp regression would
-            /// otherwise pass with only the first entry.
-            fn attribute(&self, name: &str, key: &str) -> Option<String> {
-                let spans = self.spans();
-                let span = spans.iter().find(|span| span.name == name)?;
-                let matches: Vec<_> = span
-                    .attributes
-                    .iter()
-                    .filter(|kv| kv.key.as_str() == key)
-                    .collect();
-                assert!(
-                    matches.len() <= 1,
-                    "span {name:?} must carry at most one {key} attribute, found {}: \
-                     a regression is double-stamping the same span",
-                    matches.len(),
-                );
-                matches.first().map(|kv| kv.value.to_string())
-            }
-        }
-
-        impl SpanExporter for CapturedSpans {
-            fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
-                self.spans().extend(batch);
-                Box::pin(std::future::ready(Ok(())))
-            }
-        }
+        use crate::test_span_capture::CapturedSpans;
 
         /// Run `execute_mcp_tool` under a subscriber that exports to memory,
         /// returning the `applied_headers` attribute its `mcp.tool_call`
@@ -417,7 +345,7 @@ mod tests {
                 .await
                 .expect("the loopback server completes the handshake");
 
-            let overrides = captured_overrides_for(&[
+            let overrides = crate::approver_headers::tests::captured_overrides_multi(&[
                 ("x-tenant", "acme"),
                 ("authorization", "Bearer approver-secret"),
             ]);

--- a/crates/aura/src/mcp_tool_execution.rs
+++ b/crates/aura/src/mcp_tool_execution.rs
@@ -285,12 +285,7 @@ mod tests {
         assert!(bounded.starts_with("Tool execution failed:"));
     }
 
-    /// Trace correlation: a gated call's `mcp.tool_call` span carries the
-    /// captured override's header NAMES, never their values, and an
-    /// ungated call's span carries neither.
-    ///
-    /// Gated on `otel`: without the feature there is no span data to
-    /// assert against.
+    /// Trace correlation: a gated call's `mcp.tool_call` span carries the captured override's header NAMES, never their values, and an ungated call's span carries neither. Gated on `otel`: without the feature there is no span data to assert against.
     #[cfg(feature = "otel")]
     mod applied_headers_span {
 
@@ -305,10 +300,7 @@ mod tests {
         use crate::mcp_streamable_http::tests::client_and_server;
         use crate::test_span_capture::CapturedSpans;
 
-        /// Run `execute_mcp_tool` under a subscriber that exports to memory,
-        /// returning the `applied_headers` attribute its `mcp.tool_call`
-        /// span carries. `#[tracing::instrument]` on `execute_mcp_tool`
-        /// opens the span itself, so no outer instrumentation is needed.
+        /// Run `execute_mcp_tool` under a subscriber that exports to memory, returning the `applied_headers` attribute its `mcp.tool_call` span carries.
         async fn applied_headers_on_call(
             client: &McpClient,
             overrides: Option<crate::approver_headers::ApproverHeaders>,
@@ -333,11 +325,7 @@ mod tests {
             captured.attribute("mcp.tool_call", ATTR_APPLIED_HEADERS)
         }
 
-        /// A gated call carrying an override stamps its captured names,
-        /// sorted and comma-joined, on the execution span — never a value.
-        /// Configured out of alphabetical order (`x-tenant` before
-        /// `authorization`), so a joined-but-unsorted regression would
-        /// produce `"x-tenant,authorization"` and this test would catch it.
+        /// A gated call carrying an override stamps its captured names, sorted and comma-joined, on the execution span, never a value. Configured out of order (`x-tenant` before `authorization`) to catch a regression to `"x-tenant,authorization"`.
         #[tokio::test]
         async fn gated_call_stamps_the_applied_header_names_never_values() {
             let (_server, client) = client_and_server(&HashMap::new()).await;
@@ -361,8 +349,6 @@ mod tests {
             }
         }
 
-        /// A call no approval gated carries no override, so its span records
-        /// no `applied_headers` attribute at all.
         #[tokio::test]
         async fn ungated_call_records_no_applied_headers() {
             let (_server, client) = client_and_server(&HashMap::new()).await;

--- a/crates/aura/src/mcp_tool_execution.rs
+++ b/crates/aura/src/mcp_tool_execution.rs
@@ -302,7 +302,7 @@ mod tests {
 
         use super::*;
         use crate::logging::ATTR_APPLIED_HEADERS;
-        use crate::mcp_streamable_http::tests::RecordingMcpServer;
+        use crate::mcp_streamable_http::tests::client_and_server;
         use crate::test_span_capture::CapturedSpans;
 
         /// Run `execute_mcp_tool` under a subscriber that exports to memory,
@@ -340,10 +340,7 @@ mod tests {
         /// produce `"x-tenant,authorization"` and this test would catch it.
         #[tokio::test]
         async fn gated_call_stamps_the_applied_header_names_never_values() {
-            let server = RecordingMcpServer::start().await;
-            let client = McpClient::new(server.url.clone(), &HashMap::new())
-                .await
-                .expect("the loopback server completes the handshake");
+            let (_server, client) = client_and_server(&HashMap::new()).await;
 
             let overrides = crate::approver_headers::tests::captured_overrides_multi(&[
                 ("x-tenant", "acme"),
@@ -368,10 +365,7 @@ mod tests {
         /// no `applied_headers` attribute at all.
         #[tokio::test]
         async fn ungated_call_records_no_applied_headers() {
-            let server = RecordingMcpServer::start().await;
-            let client = McpClient::new(server.url.clone(), &HashMap::new())
-                .await
-                .expect("the loopback server completes the handshake");
+            let (_server, client) = client_and_server(&HashMap::new()).await;
 
             let attribute = applied_headers_on_call(&client, None).await;
 

--- a/crates/aura/src/test_span_capture.rs
+++ b/crates/aura/src/test_span_capture.rs
@@ -31,9 +31,8 @@ impl CapturedSpans {
         self.spans().iter().any(|span| span.name == name)
     }
 
-    /// The single `key` attribute on the span named `name`, or `None`
-    /// if the span carries no such attribute. Panics if the span
-    /// carries more than one — a double-stamp regression would
+    /// The single `key` attribute on the span named `name`. Panics if
+    /// the span carries more than one — a double-stamp regression would
     /// otherwise pass with only the first entry.
     pub(crate) fn attribute(&self, name: &str, key: &str) -> Option<String> {
         let spans = self.spans();
@@ -60,9 +59,7 @@ impl SpanExporter for CapturedSpans {
     }
 }
 
-/// Run `body` inside an `execute_tool` span — the span Rig opens around
-/// a tool call — under a subscriber that exports to memory, returning
-/// the body's output and the `decision_id` the exported span carries.
+/// Run `body` inside an `execute_tool` span (the span Rig opens around a tool call) under a subscriber that exports to memory, returning the body's output and the `decision_id` the exported span carries.
 pub(crate) async fn traced_as_execute_tool<T>(
     body: impl Future<Output = T>,
 ) -> (T, Option<String>) {

--- a/crates/aura/src/test_span_capture.rs
+++ b/crates/aura/src/test_span_capture.rs
@@ -1,0 +1,94 @@
+//! In-memory OTel span capture for tests that assert on exported span
+//! attributes. Shared by the `decision_id_span` suites (`hitl::gate`,
+//! `hitl::tool`) and the `applied_headers_span` suite
+//! (`mcp_tool_execution`).
+//!
+//! Gated on `otel` and `test`: without the feature there is no span data
+//! to assert against, and nothing outside tests consumes a span sink.
+
+use std::future::Future;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use futures::future::BoxFuture;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
+use opentelemetry_sdk::trace::TracerProvider;
+use tracing::Instrument;
+use tracing_subscriber::layer::SubscriberExt;
+
+use crate::logging::ATTR_DECISION_ID;
+
+/// Spans the test subscriber has exported.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CapturedSpans(Arc<Mutex<Vec<SpanData>>>);
+
+impl CapturedSpans {
+    pub(crate) fn spans(&self) -> MutexGuard<'_, Vec<SpanData>> {
+        self.0.lock().expect("captured spans mutex")
+    }
+
+    pub(crate) fn contains(&self, name: &str) -> bool {
+        self.spans().iter().any(|span| span.name == name)
+    }
+
+    /// The single `key` attribute on the span named `name`, or `None`
+    /// if the span carries no such attribute. Panics if the span
+    /// carries more than one — a double-stamp regression would
+    /// otherwise pass with only the first entry.
+    pub(crate) fn attribute(&self, name: &str, key: &str) -> Option<String> {
+        let spans = self.spans();
+        let span = spans.iter().find(|span| span.name == name)?;
+        let matches: Vec<_> = span
+            .attributes
+            .iter()
+            .filter(|kv| kv.key.as_str() == key)
+            .collect();
+        assert!(
+            matches.len() <= 1,
+            "span {name:?} must carry at most one {key} attribute, found {}: \
+             a regression is double-stamping the same span",
+            matches.len(),
+        );
+        matches.first().map(|kv| kv.value.to_string())
+    }
+}
+
+impl SpanExporter for CapturedSpans {
+    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+        self.spans().extend(batch);
+        Box::pin(std::future::ready(Ok(())))
+    }
+}
+
+/// Run `body` inside an `execute_tool` span — the span Rig opens around
+/// a tool call — under a subscriber that exports to memory, returning
+/// the body's output and the `decision_id` the exported span carries.
+pub(crate) async fn traced_as_execute_tool<T>(
+    body: impl Future<Output = T>,
+) -> (T, Option<String>) {
+    let captured = CapturedSpans::default();
+    let provider = TracerProvider::builder()
+        .with_simple_exporter(captured.clone())
+        .build();
+    let _guard = tracing::subscriber::set_default(
+        tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test"))),
+    );
+
+    let output = body.instrument(tracing::info_span!("execute_tool")).await;
+
+    // The registry instruments a parked approval's wake task with the
+    // same span, so the export lands once that task has released it too.
+    for _ in 0..1_000 {
+        if captured.contains("execute_tool") {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        captured.contains("execute_tool"),
+        "the execute_tool span was never exported",
+    );
+
+    (output, captured.attribute("execute_tool", ATTR_DECISION_ID))
+}

--- a/crates/aura/src/tool_wrapper.rs
+++ b/crates/aura/src/tool_wrapper.rs
@@ -1141,4 +1141,77 @@ mod tests {
             "wrappers after the first rejection must not run"
         );
     }
+
+    /// Composition is a value-loss seam: it builds its own `Proceed`, so the
+    /// gate's captured identity survives only if aggregation carries it.
+    mod composed_overrides {
+        use super::*;
+        use crate::approver_headers::tests::captured_overrides;
+
+        struct Produces(&'static str);
+
+        #[async_trait]
+        impl ToolWrapper for Produces {
+            async fn pre_call(
+                &self,
+                _a: &Value,
+                _c: &ToolCallContext,
+            ) -> Result<PreCallOutcome, ToolError> {
+                Ok(PreCallOutcome::Proceed {
+                    overrides: Some(captured_overrides("x-forwarded-user", self.0)),
+                })
+            }
+        }
+
+        struct Passive;
+
+        #[async_trait]
+        impl ToolWrapper for Passive {
+            async fn pre_call(
+                &self,
+                _a: &Value,
+                _c: &ToolCallContext,
+            ) -> Result<PreCallOutcome, ToolError> {
+                Ok(PreCallOutcome::Proceed { overrides: None })
+            }
+        }
+
+        async fn compose(wrappers: Vec<Arc<dyn ToolWrapper>>) -> Result<PreCallOutcome, ToolError> {
+            ComposedWrapper::new(wrappers)
+                .pre_call(&serde_json::json!({}), &ToolCallContext::new("t"))
+                .await
+        }
+
+        #[tokio::test]
+        async fn the_single_producers_identity_survives_its_passive_neighbours() {
+            let outcome = compose(vec![
+                Arc::new(Passive),
+                Arc::new(Produces("alice")),
+                Arc::new(Passive),
+            ])
+            .await
+            .expect("one producer composes cleanly");
+
+            assert_eq!(
+                outcome,
+                PreCallOutcome::Proceed {
+                    overrides: Some(captured_overrides("x-forwarded-user", "alice")),
+                },
+            );
+        }
+
+        /// Two producers would make wrapper order decide whose identity the
+        /// call runs under. The call fails instead.
+        #[tokio::test]
+        async fn two_producers_fail_the_call_rather_than_pick_one() {
+            let error = compose(vec![Arc::new(Produces("alice")), Arc::new(Produces("bob"))])
+                .await
+                .expect_err("two producers must not resolve to either identity");
+
+            assert!(
+                error.to_string().contains("conflicting approver identity"),
+                "the error must name the conflict, got: {error}",
+            );
+        }
+    }
 }

--- a/docs/adr/2026-08-13-approver-identity-forwarding.md
+++ b/docs/adr/2026-08-13-approver-identity-forwarding.md
@@ -24,47 +24,44 @@ naming them) on the call they just authorized has no way to get it there.
 
 - Forwarding **MUST** be config-selectable: an operator may map real auth
   material (`Authorization`) or context headers, since the security posture
-  has to be designed to the auth worst case.
+  is designed to the auth worst case.
 - The override **MUST** be scoped to exactly the one gated call the approval
   releases. Every tool execution re-enters `pre_call` and the gate mints a
-  fresh `DecisionId` per call, so a retry **MUST** re-gate and re-capture
-  rather than reuse a prior decision's identity; no reuse store exists.
+  fresh `DecisionId` per call, so a retry **MUST** re-gate and re-capture;
+  no reuse store exists.
 - A missing or invalid captured header **MUST** fail the call closed, naming
-  the affected header names and never a value, rather than silently
-  substituting or dropping identity.
-- The route-wide `ApprovalOutcome`, shared with the agent-callable
-  `request_approval` surface, **MUST NOT** gain a credential-holding path —
-  that surface has no consumer for captured headers.
-- Delivery **MUST NOT** require a fork or upgrade of the pinned `rmcp` client
-  library.
+  the affected header names and never a value.
+- The route-wide `ApprovalOutcome` **MUST NOT** gain a credential-holding
+  path: the agent-callable `request_approval` surface has no consumer for
+  captured headers.
+- Delivery **MUST NOT** require a fork or upgrade of the pinned `rmcp`
+  client library.
 
 ## Considered Options
 
 Delivering a per-call header override through to the outbound MCP POST,
 verified against pinned `rmcp` 0.12.0:
 
-- Parameter threading a header override into `post_message`'s signature —
-  rejected: the signature belongs to a trait `rmcp` owns.
-- A task-local read inside the transport worker — rejected: the worker task
+- Parameter threading into `post_message`'s signature. Rejected: the
+  signature belongs to a trait `rmcp` owns.
+- A task-local read inside the transport worker. Rejected: the worker task
   is spawned once at connect time, before any gated call exists, so nothing
   scoped per call is visible to it.
-- `PeerRequestOptions.meta` — rejected: the hand-written wire serializer
-  extracts only the `Meta` extension onto the request; a header override
-  placed there would still need a second, undocumented channel to become an
-  HTTP header, and nothing reads `meta` for that purpose today.
-- An ephemeral per-call MCP client, built fresh under the approver's headers —
-  rejected: roughly 4 extra round trips per gated call, and it loses
-  manager-driven cancellation, `tool_start`/progress events, and leaks
-  sessions on an unretried `DELETE`.
-- A sidecar proxy that rewrites headers in flight — rejected: the proxy's own
-  URL is frozen the same way the MCP client's headers are today, so it
-  degenerates into a persistent, body-inspecting proxy that re-derives the
-  same call-to-approval correlation problem out of process.
-- **The `rmcp` request-extension side-channel — chosen.** `rmcp::model::Request`
-  carries an http-crate-style typed `Extensions` map, `Clone + Send + Sync +
-  'static` bound, that rides the request value intact through
-  `Peer::send_request_with_option`, the transport channel, and the worker
-  into `post_message`, which receives the message by value.
+- `PeerRequestOptions.meta`. Rejected: the hand-written wire serializer
+  extracts only the `Meta` extension; a header override there would still
+  need a second channel to become an HTTP header, and nothing reads `meta`
+  for that purpose.
+- An ephemeral per-call MCP client under the approver's headers. Rejected:
+  roughly 4 extra round trips per gated call, and it loses manager-driven
+  cancellation and `tool_start`/progress events.
+- A sidecar proxy rewriting headers in flight. Rejected: the proxy's own
+  URL is frozen the same way the client's headers are today, so it
+  degenerates into a persistent, body-inspecting proxy.
+- **The `rmcp` request-extension side-channel: chosen.** `rmcp::model::Request`
+  carries an http-crate-style typed `Extensions` map that rides the request
+  value intact through `Peer::send_request_with_option`, the transport
+  channel, and the worker into `post_message`, which receives the message
+  by value.
 
 ## Decision Outcome
 
@@ -72,29 +69,25 @@ Chosen option: **the rmcp request-extension side-channel, webhook route
 only.**
 
 A `#[derive(Clone)] ApproverHeaders(HeaderMap)` (redacting `Debug`) rides
-the one gated call's request value as an extension — inserted at every
-`call_tool*` construction site, read back at the two send points that own an
-outbound POST — so one-call scoping is structural: nothing is keyed or
+the one gated call's request value as an extension, inserted at every
+`call_tool*` construction site and read back at the two send points that
+own an outbound POST. One-call scoping is structural: nothing is keyed or
 cleaned up, and concurrent calls never leak into each other.
 
-Only the webhook route captures, and only for approvals raised by the config
-gate (`ApprovalOrigin::ConfigGate`) — never the agent-callable
-`request_approval` surface ([#306](https://github.com/mezmo/aura/issues/306)),
-whose route-wide `ApprovalOutcome` has no consumer for credentials it would
-otherwise hold with nowhere to go. The conversational route is excluded just
-as deliberately: its decision caller is the session holder already on the
-stream, so forwarding that identity adds nothing.
+Only the webhook route captures, and only for approvals raised by the
+config gate (`ApprovalOrigin::ConfigGate`), never the agent-callable
+`request_approval` surface ([#306](https://github.com/mezmo/aura/issues/306)).
+The conversational route is excluded just as deliberately: its decision
+caller is the session holder already on the stream.
 
 Capture and delivery both fail closed. A missing mapped header errors the
 call, naming every missing header and never a value. A gated stdio call
-carrying an override is refused before dispatch: stdio has no per-call
-header channel. Cleartext capture stays allowed (TLS termination ahead of
-the process is a legitimate topology) but never silent: startup logs one
-warning per `[hitl]` config at the HMAC boot-time seam, while an HMAC secret
-over `http://` remains a boot-time misconfiguration, unchanged and
-independent of capture. Audit is names-only: the applied header names land
-on the `mcp.tool_call` span as `applied_headers`, and a capture failure's
-error text is the event-level signal — no new `aura-events` wire type.
+carrying an override is refused before dispatch. Cleartext capture stays
+allowed but never silent: startup logs one warning per `[hitl]` config at
+the HMAC boot-time seam, while an HMAC secret over `http://` remains a
+boot-time misconfiguration, unchanged by capture. Audit is names-only: the
+applied header names land on the `mcp.tool_call` span as `applied_headers`,
+and a capture failure's error text is the event-level signal.
 
 Mechanism detail (config shape, capture contract, send points, extension
 lifecycle, audit fields): [docs/design/hitl.md](../design/hitl.md),
@@ -102,45 +95,40 @@ approver header forwarding section.
 
 ### Positive Consequences
 
-- No `rmcp` fork and no version bump: the extension mechanism already exists
-  in the pinned client library, unused until this feature reads it.
-- One-call scoping needs no bookkeeping — no keyed map, no expiry, no cleanup
-  — because it is structural to how the extension rides the request value.
-- HTTP-streamable and SSE share one insertion pattern and one read pattern,
-  so a third HTTP-shaped transport would only need the same read hook added
-  at its own send point.
+- No `rmcp` fork and no version bump: the pinned client already carries the
+  extension mechanism, unused until this feature reads it.
+- One-call scoping needs no bookkeeping, because it is structural to how
+  the extension rides the request value.
+- HTTP-streamable and SSE share one insertion pattern and one read pattern;
+  a third HTTP-shaped transport only needs the same read hook at its own
+  send point.
 - Audit stays cheap: a span attribute and an existing error path, no new
   wire type.
 
 ### Negative Consequences
 
 - Stdio cannot deliver a per-call header at all, so a gated stdio call that
-  carries an override fails closed rather than degrading — an operator who
-  gates a stdio tool and also configures forwarding gets a hard failure, not
-  a partial success.
-- The read point sits inside a trait method whose signature `rmcp` owns; a
-  future upgrade past the pinned version (already flagged: upstream 0.16.0
-  changes `post_message`'s shape) requires re-verifying the extension is
-  still readable there before the bump lands, not after.
-- Cleartext capture is allowed with only a boot-time log warning, not a hard
-  rejection. An operator who does not watch boot logs can run a
+  carries an override fails closed. An operator who gates a stdio tool and
+  also configures forwarding gets a hard failure, not a partial success.
+- The read point sits inside a trait method whose signature `rmcp` owns; an
+  upgrade past the pinned version (upstream 0.16.0 changes
+  `post_message`'s shape) requires re-verifying the extension is still
+  readable there before the bump lands.
+- Cleartext capture is allowed with only a boot-time log warning, not a
+  hard rejection. An operator who does not watch boot logs can run a
   credential-forwarding route over plaintext without noticing.
 - Conversational-route forwarding does not exist. A deployment whose
   approver is the attended operator on the stream has no forwarding path
-  today; nothing here builds toward one; extending it would need this
-  design's premise re-examined, not just a config addition.
-- `request_approval` ([#306](https://github.com/mezmo/aura/issues/306)) never
-  forwards identity either, so the two approval surfaces are not symmetric:
-  an operator who assumes agent-requested approvals behave like config-gated
-  ones will find no override on that path.
+  today; extending one would need this design's premise re-examined.
+- `request_approval` ([#306](https://github.com/mezmo/aura/issues/306))
+  never forwards identity either, so the two approval surfaces are not
+  symmetric.
 
 ## Links
 
 - Design and implementation note: [docs/design/hitl.md](../design/hitl.md)
   (approver header forwarding section)
 - Extends [2026-06-16-hitl-approval-architecture](2026-06-16-hitl-approval-architecture.md)
-  (the dual-channel routing and fail-closed lifecycle this decision builds on)
 - Implements [#496](https://github.com/mezmo/aura/issues/496)
-- Leaves open [#306](https://github.com/mezmo/aura/issues/306) (the
-  `request_approval` agent-callable surface never captures)
+- Leaves open [#306](https://github.com/mezmo/aura/issues/306)
 - RFC 2119: <https://www.rfc-editor.org/rfc/rfc2119>

--- a/docs/adr/2026-08-13-approver-identity-forwarding.md
+++ b/docs/adr/2026-08-13-approver-identity-forwarding.md
@@ -74,8 +74,8 @@ only.**
 A `#[derive(Clone)] ApproverHeaders(HeaderMap)` (redacting `Debug`) rides
 the one gated call's request value as an extension — inserted at every
 `call_tool*` construction site, read back at the two send points that own an
-outbound POST — so one-call scoping is structural: no keyed map, no cleanup
-step, no cross-call leakage under concurrency.
+outbound POST — so one-call scoping is structural: nothing is keyed or
+cleaned up, and concurrent calls never leak into each other.
 
 Only the webhook route captures, and only for approvals raised by the config
 gate (`ApprovalOrigin::ConfigGate`) — never the agent-callable
@@ -83,12 +83,11 @@ gate (`ApprovalOrigin::ConfigGate`) — never the agent-callable
 whose route-wide `ApprovalOutcome` has no consumer for credentials it would
 otherwise hold with nowhere to go. The conversational route is excluded just
 as deliberately: its decision caller is the session holder already on the
-stream, not a distinct identity source, so forwarding it would forward
-nothing new.
+stream, so forwarding that identity adds nothing.
 
-Capture and delivery both fail closed: a missing mapped header errors the
-call naming every missing header, never a value, and a gated stdio call
-carrying an override is refused before dispatch, since stdio has no per-call
+Capture and delivery both fail closed. A missing mapped header errors the
+call, naming every missing header and never a value. A gated stdio call
+carrying an override is refused before dispatch: stdio has no per-call
 header channel. Cleartext capture stays allowed (TLS termination ahead of
 the process is a legitimate topology) but never silent: startup logs one
 warning per `[hitl]` config at the HMAC boot-time seam, while an HMAC secret

--- a/docs/adr/2026-08-13-approver-identity-forwarding.md
+++ b/docs/adr/2026-08-13-approver-identity-forwarding.md
@@ -1,0 +1,178 @@
+<!-- markdownlint-disable MD033 -->
+# Forward the webhook approver's identity to the gated MCP call
+
+- Status: **accepted**
+- Deciders: Mike Shearer
+- Date: 2026-08-13
+
+Technical Story: [#496](https://github.com/mezmo/aura/issues/496)
+
+## Context and Problem Statement
+
+MCP client headers are resolved once per inbound chat request, at agent-build
+time: the completions handler flattens the inbound `HeaderMap`, overlays it
+per `headers_from_request` config, and the MCP client bakes the result into
+its default headers. Identity is frozen before the LLM emits any tool call,
+and before any HITL approval exists.
+
+When a human approves a gated tool call, the downstream MCP call still
+executes under the original requester's frozen identity, not the approver's.
+An operator who wants the approver's own credentials (or a context header
+naming them) on the call they just authorized has no way to get it there.
+
+## Decision Drivers
+
+- Forwarding **MUST** be config-selectable: an operator may map real auth
+  material (`Authorization`) or context headers, since the security posture
+  has to be designed to the auth worst case.
+- The override **MUST** be scoped to exactly the one gated call the approval
+  releases. Every tool execution re-enters `pre_call` and the gate mints a
+  fresh `DecisionId` per call, so a retry **MUST** re-gate and re-capture
+  rather than reuse a prior decision's identity; no reuse store exists.
+- A missing or invalid captured header **MUST** fail the call closed, naming
+  the affected header names and never a value, rather than silently
+  substituting or dropping identity.
+- The route-wide `ApprovalOutcome`, shared with the agent-callable
+  `request_approval` surface, **MUST NOT** gain a credential-holding path —
+  that surface has no consumer for captured headers.
+- Delivery **MUST NOT** require a fork or upgrade of the pinned `rmcp` client
+  library.
+
+## Considered Options
+
+Delivering a per-call header override through to the outbound MCP POST,
+verified against pinned `rmcp` 0.12.0:
+
+- Parameter threading a header override into `post_message`'s signature —
+  rejected: the signature belongs to a trait `rmcp` owns.
+- A task-local read inside the transport worker — rejected: the worker task
+  is spawned once at connect time, before any gated call exists, so nothing
+  scoped per call is visible to it.
+- `PeerRequestOptions.meta` — rejected: the hand-written wire serializer
+  extracts only the `Meta` extension onto the request; a header override
+  placed there would still need a second, undocumented channel to become an
+  HTTP header, and nothing reads `meta` for that purpose today.
+- An ephemeral per-call MCP client, built fresh under the approver's headers —
+  rejected: roughly 4 extra round trips per gated call, and it loses
+  manager-driven cancellation, `tool_start`/progress events, and leaks
+  sessions on an unretried `DELETE`.
+- A sidecar proxy that rewrites headers in flight — rejected: the proxy's own
+  URL is frozen the same way the MCP client's headers are today, so it
+  degenerates into a persistent, body-inspecting proxy that re-derives the
+  same call-to-approval correlation problem out of process.
+- **The `rmcp` request-extension side-channel — chosen.** `rmcp::model::Request`
+  carries an http-crate-style typed `Extensions` map, `Clone + Send + Sync +
+  'static` bound, that rides the request value intact through
+  `Peer::send_request_with_option`, the transport channel, and the worker
+  into `post_message`, which receives the message by value.
+
+## Decision Outcome
+
+Chosen option: **the rmcp request-extension side-channel, webhook route
+only.**
+
+A `#[derive(Clone)] ApproverHeaders(HeaderMap)` (redacting `Debug`) is
+inserted into a request's extensions at every `call_tool*` construction site
+when the gate released an override, and read back at the two send points
+that own an outbound POST: `CustomHttpClient::post_message` (HTTP-streamable)
+and aura's own `SseTransport::send`. Both apply the override as per-request
+headers, which `reqwest` uses to replace the client's frozen default header
+for that one request only — the JSON body never carries it, and the
+serializer emits no trace of it, because the hand-written wire serializer
+extracts only the `Meta` extension. One-call scoping is structural: the
+extension rides on the one request value, so there is no keyed map, no
+cleanup step, and no cross-call leakage under concurrency.
+
+Only the webhook decision route captures. The conversational route's
+decision also arrives on its own request (`POST
+/v1/approvals/{decision_id}`), which carries its own caller headers — but in
+this system's deployment model that caller is the session holder already on
+the stream, not a distinct identity source, so forwarding it would forward
+nothing new. Excluding it is a deliberate scope choice, recorded here as
+such. Capture is further conditioned
+on the approval's origin: the webhook client captures response headers only
+when the request that raised it came from the config gate
+(`ApprovalOrigin::ConfigGate`), never from the agent-callable
+`request_approval` surface ([#306](https://github.com/mezmo/aura/issues/306)),
+because that surface's route-wide `ApprovalOutcome` has no consumer for
+credentials it would otherwise hold with nowhere to go.
+
+Capture fails closed: when `tool_headers_from_response` is non-empty and the
+approved response is missing a mapped header, the approval resolves to an
+error naming every missing header — never a value. A malformed value cannot
+reach capture at all: values are read from the parsed response's header map,
+which admits only valid HTTP header values. A denied, timed-out, or cancelled
+decision captures nothing, because there is no decision to capture from.
+Every non-webhook, non-approved, or non-`ConfigGate` path produces no
+override, which the unit suite proves directly rather than by omission.
+
+Stdio fails closed on a gated call that carries an override. The tool
+adaptor is tagged with its transport kind at construction; stdio has no
+per-call header channel, so a gated call demanding identity is refused
+before dispatch, and the cached identity never runs the call in its place.
+
+Capture does not require `https://`. A cleartext webhook route with
+`tool_headers_from_response` configured is usable and unsigned, because TLS
+termination ahead of the process (a trusted gateway, service-to-service) is
+a legitimate topology. It is never silent: startup logs one warning per
+`[hitl]` config naming the exposure (scheme and host only, never path,
+query, or userinfo), at the same boot-time seam as the HMAC-signing check —
+not at webhook-client construction, which happens fresh on every request
+that builds an agent. The one rule that still rejects plaintext is unchanged
+and independent of capture: an HMAC secret configured over `http://` is a
+misconfiguration and fails at boot.
+
+Audit is names-only. `execute_mcp_tool` stamps the applied header names,
+sorted and joined, on the `mcp.tool_call` span as `applied_headers`; a
+capture failure's own error text is the event-level signal, naming every
+affected header. Under fail-closed semantics a capture-success stamp would
+be degenerate (success always equals the configured key set), so no
+`aura-events` wire type or CLI deserializer changes. This contract covers
+only the audit fields this feature emits — a tool that echoes the header it
+received puts the forwarded value into its own recorded result the same
+way any tool call's output is recorded, feature or no feature.
+
+### Positive Consequences
+
+- No `rmcp` fork and no version bump: the extension mechanism already exists
+  in the pinned client library, unused until this feature reads it.
+- One-call scoping needs no bookkeeping — no keyed map, no expiry, no cleanup
+  — because it is structural to how the extension rides the request value.
+- HTTP-streamable and SSE share one insertion pattern and one read pattern,
+  so a third HTTP-shaped transport would only need the same read hook added
+  at its own send point.
+- Audit stays cheap: a span attribute and an existing error path, no new
+  wire type.
+
+### Negative Consequences
+
+- Stdio cannot deliver a per-call header at all, so a gated stdio call that
+  carries an override fails closed rather than degrading — an operator who
+  gates a stdio tool and also configures forwarding gets a hard failure, not
+  a partial success.
+- The read point sits inside a trait method whose signature `rmcp` owns; a
+  future upgrade past the pinned version (already flagged: upstream 0.16.0
+  changes `post_message`'s shape) requires re-verifying the extension is
+  still readable there before the bump lands, not after.
+- Cleartext capture is allowed with only a boot-time log warning, not a hard
+  rejection. An operator who does not watch boot logs can run a
+  credential-forwarding route over plaintext without noticing.
+- Conversational-route forwarding does not exist. A deployment whose
+  approver is the attended operator on the stream has no forwarding path
+  today; nothing here builds toward one; extending it would need this
+  design's premise re-examined, not just a config addition.
+- `request_approval` ([#306](https://github.com/mezmo/aura/issues/306)) never
+  forwards identity either, so the two approval surfaces are not symmetric:
+  an operator who assumes agent-requested approvals behave like config-gated
+  ones will find no override on that path.
+
+## Links
+
+- Design and implementation note: [docs/design/hitl.md](../design/hitl.md)
+  (approver header forwarding section)
+- Extends [2026-06-16-hitl-approval-architecture](2026-06-16-hitl-approval-architecture.md)
+  (the dual-channel routing and fail-closed lifecycle this decision builds on)
+- Implements [#496](https://github.com/mezmo/aura/issues/496)
+- Leaves open [#306](https://github.com/mezmo/aura/issues/306) (the
+  `request_approval` agent-callable surface never captures)
+- RFC 2119: <https://www.rfc-editor.org/rfc/rfc2119>

--- a/docs/adr/2026-08-13-approver-identity-forwarding.md
+++ b/docs/adr/2026-08-13-approver-identity-forwarding.md
@@ -71,66 +71,35 @@ verified against pinned `rmcp` 0.12.0:
 Chosen option: **the rmcp request-extension side-channel, webhook route
 only.**
 
-A `#[derive(Clone)] ApproverHeaders(HeaderMap)` (redacting `Debug`) is
-inserted into a request's extensions at every `call_tool*` construction site
-when the gate released an override, and read back at the two send points
-that own an outbound POST: `CustomHttpClient::post_message` (HTTP-streamable)
-and aura's own `SseTransport::send`. Both apply the override as per-request
-headers, which `reqwest` uses to replace the client's frozen default header
-for that one request only — the JSON body never carries it, and the
-serializer emits no trace of it, because the hand-written wire serializer
-extracts only the `Meta` extension. One-call scoping is structural: the
-extension rides on the one request value, so there is no keyed map, no
-cleanup step, and no cross-call leakage under concurrency.
+A `#[derive(Clone)] ApproverHeaders(HeaderMap)` (redacting `Debug`) rides
+the one gated call's request value as an extension — inserted at every
+`call_tool*` construction site, read back at the two send points that own an
+outbound POST — so one-call scoping is structural: no keyed map, no cleanup
+step, no cross-call leakage under concurrency.
 
-Only the webhook decision route captures. The conversational route's
-decision also arrives on its own request (`POST
-/v1/approvals/{decision_id}`), which carries its own caller headers — but in
-this system's deployment model that caller is the session holder already on
-the stream, not a distinct identity source, so forwarding it would forward
-nothing new. Excluding it is a deliberate scope choice, recorded here as
-such. Capture is further conditioned
-on the approval's origin: the webhook client captures response headers only
-when the request that raised it came from the config gate
-(`ApprovalOrigin::ConfigGate`), never from the agent-callable
+Only the webhook route captures, and only for approvals raised by the config
+gate (`ApprovalOrigin::ConfigGate`) — never the agent-callable
 `request_approval` surface ([#306](https://github.com/mezmo/aura/issues/306)),
-because that surface's route-wide `ApprovalOutcome` has no consumer for
-credentials it would otherwise hold with nowhere to go.
+whose route-wide `ApprovalOutcome` has no consumer for credentials it would
+otherwise hold with nowhere to go. The conversational route is excluded just
+as deliberately: its decision caller is the session holder already on the
+stream, not a distinct identity source, so forwarding it would forward
+nothing new.
 
-Capture fails closed: when `tool_headers_from_response` is non-empty and the
-approved response is missing a mapped header, the approval resolves to an
-error naming every missing header — never a value. A malformed value cannot
-reach capture at all: values are read from the parsed response's header map,
-which admits only valid HTTP header values. A denied, timed-out, or cancelled
-decision captures nothing, because there is no decision to capture from.
-Every non-webhook, non-approved, or non-`ConfigGate` path produces no
-override, which the unit suite proves directly rather than by omission.
+Capture and delivery both fail closed: a missing mapped header errors the
+call naming every missing header, never a value, and a gated stdio call
+carrying an override is refused before dispatch, since stdio has no per-call
+header channel. Cleartext capture stays allowed (TLS termination ahead of
+the process is a legitimate topology) but never silent: startup logs one
+warning per `[hitl]` config at the HMAC boot-time seam, while an HMAC secret
+over `http://` remains a boot-time misconfiguration, unchanged and
+independent of capture. Audit is names-only: the applied header names land
+on the `mcp.tool_call` span as `applied_headers`, and a capture failure's
+error text is the event-level signal — no new `aura-events` wire type.
 
-Stdio fails closed on a gated call that carries an override. The tool
-adaptor is tagged with its transport kind at construction; stdio has no
-per-call header channel, so a gated call demanding identity is refused
-before dispatch, and the cached identity never runs the call in its place.
-
-Capture does not require `https://`. A cleartext webhook route with
-`tool_headers_from_response` configured is usable and unsigned, because TLS
-termination ahead of the process (a trusted gateway, service-to-service) is
-a legitimate topology. It is never silent: startup logs one warning per
-`[hitl]` config naming the exposure (scheme and host only, never path,
-query, or userinfo), at the same boot-time seam as the HMAC-signing check —
-not at webhook-client construction, which happens fresh on every request
-that builds an agent. The one rule that still rejects plaintext is unchanged
-and independent of capture: an HMAC secret configured over `http://` is a
-misconfiguration and fails at boot.
-
-Audit is names-only. `execute_mcp_tool` stamps the applied header names,
-sorted and joined, on the `mcp.tool_call` span as `applied_headers`; a
-capture failure's own error text is the event-level signal, naming every
-affected header. Under fail-closed semantics a capture-success stamp would
-be degenerate (success always equals the configured key set), so no
-`aura-events` wire type or CLI deserializer changes. This contract covers
-only the audit fields this feature emits — a tool that echoes the header it
-received puts the forwarded value into its own recorded result the same
-way any tool call's output is recorded, feature or no feature.
+Mechanism detail (config shape, capture contract, send points, extension
+lifecycle, audit fields): [docs/design/hitl.md](../design/hitl.md),
+approver header forwarding section.
 
 ### Positive Consequences
 

--- a/docs/design/hitl.md
+++ b/docs/design/hitl.md
@@ -448,13 +448,13 @@ on to make once the decision comes back approved. Ungated calls never reach
 
 ## Approver header forwarding
 
-Companion to the ADR [2026-08-13-approver-identity-forwarding](../adr/2026-08-13-approver-identity-forwarding.md).
+Companion to the ADR
+[2026-08-13-approver-identity-forwarding](../adr/2026-08-13-approver-identity-forwarding.md).
 
-MCP client headers are resolved once, at agent-build time, before any
-approval exists — so a gated tool call executes under the original
-requester's identity even after a human approves it. `tool_headers_from_response`
-lets an operator substitute the approver's identity onto that one gated
-call instead.
+MCP client headers are resolved once, at agent-build time, before any approval
+exists, so a gated tool call executes under the original requester's identity
+even after a human approves it. `tool_headers_from_response` lets an operator
+substitute the approver's identity onto that one gated call instead.
 
 ### Config shape
 
@@ -467,101 +467,81 @@ headers_from_request = { "authorization" = "authorization" }   # PR #490, unrela
 tool_headers_from_response = { "authorization" = "x-approver-token" }
 ```
 
-`#[serde(default)]`; absent or an empty map is the pre-existing behavior,
-unchanged. Every outbound name is lowercased at parse — the same discipline
-`resolve_mcp_headers` already applies to static headers — so a captured
-override replaces the frozen value on the wire rather than coexisting with
-it. Parse also rejects a duplicate outbound name after lowercasing and any
-name from the transport-owned reserved set (`content-type`, `accept`,
-`mcp-session-id`, `host`, `content-length`, `transfer-encoding`), so a
-mapping can never corrupt MCP framing or session routing.
+`#[serde(default)]`: absent or an empty map is the pre-existing behavior,
+unchanged. Every outbound name is lowercased at parse, so a captured override
+replaces the frozen value on the wire. Parse also rejects a duplicate outbound
+name after lowercasing and any name from the transport-owned reserved set
+(`content-type`, `accept`, `mcp-session-id`, `host`, `content-length`,
+`transfer-encoding`), so a mapping can never corrupt MCP framing or session
+routing.
 
 ### Fail-closed contract
 
-Capture runs only for an approved webhook decision whose origin is the
-config gate (`ApprovalOrigin::ConfigGate`) — never for the `request_approval`
-agent-callable surface, which stays credential-free by construction
-([#306](https://github.com/mezmo/aura/issues/306)). When
-`tool_headers_from_response` is non-empty:
+Capture runs only for an approved webhook decision whose origin is the config
+gate (`ApprovalOrigin::ConfigGate`), never for the `request_approval`
+agent-callable surface ([#306](https://github.com/mezmo/aura/issues/306)).
+When `tool_headers_from_response` is non-empty:
 
 - Every mapped outbound name must resolve to a present response header, read
-  case-insensitively and taking the first value on a repeat. One missing
-  name fails the whole capture.
-- A malformed value cannot reach capture: values are read from the parsed
-  response's header map, which admits only valid HTTP header values.
+  case-insensitively and taking the first value on a repeat. One missing name
+  fails the whole capture.
 - A capture failure resolves the approval to an error: the gated call fails
   with a message naming every missing header, never a value.
 - A denied, timed-out, or cancelled decision captures nothing, because there
   is no decision to capture from.
 
-An absent or empty map is the legacy path: an approved call proceeds under
-the requester's frozen identity, exactly as it did before this feature.
+An absent or empty map is the legacy path: an approved call proceeds under the
+requester's frozen identity.
 
 ### The https question
 
 Capture does not require `https://`. A webhook route with
 `tool_headers_from_response` configured over plain `http://` is usable and
-unsigned — a deployment that terminates TLS ahead of the process (a trusted
-gateway, service-to-service) is a legitimate topology this does not reject —
-but it is never silent: each binary's startup logs one warning per `[hitl]`
-config naming the exposure, alongside the boot-time HMAC-signing check
-(`warn_on_cleartext_capture`, called next to `validate_webhook_signing_config`;
-the standalone CLI additionally prints the warning to stderr, because its
-default tracing subscriber is a no-op without `log_file`).
-The webhook client itself, rebuilt on every request that builds an agent,
-never logs this warning; only the boot-time call does, and the log line
-carries the webhook's scheme and host only, never its path, query, or
-userinfo. The one rule `https://` still enforces is unchanged and
-independent of capture: an HMAC secret configured over `http://` is a
-misconfiguration and fails closed at boot.
+unsigned. A deployment that terminates TLS ahead of the process is a
+legitimate topology, but the route is never silent: each binary's startup logs
+one warning per `[hitl]` config naming the exposure, alongside the boot-time
+HMAC-signing check (`warn_on_cleartext_capture`). In the CLI the warning also
+reaches stderr, since its default tracing subscriber is a no-op without
+`log_file`. The webhook client itself never logs this warning; only the
+boot-time call does, and the log line carries the webhook's scheme and host
+only. The one rule `https://` still enforces is unchanged: an HMAC secret
+configured over `http://` is a misconfiguration and fails closed at boot.
 
 ### Transport support
 
 The override rides the outbound `rmcp::model::Request` as a typed extension;
 only the transports that read it back before serializing can deliver it:
 
-- **HTTP-streamable and SSE**: both send paths read the extension and apply
-  it as a per-request header, which replaces the client's frozen default
-  header for that one request only. The override never reaches the JSON
-  body — the hand-written wire serializer extracts only the `Meta`
-  extension, so anything else placed in `Extensions` never reaches the wire
-  as data.
+- **HTTP-streamable and SSE**: both send paths read the extension and apply it
+  as a per-request header, which replaces the client's frozen default header
+  for that one request only. The override never reaches the JSON body.
 - **Stdio**: the tool adaptor is tagged with its transport kind at
   construction. A gated stdio call that carries an override fails closed
-  before dispatch — identity was demanded and stdio has no per-call header
-  channel to deliver it.
+  before dispatch; identity was demanded and stdio has no per-call header
+  channel.
 
 ### One-call scoping
 
-The override rides the one request value the gate released, inserted into
-that request's `Extensions` map and read back by the transport before the
-outbound POST. There is no keyed map and nothing to clean up: every tool
-execution re-enters `pre_call` and the gate mints a fresh `DecisionId` per
-call, so an LLM- or orchestration-initiated retry re-gates, fires a fresh
-webhook approval, and captures fresh response headers rather than reusing a
-prior decision's identity.
+The override rides the one request value the gate released, inserted into that
+request's `Extensions` map and read back by the transport before the outbound
+POST. There is no keyed map and nothing to clean up: every tool execution
+re-enters `pre_call` and the gate mints a fresh `DecisionId` per call.
 
 ### Application-time audit
 
-`execute_mcp_tool` (`crates/aura/src/mcp_tool_execution.rs`) stamps the
-outbound header NAMES an override applied — sorted, comma-joined, never the
-values — on the `mcp.tool_call` span as `applied_headers`, present only when
-the call carried an override. Event-level audit is the capture failure's own
-error text: a missing header fails the approval with a message naming
-every affected header, which is what both a caller and the trace see.
+`execute_mcp_tool` stamps the outbound header NAMES an override applied
+(sorted, comma-joined, never the values) on the `mcp.tool_call` span as
+`applied_headers`. Event-level audit uses the capture failure's error text,
+which names every missing header. No missing-header failure reaches the wire.
 No `aura-events` wire type changes: under fail-closed semantics a capture
-success stamp would be degenerate (success always equals the configured key
-set), so the existing `Errored` outcome already carries the full audit
-signal.
+success stamp would be degenerate, so the existing `Errored` outcome already
+carries the full audit signal.
 
-The names-only contract covers this feature's own audit fields — the span
-attribute and the capture-failure error text. It does not extend to a
-gated tool's own output: a tool whose result echoes the header it received
-(as `echo_headers` does, by design, for testing) puts the forwarded value
-into that tool's recorded result the same way any tool call's output is
-recorded, whether or not an override applied. Forwarding credentials to a
-tool that echoes them back makes the value visible wherever tool results
-are recorded.
+The names-only contract covers this feature's own audit fields: the span
+attribute and the capture-failure error text. It does not extend to a gated
+tool's own output: a tool whose result echoes the header it received puts the
+forwarded value into that tool's recorded result the same way any tool call's
+output is recorded.
 
 ## Orchestration behavior
 

--- a/docs/design/hitl.md
+++ b/docs/design/hitl.md
@@ -418,11 +418,18 @@ telemetry.
 
 ## Trace correlation
 
-`DecisionRoute::decide` stamps the request's `decision_id` on the current span,
-which is the gated call's Rig `execute_tool` span: both surfaces await `decide`
-inline, and `WrappedTool` carries that span across the approval gate into the
-inner tool. One stamp, ahead of the route split, gives every approval-gated
-execution the id the payload and the lifecycle events carry:
+`DecisionRoute::decide_for_gate` and `DecisionRoute::decide` each stamp the
+request's `decision_id` on the current span, ahead of their own route split
+and of any outcome: the config gate awaits `decide_for_gate` inline from the
+gated call's Rig `execute_tool` span, and `WrappedTool` carries that span
+across the approval gate into the inner tool; the agent-callable
+`request_approval` tool awaits `decide` directly on its own `execute_tool`
+span instead of going through the gate. Neither entry point is reached
+through the other on every route — `decide_for_gate`'s webhook arm never
+calls `decide`, and `request_approval` never calls `decide_for_gate` — so
+each stamps independently rather than relying on the other to have done it.
+Stamping ahead of the split gives every approval-gated execution the id the
+payload and the lifecycle events carry:
 
 ```text
 execute_tool
@@ -431,9 +438,13 @@ execute_tool
         status = OK | ERROR
 ```
 
-A trace consumer joins the approval to the result of the action it released
-without a second reporting channel. Ungated calls never reach `decide`, so they
-carry no `decision_id`.
+On the config-gate surface, this is the gated action's own span — the approval
+joins the result of the action it released on one span, without a second
+reporting channel. On the agent-callable surface, the stamp lands on
+`request_approval`'s own execution span instead: it correlates the approval
+decision to that tool call, not to whatever separate tool call the agent goes
+on to make once the decision comes back approved. Ungated calls never reach
+`decide_for_gate` or `decide`, so they carry no `decision_id`.
 
 ## Orchestration behavior
 

--- a/docs/design/hitl.md
+++ b/docs/design/hitl.md
@@ -446,6 +446,121 @@ decision to that tool call, not to whatever separate tool call the agent goes
 on to make once the decision comes back approved. Ungated calls never reach
 `decide_for_gate` or `decide`, so they carry no `decision_id`.
 
+## Approver header forwarding
+
+Companion to the ADR [2026-08-13-approver-identity-forwarding](../adr/2026-08-13-approver-identity-forwarding.md).
+
+MCP client headers are resolved once, at agent-build time, before any
+approval exists — so a gated tool call executes under the original
+requester's identity even after a human approves it. `tool_headers_from_response`
+lets an operator substitute the approver's identity onto that one gated
+call instead.
+
+### Config shape
+
+```toml
+[hitl.route]
+mode = "webhook"
+url = "https://approvals.example.com/hook"
+headers_from_request = { "authorization" = "authorization" }   # PR #490, unrelated
+# outbound MCP header name -> webhook response header name
+tool_headers_from_response = { "authorization" = "x-approver-token" }
+```
+
+`#[serde(default)]`; absent or an empty map is the pre-existing behavior,
+unchanged. Every outbound name is lowercased at parse — the same discipline
+`resolve_mcp_headers` already applies to static headers — so a captured
+override replaces the frozen value on the wire rather than coexisting with
+it. Parse also rejects a duplicate outbound name after lowercasing and any
+name from the transport-owned reserved set (`content-type`, `accept`,
+`mcp-session-id`, `host`, `content-length`, `transfer-encoding`), so a
+mapping can never corrupt MCP framing or session routing.
+
+### Fail-closed contract
+
+Capture runs only for an approved webhook decision whose origin is the
+config gate (`ApprovalOrigin::ConfigGate`) — never for the `request_approval`
+agent-callable surface, which stays credential-free by construction
+([#306](https://github.com/mezmo/aura/issues/306)). When
+`tool_headers_from_response` is non-empty:
+
+- Every mapped outbound name must resolve to a present response header, read
+  case-insensitively and taking the first value on a repeat. One missing
+  name fails the whole capture.
+- A malformed value cannot reach capture: values are read from the parsed
+  response's header map, which admits only valid HTTP header values.
+- A capture failure resolves the approval to an error: the gated call fails
+  with a message naming every missing header, never a value.
+- A denied, timed-out, or cancelled decision captures nothing, because there
+  is no decision to capture from.
+
+An absent or empty map is the legacy path: an approved call proceeds under
+the requester's frozen identity, exactly as it did before this feature.
+
+### The https question
+
+Capture does not require `https://`. A webhook route with
+`tool_headers_from_response` configured over plain `http://` is usable and
+unsigned — a deployment that terminates TLS ahead of the process (a trusted
+gateway, service-to-service) is a legitimate topology this does not reject —
+but it is never silent: server startup logs one warning per `[hitl]` config
+naming the exposure, alongside the boot-time HMAC-signing check
+(`warn_on_cleartext_capture`, called next to `validate_webhook_signing_config`).
+The webhook client itself, rebuilt on every request that builds an agent,
+never logs this warning; only the boot-time call does, and the log line
+carries the webhook's scheme and host only, never its path, query, or
+userinfo. The one rule `https://` still enforces is unchanged and
+independent of capture: an HMAC secret configured over `http://` is a
+misconfiguration and fails closed at boot.
+
+### Transport support
+
+The override rides the outbound `rmcp::model::Request` as a typed extension;
+only the transports that read it back before serializing can deliver it:
+
+- **HTTP-streamable and SSE**: both send paths read the extension and apply
+  it as a per-request header, which replaces the client's frozen default
+  header for that one request only. The override never reaches the JSON
+  body — the hand-written wire serializer extracts only the `Meta`
+  extension, so anything else placed in `Extensions` never reaches the wire
+  as data.
+- **Stdio**: the tool adaptor is tagged with its transport kind at
+  construction. A gated stdio call that carries an override fails closed
+  before dispatch — identity was demanded and stdio has no per-call header
+  channel to deliver it.
+
+### One-call scoping
+
+The override rides the one request value the gate released, inserted into
+that request's `Extensions` map and read back by the transport before the
+outbound POST. There is no keyed map and nothing to clean up: every tool
+execution re-enters `pre_call` and the gate mints a fresh `DecisionId` per
+call, so an LLM- or orchestration-initiated retry re-gates, fires a fresh
+webhook approval, and captures fresh response headers rather than reusing a
+prior decision's identity.
+
+### Application-time audit
+
+`execute_mcp_tool` (`crates/aura/src/mcp_tool_execution.rs`) stamps the
+outbound header NAMES an override applied — sorted, comma-joined, never the
+values — on the `mcp.tool_call` span as `applied_headers`, present only when
+the call carried an override. Event-level audit is the capture failure's own
+error text: a missing header fails the approval with a message naming
+every affected header, which is what both a caller and the trace see.
+No `aura-events` wire type changes: under fail-closed semantics a capture
+success stamp would be degenerate (success always equals the configured key
+set), so the existing `Errored` outcome already carries the full audit
+signal.
+
+The names-only contract covers this feature's own audit fields — the span
+attribute and the capture-failure error text. It does not extend to a
+gated tool's own output: a tool whose result echoes the header it received
+(as `echo_headers` does, by design, for testing) puts the forwarded value
+into that tool's recorded result the same way any tool call's output is
+recorded, whether or not an override applied. Forwarding credentials to a
+tool that echoes them back makes the value visible wherever tool results
+are recorded.
+
 ## Orchestration behavior
 
 Workers share the parent's request id, so `approval_pending` events from a parked

--- a/docs/design/hitl.md
+++ b/docs/design/hitl.md
@@ -503,9 +503,11 @@ Capture does not require `https://`. A webhook route with
 `tool_headers_from_response` configured over plain `http://` is usable and
 unsigned — a deployment that terminates TLS ahead of the process (a trusted
 gateway, service-to-service) is a legitimate topology this does not reject —
-but it is never silent: server startup logs one warning per `[hitl]` config
-naming the exposure, alongside the boot-time HMAC-signing check
-(`warn_on_cleartext_capture`, called next to `validate_webhook_signing_config`).
+but it is never silent: each binary's startup logs one warning per `[hitl]`
+config naming the exposure, alongside the boot-time HMAC-signing check
+(`warn_on_cleartext_capture`, called next to `validate_webhook_signing_config`;
+the standalone CLI additionally prints the warning to stderr, because its
+default tracing subscriber is a no-op without `log_file`).
 The webhook client itself, rebuilt on every request that builds an agent,
 never logs this warning; only the boot-time call does, and the log line
 carries the webhook's scheme and host only, never its path, query, or


### PR DESCRIPTION
Forwards the approving human's identity headers from an approved webhook decision onto the single gated MCP call that decision unblocks.

- The approval decision id is stamped at both entry points, the webhook arm and the `request_approval` tool, so every gated call carries one.
- An approved webhook response can supply the configured `tool_headers_from_response` values. They are captured as validated overrides on the decision, only on approval, and the capture fails closed naming any missing header, never a value.
- The overrides ride the rmcp request extension onto exactly one outbound request on the http-streamable and SSE transports, replacing the frozen client identity for that call only. A gated stdio call carrying overrides fails closed.
- The gated call's `mcp.tool_call` span records the applied override names, never values. A route that would capture over cleartext warns at boot instead of being rejected, since TLS can terminate outside the process.
- A hitl integration suite lands behind its own feature flag with a make target against the mock fixture. The transport and route-scope decisions are recorded in an ADR.

This change was reviewed as five parts (#571, #572, #573, #574, then this PR). GitHub's stack merge would not land the stack against this repository's review rules, so the parts are closed unmerged and the whole change lands here as one rebase merge. The per-part review threads stay on those PRs; the commits here are the same patches rebased onto current `main`.

Fixes: #496
