### PR TITLE
ci: create the release branch before computing the version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -456,6 +456,8 @@ pipeline {
           }
 
           steps {
+            sh "git checkout -B ${CURRENT_BRANCH}"
+
             script {
               env.NEXT_RELEASE_VERSION = sh(
                 script: "npm run --silent release:version 'file://${env.WORKSPACE}'",


### PR DESCRIPTION
Compute Release Version resolves branches against the workspace, and git ls-remote on a local repository lists only local heads. The Jenkins checkout is detached, so main was absent and semantic-release failed branch expansion with ERELEASEBRANCHES on an empty branch list.