### PR TITLE
ci(release): release per-channel from nightly, beta and main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,13 @@ make ci                     # Bundle: fmt-check + lint (test hook is empty)
 --check` — not `cargo fmt` — to match CI. See `CONTRIBUTING.md` for the
 full workflow.
 
+### Release channels
+
+One branch per channel: `nightly` (development, `X.Y.Z-nightly.N`), a
+per-cycle `beta` (`X.Y.Z-beta.N`), and `main` (stable `X.Y.Z`, what
+`latest`/Homebrew/the package repo follow). **Branch from and target
+`nightly`**, not `main`. See `docs/design/release-channels.md`.
+
 ## Code Comment Conventions
 
 - **Document behavior where it lives, not on data.** A comment describing *what

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Setup, build, test, and architecture documentation lives in [DEVELOPMENT.md](DEV
 
 ## The Short Version
 
-1. Fork the repo (external contributors) or branch from `main` (maintainers).
+1. Fork the repo (external contributors) or branch from `nightly` (maintainers).
 2. Make a focused change: one logical change per PR, with tests.
 3. Run `make fmt-check`, `cargo test --workspace`, and `make lint` before pushing.
 4. Write [Conventional Commits](#commit-messages); verify with `make lint-commits`.
@@ -31,11 +31,11 @@ Organizations with ten (10) or more contributors may contact [cla@mezmo.com](mai
 
 Environment setup, build instructions, project structure, and Make targets are documented in [DEVELOPMENT.md](DEVELOPMENT.md).
 
-1. Create a branch from the latest `main`:
+1. Create a branch from the latest `nightly`:
 
    ```bash
-   git checkout main
-   git pull origin main
+   git checkout nightly
+   git pull origin nightly
    git checkout -b feat/your-feature-name
    ```
 
@@ -53,7 +53,17 @@ Environment setup, build instructions, project structure, and Make targets are d
 
 4. Push your branch and open a pull request.
 
-All changes are merged to `main` via **rebase merging** to maintain a linear commit history, so every commit must follow the [commit message convention](#commit-messages).
+Contributions are merged to `nightly` via **rebase merging** to maintain a linear commit history, so every commit must follow the [commit message convention](#commit-messages).
+
+## Release Branches
+
+| Branch | Channel | What it is |
+| --- | --- | --- |
+| `nightly` | nightly | Where development lands; every releasable merge publishes `X.Y.Z-nightly.N`. |
+| `beta` | beta | A candidate cut from `nightly`, iterated as `X.Y.Z-beta.N`. Exists only during a release cycle. |
+| `main` | stable | What `latest`, the Homebrew tap, and the package repository follow. |
+
+**Branch from and target `nightly`**, not `main`. Maintainers move changes between channels. See [the design note](docs/design/release-channels.md) for the promotion workflow and the [ADR](docs/adr/2026-07-29-release-channels.md) for the rationale.
 
 ## Code Quality
 
@@ -120,7 +130,7 @@ Update your config.toml files accordingly.
 
 Before you submit:
 
-1. Rebase on the latest `main` (`git fetch origin && git rebase origin/main`).
+1. Rebase on the latest `nightly` (`git fetch origin && git rebase origin/nightly`).
 2. Run the quality checks above, plus `make lint-commits`.
 3. Update documentation if your change affects user-facing behavior, configuration, or APIs (see [Updating Documentation](#updating-documentation)).
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,7 +81,7 @@ Make targets are composed from modular includes under `.makefiles/` (rust, docke
 | `make lint`            | Run clippy with warnings as errors             |
 | `make ci`              | Run fmt-check and lint (the `test` hook is empty; run `cargo test --workspace` separately) |
 | `make coverage`        | Run the test suite with code coverage          |
-| `make lint-commits`    | Lint commits on the current branch against main |
+| `make lint-commits`    | Lint commits on the current branch against its base (`nightly`, or the change request's target branch in CI; override with `COMMITLINT_BASE`) |
 | `make clean`           | Clean build artifacts                          |
 | `make docker-build`    | Build the Docker image (full release)          |
 | `make docker-test`     | Run the Docker build's lint/test stage         |
@@ -216,4 +216,5 @@ Worth reading before diving into the code:
 - [Streaming API Guide](https://docs.mezmo.com/aura/streaming-api-guide): SSE protocol, event types, and client handling.
 - [Request Lifecycle](https://docs.mezmo.com/aura/request-lifecycle): request flow, timeouts, cancellation, and shutdown.
 - [docs/rig-fork-changes.md](docs/rig-fork-changes.md): why AURA uses a Rig.rs fork, what changed, and tool execution ordering (important for `tool_event_broker.rs`).
+- [docs/adr/2026-07-29-release-channels.md](docs/adr/2026-07-29-release-channels.md) and [docs/design/release-channels.md](docs/design/release-channels.md): the `nightly` / `beta` / `main` release channels, what each publishes, and how a release is promoted.
 - [Tracing & Span Layout](https://docs.mezmo.com/aura/tracing-spans): OpenTelemetry span layout and trace parenting.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 library 'magic-butler-catalogue'
 def PROJECT_NAME = 'aura'
-def DEFAULT_BRANCH = 'main'
+// One branch per release channel; see docs/design/release-channels.md.
+def RELEASE_BRANCHES = ['main', 'beta', 'nightly']
 def CURRENT_BRANCH = [env.CHANGE_BRANCH, env.BRANCH_NAME]?.find{branch -> branch != null}
 def DOCKER_REPO = "docker.io/mezmo"
 def BUILD_SLUG = slugify(env.BUILD_TAG)
@@ -37,14 +38,15 @@ pipeline {
     timeout time: 90, unit: 'MINUTES'
     timestamps()
     ansiColor 'xterm'
-    // On main, don't abort: a release build pushes a [skip ci] version commit
+    // On a release branch, don't abort: main pushes a [skip ci] version commit
     // that spawns a follow-on build, and aborting would mark the still-publishing
-    // release build as superseded. Non-main branches still abort stale builds.
-    disableConcurrentBuilds(abortPrevious: env.BRANCH_NAME != DEFAULT_BRANCH)
+    // release build as superseded. Serializing also stops an older build from
+    // moving a channel tag after a newer one. Other branches abort stale builds.
+    disableConcurrentBuilds(abortPrevious: !RELEASE_BRANCHES.contains(env.BRANCH_NAME))
     buildDiscarder(
       logRotator(
-        numToKeepStr: env.BRANCH_NAME == DEFAULT_BRANCH ? '30' : '5',
-        artifactNumToKeepStr: env.BRANCH_NAME == DEFAULT_BRANCH ? '30' : '5'
+        numToKeepStr: RELEASE_BRANCHES.contains(env.BRANCH_NAME) ? '30' : '5',
+        artifactNumToKeepStr: RELEASE_BRANCHES.contains(env.BRANCH_NAME) ? '30' : '5'
       )
     )
   }
@@ -94,7 +96,7 @@ pipeline {
         beforeAgent true
         not {
           anyOf {
-            branch DEFAULT_BRANCH
+            expression { RELEASE_BRANCHES.contains(env.BRANCH_NAME) }
             changeRequest()
             triggeredBy cause: "UserIdCause"
           }
@@ -341,7 +343,7 @@ pipeline {
         not {
           anyOf {
             changelog '\\[skip ci\\]'
-            expression { CURRENT_BRANCH == DEFAULT_BRANCH }
+            expression { RELEASE_BRANCHES.contains(CURRENT_BRANCH) }
           }
         }
       }
@@ -361,7 +363,7 @@ pipeline {
           // run is done with it.
           def startSha = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
           try {
-            sh "git checkout -B ${CURRENT_BRANCH}"
+            sh 'git checkout -B "$BRANCH_NAME"'
 
             // A breaking empty commit guarantees a version is computed, so the
             // verify path runs on every change request.
@@ -393,8 +395,12 @@ pipeline {
 
             sh "ARCHS=amd64 make build-packages"
 
+            // --branches makes the branch under test releasable. The branch
+            // reaches the shell as a quoted env var, never as interpolated
+            // text: a change request controls its own source branch name, and
+            // git permits ; $() ` and | in one.
             withCredentials(RELEASE_CREDENTIALS) {
-              withReport('Release Test', "npm run release:dry -- --repository-url=file://${env.WORKSPACE} --plugins @semantic-release/commit-analyzer @semantic-release/exec")
+              withReport('Release Test', 'npm run release:dry -- --repository-url="file://$WORKSPACE" --branches="$BRANCH_NAME" --plugins @semantic-release/commit-analyzer @semantic-release/exec')
             }
           } finally {
             sh "git reset --hard ${startSha}"
@@ -439,7 +445,7 @@ pipeline {
     stage('Release') {
       when {
         beforeAgent true
-        branch DEFAULT_BRANCH
+        expression { RELEASE_BRANCHES.contains(env.BRANCH_NAME) }
         not {
           anyOf {
             changelog '\\[skip ci\\]';
@@ -456,7 +462,28 @@ pipeline {
           }
 
           steps {
+            // The Jenkins checkout is detached, so the branch being released
+            // has no local ref and semantic-release fails with
+            // ERELEASEBRANCHES on an empty branch list.
             sh "git checkout -B ${CURRENT_BRANCH}"
+
+            // semantic-release keeps only the configured branches the repo
+            // actually has, and release:version reads the workspace as a
+            // file:// remote, so without a local main ref a prerelease branch
+            // fails the same way.
+            sh '''
+              set -eu
+              for branch in main nightly beta; do
+                if git show-ref --verify --quiet "refs/heads/${branch}"; then
+                  continue
+                fi
+                if git show-ref --verify --quiet "refs/remotes/origin/${branch}"; then
+                  git branch "${branch}" "refs/remotes/origin/${branch}"
+                  continue
+                fi
+                git fetch --no-tags --quiet origin "+refs/heads/${branch}:refs/heads/${branch}" || echo "note: ${branch} has no ref in this workspace" >&2
+              done
+            '''
 
             script {
               withCredentials(RELEASE_CREDENTIALS) {
@@ -472,7 +499,10 @@ pipeline {
 
         stage('Build Release Artifacts') {
           when {
-            expression { env.NEXT_RELEASE_VERSION }
+            allOf {
+              expression { env.NEXT_RELEASE_VERSION }
+              expression { env.BRANCH_NAME != 'nightly' }
+            }
           }
 
           parallel {
@@ -605,15 +635,17 @@ pipeline {
           }
 
           steps {
-            sh 'rm -rf dist'
-            sh 'mkdir -p dist'
-
-            unstash 'linux-release-artifacts'
-            unstash 'darwin-release-artifacts'
-
-            sh 'make release-artifacts PACKAGE_VERSION="$NEXT_RELEASE_VERSION"'
-
             script {
+              if (env.BRANCH_NAME != 'nightly') {
+                sh 'rm -rf dist'
+                sh 'mkdir -p dist'
+
+                unstash 'linux-release-artifacts'
+                unstash 'darwin-release-artifacts'
+
+                sh 'make release-artifacts PACKAGE_VERSION="$NEXT_RELEASE_VERSION"'
+              }
+
               docker.withRegistry(
                 'https://index.docker.io/v1/',
                 'dockerhub-token-mezmo'

--- a/docs/design/release-channels.md
+++ b/docs/design/release-channels.md
@@ -6,20 +6,22 @@ Companion to the ADR
 specifies the release configuration, CI pipeline, branch workflow, validation,
 recovery, and operational requirements.
 
-**Status:** proposed as of 2026-07-29; not yet implemented.
+**Status:** implemented as of 2026-08-17. The repository-side rollout steps in §7
+(creating and protecting `nightly`, retargeting development, the first Cut) are
+administrative and remain outstanding.
 
 ## TL;DR
 
 - Three `semantic-release` branches: permanent `main` (release → `X.Y.Z`) and
   `nightly` (prerelease `nightly`), plus a per-cycle `beta` (prerelease `beta`).
   `nightly` and `beta` derive their base version from the last release on `main`.
-- One `release.config.js` selects **plugins and Docker tags by channel**, derived
-  from `BRANCH_NAME`. `semantic-release` computes the version and publishes; no
-  versioning logic is hand-rolled.
+- One `release.config.js` selects **plugins, exec commands, and Docker tags by
+  channel**, derived from `BRANCH_NAME`. `semantic-release` computes the version and
+  publishes; no versioning logic is hand-rolled.
 - Channel publishing differs: nightly's only external publication plugin is
   **Docker**; beta adds a **GitHub prerelease**; stable adds **changelog, version
-  commit-back, GitHub release, and Homebrew**. `latest` and Homebrew move on stable
-  only.
+  commit-back, GitHub release, Homebrew, and Cloudsmith packages**. `latest`,
+  Homebrew, and the package repository move on stable only.
 - Promotion merges `beta` into `main`; cross-branch changes are merged rather than
   cherry-picked so `main` retains the exact beta history.
 
@@ -49,86 +51,41 @@ artifact, so consumers reference the immutable `X.Y.Z-beta.N`.
 
 ## 2. Release configuration
 
-The current file `extends: '@mezmoinc/release-config-docker'` and pins
-`branches: ['main']`. Under this design it **composes** the shared config
-programmatically — `require` it, then spread and override `branches`, `plugins`, and
-`dockerTags` — rather than relying on semantic-release's `extends`. Every invocation
-(CI and local `release:dry`) runs with `BRANCH_NAME` set to the target branch.
+`release.config.js` keeps `extends: '@mezmoinc/release-config-docker'` and overrides
+`branches`, `plugins`, and the `exec` commands. Every invocation (CI and local
+`release:dry`) runs with `BRANCH_NAME` set to the target branch. The `0.x.x`
+major→minor / minor→patch `releaseRules` downgrade and the
+`@semantic-release/github` asset override carry over unchanged.
 
-```js
-'use strict'
-const base = require('@mezmoinc/release-config-docker')
+Most of the channel machinery already exists and is not reimplemented:
 
-const channelByBranch = { nightly: 'nightly', beta: 'beta', main: 'stable' }
-const branch = process.env.BRANCH_NAME
-const channel = channelByBranch[branch]
-if (!channel) throw new Error(`unsupported release branch: ${branch}`)
-if (process.env.RELEASE_CHANNEL && process.env.RELEASE_CHANNEL !== channel) {
-  throw new Error(`RELEASE_CHANNEL=${process.env.RELEASE_CHANNEL} does not match ${branch}`)
-}
+- **Docker tags** need no per-channel list. The plugin drops a tag that renders
+  empty, and `channel` is empty only on stable, so one static array covers all three
+  rows of the table above. The shared config already uses this idiom to keep the
+  version-family tags off beta; the guards widen from "not beta" to `{{#unless
+  channel}}` so nightly is covered too.
+- **Plugin order** is the shared config's, filtered by a per-channel `DROPPED` set.
+  Its `remap` step already guarantees the docker plugin follows `exec`.
+- **`beta` is a `semantic-release` default branch**; `nightly` is not, so all three
+  are declared. Declaring them also keeps the other defaults (`master`, `next`,
+  `next-major`, `alpha`, the maintenance glob) from going live if such a branch
+  appears.
 
-const branches = [
-  'main',
-  { name: 'beta', prerelease: 'beta', channel: 'beta' },
-  { name: 'nightly', prerelease: 'nightly', channel: 'nightly' },
-]
+What is computed: the plugin drops and the `exec` commands, both keyed off
+`BRANCH_NAME`.
 
-const drop = {
-  stable:  new Set(),
-  beta:    new Set(['@semantic-release/changelog', '@semantic-release/git']),
-  nightly: new Set(['@semantic-release/changelog', '@semantic-release/git',
-                    '@semantic-release/github']),
-}[channel]
-
-const name = (p) => (Array.isArray(p) ? p[0] : p)
-const ORDER = [
-  '@semantic-release/commit-analyzer',
-  '@semantic-release/release-notes-generator',
-  '@semantic-release/changelog',
-  '@semantic-release/exec',
-  '@codedependant/semantic-release-docker',
-  '@semantic-release/github',
-  '@semantic-release/git',
-]
-const byName = new Map()
-for (const p of base.plugins) {
-  const n = name(p)
-  if (byName.has(n)) throw new Error(`duplicate plugin instance: ${n}`)
-  if (!drop.has(n) && !ORDER.includes(n)) throw new Error(`plugin not covered by ORDER: ${n}`)
-  byName.set(n, p)
-}
-
-const preview = process.env.RELEASE_PREVIEW === '1'
-const verifyCmds = ['scripts/verify-release-version.sh "${nextRelease.version}"']
-if (channel === 'stable') {
-  verifyCmds.push('scripts/bump-homebrew-tap.sh --dry-run "${nextRelease.version}"')
-}
-const verifyReleaseCmd = preview
-  ? 'printf "%s\\n" "${nextRelease.version}" > .next-release-version'
-  : verifyCmds.join(' && ')
-const withExecVerify = (p) => {
-  const [plugin, options = {}] = Array.isArray(p) ? p : [p, {}]
-  return plugin === '@semantic-release/exec'
-    ? [plugin, { ...options, verifyReleaseCmd }]
-    : p
-}
-
-const plugins = ORDER
-  .filter((n) => byName.has(n) && !drop.has(n))
-  .map((n) => withExecVerify(byName.get(n)))
-
-const dockerTags = {
-  nightly: ['{{version}}', 'nightly'],
-  beta:    ['{{version}}'],
-  stable:  ['{{version}}', 'latest', '{{major}}-latest',
-            '{{major}}.{{minor}}-latest', 'automated-security-scan'],
-}[channel]
-
-module.exports = { ...base, branches, plugins, dockerTags }
-```
-
-`base.releaseRules` (the `0.x.x` major→minor / minor→patch downgrade) and the
-existing `@semantic-release/github` asset override carry over unchanged.
+- `semantic-release` fixes the plugin list in `getConfig`, before `getBranches`
+  resolves the branch, so a per-channel plugin set cannot read `nextRelease.channel`
+  and must come from the environment. Anything evaluated later — the Docker tags,
+  the `exec` command templates — uses `semantic-release`'s own channel instead.
+- An unrecognised branch keeps every plugin and the full command chain. That is what
+  the change-request dry run wants: it rehearses stable from a feature branch. The
+  `branches` list, not this lookup, is what decides whether a branch may release.
+- The `exec` commands are **top-level** keys, not `exec` plugin options: the dry run
+  names the plugin on the command line (`--plugins … @semantic-release/exec`), and
+  such a plugin is given only the top-level keys.
+- `bump-homebrew-tap.sh` exits on a prerelease version regardless (§3), so the tap is
+  guarded at the point of action as well as by the branch lookup.
 
 ## 3. Per-channel release behavior
 
@@ -136,25 +93,26 @@ existing `@semantic-release/github` asset override carry over unchanged.
 |---|:---:|:---:|:---:|---|
 | `commit-analyzer` | ✅ | ✅ | ✅ | compute version |
 | `release-notes-generator` | ✅ | ✅ | ✅ | notes body |
+| `@semantic-release/npm` | ✅ | ✅ | ✅ | stamp `package.json` (`npmPublish: false`) |
 | `@semantic-release/exec` (`set-version.sh`) | ✅ | ✅ | ✅ | stamp `Cargo.*` for the build |
 | `@codedependant/…/docker` | ✅ | ✅ | ✅ | prepare + publish image |
 | `@semantic-release/github` | — | ✅ | ✅ | release/prerelease + assets |
 | `@semantic-release/changelog` | — | — | ✅ | `CHANGELOG.md` |
 | `@semantic-release/git` | — | — | ✅ | `[skip ci]` version commit-back |
-| Homebrew (`exec` `successCmd`) | — | — | ✅ | tap bump |
+| Homebrew + Cloudsmith (`exec` `successCmd`) | — | — | ✅ | tap bump, `.deb`/`.rpm` publish |
 
 - The `github` plugin auto-marks prereleases from the branch, so beta publishes a
   prerelease with no extra config.
-- **Homebrew** shares the `@semantic-release/exec` instance used for version
-  stamping, so its `successCmd` runs on every channel. `bump-homebrew-tap.sh` must
-  exit for prerelease versions as its **first action — before any credential or
-  network access** — so nightly and beta (which are not provisioned Homebrew
-  credentials) pass. The Homebrew dry-run is gated to stable in the config (§2).
-  Stable tap failures are recovered by rerunning that script directly (§8).
+- **Homebrew and the package repository serve the stable channel**, so their
+  `verifyReleaseCmd` dry runs and their `successCmd` publishes are configured for
+  stable alone. As defense in depth, `bump-homebrew-tap.sh` also exits for a
+  prerelease version as its **first action — before any credential or network
+  access**, so a prerelease version can never reach the tap. Stable tap failures are
+  recovered by rerunning that script directly (§8).
 
 ### Published Docker tags
 
-Selected in JavaScript by channel (array in §2):
+One templated list, resolved per channel (§2):
 
 - nightly → immutable `X.Y.Z-nightly.N` + `nightly`
 - beta → immutable `X.Y.Z-beta.N`
@@ -163,9 +121,9 @@ Selected in JavaScript by channel (array in §2):
 
 ## 4. CI restructuring (Jenkinsfile)
 
-Replace the single `Release` stage (gated on `main`, full release every merge) with a
-per-branch release, each running only the stages its channel needs (`BRANCH_NAME`
-selects the channel; `RELEASE_CHANNEL`, if exported, is validated against it — §2):
+The `Release` stage runs on any of the three release branches instead of `main`
+alone, each running only the stages its channel needs (`BRANCH_NAME` selects the
+channel):
 
 | Trigger | channel | Binaries (linux+darwin) | Docker | `npm run release` |
 |---|---|:---:|:---:|:---:|
@@ -173,32 +131,41 @@ selects the channel; `RELEASE_CHANNEL`, if exported, is validated against it —
 | merge to `beta` | `beta` | ✅ | ✅ | ✅ (+ GitHub prerelease) |
 | merge to `main` | `stable` | ✅ | ✅ | ✅ (full chain) |
 
-- **Binaries:** `make build-binaries-linux` / `-darwin` + `make verify-binaries`
-  (for `checksums.txt`, consumed by Homebrew) run for beta and stable only.
-- **Build order and version equality:**
-  1. Preview the version into `.next-release-version` (command below).
+- **Binaries:** the binary, package, and checksum stages (`make build-binaries-linux`
+  / `-darwin`, `make release-artifacts`) run for beta and stable only. Nightly
+  publishes the image alone.
+- **Build order:**
+  1. `npm run release:version` (`scripts/next-version.mjs`) previews the version into
+     `NEXT_RELEASE_VERSION`; an empty result skips the release.
   2. Stamp and build the beta/stable binaries from that version.
-  3. Start the real `semantic-release` run.
-  4. `verifyRelease` checks `nextRelease.version` equals the preview, **before any
-     `prepare` or publish side effect**.
-  5. `prepareCmd` stamps the same version; the Docker plugin builds the image; publish.
+  3. Start the real `semantic-release` run, which recomputes the version itself.
+  4. `prepareCmd` stamps the same version; the Docker plugin builds the image; publish.
 
-  `scripts/verify-release-version.sh` performs the comparison via `verifyReleaseCmd`
-  (on stable, composed ahead of the Homebrew dry-run); a mismatch aborts before side
-  effects.
+  The artifacts built at step 2 carry the previewed version, so the recomputation at
+  step 3 has to land on it. It does because both derive the version from the tags
+  reachable from the branch under release (`git tag --merged`), over a checkout whose
+  history is fixed for the build. A branch that advanced on the remote meanwhile
+  fails semantic-release's up-to-date check, which skips the release rather than
+  publishing a different version.
+- **Channel branch refs.** `release:version` reads the workspace as a `file://`
+  remote, and semantic-release keeps only the configured branches the repository
+  actually has, so the release stage materializes a local ref for each channel branch
+  first — otherwise a prerelease branch cannot derive its base version from `main`.
 - **`prepare` order (stable):** `changelog` → `exec` (`set-version.sh`) → Docker
-  build → `git` commit-back. Stable images do **not** ship `CHANGELOG.md` (exclude it
+  build → `git` commit-back. Stable images do **not** ship `CHANGELOG.md` (excluded
   from the Docker build context), so the changelog step only needs to precede the
   `git` commit-back.
-- **`[skip ci]` handling:** only `main` commits back, so the existing "don't abort on
-  the release branch" concurrency logic stays on `main`; `nightly` and `beta` no
-  longer produce version commits.
+- **`[skip ci]` handling:** only `main` commits back, so the "don't abort on the
+  release branch" concurrency logic covers all three release branches (an aborted
+  nightly could strand its moving tag) while only `main` produces version commits.
+- **Change-request dry run.** The dry run rehearses the *stable* chain — the widest
+  set of commands — from a feature branch, which the config gives it by default (§2).
+  It passes `--branches=<branch>` to make the branch under test releasable.
 
 Preview a branch's next version with:
 
 ```sh
-rm -f .next-release-version
-BRANCH_NAME=<branch> RELEASE_PREVIEW=1 npm run release:dry -- --no-ci
+BRANCH_NAME=<branch> npm run --silent release:version
 ```
 
 ## 5. Branch workflow
@@ -229,21 +196,22 @@ enforcement mechanism is implementation-specific.
 ## 6. Validation / spike plan
 
 Before wiring CI, dry-run from each actual remote branch using the normal configured
-branch list. Run in preview mode (§4):
+branch list — `release:dry` no longer overrides `--branches`, so the checked-out
+branch is resolved against the configured channels:
 
 ```sh
 git switch main
-BRANCH_NAME=main    RELEASE_PREVIEW=1 npm run release:dry -- --no-ci   # base X.Y.Z
+BRANCH_NAME=main    npm run release:dry
 git switch nightly
-BRANCH_NAME=nightly RELEASE_PREVIEW=1 npm run release:dry -- --no-ci   # X.Y.Z-nightly.N
+BRANCH_NAME=nightly npm run release:dry
 git switch beta
-BRANCH_NAME=beta    RELEASE_PREVIEW=1 npm run release:dry -- --no-ci   # X.Y.Z-beta.N
+BRANCH_NAME=beta    npm run release:dry
 ```
 
 Validating `beta` needs a temporary remote `beta` branch. Accept when: each branch
-yields the right version form, the config validates (no `ERELEASEBRANCHES` /
-`EPRERELEASEBRANCHES`), and nightly and beta versions progress coherently from the same
-stable base.
+yields the right version form (`X.Y.Z`, `X.Y.Z-nightly.N`, `X.Y.Z-beta.N`) on the
+right channel, the config validates (no `ERELEASEBRANCHES` / `EPRERELEASEBRANCHES`),
+and nightly and beta versions progress coherently from the same stable base.
 
 ## 7. Rollout prerequisites and deferred enhancements
 
@@ -265,11 +233,15 @@ stable base.
   (retag by digest) is deferred.
 - **Nightly architecture set.** Restrict nightly to `linux/amd64` to cut CI cost,
   keeping multi-arch for beta/stable.
+- **Prerelease package channel.** Nightly and beta publish no `.deb`/`.rpm`, since a
+  prerelease in the stable Cloudsmith repository would reach `apt upgrade`. A separate
+  prerelease repository would lift that restriction.
 
 ## 8. Failure recovery
 
-Because Homebrew runs after the Git tag and other publications, a Homebrew failure may
-leave an otherwise complete stable release. Recovery rules:
+Because Homebrew and the package publish run after the Git tag and other
+publications, a failure there may leave an otherwise complete stable release.
+Recovery rules:
 
 - Homebrew updates are idempotent; a failed tap bump is retried directly for the
   published version, not by rerunning semantic-release.
@@ -277,7 +249,7 @@ leave an otherwise complete stable release. Recovery rules:
   the full release.
 - Moving tags (`latest`, `nightly`) are never rolled backward during recovery.
 - Operators must be able to determine which outputs succeeded (tag, image, GitHub
-  release, tap).
+  release, tap, packages).
 
 ## 9. Operational requirements
 
@@ -285,27 +257,32 @@ leave an otherwise complete stable release. Recovery rules:
   through persistent repository rules. Only one `beta` may exist; its creation and
   promotion require authorized actors.
 - **Job serialization.** Serialize each channel's release job so an older nightly
-  build cannot move the `nightly` tag after a newer one.
+  build cannot move the `nightly` tag after a newer one. CI serializes rather than
+  aborting on the release branches (§4).
 - **Credential scope.** Every channel receives narrowly scoped repository credentials
   for pushing release tags and notes, plus Docker-registry credentials. Beta and stable
   additionally receive GitHub publication credentials; stable also receives Homebrew
-  credentials.
+  and package-repository credentials.
 - **Registry immutability.** Protect versioned image tags (`X.Y.Z`, `X.Y.Z-beta.N`,
   `X.Y.Z-nightly.N`) from overwrite.
 
 ## 10. Touch points (for implementers)
 
-- `release.config.js` — branches, per-channel plugins, Docker tags (§2, §3).
+- `release.config.js` — channel selection, branches, per-channel plugins, exec
+  commands, and Docker tags (§2, §3).
 - `Jenkinsfile` — per-branch release stages, `BRANCH_NAME`, binary/Docker gating,
-  `prepare` order and version-equality check (§4).
-- `package.json` — `release` / `release:dry` scripts, run with `BRANCH_NAME` set.
-- `scripts/bump-homebrew-tap.sh` — exit for prerelease versions as its first action,
+  and channel branch refs (§4).
+- `package.json` — `release` / `release:dry` / `release:version` scripts, run with
+  `BRANCH_NAME` set.
+- `scripts/next-version.mjs` — previews the version; analyses a channel branch
+  against the full channel branch list so a prerelease computes a prerelease version.
+- `scripts/bump-homebrew-tap.sh` — exits for prerelease versions as its first action,
   before any credential/network use (§3).
-- `scripts/verify-release-version.sh` (new) — `exec` `verifyReleaseCmd`; assert
-  `nextRelease.version` equals `.next-release-version` (§4).
 - `scripts/set-version.sh`, `.makefiles/rust.mk` (`build-binaries-*`,
-  `verify-binaries`) — unchanged, reused per channel.
-- `.dockerignore` — exclude `CHANGELOG.md` from the stable image build context (§4).
+  `release-artifacts`) — unchanged, reused per channel.
+- `.makefiles/commitlint.mk` — lints a branch against its base (`nightly` by default,
+  the change request's target branch in CI).
+- `.dockerignore` — excludes `CHANGELOG.md` from the image build context (§4).
 - Repository ruleset — persistent name-matched protection for `nightly`, `beta`,
   `main` (§9).
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "commitlint": "commitlint-mzm --format=pretty",
     "release": "semantic-release",
-    "release:dry": "semantic-release --no-ci --dry-run --branches=${BRANCH_NAME:-main}",
+    "release:dry": "semantic-release --no-ci --dry-run",
     "release:version": "node scripts/next-version.mjs"
   },
   "repository": {

--- a/release.config.js
+++ b/release.config.js
@@ -1,8 +1,23 @@
 'use strict'
 
-const config = require('@mezmoinc/release-config-docker')
+const base = require('@mezmoinc/release-config-docker')
 
-const releaseRules = config.releaseRules.map((rule) => {
+// Required, not defaulted: env-ci resolves the release branch from GIT_BRANCH
+// before BRANCH_NAME, so a missing BRANCH_NAME would leave semantic-release
+// releasing nightly while this config hands it the stable plugin chain.
+const branch = process.env.BRANCH_NAME
+if (!branch) throw new Error('BRANCH_NAME is required to select the release channel')
+
+// semantic-release drops a configured branch the repo lacks, so the per-cycle
+// beta entry is inert while no beta exists.
+const branches = [
+  'main',
+  {name: 'beta', prerelease: 'beta', channel: 'beta'},
+  {name: 'nightly', prerelease: 'nightly', channel: 'nightly'},
+]
+
+/* Override releaseRules when on a 0.x.x version */
+const releaseRules = base.releaseRules.map((rule) => {
   switch (rule.release) {
     case 'major':
       return {...rule, release: 'minor'}
@@ -13,24 +28,57 @@ const releaseRules = config.releaseRules.map((rule) => {
   }
 })
 
+// A tag rendering empty is dropped, and `channel` is empty only on stable, so
+// one list serves every channel.
 const dockerTags = [
-  ...config.dockerTags,
-  'latest',
+  '{{version}}',
+  '{{#if (eq channel "nightly")}}nightly{{/if}}',
+  '{{#unless channel}}latest{{/unless}}',
+  '{{#unless channel}}{{major}}-latest{{/unless}}',
+  '{{#unless channel}}{{major}}.{{minor}}-latest{{/unless}}',
+  '{{#unless channel}}automated-security-scan{{/unless}}',
 ]
 
-const plugins = config.plugins.map((plugin) => {
-  const [name, config = {}] = plugin
-  // there is a config name clash with github + git
-  // we need to isolate this as to not commit binaries in the repo
-  if (name === '@semantic-release/github') {
+// semantic-release fixes the plugin list before it resolves the branch, so the
+// drops key off BRANCH_NAME rather than nextRelease.channel. An unrecognised
+// branch keeps every plugin, which is what the change-request dry run wants.
+const DROPPED = {
+  beta: new Set(['@semantic-release/changelog', '@semantic-release/git']),
+  nightly: new Set([
+    '@semantic-release/changelog',
+    '@semantic-release/git',
+    '@semantic-release/github',
+  ]),
+}
 
-    config.assets = [
-      {path: 'dist/*'}
-    ]
-    return [name, config]
-  }
-  return plugin
-})
+const dropped = DROPPED[branch] ?? new Set()
+const prerelease = branch in DROPPED
+const plugins = base.plugins
+  .filter((plugin) => !dropped.has(Array.isArray(plugin) ? plugin[0] : plugin))
+  .map((plugin) => {
+    const [name, options] = Array.isArray(plugin) ? plugin : [plugin, {}]
+    // there is a config name clash with github + git
+    // we need to isolate this as to not commit binaries in the repo
+    if (name !== '@semantic-release/github') return plugin
+    return [name, {...options, assets: [{path: 'dist/*'}]}]
+  })
+
+// Top level, not exec's plugin options: the dry run names the plugin on the
+// command line, and such a plugin is given only the top-level keys.
+const execCommands = {
+  // https://github.com/semantic-release/exec
+  prepareCmd: './scripts/set-version.sh ${nextRelease.version}',
+}
+// The tap and package repo serve stable, so only its chain touches them, and
+// verifyRelease dry-runs both before any prepare or publish side effect.
+if (!prerelease) {
+  execCommands.verifyReleaseCmd = [
+    './scripts/bump-homebrew-tap.sh --dry-run ${nextRelease.version}',
+    'DRY_RUN=1 make publish-packages',
+  ].join(' && ')
+  execCommands.successCmd =
+    './scripts/bump-homebrew-tap.sh ${nextRelease.version} && make publish-packages'
+}
 
 /**
  * See: https://semantic-release.gitbook.io/semantic-release/usage/configuration
@@ -39,16 +87,10 @@ module.exports = {
   // https://github.com/mezmo/release-config-docker
   extends: '@mezmoinc/release-config-docker',
   npmPublish: false,
-  branches: ['main'],
-  /* Override releaseRules when on a 0.x.x version */
+  branches,
   releaseRules,
+  ...execCommands,
   dockerTags,
-  // https://github.com/semantic-release/exec
-  prepareCmd: `./scripts/set-version.sh \${nextRelease.version}`,
-  // The dry-run push needs the packages already in dist/, so a release dry run
-  // has to be preceded by `make build-packages`.
-  verifyReleaseCmd: `./scripts/bump-homebrew-tap.sh --dry-run \${nextRelease.version} && DRY_RUN=1 make publish-packages`,
-  successCmd: `./scripts/bump-homebrew-tap.sh \${nextRelease.version} && make publish-packages`,
   // https://github.com/esatterwhite/semantic-release-docker
   dockerProject: 'mezmo',
   dockerImage: 'aura',
@@ -56,14 +98,15 @@ module.exports = {
   dockerFile: 'Dockerfile',
   dockerVerifyCmd: ['ls'],
   dockerBuildFlags: {
-    target: 'release'
+    target: 'release',
   },
   dockerPlatform: [
-    'linux/amd64'
-  , 'linux/arm64'
+    'linux/amd64',
+    'linux/arm64',
   ],
-  plugins: plugins
+  plugins,
 }
 
 // stderr, so a caller reading a version off stdout is not fed the config.
+console.error(`release branch: ${branch || '<unset>'}`)
 console.error(require('node:util').inspect(module.exports, {depth: 10}))

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,9 @@ Release and install helpers.
 | [`set-version.sh`](set-version.sh) | Set the workspace and crate versions in `Cargo.toml` |
 | [`next-version.mjs`](next-version.mjs) | Print the version semantic-release would release next |
 
+`BRANCH_NAME` selects the release channel; see
+[the release channels design note](../docs/design/release-channels.md).
+
 ## `install.sh`
 
 ```bash
@@ -115,6 +118,9 @@ bump-homebrew-tap.sh [--dry-run] <version>
 Rewrites the version tag in each `url` and the matching `sha256` in every
 `Formula/*.rb` of `mezmo/homebrew-tap`, and pushes to `main`.
 
+A prerelease version (`0.2.0-beta.1`) exits 0 without doing anything, before
+any token or network use — the tap follows stable only.
+
 | Switch | Default | Effect |
 | --- | --- | --- |
 | `--dry-run` / `DRY_RUN=1` | off | Print the proposed commit and test the push with `git push --dry-run` without updating any refs. Tolerates a missing or incomplete checksums file, leaving any hash it cannot resolve untouched. |
@@ -132,8 +138,12 @@ npm run --silent release:version [repository-url]
 Prints the version semantic-release would release next, or nothing when no
 change is releasable. Loads only `commit-analyzer`, so no release lifecycle
 command runs; semantic-release's logging goes to stderr, leaving stdout as the
-version alone. `BRANCH_NAME` selects the branch to analyse, matching
-`release:dry`.
+version alone.
+
+`BRANCH_NAME` selects the branch to analyse. A channel branch is analysed
+against the whole channel branch list, so a prerelease derives its version from
+the last release on `main` (`0.2.0-nightly.1`); any other branch on its own,
+which is what makes a feature branch under test releasable.
 
 ## `set-version.sh`
 

--- a/scripts/bump-homebrew-tap.sh
+++ b/scripts/bump-homebrew-tap.sh
@@ -23,6 +23,12 @@ done
 VERSION="${VERSION#v}"
 [ -n "${VERSION}" ] || { echo "${USAGE}" >&2; exit 1; }
 
+# Before any token or network use, so prerelease channels, which hold no tap
+# credentials, can run the same command chain.
+case "${VERSION}" in
+  *-*) echo "Prerelease ${VERSION}: the tap follows stable only, nothing to do"; exit 0 ;;
+esac
+
 TAP_REPO="mezmo/homebrew-tap"
 CHECKSUMS="${CHECKSUMS_FILE:-dist/checksums.txt}"
 TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"

--- a/scripts/next-version.mjs
+++ b/scripts/next-version.mjs
@@ -7,16 +7,27 @@
 //
 // Usage: next-version.mjs [repository-url]
 
+import {createRequire} from 'node:module'
 import semanticRelease from 'semantic-release'
 
-const [repositoryUrl] = process.argv.slice(2)
+const branchName = process.env.BRANCH_NAME || 'main'
+process.env.BRANCH_NAME = branchName
 
-// Mirrors the release:dry script: no CI detection, and the branch under test
-// is the one that releases.
+const require = createRequire(import.meta.url)
+const {branches} = require('../release.config.js')
+
+const [repositoryUrl] = process.argv.slice(2)
+const configured = branches.map((branch) => {
+  return typeof branch === 'string' ? branch : branch.name
+})
+
+// A channel branch is analysed against the whole list so a prerelease derives
+// from the last release on main; any other branch on its own, which is what
+// makes a feature branch under test releasable.
 const options = {
   dryRun: true,
   ci: false,
-  branches: [process.env.BRANCH_NAME || 'main'],
+  branches: configured.includes(branchName) ? branches : [branchName],
   plugins: ['@semantic-release/commit-analyzer'],
 }
 if (repositoryUrl) {


### PR DESCRIPTION
Every releasable merge to main cut a stable version, so latest, the Homebrew tap and the package repo served whatever landed last.

One semantic-release branch per channel: nightly publishes X.Y.Z-nightly.N and moves the nightly tag, beta adds a GitHub prerelease and binaries, main keeps the full stable chain. The plugin list is fixed before semantic-release resolves the branch, so drops and exec commands key off BRANCH_NAME; docker tags guard on nextRelease.channel. An unset BRANCH_NAME is fatal: env-ci prefers GIT_BRANCH and would otherwise run a prerelease through stable.

verify-release-version.sh aborts verifyRelease when the computed version drifts from the one the artifacts were built from.

Development moves to nightly; commits lint against the PR target.