### PR TITLE
chore(packaging): compress deb and rpm payloads with xz

### DIFF
--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -78,6 +78,10 @@ contents:
     dst: "/usr/bin/${binary}"
     file_info:
       mode: 0755
+deb:
+  compression: xz
+rpm:
+  compression: xz
 EOF
 }
 


### PR DESCRIPTION
nfpm defaulted to gzip for deb and gzip:-1 for rpm. Set both to xz in the generated config, which cuts the release package size by roughly 20%.