### PR TITLE
build: enable fat lto, single codegen unit, and symbol stripping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ authors = ["Mezmo <support@mezmo.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/mezmo/aura"
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = "symbols"
+
 [workspace.dependencies]
 rig-core = { git = "https://github.com/mezmo/rig.git", rev = "5b0238a1d74e1d7c68034384b69e17f62890d517", default-features = false, features = ["rmcp", "reqwest-rustls"] }
 # Pinned to exact versions compatible with our rig-core 0.28.x fork.


### PR DESCRIPTION
Set a workspace [profile.release] so release builds link with fat LTO, compile as a single codegen unit, and strip symbols.

Measured against the v0.2.0 release artifacts, the binaries shrink by roughly 17-19% on linux and 28-33% on darwin, where the unstripped Mach-O symbol tables were larger. Combined with xz-compressed payloads, the deb and rpm packages come down about 28-36%.

Build times increase, since fat LTO and codegen-units = 1 give up parallelism within each crate.