### PR TITLE
ci: compute the release version against the remote

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -459,10 +459,12 @@ pipeline {
             sh "git checkout -B ${CURRENT_BRANCH}"
 
             script {
-              env.NEXT_RELEASE_VERSION = sh(
-                script: "npm run --silent release:version 'file://${env.WORKSPACE}'",
-                returnStdout: true
-              ).trim()
+              withCredentials(RELEASE_CREDENTIALS) {
+                env.NEXT_RELEASE_VERSION = sh(
+                  script: 'npm run --silent release:version',
+                  returnStdout: true
+                ).trim()
+              }
               echo env.NEXT_RELEASE_VERSION ? "Release version: ${env.NEXT_RELEASE_VERSION}" : 'No release version determined; skipping build'
             }
           }


### PR DESCRIPTION
Compute Release Version resolved the previous release from the workspace, which carries no tags, so semantic-release fell back to its 1.0.0 first-release default and stamped the binaries and packages with a version the release never published.

Drop the workspace repository URL so the version is computed from the tags of the same remote the release publishes to, and bind the release credentials that the token auth needs.