### PR TITLE
feat: agent descriptions in config, API, and the CLI /model picker

### DIFF
--- a/crates/aura-cli/src/api/types.rs
+++ b/crates/aura-cli/src/api/types.rs
@@ -7,9 +7,13 @@ pub struct ModelList {
     pub data: Vec<ModelEntry>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+/// One `/v1/models` entry: the id clients send as `model`, plus the server's
+/// optional `description` extension.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct ModelEntry {
     pub id: String,
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -349,6 +353,35 @@ pub mod duration_millis {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // ModelList
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn model_list_reads_optional_descriptions() {
+        let list: ModelList = serde_json::from_str(
+            r#"{"object":"list","data":[
+                {"id":"sre","object":"model","created":1,"owned_by":"mezmo",
+                 "description":"Triage production incidents"},
+                {"id":"gpt-4o","object":"model","created":1,"owned_by":"openai"}
+            ]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            list.data,
+            vec![
+                ModelEntry {
+                    id: "sre".to_string(),
+                    description: Some("Triage production incidents".to_string()),
+                },
+                ModelEntry {
+                    id: "gpt-4o".to_string(),
+                    description: None,
+                },
+            ]
+        );
+    }
 
     // -----------------------------------------------------------------------
     // Message constructors

--- a/crates/aura-cli/src/api/types.rs
+++ b/crates/aura-cli/src/api/types.rs
@@ -9,10 +9,10 @@ pub struct ModelList {
 
 /// One `/v1/models` entry: the id clients send as `model`, plus the server's
 /// optional `description` extension.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ModelEntry {
     pub id: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
 

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -29,7 +29,7 @@ use aura_web_server::types::{
 };
 
 use crate::api::stream::{StreamHandler, StreamResult, process_sse_events};
-use crate::api::types::{Message, ToolCallInfo, ToolDefinition};
+use crate::api::types::{Message, ModelEntry, ToolCallInfo, ToolDefinition};
 use crate::ui::prompt::get_selected_model;
 
 /// Factory for `additional_tools` registered on every standalone agent.
@@ -162,11 +162,20 @@ impl DirectBackend {
 
     /// Return the effective model ID for each loaded config.
     pub(crate) fn model_ids(&self) -> Vec<String> {
+        self.model_choices().into_iter().map(|m| m.id).collect()
+    }
+
+    /// Return the effective model ID and `[agent].description` of each
+    /// loaded, non-hidden config.
+    pub(crate) fn model_choices(&self) -> Vec<ModelEntry> {
         self.app_state
             .configs
             .iter()
             .filter(|c| !c.agent.hidden)
-            .map(|c| c.agent_id().to_string())
+            .map(|c| ModelEntry {
+                id: c.agent_id().to_string(),
+                description: c.agent.description.clone(),
+            })
             .collect()
     }
 
@@ -629,6 +638,26 @@ preamble = "p"
             make_config("Code Agent", None, ""),
         ]);
         assert_eq!(backend.model_ids(), vec!["math", "Code Agent"]);
+    }
+
+    #[test]
+    fn model_choices_carry_agent_descriptions() {
+        let mut described = make_config("SRE Agent", Some("sre"), "");
+        described.agent.description = Some("Triage production incidents".to_string());
+        let backend = make_backend(vec![described, make_config("Plain", None, "")]);
+        assert_eq!(
+            backend.model_choices(),
+            vec![
+                ModelEntry {
+                    id: "sre".to_string(),
+                    description: Some("Triage production incidents".to_string()),
+                },
+                ModelEntry {
+                    id: "Plain".to_string(),
+                    description: None,
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/aura-cli/src/backend/mod.rs
+++ b/crates/aura-cli/src/backend/mod.rs
@@ -154,7 +154,7 @@ impl Backend {
             }
             #[cfg(feature = "standalone-cli")]
             Self::Direct(direct) => {
-                crate::ui::prompt::seed_model_cache(direct.model_ids());
+                crate::ui::prompt::seed_model_cache(direct.model_choices());
             }
         }
     }

--- a/crates/aura-cli/src/repl/commands.rs
+++ b/crates/aura-cli/src/repl/commands.rs
@@ -44,14 +44,12 @@ fn model_matches_for_command(filter: &str) -> Vec<String> {
     if cached.is_empty() {
         return get_model_matches();
     }
-    if filter.is_empty() {
-        return cached;
-    }
 
     let lower = filter.to_lowercase();
     cached
         .into_iter()
-        .filter(|model| model.to_lowercase().contains(&lower))
+        .map(|model| model.id)
+        .filter(|id| lower.is_empty() || id.to_lowercase().contains(&lower))
         .collect()
 }
 

--- a/crates/aura-cli/src/repl/conversations.rs
+++ b/crates/aura-cli/src/repl/conversations.rs
@@ -2,7 +2,8 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use crate::api::types::{DisplayEvent, Message};
+use crate::api::types::{DisplayEvent, Message, ModelEntry};
+use crate::ui::text::collapse_whitespace;
 
 pub struct ConversationStore {
     pub uuid: String,
@@ -256,21 +257,38 @@ impl ConversationStore {
             .collect()
     }
 
-    /// Save the available model list for this conversation's server.
-    #[allow(dead_code)]
-    pub fn save_models_cache(&self, models: &[String]) {
-        let path = self.dir.join("models_cache");
-        let _ = fs::write(&path, models.join("\n"));
+    /// Write `models` to `<dir>/models_cache`, one model per line as
+    /// `id[\tdescription]`. Descriptions are flattened to a single line so
+    /// they cannot break the line-per-model layout.
+    pub fn write_models_cache(dir: &Path, models: &[ModelEntry]) {
+        let lines: Vec<String> = models
+            .iter()
+            .map(|m| match m.description.as_deref() {
+                Some(desc) => format!("{}\t{}", m.id, collapse_whitespace(desc)),
+                None => m.id.clone(),
+            })
+            .collect();
+        let _ = fs::write(dir.join("models_cache"), lines.join("\n"));
     }
 
-    /// Load the cached model list from this conversation's directory.
-    pub fn load_models_cache(&self) -> Option<Vec<String>> {
+    /// Load the cached model list from this conversation's directory. A line
+    /// without a tab loads as an id with no description.
+    pub fn load_models_cache(&self) -> Option<Vec<ModelEntry>> {
         let path = self.dir.join("models_cache");
         let data = fs::read_to_string(&path).ok()?;
-        let models: Vec<String> = data
+        let models: Vec<ModelEntry> = data
             .lines()
             .filter(|l| !l.is_empty())
-            .map(String::from)
+            .map(|line| match line.split_once('\t') {
+                Some((id, desc)) => ModelEntry {
+                    id: id.to_string(),
+                    description: (!desc.is_empty()).then(|| desc.to_string()),
+                },
+                None => ModelEntry {
+                    id: line.to_string(),
+                    description: None,
+                },
+            })
             .collect();
         if models.is_empty() {
             None
@@ -525,13 +543,60 @@ mod tests {
         assert!(store.load_system_prompt().is_none());
     }
 
+    fn model(id: &str, description: Option<&str>) -> ModelEntry {
+        ModelEntry {
+            id: id.to_string(),
+            description: description.map(str::to_string),
+        }
+    }
+
     #[test]
     fn models_cache_roundtrip() {
         let tmp = TempDir::new().unwrap();
         let store = make_store(&tmp);
         assert!(store.load_models_cache().is_none());
-        store.save_models_cache(&["gpt-4".to_string(), "gpt-3.5".to_string()]);
+        ConversationStore::write_models_cache(
+            store.dir(),
+            &[
+                model("gpt-4", None),
+                model("sre", Some("Anthropic-backed SRE agent")),
+            ],
+        );
         let cached = store.load_models_cache().unwrap();
-        assert_eq!(cached, vec!["gpt-4", "gpt-3.5"]);
+        assert_eq!(
+            cached,
+            vec![
+                model("gpt-4", None),
+                model("sre", Some("Anthropic-backed SRE agent")),
+            ]
+        );
+    }
+
+    #[test]
+    fn models_cache_flattens_multiline_descriptions() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp);
+        ConversationStore::write_models_cache(
+            store.dir(),
+            &[
+                model("sre", Some("Line one\nline\ttwo  \n")),
+                model("next", None),
+            ],
+        );
+        assert_eq!(
+            store.load_models_cache().unwrap(),
+            vec![model("sre", Some("Line one line two")), model("next", None)]
+        );
+    }
+
+    #[test]
+    fn models_cache_reads_id_only_files() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp);
+        fs::write(store.dir().join("models_cache"), "gpt-4\ngpt-3.5\n").unwrap();
+        assert_eq!(
+            store.load_models_cache().unwrap(),
+            vec![model("gpt-4", None), model("gpt-3.5", None)]
+        );
     }
 }

--- a/crates/aura-cli/src/repl/conversations.rs
+++ b/crates/aura-cli/src/repl/conversations.rs
@@ -3,7 +3,6 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use crate::api::types::{DisplayEvent, Message, ModelEntry};
-use crate::ui::text::collapse_whitespace;
 
 pub struct ConversationStore {
     pub uuid: String,
@@ -257,39 +256,29 @@ impl ConversationStore {
             .collect()
     }
 
-    /// Write `models` to `<dir>/models_cache`, one model per line as
-    /// `id[\tdescription]`. Descriptions are flattened to a single line so
-    /// they cannot break the line-per-model layout.
+    /// Write `models` to `<dir>/models_cache` as a JSON array, so ids and
+    /// descriptions round-trip verbatim whatever characters they contain.
     pub fn write_models_cache(dir: &Path, models: &[ModelEntry]) {
-        let lines: Vec<String> = models
-            .iter()
-            .map(|m| match m.description.as_deref() {
-                Some(desc) => format!("{}\t{}", m.id, collapse_whitespace(desc)),
-                None => m.id.clone(),
-            })
-            .collect();
-        let _ = fs::write(dir.join("models_cache"), lines.join("\n"));
+        if let Ok(json) = serde_json::to_string(models) {
+            let _ = fs::write(dir.join("models_cache"), json);
+        }
     }
 
-    /// Load the cached model list from this conversation's directory. A line
-    /// without a tab loads as an id with no description.
+    /// Load the cached model list from this conversation's directory. Reads
+    /// the JSON array form, and the earlier one-id-per-line form as ids with
+    /// no description.
     pub fn load_models_cache(&self) -> Option<Vec<ModelEntry>> {
         let path = self.dir.join("models_cache");
         let data = fs::read_to_string(&path).ok()?;
-        let models: Vec<ModelEntry> = data
-            .lines()
-            .filter(|l| !l.is_empty())
-            .map(|line| match line.split_once('\t') {
-                Some((id, desc)) => ModelEntry {
+        let models: Vec<ModelEntry> = serde_json::from_str(&data).unwrap_or_else(|_| {
+            data.lines()
+                .filter(|l| !l.is_empty())
+                .map(|id| ModelEntry {
                     id: id.to_string(),
-                    description: (!desc.is_empty()).then(|| desc.to_string()),
-                },
-                None => ModelEntry {
-                    id: line.to_string(),
                     description: None,
-                },
-            })
-            .collect();
+                })
+                .collect()
+        });
         if models.is_empty() {
             None
         } else {
@@ -573,20 +562,15 @@ mod tests {
     }
 
     #[test]
-    fn models_cache_flattens_multiline_descriptions() {
+    fn models_cache_round_trips_delimiter_and_control_characters_verbatim() {
         let tmp = TempDir::new().unwrap();
         let store = make_store(&tmp);
-        ConversationStore::write_models_cache(
-            store.dir(),
-            &[
-                model("sre", Some("Line one\nline\ttwo  \n")),
-                model("next", None),
-            ],
-        );
-        assert_eq!(
-            store.load_models_cache().unwrap(),
-            vec![model("sre", Some("Line one line two")), model("next", None)]
-        );
+        let models = [
+            model("odd\tid\nwith breaks", Some("Line one\nline\ttwo \x1b[31m")),
+            model("next", None),
+        ];
+        ConversationStore::write_models_cache(store.dir(), &models);
+        assert_eq!(store.load_models_cache().unwrap(), models);
     }
 
     #[test]

--- a/crates/aura-cli/src/repl/mcp/mod.rs
+++ b/crates/aura-cli/src/repl/mcp/mod.rs
@@ -89,25 +89,8 @@ fn format_server_list(agent: Option<&AgentInfo>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_fixtures::strip_sgr;
     use std::collections::BTreeMap;
-
-    /// Strip SGR sequences (`ESC[…m`) so assertions are theme-independent.
-    fn strip_sgr(s: &str) -> String {
-        let mut out = String::new();
-        let mut chars = s.chars();
-        while let Some(c) = chars.next() {
-            if c == '\u{1b}' {
-                for c2 in chars.by_ref() {
-                    if c2 == 'm' {
-                        break;
-                    }
-                }
-            } else {
-                out.push(c);
-            }
-        }
-        out
-    }
 
     #[test]
     fn lists_servers_with_transport_and_target() {

--- a/crates/aura-cli/src/test_fixtures.rs
+++ b/crates/aura-cli/src/test_fixtures.rs
@@ -13,6 +13,7 @@ pub(crate) fn worker(name: &str) -> WorkerOverview {
 pub(crate) fn agent(id: &str, workers: Vec<WorkerOverview>) -> AgentInfo {
     AgentInfo {
         id: id.to_string(),
+        description: None,
         model: "gpt-4o".to_string(),
         workers,
         mcp_servers: None,

--- a/crates/aura-cli/src/test_fixtures.rs
+++ b/crates/aura-cli/src/test_fixtures.rs
@@ -1,6 +1,30 @@
-//! Shared test fixtures for `aura_events` overview types.
+//! Shared test fixtures: `aura_events` overview types and terminal-output
+//! helpers.
 
 use aura_events::{AgentInfo, WorkerOverview};
+
+/// Strip SGR sequences (`ESC[…m`) so layout assertions are theme-independent.
+pub(crate) fn strip_sgr(s: &str) -> String {
+    let mut out = String::new();
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            for c2 in chars.by_ref() {
+                if c2 == 'm' {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// [`strip_sgr`] over every line.
+pub(crate) fn plain(lines: &[String]) -> Vec<String> {
+    lines.iter().map(|l| strip_sgr(l)).collect()
+}
 
 pub(crate) fn worker(name: &str) -> WorkerOverview {
     WorkerOverview {

--- a/crates/aura-cli/src/ui/agent_overview.rs
+++ b/crates/aura-cli/src/ui/agent_overview.rs
@@ -1,10 +1,8 @@
-use std::borrow::Cow;
-
 use aura_events::{AgentInfo, WorkerOverview};
 
 use crate::theme::{AuraStyle, Themed};
 use crate::ui::state::term_size;
-use crate::ui::text::wrap_words;
+use crate::ui::text::{strip_control_chars, wrap_words};
 
 const INDENT: &str = "  ";
 
@@ -29,6 +27,8 @@ pub fn print_startup_cta(agent: &AgentInfo) {
     println!();
 }
 
+/// Every string in an [`AgentInfo`] arrives from the server, so each is
+/// stripped of control characters before it reaches the terminal.
 fn agent_overview_block_lines(agent: &AgentInfo, width: usize) -> Vec<String> {
     let mut lines = Vec::with_capacity(agent.workers.len() + 3);
     let role = if agent.workers.is_empty() {
@@ -41,16 +41,17 @@ fn agent_overview_block_lines(agent: &AgentInfo, width: usize) -> Vec<String> {
     lines.push(format!(
         "{INDENT}{} {} {} {}: {}",
         "•".themed(AuraStyle::Muted),
-        agent.id.as_str().themed(AuraStyle::Heading),
+        strip_control_chars(&agent.id).themed(AuraStyle::Heading),
         "—".themed(AuraStyle::Muted),
         role.themed(AuraStyle::Muted),
-        agent.model.as_str().themed(AuraStyle::Muted),
+        strip_control_chars(&agent.model).themed(AuraStyle::Muted),
     ));
     if let Some(description) = agent.description.as_deref() {
         // Wrapped under the bullet, aligned with the agent id.
         let desc_indent = INDENT.len() + 2;
         let pad = " ".repeat(desc_indent);
-        for line in wrap_words(description, width.saturating_sub(desc_indent)) {
+        let description = strip_control_chars(description);
+        for line in wrap_words(&description, width.saturating_sub(desc_indent)) {
             lines.push(format!("{pad}{}", line.as_str().themed(AuraStyle::Muted)));
         }
     }
@@ -69,19 +70,20 @@ fn worker_block_lines(workers: &[WorkerOverview], width: usize) -> Vec<String> {
     lines.push(format!("{}", "Workers".themed(AuraStyle::Heading)));
 
     for worker in workers {
-        let text = match &worker.model {
-            Some(model) => Cow::Owned(format!("{} ({model})", worker.description)),
-            None => Cow::Borrowed(worker.description.as_str()),
-        };
+        let name = strip_control_chars(&worker.name);
+        let text = strip_control_chars(&match &worker.model {
+            Some(model) => format!("{} ({model})", worker.description),
+            None => worker.description.clone(),
+        });
         // Width of the "  • name — " prefix.
-        let prefix_len = INDENT.len() + 2 + worker.name.chars().count() + 3;
+        let prefix_len = INDENT.len() + 2 + name.chars().count() + 3;
 
         if width >= prefix_len + MIN_DESC_WIDTH {
             let wrapped = wrap_words(&text, width - prefix_len);
             lines.push(format!(
                 "{INDENT}{} {} {} {}",
                 "•".themed(AuraStyle::Muted),
-                worker.name.as_str().themed(AuraStyle::Heading),
+                name.as_str().themed(AuraStyle::Heading),
                 "—".themed(AuraStyle::Muted),
                 wrapped[0].as_str().themed(AuraStyle::Muted),
             ));
@@ -95,7 +97,7 @@ fn worker_block_lines(workers: &[WorkerOverview], width: usize) -> Vec<String> {
             lines.push(format!(
                 "{INDENT}{} {}",
                 "•".themed(AuraStyle::Muted),
-                worker.name.as_str().themed(AuraStyle::Heading),
+                name.as_str().themed(AuraStyle::Heading),
             ));
             let desc_indent = INDENT.len() + 2;
             let pad = " ".repeat(desc_indent);
@@ -152,6 +154,31 @@ mod tests {
                 "  • sre — model: gpt-4o",
                 "    Anthropic backed config to solve all of your production",
                 "    problems",
+            ]
+        );
+    }
+
+    #[test]
+    fn agent_overview_strips_control_characters_from_server_text() {
+        let mut agent = agent("sre\x1b]0;pwned\x07", vec![worker("w\x1b[2J")]);
+        agent.model = "gpt\u{9b}31m".to_string();
+        agent.description = Some("desc\x1b[31m red".to_string());
+        agent.workers[0].description = "does\x07 work".to_string();
+        agent.workers[0].model = Some("mini\x1b[K".to_string());
+
+        let lines = plain(&agent_overview_block_lines(&agent, 80));
+        assert!(
+            lines.iter().all(|l| l.chars().all(|c| !c.is_control())),
+            "{lines:?}"
+        );
+        assert_eq!(
+            lines,
+            [
+                "Agent",
+                "  • sre]0;pwned — coordinator: gpt31m",
+                "    desc[31m red",
+                "Workers",
+                "  • w[2J — does work (mini[K)",
             ]
         );
     }

--- a/crates/aura-cli/src/ui/agent_overview.rs
+++ b/crates/aura-cli/src/ui/agent_overview.rs
@@ -71,10 +71,10 @@ fn worker_block_lines(workers: &[WorkerOverview], width: usize) -> Vec<String> {
 
     for worker in workers {
         let name = strip_control_chars(&worker.name);
-        let text = strip_control_chars(&match &worker.model {
-            Some(model) => format!("{} ({model})", worker.description),
-            None => worker.description.clone(),
-        });
+        let mut text = strip_control_chars(&worker.description);
+        if let Some(model) = &worker.model {
+            text.push_str(&format!(" ({})", strip_control_chars(model)));
+        }
         // Width of the "  • name — " prefix.
         let prefix_len = INDENT.len() + 2 + name.chars().count() + 3;
 

--- a/crates/aura-cli/src/ui/agent_overview.rs
+++ b/crates/aura-cli/src/ui/agent_overview.rs
@@ -46,6 +46,14 @@ fn agent_overview_block_lines(agent: &AgentInfo, width: usize) -> Vec<String> {
         role.themed(AuraStyle::Muted),
         agent.model.as_str().themed(AuraStyle::Muted),
     ));
+    if let Some(description) = agent.description.as_deref() {
+        // Wrapped under the bullet, aligned with the agent id.
+        let desc_indent = INDENT.len() + 2;
+        let pad = " ".repeat(desc_indent);
+        for line in wrap_words(description, width.saturating_sub(desc_indent)) {
+            lines.push(format!("{pad}{}", line.as_str().themed(AuraStyle::Muted)));
+        }
+    }
 
     lines.extend(worker_block_lines(&agent.workers, width));
 
@@ -116,31 +124,9 @@ fn startup_cta_lines(agent: &AgentInfo, width: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_fixtures::{agent, worker};
+    use crate::test_fixtures::{agent, plain, worker};
     use aura_events::McpServerOverview;
     use std::collections::BTreeMap;
-
-    /// Strip SGR sequences (`ESC[…m`) so frame assertions are theme-independent.
-    fn strip_sgr(s: &str) -> String {
-        let mut out = String::new();
-        let mut chars = s.chars();
-        while let Some(c) = chars.next() {
-            if c == '\u{1b}' {
-                for c2 in chars.by_ref() {
-                    if c2 == 'm' {
-                        break;
-                    }
-                }
-            } else {
-                out.push(c);
-            }
-        }
-        out
-    }
-
-    fn plain(lines: &[String]) -> Vec<String> {
-        lines.iter().map(|l| strip_sgr(l)).collect()
-    }
 
     #[test]
     fn agent_overview_renders_single_agent_model_without_workers() {
@@ -152,6 +138,22 @@ mod tests {
         assert!(all.contains("model"));
         assert!(all.contains("gpt-4o"));
         assert!(!all.contains("Workers"));
+    }
+
+    #[test]
+    fn agent_overview_wraps_the_description_under_the_agent_line() {
+        let mut agent = agent("sre", Vec::new());
+        agent.description =
+            Some("Anthropic backed config to solve all of your production problems".to_string());
+        assert_eq!(
+            plain(&agent_overview_block_lines(&agent, 60)),
+            [
+                "Agent",
+                "  • sre — model: gpt-4o",
+                "    Anthropic backed config to solve all of your production",
+                "    problems",
+            ]
+        );
     }
 
     #[test]

--- a/crates/aura-cli/src/ui/input_hint.rs
+++ b/crates/aura-cli/src/ui/input_hint.rs
@@ -2,13 +2,13 @@
 // Input validation and hints
 // ---------------------------------------------------------------------------
 
-use std::fs;
 use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
 
 use crossterm::style::Stylize;
 
+use crate::api::types::ModelEntry;
 use crate::repl::conversations::ConversationStore;
 use crate::repl::registry::{lookup, matching_commands, split_command};
 
@@ -16,21 +16,22 @@ use super::input_frame::resize_status_area;
 use super::state::{
     CTRLC_HINT_VISIBLE, LAST_HINT_LINE, MODEL_CACHE, MODEL_ERROR, MODEL_FETCH_CONFIG,
     MODEL_FETCH_IN_PROGRESS, MODEL_MATCHES, RESUME_MATCHES, STATUS_HINT, STATUS_ROWS,
-    STREAM_CONV_DIR, STYLE_MATCHES, get_tab_select_index, lock_term, random_bullet_color,
-    status_rows, term_size,
+    STREAM_CONV_DIR, STYLE_MATCHES, get_selected_model, get_tab_select_index, lock_term,
+    random_bullet_color, status_rows, term_size,
 };
 use super::status_bar::{notice_status_rows, update_status_bar};
+use super::text::{collapse_whitespace, truncate_with_ellipsis};
 use crate::theme::{AuraStyle, STYLE_NAMES, Themed, theme};
 
 /// Update the model cache from a successful fetch.
-pub fn set_model_cache(models: Vec<String>) {
+pub fn set_model_cache(models: Vec<ModelEntry>) {
+    persist_model_cache(&models);
     if let Ok(mut g) = MODEL_CACHE.lock() {
-        *g = models.clone();
+        *g = models;
     }
     if let Ok(mut g) = MODEL_ERROR.lock() {
         g.clear();
     }
-    persist_model_cache(&models);
     refresh_model_hints();
 }
 
@@ -52,7 +53,7 @@ pub fn trigger_model_fetch(
         return;
     }
     thread::spawn(move || {
-        let result = (|| -> Result<Vec<String>, String> {
+        let result = (|| -> Result<Vec<ModelEntry>, String> {
             let client = reqwest::blocking::Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
@@ -69,7 +70,7 @@ pub fn trigger_model_fetch(
                 return Err(format!("HTTP {}", resp.status()));
             }
             let list: crate::api::types::ModelList = resp.json().map_err(|e| e.to_string())?;
-            Ok(list.data.into_iter().map(|m| m.id).collect())
+            Ok(list.data)
         })();
         match result {
             Ok(models) => set_model_cache(models),
@@ -108,16 +109,14 @@ fn refresh_model_hints() {
 }
 
 /// Persist the model list to the current conversation directory.
-fn persist_model_cache(models: &[String]) {
-    let dir = match STREAM_CONV_DIR.lock().ok().and_then(|g| g.clone()) {
-        Some(d) => d,
-        None => return,
-    };
-    let _ = fs::write(dir.join("models_cache"), models.join("\n"));
+fn persist_model_cache(models: &[ModelEntry]) {
+    if let Some(dir) = STREAM_CONV_DIR.lock().ok().and_then(|g| g.clone()) {
+        ConversationStore::write_models_cache(&dir, models);
+    }
 }
 
 /// Seed the in-memory model cache.
-pub fn seed_model_cache(models: Vec<String>) {
+pub fn seed_model_cache(models: Vec<ModelEntry>) {
     if let Ok(mut g) = MODEL_CACHE.lock()
         && g.is_empty()
     {
@@ -125,12 +124,60 @@ pub fn seed_model_cache(models: Vec<String>) {
     }
 }
 
+/// Maximum rows a scrolling hint list shows at once.
+const MAX_VISIBLE: usize = 5;
+
+/// Narrowest column worth truncating a model description into; below it a
+/// description that does not fit whole is dropped rather than shown as a stub.
+const MIN_DESC_WIDTH: usize = 12;
+
+/// Render `lines` (each the entry indices it holds) through `render`, showing
+/// at most [`MAX_VISIBLE`] of them. `render` also receives the styled
+/// two-column `▲ `/`▼ ` scroll cue on the window's edge lines when more lines
+/// lie beyond them. The window keeps the tab selection in its middle row where
+/// it can, so the selected line is never also an edge line carrying a cue —
+/// layouts may share one gutter for both.
+fn windowed_hint_lines(
+    lines: &[Vec<usize>],
+    tab_idx: Option<usize>,
+    render: impl Fn(&[usize], Option<&str>) -> String,
+) -> Vec<String> {
+    let total_lines = lines.len();
+    let (window_start, window_end) = if total_lines <= MAX_VISIBLE {
+        (0, total_lines)
+    } else {
+        let selected_line = tab_idx
+            .and_then(|idx| lines.iter().position(|line| line.contains(&idx)))
+            .unwrap_or(0);
+        let start = selected_line
+            .saturating_sub(MAX_VISIBLE / 2)
+            .min(total_lines - MAX_VISIBLE);
+        (start, start + MAX_VISIBLE)
+    };
+
+    lines[window_start..window_end]
+        .iter()
+        .enumerate()
+        .map(|(line_offset, line_entries)| {
+            let glyph = if line_offset == 0 && window_start > 0 {
+                Some("▲")
+            } else if line_offset == window_end - window_start - 1 && window_end < total_lines {
+                Some("▼")
+            } else {
+                None
+            };
+            let cue = glyph.map(|g| format!("{} ", g.themed(AuraStyle::Connector)));
+            render(line_entries, cue.as_deref())
+        })
+        .collect()
+}
+
 /// Build columnar hint lines from a list of display entries.
 /// Each entry is rendered with per-item styling: the tab-highlighted entry (if any)
 /// gets `AuraStyle::Selected`, others get `AuraStyle::Muted`.
 ///
-/// For large lists, shows a scrolling 5-line window with ▲/▼ indicators.
-/// The window follows the tab selection to keep it visible.
+/// For large lists, shows a scrolling window with ▲/▼ indicators that follows
+/// the tab selection (see [`windowed_hint_lines`]).
 fn build_columnar_hints(entries: &[String], tab_idx: Option<usize>) -> Vec<String> {
     if entries.is_empty() {
         return vec![];
@@ -142,14 +189,10 @@ fn build_columnar_hints(entries: &[String], tab_idx: Option<usize>) -> Vec<Strin
         return vec![];
     }
 
-    const MAX_VISIBLE: usize = 5;
-
-    // First pass: assign each entry index to a line number.
-    let mut line_of: Vec<usize> = Vec::with_capacity(entries.len());
+    // Pack entries into lines of equal-width columns.
     let mut entries_per_line: Vec<Vec<usize>> = vec![vec![]];
     let mut current_raw_len: usize = 0;
-
-    for (i, _entry) in entries.iter().enumerate() {
+    for i in 0..entries.len() {
         if current_raw_len > 0 && current_raw_len + 2 + col_w > max_w {
             entries_per_line.push(vec![]);
             current_raw_len = 0;
@@ -158,41 +201,11 @@ fn build_columnar_hints(entries: &[String], tab_idx: Option<usize>) -> Vec<Strin
             current_raw_len += 2;
         }
         current_raw_len += col_w;
-        let line_num = entries_per_line.len() - 1;
-        line_of.push(line_num);
         entries_per_line.last_mut().unwrap().push(i);
     }
 
-    let total_lines = entries_per_line.len();
-
-    // Determine visible window
-    let (window_start, window_end, has_above, has_below) = if total_lines <= MAX_VISIBLE {
-        (0, total_lines, false, false)
-    } else {
-        let selected_line = tab_idx.map(|idx| line_of[idx]).unwrap_or(0);
-        let start = selected_line.min(total_lines - MAX_VISIBLE);
-        let end = start + MAX_VISIBLE;
-        (start, end, start > 0, end < total_lines)
-    };
-
-    // Render visible lines
-    let mut result = Vec::new();
-    for (line_offset, line_entries) in entries_per_line[window_start..window_end]
-        .iter()
-        .enumerate()
-    {
-        let mut line_str = String::new();
-
-        // Scroll indicators on first/last visible line
-        let is_first = line_offset == 0;
-        let is_last = line_offset == window_end - window_start - 1;
-        if is_first && has_above {
-            line_str.push_str(&format!("{} ", "▲".themed(AuraStyle::Connector)));
-        }
-        if is_last && has_below {
-            line_str.push_str(&format!("{} ", "▼".themed(AuraStyle::Connector)));
-        }
-
+    windowed_hint_lines(&entries_per_line, tab_idx, |line_entries, cue| {
+        let mut line_str = cue.unwrap_or_default().to_string();
         for (pos, &idx) in line_entries.iter().enumerate() {
             if pos > 0 {
                 line_str.push_str("  ");
@@ -204,9 +217,105 @@ fn build_columnar_hints(entries: &[String], tab_idx: Option<usize>) -> Vec<Strin
                 line_str.push_str(&format!("{}", padded.themed(AuraStyle::Muted)));
             }
         }
-        result.push(line_str);
+        line_str
+    })
+}
+
+/// A model's description flattened to one line and truncated to `room`
+/// columns. `None` when the model has no description, or when it would need
+/// truncating and `room` is too narrow to say anything useful.
+fn description_column(model: &ModelEntry, room: usize) -> Option<String> {
+    let desc = collapse_whitespace(model.description.as_deref()?);
+    if desc.is_empty() {
+        return None;
     }
-    result
+    let fits = desc.chars().count() <= room;
+    (fits || room >= MIN_DESC_WIDTH).then(|| truncate_with_ellipsis(&desc, room))
+}
+
+/// Build hint lines for the `/model` picker at `width` columns, one model per
+/// numbered row:
+///
+/// ```text
+///      Name                Description
+///   1. sre/openai          OpenAI backed SRE agent
+/// ❯ 2. sre/anthropic ✓     Anthropic backed SRE agent
+/// ```
+///
+/// The two-column gutter holds the `❯` cursor on the tab-selected row and the
+/// ▲/▼ scroll cue on the window's edge rows; `✓` marks `current`. The
+/// header appears once any model has a description; descriptions are
+/// truncated to fit. Numbers count within `models` as given, so a filtered
+/// list renumbers from 1.
+fn build_model_hints(
+    models: &[ModelEntry],
+    tab_idx: Option<usize>,
+    current: Option<&str>,
+    width: usize,
+) -> Vec<String> {
+    const CHECK: &str = " ✓";
+    let is_current = |m: &ModelEntry| current.is_some_and(|c| c.eq_ignore_ascii_case(&m.id));
+    // Columns the id (plus its check, when current) occupies in the name column.
+    let name_cols = |m: &ModelEntry| {
+        m.id.chars().count()
+            + if is_current(m) {
+                CHECK.chars().count()
+            } else {
+                0
+            }
+    };
+    let has_descriptions = models.iter().any(|m| m.description.is_some());
+    let num_w = models.len().to_string().len();
+    let name_w = models
+        .iter()
+        .map(name_cols)
+        .chain(has_descriptions.then_some("Name".len()))
+        .max()
+        .unwrap_or(0);
+    // "❯ " + "NN. " precede the name column; two spaces separate the columns.
+    let prefix_w = 2 + num_w + 2;
+    let desc_room = width.saturating_sub(prefix_w + name_w + 2);
+    let lines: Vec<Vec<usize>> = (0..models.len()).map(|i| vec![i]).collect();
+
+    let header = has_descriptions.then(|| {
+        format!(
+            "{}{}{}  {}",
+            " ".repeat(prefix_w),
+            "Name".themed(AuraStyle::KeyLabel),
+            " ".repeat(name_w - "Name".len()),
+            "Description".themed(AuraStyle::KeyLabel),
+        )
+    });
+    let rows = windowed_hint_lines(&lines, tab_idx, |line_entries, cue| {
+        let idx = line_entries[0];
+        let model = &models[idx];
+        let selected = tab_idx == Some(idx);
+        let gutter = if selected {
+            format!("{} ", "❯".themed(AuraStyle::Prompt))
+        } else {
+            cue.unwrap_or("  ").to_string()
+        };
+        let number = format!("{:>num_w$}.", idx + 1);
+        let name_style = if selected {
+            AuraStyle::Selected
+        } else {
+            AuraStyle::Muted
+        };
+        let mut row = format!(
+            "{gutter}{} {}",
+            number.themed(AuraStyle::Muted),
+            model.id.as_str().themed(name_style)
+        );
+        if is_current(model) {
+            row.push_str(&format!("{}", CHECK.themed(AuraStyle::Success)));
+        }
+        if let Some(desc) = description_column(model, desc_room) {
+            row.push_str(&" ".repeat(name_w - name_cols(model) + 2));
+            row.push_str(&format!("{}", desc.themed(AuraStyle::Muted)));
+        }
+        row
+    });
+    header.into_iter().chain(rows).collect()
 }
 
 /// Update the status bar hint based on the current input line.
@@ -279,17 +388,17 @@ pub fn update_input_hint(line: &str) {
             )]
         } else {
             let cached = MODEL_CACHE.lock().map(|g| g.clone()).unwrap_or_default();
-            let filtered: Vec<String> = if filter.is_empty() {
+            let filtered: Vec<ModelEntry> = if filter.is_empty() {
                 cached
             } else {
                 let lower = filter.to_lowercase();
                 cached
                     .into_iter()
-                    .filter(|m| m.to_lowercase().contains(&lower))
+                    .filter(|m| m.id.to_lowercase().contains(&lower))
                     .collect()
             };
             if let Ok(mut guard) = MODEL_MATCHES.lock() {
-                *guard = filtered.clone();
+                *guard = filtered.iter().map(|m| m.id.clone()).collect();
             }
             if filtered.is_empty() {
                 if MODEL_FETCH_IN_PROGRESS.load(Ordering::Relaxed) {
@@ -306,15 +415,25 @@ pub fn update_input_hint(line: &str) {
                 }
             } else if filtered.len() == 1 {
                 let color = random_bullet_color();
+                let model = &filtered[0];
+                let cta = "press enter to auto-complete";
+                // "▸  id  [description  ]cta"
+                let (width, _) = term_size();
+                let used = 3 + model.id.chars().count() + 2 + cta.len() + 2;
+                let desc = description_column(model, (width as usize).saturating_sub(used))
+                    .map(|d| format!("{}  ", d.themed(AuraStyle::Muted)))
+                    .unwrap_or_default();
                 vec![format!(
-                    "{}  {}  {}",
+                    "{}  {}  {desc}{}",
                     "▸".themed(AuraStyle::Connector),
-                    filtered[0].clone().themed(AuraStyle::Muted),
-                    "press enter to auto-complete".with(color),
+                    model.id.as_str().themed(AuraStyle::Muted),
+                    cta.with(color),
                 )]
             } else {
                 let tab_idx = get_tab_select_index();
-                build_columnar_hints(&filtered, tab_idx)
+                let current = get_selected_model();
+                let (width, _) = term_size();
+                build_model_hints(&filtered, tab_idx, current.as_deref(), width as usize)
             }
         }
     } else if line == "/style" || line.starts_with("/style ") {
@@ -449,7 +568,169 @@ pub fn validate_command_input(line: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_command_input;
+    use super::{
+        MAX_VISIBLE, ModelEntry, build_model_hints, description_column, validate_command_input,
+    };
+    use crate::test_fixtures::plain;
+
+    fn model(id: &str, description: Option<&str>) -> ModelEntry {
+        ModelEntry {
+            id: id.to_string(),
+            description: description.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn model_list_numbers_rows_and_omits_header_without_descriptions() {
+        let models = [model("gpt-4o", None), model("gpt-4o-mini", None)];
+        assert_eq!(
+            plain(&build_model_hints(&models, None, None, 80)),
+            ["  1. gpt-4o", "  2. gpt-4o-mini"]
+        );
+    }
+
+    #[test]
+    fn model_list_has_header_and_aligned_columns_with_descriptions() {
+        let models = [
+            model(
+                "Mezmo Anthropic SRE Agent",
+                Some("Anthropic-backed SRE agent"),
+            ),
+            model("Mezmo OpenAI SRE Agent", Some("OpenAI-backed SRE agent")),
+            model("plain", None),
+        ];
+        assert_eq!(
+            plain(&build_model_hints(&models, None, None, 80)),
+            [
+                "     Name                       Description",
+                "  1. Mezmo Anthropic SRE Agent  Anthropic-backed SRE agent",
+                "  2. Mezmo OpenAI SRE Agent     OpenAI-backed SRE agent",
+                "  3. plain",
+            ]
+        );
+    }
+
+    #[test]
+    fn model_list_marks_cursor_and_current_model() {
+        let models = [
+            model("sre/openai", Some("OpenAI")),
+            model("sre/anthropic", Some("Anthropic")),
+        ];
+        // The check widens the name column; the cursor sits in the gutter.
+        assert_eq!(
+            plain(&build_model_hints(
+                &models,
+                Some(1),
+                Some("SRE/Anthropic"),
+                80
+            )),
+            [
+                "     Name             Description",
+                "  1. sre/openai       OpenAI",
+                "❯ 2. sre/anthropic ✓  Anthropic",
+            ]
+        );
+    }
+
+    #[test]
+    fn model_list_right_aligns_numbers_past_nine() {
+        let models: Vec<ModelEntry> = (0..10).map(|i| model(&format!("m{i}"), None)).collect();
+        let lines = plain(&build_model_hints(&models, Some(9), None, 80));
+        assert_eq!(lines[MAX_VISIBLE - 1], "❯ 10. m9");
+        assert!(lines[MAX_VISIBLE - 2].ends_with("  9. m8"), "{lines:?}");
+    }
+
+    #[test]
+    fn model_list_truncates_descriptions_to_the_terminal_width() {
+        let models = [
+            model(
+                "sre",
+                Some("A very long description that will not fit here"),
+            ),
+            model("ops", Some("short")),
+        ];
+        let lines = plain(&build_model_hints(&models, None, None, 36));
+        assert_eq!(
+            lines,
+            [
+                "     Name  Description",
+                "  1. sre   A very long descriptio...",
+                "  2. ops   short",
+            ]
+        );
+        assert!(lines.iter().all(|l| l.chars().count() <= 36));
+    }
+
+    #[test]
+    fn model_list_drops_only_descriptions_that_cannot_fit_when_narrow() {
+        let models = [
+            model("agent-one", Some("a description")),
+            model("agent-two", Some("ok")),
+        ];
+        // 5 prefix + 9-char name + 2 leaves 4 columns at width 20: below
+        // MIN_DESC_WIDTH, so a description that needs truncating is dropped
+        // while one that fits whole still shows.
+        assert_eq!(
+            plain(&build_model_hints(&models, None, None, 20)),
+            [
+                "     Name       Description",
+                "  1. agent-one",
+                "  2. agent-two  ok",
+            ]
+        );
+    }
+
+    #[test]
+    fn model_list_windows_around_the_cursor_and_marks_overflow() {
+        let models: Vec<ModelEntry> = (0..MAX_VISIBLE + 3)
+            .map(|i| model(&format!("m{i}"), Some(&format!("model {i}"))))
+            .collect();
+
+        // No selection: top of the list, ▼ on the last visible row.
+        let top = plain(&build_model_hints(&models, None, None, 80));
+        assert_eq!(top.len(), MAX_VISIBLE + 1, "{top:?}");
+        assert!(top[1].starts_with("  1. m0  "), "{top:?}");
+        assert!(top[MAX_VISIBLE].starts_with("▼ 5. m4"), "{top:?}");
+
+        // A mid-list selection is centred: ▲ above, ▼ below, ❯ in between.
+        let mid = plain(&build_model_hints(&models, Some(4), None, 80));
+        assert!(mid[1].starts_with("▲ 3. m2"), "{mid:?}");
+        assert!(mid[3].starts_with("❯ 5. m4"), "{mid:?}");
+        assert!(mid[MAX_VISIBLE].starts_with("▼ 7. m6"), "{mid:?}");
+
+        // Selecting the last entry pins the window to the bottom.
+        let bottom = plain(&build_model_hints(
+            &models,
+            Some(models.len() - 1),
+            None,
+            80,
+        ));
+        assert!(bottom[1].starts_with("▲ 4. m3"), "{bottom:?}");
+        assert!(bottom[MAX_VISIBLE].starts_with("❯ 8. m7"), "{bottom:?}");
+        assert!(bottom.iter().all(|l| l.chars().count() <= 80));
+    }
+
+    #[test]
+    fn description_column_flattens_and_respects_room() {
+        let multi = model("m", Some("  first\nsecond   line  "));
+        assert_eq!(
+            description_column(&multi, 40).as_deref(),
+            Some("first second line")
+        );
+        assert_eq!(
+            description_column(&multi, 12).as_deref(),
+            Some("first sec...")
+        );
+        assert_eq!(description_column(&multi, 11), None);
+        // A short description that fits whole shows even in a narrow column.
+        assert_eq!(
+            description_column(&model("m", Some("SRE")), 3).as_deref(),
+            Some("SRE")
+        );
+        assert_eq!(description_column(&model("m", Some("SRE")), 2), None);
+        assert_eq!(description_column(&model("m", Some("   ")), 40), None);
+        assert_eq!(description_column(&model("m", None), 40), None);
+    }
 
     #[test]
     fn plain_text_submits() {

--- a/crates/aura-cli/src/ui/input_hint.rs
+++ b/crates/aura-cli/src/ui/input_hint.rs
@@ -235,6 +235,28 @@ fn description_column(model: &ModelEntry, room: usize) -> Option<String> {
     (fits || room >= MIN_DESC_WIDTH).then(|| truncate_with_ellipsis(&desc, room))
 }
 
+/// The single-row hint for a `/model` filter that leaves exactly one match:
+/// `▸  id  [description  ]press enter to auto-complete`. The id yields to the
+/// call to action and the description to both, so the row fits `width`
+/// columns for any id the server hands out.
+fn unique_model_hint(model: &ModelEntry, width: usize) -> String {
+    let cta = "press enter to auto-complete";
+    let name = truncate_with_ellipsis(
+        &strip_control_chars(&model.id),
+        width.saturating_sub(3 + 2 + cta.len()),
+    );
+    let used = 3 + UnicodeWidthStr::width(name.as_str()) + 2 + cta.len() + 2;
+    let desc = description_column(model, width.saturating_sub(used))
+        .map(|d| format!("{}  ", d.themed(AuraStyle::Muted)))
+        .unwrap_or_default();
+    format!(
+        "{}  {}  {desc}{}",
+        "▸".themed(AuraStyle::Connector),
+        name.themed(AuraStyle::Muted),
+        cta.with(random_bullet_color()),
+    )
+}
+
 /// Build hint lines for the `/model` picker at `width` columns, one model per
 /// numbered row:
 ///
@@ -421,22 +443,8 @@ pub fn update_input_hint(line: &str) {
                     vec![format!("{}", "no matching models".themed(AuraStyle::Muted))]
                 }
             } else if filtered.len() == 1 {
-                let color = random_bullet_color();
-                let model = &filtered[0];
-                let name = strip_control_chars(&model.id);
-                let cta = "press enter to auto-complete";
-                // "▸  id  [description  ]cta"
                 let (width, _) = term_size();
-                let used = 3 + UnicodeWidthStr::width(name.as_str()) + 2 + cta.len() + 2;
-                let desc = description_column(model, (width as usize).saturating_sub(used))
-                    .map(|d| format!("{}  ", d.themed(AuraStyle::Muted)))
-                    .unwrap_or_default();
-                vec![format!(
-                    "{}  {}  {desc}{}",
-                    "▸".themed(AuraStyle::Connector),
-                    name.themed(AuraStyle::Muted),
-                    cta.with(color),
-                )]
+                vec![unique_model_hint(&filtered[0], width as usize)]
             } else {
                 let tab_idx = get_tab_select_index();
                 let current = get_selected_model();
@@ -577,9 +585,10 @@ pub fn validate_command_input(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        MAX_VISIBLE, ModelEntry, build_model_hints, description_column, validate_command_input,
+        MAX_VISIBLE, ModelEntry, build_model_hints, description_column, unique_model_hint,
+        validate_command_input,
     };
-    use crate::test_fixtures::plain;
+    use crate::test_fixtures::{plain, strip_sgr};
 
     fn model(id: &str, description: Option<&str>) -> ModelEntry {
         ModelEntry {
@@ -738,6 +747,27 @@ mod tests {
         let lines = plain(&build_model_hints(&models, None, None, 20));
         assert_eq!(lines[0], "  1. a-model-id-t...");
         assert_eq!(lines[1], "  2. short");
+    }
+
+    #[test]
+    fn unique_match_hint_fits_the_terminal_for_any_id() {
+        let long = "a-model-id-that-is-far-longer-than-any-sane-terminal-would-be";
+        let model = model(long, Some("with a description as well"));
+        for width in [40usize, 60, 80, 120] {
+            let line = strip_sgr(&unique_model_hint(&model, width));
+            let cols = unicode_width::UnicodeWidthStr::width(line.as_str());
+            assert!(cols <= width, "width {width}: {cols} cols in {line:?}");
+            assert!(line.ends_with("press enter to auto-complete"), "{line:?}");
+        }
+        // Wide enough: id whole, description truncated to what is left.
+        let line = strip_sgr(&unique_model_hint(&model, 120));
+        assert_eq!(
+            line,
+            format!("▸  {long}  with a description as...  press enter to auto-complete")
+        );
+        // Narrow: the id itself is truncated and the description dropped.
+        let line = strip_sgr(&unique_model_hint(&model, 50));
+        assert_eq!(line, "▸  a-model-id-tha...  press enter to auto-complete");
     }
 
     #[test]

--- a/crates/aura-cli/src/ui/input_hint.rs
+++ b/crates/aura-cli/src/ui/input_hint.rs
@@ -7,6 +7,7 @@ use std::thread;
 use std::time::Duration;
 
 use crossterm::style::Stylize;
+use unicode_width::UnicodeWidthStr;
 
 use crate::api::types::ModelEntry;
 use crate::repl::conversations::ConversationStore;
@@ -20,7 +21,7 @@ use super::state::{
     random_bullet_color, status_rows, term_size,
 };
 use super::status_bar::{notice_status_rows, update_status_bar};
-use super::text::{collapse_whitespace, truncate_with_ellipsis};
+use super::text::{collapse_whitespace, strip_control_chars, truncate_with_ellipsis};
 use crate::theme::{AuraStyle, STYLE_NAMES, Themed, theme};
 
 /// Update the model cache from a successful fetch.
@@ -221,15 +222,16 @@ fn build_columnar_hints(entries: &[String], tab_idx: Option<usize>) -> Vec<Strin
     })
 }
 
-/// A model's description flattened to one line and truncated to `room`
-/// columns. `None` when the model has no description, or when it would need
-/// truncating and `room` is too narrow to say anything useful.
+/// A model's description flattened to one line, stripped of control
+/// characters, and truncated to `room` columns. `None` when the model has no
+/// description, or when it would need truncating and `room` is too narrow to
+/// say anything useful.
 fn description_column(model: &ModelEntry, room: usize) -> Option<String> {
-    let desc = collapse_whitespace(model.description.as_deref()?);
+    let desc = strip_control_chars(&collapse_whitespace(model.description.as_deref()?));
     if desc.is_empty() {
         return None;
     }
-    let fits = desc.chars().count() <= room;
+    let fits = UnicodeWidthStr::width(desc.as_str()) <= room;
     (fits || room >= MIN_DESC_WIDTH).then(|| truncate_with_ellipsis(&desc, room))
 }
 
@@ -244,9 +246,10 @@ fn description_column(model: &ModelEntry, room: usize) -> Option<String> {
 ///
 /// The two-column gutter holds the `❯` cursor on the tab-selected row and the
 /// ▲/▼ scroll cue on the window's edge rows; `✓` marks `current`. The
-/// header appears once any model has a description; descriptions are
-/// truncated to fit. Numbers count within `models` as given, so a filtered
-/// list renumbers from 1.
+/// header appears once any model has a description and the header fits.
+/// Ids and descriptions are stripped of control characters and truncated so
+/// no row exceeds `width` display columns. Numbers count within `models` as
+/// given, so a filtered list renumbers from 1.
 fn build_model_hints(
     models: &[ModelEntry],
     tab_idx: Option<usize>,
@@ -254,30 +257,34 @@ fn build_model_hints(
     width: usize,
 ) -> Vec<String> {
     const CHECK: &str = " ✓";
+    let check_w = UnicodeWidthStr::width(CHECK);
     let is_current = |m: &ModelEntry| current.is_some_and(|c| c.eq_ignore_ascii_case(&m.id));
-    // Columns the id (plus its check, when current) occupies in the name column.
-    let name_cols = |m: &ModelEntry| {
-        m.id.chars().count()
-            + if is_current(m) {
-                CHECK.chars().count()
-            } else {
-                0
-            }
-    };
     let has_descriptions = models.iter().any(|m| m.description.is_some());
     let num_w = models.len().to_string().len();
-    let name_w = models
+    // "❯ " + "NN. " precede the name column; two spaces separate the columns.
+    let prefix_w = 2 + num_w + 2;
+    // Every row must hold its prefix, name, and check without wrapping.
+    let max_name_w = width.saturating_sub(prefix_w);
+    let names: Vec<String> = models
         .iter()
+        .map(|m| {
+            let room = max_name_w.saturating_sub(if is_current(m) { check_w } else { 0 });
+            truncate_with_ellipsis(&strip_control_chars(&m.id), room)
+        })
+        .collect();
+    // Columns the name (plus its check, when current) occupies in the name column.
+    let name_cols = |i: usize| {
+        UnicodeWidthStr::width(names[i].as_str()) + if is_current(&models[i]) { check_w } else { 0 }
+    };
+    let name_w = (0..models.len())
         .map(name_cols)
         .chain(has_descriptions.then_some("Name".len()))
         .max()
         .unwrap_or(0);
-    // "❯ " + "NN. " precede the name column; two spaces separate the columns.
-    let prefix_w = 2 + num_w + 2;
     let desc_room = width.saturating_sub(prefix_w + name_w + 2);
     let lines: Vec<Vec<usize>> = (0..models.len()).map(|i| vec![i]).collect();
 
-    let header = has_descriptions.then(|| {
+    let header = (has_descriptions && desc_room >= "Description".len()).then(|| {
         format!(
             "{}{}{}  {}",
             " ".repeat(prefix_w),
@@ -304,13 +311,13 @@ fn build_model_hints(
         let mut row = format!(
             "{gutter}{} {}",
             number.themed(AuraStyle::Muted),
-            model.id.as_str().themed(name_style)
+            names[idx].as_str().themed(name_style)
         );
         if is_current(model) {
             row.push_str(&format!("{}", CHECK.themed(AuraStyle::Success)));
         }
         if let Some(desc) = description_column(model, desc_room) {
-            row.push_str(&" ".repeat(name_w - name_cols(model) + 2));
+            row.push_str(&" ".repeat(name_w - name_cols(idx) + 2));
             row.push_str(&format!("{}", desc.themed(AuraStyle::Muted)));
         }
         row
@@ -416,17 +423,18 @@ pub fn update_input_hint(line: &str) {
             } else if filtered.len() == 1 {
                 let color = random_bullet_color();
                 let model = &filtered[0];
+                let name = strip_control_chars(&model.id);
                 let cta = "press enter to auto-complete";
                 // "▸  id  [description  ]cta"
                 let (width, _) = term_size();
-                let used = 3 + model.id.chars().count() + 2 + cta.len() + 2;
+                let used = 3 + UnicodeWidthStr::width(name.as_str()) + 2 + cta.len() + 2;
                 let desc = description_column(model, (width as usize).saturating_sub(used))
                     .map(|d| format!("{}  ", d.themed(AuraStyle::Muted)))
                     .unwrap_or_default();
                 vec![format!(
                     "{}  {}  {desc}{}",
                     "▸".themed(AuraStyle::Connector),
-                    model.id.as_str().themed(AuraStyle::Muted),
+                    name.themed(AuraStyle::Muted),
                     cta.with(color),
                 )]
             } else {
@@ -669,15 +677,67 @@ mod tests {
         ];
         // 5 prefix + 9-char name + 2 leaves 4 columns at width 20: below
         // MIN_DESC_WIDTH, so a description that needs truncating is dropped
-        // while one that fits whole still shows.
+        // while one that fits whole still shows; the header no longer fits.
         assert_eq!(
             plain(&build_model_hints(&models, None, None, 20)),
+            ["  1. agent-one", "  2. agent-two  ok"]
+        );
+    }
+
+    #[test]
+    fn model_list_strips_control_characters_from_remote_text() {
+        let models = [
+            model("sre\x1b]0;pwned\x07", Some("desc\x1b[31m red\u{9b}2J")),
+            model("ok", None),
+        ];
+        // Checked before theming, since `plain` would itself swallow an SGR.
+        assert_eq!(
+            description_column(&models[0], 80).as_deref(),
+            Some("desc[31m red2J")
+        );
+        let lines = plain(&build_model_hints(&models, None, None, 80));
+        assert!(
+            lines.iter().all(|l| l.chars().all(|c| !c.is_control())),
+            "{lines:?}"
+        );
+        assert_eq!(lines[1], "  1. sre]0;pwned  desc[31m red2J");
+    }
+
+    #[test]
+    fn model_list_measures_wide_glyphs_in_columns() {
+        let models = [
+            model("漢字モデル", Some("wide id")),
+            model("ascii", Some("narrow id")),
+        ];
+        // "漢字モデル" is 5 scalars but 10 columns, so "ascii" pads to 10.
+        assert_eq!(
+            plain(&build_model_hints(&models, None, None, 80)),
             [
-                "     Name       Description",
-                "  1. agent-one",
-                "  2. agent-two  ok",
+                "     Name        Description",
+                "  1. 漢字モデル  wide id",
+                "  2. ascii       narrow id",
             ]
         );
+    }
+
+    #[test]
+    fn model_list_never_exceeds_the_terminal_width() {
+        let long = "a-model-id-that-is-far-longer-than-any-sane-terminal-would-be";
+        let models = [
+            model(long, Some("and a description on top of that")),
+            model("short", Some("x")),
+        ];
+        for width in [12usize, 20, 30, 40] {
+            let lines = build_model_hints(&models, Some(0), Some(long), width);
+            for line in plain(&lines) {
+                let cols = unicode_width::UnicodeWidthStr::width(line.as_str());
+                assert!(cols <= width, "width {width}: {cols} cols in {line:?}");
+            }
+        }
+        // At 20 columns the long id is truncated to fit its row alone.
+        let lines = plain(&build_model_hints(&models, None, None, 20));
+        assert_eq!(lines[0], "  1. a-model-id-t...");
+        assert_eq!(lines[1], "  2. short");
     }
 
     #[test]

--- a/crates/aura-cli/src/ui/input_hint.rs
+++ b/crates/aura-cli/src/ui/input_hint.rs
@@ -236,25 +236,48 @@ fn description_column(model: &ModelEntry, room: usize) -> Option<String> {
 }
 
 /// The single-row hint for a `/model` filter that leaves exactly one match:
-/// `▸  id  [description  ]press enter to auto-complete`. The id yields to the
-/// call to action and the description to both, so the row fits `width`
-/// columns for any id the server hands out.
+/// `▸  id  [description  ][press enter to auto-complete]`. As `width` shrinks
+/// the description goes first, then the call to action, and finally the id
+/// is truncated, so the row fits any terminal for any id the server hands out.
 fn unique_model_hint(model: &ModelEntry, width: usize) -> String {
+    let marker = "▸  ";
+    let marker_w = UnicodeWidthStr::width(marker);
+    if width < marker_w {
+        let partial: String = marker.chars().take(width).collect();
+        return format!("{}", partial.themed(AuraStyle::Connector));
+    }
     let cta = "press enter to auto-complete";
-    let name = truncate_with_ellipsis(
-        &strip_control_chars(&model.id),
-        width.saturating_sub(3 + 2 + cta.len()),
-    );
-    let used = 3 + UnicodeWidthStr::width(name.as_str()) + 2 + cta.len() + 2;
-    let desc = description_column(model, width.saturating_sub(used))
-        .map(|d| format!("{}  ", d.themed(AuraStyle::Muted)))
-        .unwrap_or_default();
-    format!(
-        "{}  {}  {desc}{}",
-        "▸".themed(AuraStyle::Connector),
-        name.themed(AuraStyle::Muted),
-        cta.with(random_bullet_color()),
-    )
+    let name = strip_control_chars(&model.id);
+    let with_cta = marker_w + UnicodeWidthStr::width(name.as_str()) + 2 + cta.len();
+    let mut line = format!("{}", marker.themed(AuraStyle::Connector));
+    if with_cta <= width {
+        line.push_str(&format!("{}  ", name.themed(AuraStyle::Muted)));
+        if let Some(desc) = description_column(model, width.saturating_sub(with_cta + 2)) {
+            line.push_str(&format!("{}  ", desc.themed(AuraStyle::Muted)));
+        }
+        line.push_str(&format!("{}", cta.with(random_bullet_color())));
+    } else {
+        let name = truncate_with_ellipsis(&name, width - marker_w);
+        line.push_str(&format!("{}", name.themed(AuraStyle::Muted)));
+    }
+    line
+}
+
+/// Hint lines for `/model <filter>` over the models `filtered` leaves. A typed
+/// filter that narrows to one model gets the auto-complete row; everything
+/// else — including a bare `/model` with a single model — is the numbered
+/// table.
+fn model_hint_lines(
+    filtered: &[ModelEntry],
+    filter: &str,
+    tab_idx: Option<usize>,
+    current: Option<&str>,
+    width: usize,
+) -> Vec<String> {
+    match filtered {
+        [only] if !filter.is_empty() => vec![unique_model_hint(only, width)],
+        _ => build_model_hints(filtered, tab_idx, current, width),
+    }
 }
 
 /// Build hint lines for the `/model` picker at `width` columns, one model per
@@ -285,8 +308,23 @@ fn build_model_hints(
     let num_w = models.len().to_string().len();
     // "❯ " + "NN. " precede the name column; two spaces separate the columns.
     let prefix_w = 2 + num_w + 2;
+    let lines: Vec<Vec<usize>> = (0..models.len()).map(|i| vec![i]).collect();
+    // A terminal too narrow for the prefix plus a few name columns gets bare
+    // truncated names, so rows fit any width at all.
+    if width < prefix_w + 4 {
+        return windowed_hint_lines(&lines, tab_idx, |line_entries, _| {
+            let idx = line_entries[0];
+            let name = truncate_with_ellipsis(&strip_control_chars(&models[idx].id), width);
+            let style = if tab_idx == Some(idx) {
+                AuraStyle::Selected
+            } else {
+                AuraStyle::Muted
+            };
+            format!("{}", name.themed(style))
+        });
+    }
     // Every row must hold its prefix, name, and check without wrapping.
-    let max_name_w = width.saturating_sub(prefix_w);
+    let max_name_w = width - prefix_w;
     let names: Vec<String> = models
         .iter()
         .map(|m| {
@@ -304,7 +342,6 @@ fn build_model_hints(
         .max()
         .unwrap_or(0);
     let desc_room = width.saturating_sub(prefix_w + name_w + 2);
-    let lines: Vec<Vec<usize>> = (0..models.len()).map(|i| vec![i]).collect();
 
     let header = (has_descriptions && desc_room >= "Description".len()).then(|| {
         format!(
@@ -442,14 +479,17 @@ pub fn update_input_hint(line: &str) {
                 } else {
                     vec![format!("{}", "no matching models".themed(AuraStyle::Muted))]
                 }
-            } else if filtered.len() == 1 {
-                let (width, _) = term_size();
-                vec![unique_model_hint(&filtered[0], width as usize)]
             } else {
                 let tab_idx = get_tab_select_index();
                 let current = get_selected_model();
                 let (width, _) = term_size();
-                build_model_hints(&filtered, tab_idx, current.as_deref(), width as usize)
+                model_hint_lines(
+                    &filtered,
+                    filter,
+                    tab_idx,
+                    current.as_deref(),
+                    width as usize,
+                )
             }
         }
     } else if line == "/style" || line.starts_with("/style ") {
@@ -585,8 +625,8 @@ pub fn validate_command_input(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        MAX_VISIBLE, ModelEntry, build_model_hints, description_column, unique_model_hint,
-        validate_command_input,
+        MAX_VISIBLE, ModelEntry, build_model_hints, description_column, model_hint_lines,
+        unique_model_hint, validate_command_input,
     };
     use crate::test_fixtures::{plain, strip_sgr};
 
@@ -732,42 +772,69 @@ mod tests {
     #[test]
     fn model_list_never_exceeds_the_terminal_width() {
         let long = "a-model-id-that-is-far-longer-than-any-sane-terminal-would-be";
-        let models = [
-            model(long, Some("and a description on top of that")),
-            model("short", Some("x")),
-        ];
-        for width in [12usize, 20, 30, 40] {
-            let lines = build_model_hints(&models, Some(0), Some(long), width);
-            for line in plain(&lines) {
-                let cols = unicode_width::UnicodeWidthStr::width(line.as_str());
-                assert!(cols <= width, "width {width}: {cols} cols in {line:?}");
+        let models: Vec<ModelEntry> = std::iter::once(model(long, Some("and a description")))
+            .chain((0..12).map(|i| model(&format!("m{i}"), Some("漢字 wide"))))
+            .collect();
+        for width in (0..=60).chain([80, 120, 200]) {
+            for (tab_idx, current) in [(None, None), (Some(0), Some(long)), (Some(12), Some("m11"))]
+            {
+                let lines = build_model_hints(&models, tab_idx, current, width);
+                assert!(!lines.is_empty());
+                for line in plain(&lines) {
+                    let cols = unicode_width::UnicodeWidthStr::width(line.as_str());
+                    assert!(cols <= width, "width {width}: {cols} cols in {line:?}");
+                }
             }
         }
         // At 20 columns the long id is truncated to fit its row alone.
-        let lines = plain(&build_model_hints(&models, None, None, 20));
+        let lines = plain(&build_model_hints(&models[..2], None, None, 20));
         assert_eq!(lines[0], "  1. a-model-id-t...");
-        assert_eq!(lines[1], "  2. short");
+        assert_eq!(lines[1], "  2. m0");
+        // Narrower than the prefix allows: bare names, still cut to fit.
+        let lines = plain(&build_model_hints(&models[..2], Some(1), None, 6));
+        assert_eq!(lines, ["a-m...", "m0"]);
     }
 
     #[test]
-    fn unique_match_hint_fits_the_terminal_for_any_id() {
+    fn unique_match_hint_fits_the_terminal_for_any_id_and_width() {
         let long = "a-model-id-that-is-far-longer-than-any-sane-terminal-would-be";
         let model = model(long, Some("with a description as well"));
-        for width in [40usize, 60, 80, 120] {
+        for width in [0usize, 1, 2, 3, 5, 8, 20, 36, 50, 80, 120, 200] {
             let line = strip_sgr(&unique_model_hint(&model, width));
             let cols = unicode_width::UnicodeWidthStr::width(line.as_str());
             assert!(cols <= width, "width {width}: {cols} cols in {line:?}");
-            assert!(line.ends_with("press enter to auto-complete"), "{line:?}");
         }
-        // Wide enough: id whole, description truncated to what is left.
+        // Wide: id whole, description truncated to what is left, then the cta.
         let line = strip_sgr(&unique_model_hint(&model, 120));
         assert_eq!(
             line,
             format!("▸  {long}  with a description as...  press enter to auto-complete")
         );
-        // Narrow: the id itself is truncated and the description dropped.
-        let line = strip_sgr(&unique_model_hint(&model, 50));
-        assert_eq!(line, "▸  a-model-id-tha...  press enter to auto-complete");
+        // Room for id and cta but not the description: description goes.
+        let line = strip_sgr(&unique_model_hint(&model, 100));
+        assert_eq!(line, format!("▸  {long}  press enter to auto-complete"));
+        // Room for the id alone: the cta goes before the id is cut.
+        let line = strip_sgr(&unique_model_hint(&model, 70));
+        assert_eq!(line, format!("▸  {long}"));
+        // Narrower still: the id itself is truncated.
+        let line = strip_sgr(&unique_model_hint(&model, 20));
+        assert_eq!(line, "▸  a-model-id-tha...");
+    }
+
+    #[test]
+    fn bare_model_command_lists_even_a_single_model_but_a_filter_autocompletes() {
+        let only = [model("Mezmo SRE Agent", Some("Testing the description"))];
+        assert_eq!(
+            plain(&model_hint_lines(&only, "", None, None, 80)),
+            [
+                "     Name             Description",
+                "  1. Mezmo SRE Agent  Testing the description",
+            ]
+        );
+        assert_eq!(
+            plain(&model_hint_lines(&only, "mez", None, None, 80)),
+            ["▸  Mezmo SRE Agent  Testing the description  press enter to auto-complete"]
+        );
     }
 
     #[test]

--- a/crates/aura-cli/src/ui/state.rs
+++ b/crates/aura-cli/src/ui/state.rs
@@ -14,7 +14,7 @@ use std::time::Instant;
 
 use crossterm::style::Color;
 
-use crate::api::types::DisplayEvent;
+use crate::api::types::{DisplayEvent, ModelEntry};
 use crate::repl::registry::PendingCommand;
 use crate::ui::welcome::WelcomeState;
 
@@ -227,8 +227,9 @@ pub(crate) static STYLE_PREVIEW_ORIGINAL: Mutex<Option<&'static crate::theme::Th
 // Cached matches from the last /resume autocomplete lookup.
 pub(crate) static RESUME_MATCHES: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
 
-// Model selection state
-pub(crate) static MODEL_CACHE: Mutex<Vec<String>> = Mutex::new(Vec::new());
+// Model selection state. `MODEL_CACHE` holds every model the backend offers;
+// `MODEL_MATCHES` holds the ids of those matching the current `/model` filter.
+pub(crate) static MODEL_CACHE: Mutex<Vec<ModelEntry>> = Mutex::new(Vec::new());
 pub(crate) static MODEL_MATCHES: Mutex<Vec<String>> = Mutex::new(Vec::new());
 pub(crate) static MODEL_ERROR: Mutex<String> = Mutex::new(String::new());
 
@@ -442,7 +443,7 @@ pub fn get_model_matches() -> Vec<String> {
     MODEL_MATCHES.lock().map(|g| g.clone()).unwrap_or_default()
 }
 
-pub fn get_model_cache() -> Vec<String> {
+pub fn get_model_cache() -> Vec<ModelEntry> {
     MODEL_CACHE.lock().map(|g| g.clone()).unwrap_or_default()
 }
 

--- a/crates/aura-cli/src/ui/text.rs
+++ b/crates/aura-cli/src/ui/text.rs
@@ -14,8 +14,11 @@ pub fn truncate_with_ellipsis(text: &str, max: usize) -> String {
     if UnicodeWidthStr::width(text) <= max {
         return text.to_string();
     }
+    if max < 3 {
+        return ".".repeat(max);
+    }
     // Reserve three columns for the ellipsis so the result fits in `max`.
-    let keep = max.saturating_sub(3);
+    let keep = max - 3;
     let mut width = 0;
     let mut end = 0;
     for (i, grapheme) in text.grapheme_indices(true) {
@@ -78,6 +81,13 @@ mod tests {
     #[test]
     fn short_text_is_unchanged() {
         assert_eq!(truncate_with_ellipsis("hello", 120), "hello");
+    }
+
+    #[test]
+    fn truncation_never_exceeds_max_even_below_the_ellipsis_width() {
+        assert_eq!(truncate_with_ellipsis("hello", 2), "..");
+        assert_eq!(truncate_with_ellipsis("hello", 0), "");
+        assert_eq!(truncate_with_ellipsis("hi", 2), "hi");
     }
 
     #[test]

--- a/crates/aura-cli/src/ui/text.rs
+++ b/crates/aura-cli/src/ui/text.rs
@@ -15,7 +15,13 @@ pub fn truncate_with_ellipsis(text: &str, max: usize) -> String {
     // Reserve three clusters for the ellipsis so the result fits in `max`.
     let keep = max.saturating_sub(3);
     let prefix: String = text.graphemes(true).take(keep).collect();
-    format!("{prefix}...")
+    format!("{}...", prefix.trim_end())
+}
+
+/// Collapse every run of whitespace (newlines included) into one space and
+/// trim the ends, so multi-line text renders on a single terminal row.
+pub fn collapse_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// Greedy word-wrap of `text` into lines of at most `width` columns.
@@ -55,6 +61,22 @@ mod tests {
     #[test]
     fn short_text_is_unchanged() {
         assert_eq!(truncate_with_ellipsis("hello", 120), "hello");
+    }
+
+    #[test]
+    fn truncation_does_not_leave_a_space_before_the_ellipsis() {
+        assert_eq!(truncate_with_ellipsis("hello brave world", 9), "hello...");
+        assert_eq!(
+            truncate_with_ellipsis("hello brave world", 10),
+            "hello b..."
+        );
+    }
+
+    #[test]
+    fn collapse_whitespace_flattens_runs_and_newlines() {
+        assert_eq!(collapse_whitespace("  a\tb  \n\n c\r\n"), "a b c");
+        assert_eq!(collapse_whitespace("single"), "single");
+        assert_eq!(collapse_whitespace("   "), "");
     }
 
     #[test]

--- a/crates/aura-cli/src/ui/text.rs
+++ b/crates/aura-cli/src/ui/text.rs
@@ -1,21 +1,38 @@
-//! Grapheme-aware text helpers for terminal display.
+//! Grapheme- and width-aware text helpers for terminal display.
 
 use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
-/// Truncate `text` to at most `max` grapheme clusters, appending `...` when
-/// truncation occurs (so the result stays within `max` clusters).
+/// Truncate `text` to at most `max` display columns, appending `...` when
+/// truncation occurs (so the result stays within `max` columns).
 ///
-/// Counts and splits on grapheme cluster boundaries, not `char`s, so
+/// Width is measured with `unicode-width`, so double-width glyphs (CJK, many
+/// emoji) count as 2 columns. Splits only on grapheme cluster boundaries, so
 /// multi-scalar glyphs — ZWJ emoji sequences (👨‍👩‍👧), skin-tone modifiers
 /// (👋🏽), and regional-indicator flags (🇯🇵) — are never cut mid-glyph.
 pub fn truncate_with_ellipsis(text: &str, max: usize) -> String {
-    if text.graphemes(true).count() <= max {
+    if UnicodeWidthStr::width(text) <= max {
         return text.to_string();
     }
-    // Reserve three clusters for the ellipsis so the result fits in `max`.
+    // Reserve three columns for the ellipsis so the result fits in `max`.
     let keep = max.saturating_sub(3);
-    let prefix: String = text.graphemes(true).take(keep).collect();
-    format!("{}...", prefix.trim_end())
+    let mut width = 0;
+    let mut end = 0;
+    for (i, grapheme) in text.grapheme_indices(true) {
+        let w = UnicodeWidthStr::width(grapheme);
+        if width + w > keep {
+            break;
+        }
+        width += w;
+        end = i + grapheme.len();
+    }
+    format!("{}...", text[..end].trim_end())
+}
+
+/// Drop control characters (C0, C1, DEL) so text from a remote source cannot
+/// carry terminal escape sequences into the display.
+pub fn strip_control_chars(text: &str) -> String {
+    text.chars().filter(|c| !c.is_control()).collect()
 }
 
 /// Collapse every run of whitespace (newlines included) into one space and
@@ -88,27 +105,53 @@ mod tests {
     }
 
     #[test]
+    fn truncation_counts_display_columns_not_scalars() {
+        // Each CJK glyph is one scalar but two columns.
+        let s = "漢字".repeat(20);
+        let out = truncate_with_ellipsis(&s, 11);
+        // 8 columns of glyphs (4 whole chars) + "..." = 11 columns.
+        assert_eq!(out, "漢字漢字...");
+        assert_eq!(UnicodeWidthStr::width(out.as_str()), 11);
+        // A boundary that would split a wide glyph rounds down instead.
+        assert_eq!(truncate_with_ellipsis(&s, 10), "漢字漢...");
+    }
+
+    #[test]
     fn does_not_split_zwj_emoji() {
         // Family emoji is a single grapheme made of multiple scalars.
         let family = "👨‍👩‍👧";
+        let family_w = UnicodeWidthStr::width(family);
         // Pad with enough families to force truncation at a boundary.
         let s = family.repeat(50);
         let out = truncate_with_ellipsis(&s, 10);
-        // Truncation point keeps 7 whole families + "...". Crucially, the
-        // output must still be valid and contain only whole families.
-        let body = out.strip_suffix("...").unwrap();
-        assert_eq!(body, family.repeat(7));
-        assert_eq!(out, format!("{}...", family.repeat(7)));
+        // Whole families only, as many as fit beside "...".
+        let kept = (10 - 3) / family_w;
+        assert_eq!(out, format!("{}...", family.repeat(kept)));
+        assert!(UnicodeWidthStr::width(out.as_str()) <= 10);
     }
 
     #[test]
     fn does_not_split_skin_tone_or_flag() {
         let wave = "👋🏽"; // base + skin-tone modifier
         let flag = "🇯🇵"; // two regional indicators
+        let wave_w = UnicodeWidthStr::width(wave);
         let s = format!("{}{}", wave.repeat(8), flag.repeat(8));
         let out = truncate_with_ellipsis(&s, 6);
-        // 3 kept clusters + ellipsis; all kept clusters are whole waves.
-        assert_eq!(out, format!("{}...", wave.repeat(3)));
+        // Whole waves only, as many as fit beside "...".
+        let kept = (6 - 3) / wave_w;
+        assert_eq!(out, format!("{}...", wave.repeat(kept)));
+    }
+
+    #[test]
+    fn strip_control_chars_removes_escape_introducers() {
+        assert_eq!(
+            strip_control_chars("red\x1b[31m text\x07 \u{9b}31m ok\x7f"),
+            "red[31m text 31m ok"
+        );
+        assert_eq!(
+            strip_control_chars("plain ünïcödé 漢字"),
+            "plain ünïcödé 漢字"
+        );
     }
 
     #[test]

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -767,6 +767,9 @@ pub struct AgentConfig {
     pub name: String,
     #[serde(default)]
     pub alias: Option<String>,
+    /// Short human-readable summary of what this agent does.
+    #[serde(default)]
+    pub description: Option<String>,
     pub system_prompt: String,
     #[serde(default)]
     pub context: Vec<String>,
@@ -843,6 +846,7 @@ impl Default for AgentConfig {
         Self {
             name: "Assistant".to_string(),
             alias: None,
+            description: None,
             system_prompt: "You are a helpful assistant.".to_string(),
             context: Vec::new(),
             turn_depth: default_turn_depth(),

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -995,6 +995,42 @@ model = "llama3.2"
     }
 
     #[test]
+    fn test_description_defaults_to_none() {
+        let config_str = r#"
+[agent]
+name = "Test"
+system_prompt = "Test"
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
+"#;
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+        assert_eq!(config.agent.description, None);
+    }
+
+    #[test]
+    fn test_description_explicit_value() {
+        let config_str = r#"
+[agent]
+name = "Test"
+description = "Anthropic-backed SRE agent for production incidents"
+system_prompt = "Test"
+
+[agent.llm]
+provider = "ollama"
+model = "llama3.2"
+
+"#;
+        let config = load_config_from_str(config_str).expect("Failed to parse config");
+        assert_eq!(
+            config.agent.description.as_deref(),
+            Some("Anthropic-backed SRE agent for production incidents")
+        );
+    }
+
+    #[test]
     fn test_ollama_config_all_params() {
         println!("\n=== TEST_OLLAMA_CONFIG_ALL_PARAMS ===");
         let config_str = r#"

--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -205,6 +205,9 @@ pub enum McpServerOverview {
 pub struct AgentInfo {
     /// Agent identifier — matches the `id` field in `/v1/models` (alias or name).
     pub id: String,
+    /// Short human-readable summary of what the agent does.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// LLM model name (e.g., "gpt-4o").
     pub model: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -617,10 +620,10 @@ mod tests {
         .unwrap();
         let unknown = &old.agents[0];
         assert_eq!(unknown.mcp_servers, None);
-        assert!(serde_json::to_value(unknown)
-            .unwrap()
-            .get("mcp_servers")
-            .is_none());
+        assert_eq!(unknown.description, None);
+        let serialized = serde_json::to_value(unknown).unwrap();
+        assert!(serialized.get("mcp_servers").is_none());
+        assert!(serialized.get("description").is_none());
 
         // A populated config view round-trips through the standard keyed-map
         // shape; `description` is omitted when absent.

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1008,7 +1008,9 @@ pub async fn info(State(state): State<Arc<AppState>>) -> Response {
 
 /// OpenAI-compatible model listing endpoint.
 /// Each model `id` maps to an agent's `alias` (if set) or `name` from the TOML config.
-/// Filters out `hidden` agents
+/// Filters out `hidden` agents. `description` is an additive extension of
+/// the OpenAI model object, absent unless `[agent].description` is set, so
+/// strict OpenAI clients can ignore it.
 pub async fn list_models(State(state): State<Arc<AppState>>) -> Response {
     let models: Vec<serde_json::Value> = state
         .configs
@@ -1021,12 +1023,16 @@ pub async fn list_models(State(state): State<Arc<AppState>>) -> Response {
                 let (provider, _) = config.agent.llm.model_info();
                 provider.to_string()
             });
-            serde_json::json!({
+            let mut model = serde_json::json!({
                 "id": id,
                 "object": "model",
                 "created": created,
                 "owned_by": owned_by
-            })
+            });
+            if let Some(description) = &config.agent.description {
+                model["description"] = serde_json::Value::String(description.clone());
+            }
+            model
         })
         .collect();
 
@@ -1741,6 +1747,39 @@ model = "gpt-4o"
         assert_eq!(data[0]["id"], "visible-agent");
         assert_eq!(data[0]["object"], "model");
         assert_eq!(data[0]["owned_by"], "openai");
+        assert!(data[0].get("description").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_models_includes_configured_description() {
+        let described = parse_config(
+            r#"
+[agent]
+name = "sre-agent"
+description = "Anthropic-backed SRE agent for production incidents"
+system_prompt = "You triage incidents."
+
+[agent.llm]
+provider = "openai"
+api_key = "test"
+model = "gpt-4o"
+"#,
+        );
+
+        let state = make_state(vec![described]);
+        let resp = list_models(State(state)).await;
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        let data = json["data"].as_array().unwrap();
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0]["id"], "sre-agent");
+        assert_eq!(
+            data[0]["description"],
+            "Anthropic-backed SRE agent for production incidents"
+        );
     }
 
     // --- info endpoint tests ---
@@ -1833,6 +1872,7 @@ model = "gpt-4o-mini"
         assert_eq!(info.agents.len(), 1);
         let agent = &info.agents[0];
         assert_eq!(agent.id, "orch");
+        assert_eq!(agent.description, None);
         assert_eq!(agent.model, "gpt-4o");
         assert_eq!(agent.workers.len(), 2);
         assert_eq!(agent.workers[0].name, "planner");
@@ -1840,6 +1880,24 @@ model = "gpt-4o-mini"
         assert_eq!(agent.workers[1].name, "writer");
         assert_eq!(agent.workers[1].model.as_deref(), Some("gpt-4o-mini"));
         assert_eq!(agent.mcp_servers, Some(std::collections::BTreeMap::new()));
+    }
+
+    #[tokio::test]
+    async fn test_info_carries_agent_description() {
+        let state = make_info_state(
+            vec![info_config(
+                "sre",
+                r#"description = "Triage production incidents""#,
+                "",
+            )],
+            None,
+        );
+        let info = parse_info_response(info(State(state)).await).await;
+
+        assert_eq!(
+            info.agents[0].description.as_deref(),
+            Some("Triage production incidents")
+        );
     }
 
     #[tokio::test]

--- a/crates/aura/src/orchestration/overview.rs
+++ b/crates/aura/src/orchestration/overview.rs
@@ -7,6 +7,7 @@ use aura_events::{AgentInfo, McpServerOverview, WorkerOverview};
 pub fn agent_info(config: &Config) -> AgentInfo {
     AgentInfo {
         id: config.agent_id().to_owned(),
+        description: config.agent.description.clone(),
         model: config.agent.llm.model_info().1.to_owned(),
         workers: worker_overview(config),
         // `Some(empty)` means this config has no servers; `None` is reserved
@@ -184,6 +185,35 @@ api_key = "k"
         assert_eq!(workers[0].model, None);
         assert_eq!(workers[1].model, Some("gpt-4o-mini".to_string()));
         assert_eq!(workers[2].model, None);
+    }
+
+    #[test]
+    fn agent_info_carries_the_configured_description() {
+        let config_with = |agent_fields: &str| {
+            load_config_from_str(&format!(
+                r#"
+[agent]
+name = "described"
+system_prompt = "p"
+{agent_fields}
+[agent.llm]
+provider = "openai"
+model = "gpt-4o"
+api_key = "k"
+"#
+            ))
+            .expect("config should parse")
+        };
+
+        assert_eq!(agent_info(&config_with("")).description, None);
+        assert_eq!(
+            agent_info(&config_with(
+                r#"description = "Triage production incidents""#
+            ))
+            .description
+            .as_deref(),
+            Some("Triage production incidents")
+        );
     }
 
     #[test]

--- a/examples/complete/incident-response-datadog.toml
+++ b/examples/complete/incident-response-datadog.toml
@@ -35,6 +35,7 @@ DD-APPLICATION-KEY = "{{ env.DD_APPLICATION_KEY | default: '' }}"
 [agent]
 name = "Incident Response Agent"
 alias = "incident-response/datadog"
+description = "Incident triage with PagerDuty context and Datadog metrics"
 model_owner = "mezmo"
 system_prompt = """
 You are an incident response agent with access to PagerDuty and

--- a/examples/complete/incident-response-mezmo.toml
+++ b/examples/complete/incident-response-mezmo.toml
@@ -33,6 +33,7 @@ Authorization = "Bearer {{ env.MEZMO_API_KEY | default: '' }}"
 [agent]
 name = "Incident Response Agent"
 alias = "incident-response/mezmo"
+description = "Incident triage with PagerDuty context and Mezmo log analysis"
 model_owner = "mezmo"
 system_prompt = """
 You are an incident response agent with access to PagerDuty and

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -157,6 +157,9 @@ name = "Assistant"
 #                         # Clients send this as the "model" field in requests.
 #                         # If omitted, the agent name is used as the identifier.
 #                         # Must be unique across all loaded configs.
+# description = "General-purpose assistant with tool access"
+#                         # optional: one-line summary shown next to the model
+#                         # id in /v1/models, /aura/info, and the CLI's /model picker.
 system_prompt = """
 You are a helpful assistant with access to external tools and
 knowledge bases. Use them to provide accurate, grounded answers.


### PR DESCRIPTION
## Summary

- Add optional `[agent].description` — a one-line summary of what an agent does, so deployments that load several agent configs can tell them apart by more than name/alias. Display-only; not part of the runtime `AgentSettings` and never reaches the model.
- Expose it over the wire: `description` on each `GET /v1/models` entry (additive extension of the OpenAI model object, absent when unset) and `AgentInfo.description` in `GET /aura/info`. Older servers/clients stay compatible.
- Turn the CLI's `/model` picker into a numbered menu, one model per row whether or not anything has a description:

  ```
       Name                       Description
    1. Mezmo Anthropic SRE Agent  Anthropic backed config to solve all of your production problems
  ❯ 2. Mezmo OpenAI SRE Agent ✓   OpenAI backed config for the same production problems
  ```

  `❯` marks the Tab-selected row, `✓` the model in use, the Name/Description header appears once any model has a description, and descriptions are truncated to the terminal width. Descriptions flow from `/v1/models` in HTTP mode, from the loaded configs in standalone mode, and are persisted in the per-conversation `models_cache` (`id<TAB>description` per line; tab-less lines still load). The unique-match line and the agent overview printed after selection show the description too.
- The scroll window shared by every hint list now keeps the Tab selection in its middle row (rather than pinned to the top), so the cursor row and the ▲/▼ scroll cue never share a row and one gutter serves both.
- Describe the two `incident-response-*` example agents, which share a name and differ only by alias — the case this field is for — and document the field in `examples/reference.toml`.

Follow-up (separate repo): document `[agent].description`, the new `/v1/models` and `/aura/info` fields, and the `/model` picker in `mezmo/documentation` under `aura/`.
