### PR TITLE
feat(logging-otel): add HTTP transport and TLS support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml 0.8.23",
+ "tonic 0.12.3",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2945,6 +2945,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
 name = "opentelemetry-otlp"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,9 +2967,11 @@ dependencies = [
  "futures-core",
  "http 1.4.0",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.13.5",
+ "reqwest",
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.14",
+ "h2 0.4.17",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -2100,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2290,7 +2290,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -3715,7 +3715,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4881,7 +4881,7 @@ dependencies = [
  "base64",
  "bytes",
  "flate2",
- "h2 0.4.14",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4913,7 +4913,7 @@ dependencies = [
  "axum 0.8.9",
  "base64",
  "bytes",
- "h2 0.4.14",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,12 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 opentelemetry = "0.27"
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.27", features = ["tonic"] }
+opentelemetry-otlp = { version = "0.27", features = ["tonic", "tls-roots"] }
 tracing-opentelemetry = "0.28"
+# Matches the tonic version opentelemetry-otlp 0.27 resolves to. Direct
+# dependency only for `ClientTlsConfig`, which opentelemetry-otlp takes in
+# its public API without re-exporting.
+tonic = { version = "0.12", default-features = false }
 
 # CLI
 clap = { version = "4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 opentelemetry = "0.27"
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.27", features = ["tonic", "tls-roots"] }
+opentelemetry-otlp = { version = "0.27", features = ["tonic", "tls-roots", "http-proto", "reqwest-client"] }
 tracing-opentelemetry = "0.28"
 # Matches the tonic version opentelemetry-otlp 0.27 resolves to. Direct
 # dependency only for `ClientTlsConfig`, which opentelemetry-otlp takes in

--- a/crates/aura-cli/README.md
+++ b/crates/aura-cli/README.md
@@ -478,19 +478,20 @@ runtime that drives the request loop. `main` flushes via
 `aura::logging::shutdown_tracer()` before the runtime drops so trailing
 spans aren't lost.
 
-An `https://` endpoint is connected over TLS using the platform's native root
-certificates; `http://` connects in plaintext. Combined with
-`OTEL_EXPORTER_OTLP_HEADERS`, that covers a collector sitting behind an
-authenticating proxy.
+Two wire protocols are supported, selected by `OTEL_EXPORTER_OTLP_PROTOCOL`:
+`grpc` (the default) and `http/protobuf`.
+With HTTP `/v1/traces` is appended to `OTEL_EXPORTER_OTLP_ENDPOINT`.
+(Use `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` if you need an explicit path).
 
 Other relevant OTel env vars (read by the `aura` crate, unchanged from the
 server):
 
 | Variable                                | Purpose                                                                                              |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`           | OTLP collector endpoint (gRPC). When unset, no OTel layer is installed even in standalone mode.      |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`           | OTLP collector endpoint. When unset, no OTel layer is installed even in standalone mode.             |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`    | Traces-specific endpoint; takes precedence over the generic one.                                     |
-| `OTEL_EXPORTER_OTLP_HEADERS`            | Comma-separated `key=value` pairs sent as gRPC metadata (e.g. proxy auth credentials).               |
+| `OTEL_EXPORTER_OTLP_PROTOCOL`           | `grpc` (default) or `http/protobuf`. `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` takes precedence.          |
+| `OTEL_EXPORTER_OTLP_HEADERS`            | Comma-separated `key=value` pairs sent as gRPC metadata / HTTP headers (e.g. proxy auth).            |
 | `OTEL_SERVICE_NAME`                     | Resource attribute (defaults to `aura`).                                                             |
 | `OTEL_LOG_LEVEL`                        | Override the OTel layer's filter. Default captures `aura=trace`, `aura_cli=info`, and rig spans.     |
 | `OTEL_RECORD_CONTENT`                   | When `true`, prompt/completion/tool args/results are recorded as span attributes.                    |

--- a/crates/aura-cli/README.md
+++ b/crates/aura-cli/README.md
@@ -478,12 +478,19 @@ runtime that drives the request loop. `main` flushes via
 `aura::logging::shutdown_tracer()` before the runtime drops so trailing
 spans aren't lost.
 
+An `https://` endpoint is connected over TLS using the platform's native root
+certificates; `http://` connects in plaintext. Combined with
+`OTEL_EXPORTER_OTLP_HEADERS`, that covers a collector sitting behind an
+authenticating proxy.
+
 Other relevant OTel env vars (read by the `aura` crate, unchanged from the
 server):
 
 | Variable                                | Purpose                                                                                              |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `OTEL_EXPORTER_OTLP_ENDPOINT`           | OTLP collector endpoint (gRPC). When unset, no OTel layer is installed even in standalone mode.      |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`    | Traces-specific endpoint; takes precedence over the generic one.                                     |
+| `OTEL_EXPORTER_OTLP_HEADERS`            | Comma-separated `key=value` pairs sent as gRPC metadata (e.g. proxy auth credentials).               |
 | `OTEL_SERVICE_NAME`                     | Resource attribute (defaults to `aura`).                                                             |
 | `OTEL_LOG_LEVEL`                        | Override the OTel layer's filter. Default captures `aura=trace`, `aura_cli=info`, and rig spans.     |
 | `OTEL_RECORD_CONTENT`                   | When `true`, prompt/completion/tool args/results are recorded as span attributes.                    |

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -55,6 +55,7 @@ opentelemetry = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
+tonic = { workspace = true, optional = true }
 chrono = { version = "0.4", features = ["serde"] }
 
 # Vector stores - Qdrant support
@@ -73,7 +74,7 @@ gemini-tokenizer = "0.2.0"
 
 [features]
 default = ["otel"]
-otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]
+otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry", "dep:tonic"]
 # Integration test umbrella (mirrors aura-web-server pattern)
 integration = ["integration-stdio"]
 integration-stdio = []

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -8,6 +8,11 @@
 //! When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, all tracing spans are
 //! automatically exported as OpenTelemetry spans via the OTLP exporter.
 //!
+//! `OTEL_EXPORTER_OTLP_PROTOCOL` selects the wire protocol: `grpc` (the
+//! default) or `http/protobuf`.  Either way an `https://` endpoint is served
+//! with the platform's native root certificates and `http://` connects in
+//! plaintext.
+//!
 //! ## Per-layer filtering
 //!
 //! The console (fmt) layer uses the same filter as before (controlled by
@@ -76,14 +81,6 @@
 //! Tool errors are only recorded on the `mcp.tool_call` child span (by
 //! `mcp_tool_execution.rs`), not on Rig's `execute_tool` parent.  This is
 //! intentional: `mcp.tool_call` is the canonical TOOL span for Phoenix.
-//!
-//! ## Transport
-//!
-//! Spans are exported over OTLP/gRPC.  An `https://` endpoint is served with
-//! the platform's native root certificates; `http://` connects in plaintext.
-//! `OTEL_EXPORTER_OTLP_HEADERS` (comma-separated `key=value` pairs) is read by
-//! the OTLP exporter and attached as gRPC metadata on every export, which is
-//! how an authenticating proxy in front of the collector gets its credentials.
 //!
 //! ## Content recording
 //!
@@ -286,43 +283,116 @@ fn endpoint_uses_tls(endpoint: &str) -> bool {
     endpoint.trim().to_ascii_lowercase().starts_with("https://")
 }
 
+/// Wire protocol carrying spans to the collector.
+#[cfg(feature = "otel")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OtlpProtocol {
+    Grpc,
+    HttpProtobuf,
+}
+
+/// Parse an OTLP protocol from its spec spelling.
+///
+/// `http/json` is deliberately unrecognised: the exporter is built without
+/// the `http-json` feature, so accepting the name would promise a transport
+/// that cannot be constructed.
+#[cfg(feature = "otel")]
+fn parse_otlp_protocol(value: &str) -> Option<OtlpProtocol> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "grpc" => Some(OtlpProtocol::Grpc),
+        "http/protobuf" => Some(OtlpProtocol::HttpProtobuf),
+        _ => None,
+    }
+}
+
+/// Resolve the export protocol from the environment, defaulting to gRPC.
+///
+/// `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` wins over the generic
+/// `OTEL_EXPORTER_OTLP_PROTOCOL`. An unrecognised value warns and falls back
+/// rather than dropping traces silently.
+#[cfg(feature = "otel")]
+fn resolve_otlp_protocol() -> OtlpProtocol {
+    let configured = std::env::var("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
+        .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_PROTOCOL"))
+        .ok();
+
+    match configured {
+        None => OtlpProtocol::Grpc,
+        Some(value) => parse_otlp_protocol(&value).unwrap_or_else(|| {
+            eprintln!(
+                "WARNING: unsupported OTLP protocol '{value}' — falling back to grpc. \
+                 Supported values: grpc, http/protobuf."
+            );
+            OtlpProtocol::Grpc
+        }),
+    }
+}
+
+/// Build the gRPC span exporter.
+///
+/// An `https://` endpoint is given a `ClientTlsConfig` using the platform's
+/// native root store; tonic refuses to connect to an `https://` URI when no
+/// TLS config was attached, so this must be set before `build()`.
+#[cfg(feature = "otel")]
+fn build_grpc_span_exporter(
+    endpoint: &str,
+) -> Result<opentelemetry_otlp::SpanExporter, opentelemetry::trace::TraceError> {
+    use opentelemetry_otlp::WithTonicConfig;
+
+    let mut builder = opentelemetry_otlp::SpanExporter::builder().with_tonic();
+    if endpoint_uses_tls(endpoint) {
+        builder =
+            builder.with_tls_config(tonic::transport::ClientTlsConfig::new().with_native_roots());
+    }
+    builder.build()
+}
+
+/// Build the HTTP/protobuf span exporter.
+///
+/// TLS needs no configuration here — the reqwest client the exporter
+/// defaults to carries its own rustls stack and root certificates. The
+/// exporter appends `/v1/traces` to a generic `OTEL_EXPORTER_OTLP_ENDPOINT`
+/// and uses `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` verbatim.
+#[cfg(feature = "otel")]
+fn build_http_span_exporter()
+-> Result<opentelemetry_otlp::SpanExporter, opentelemetry::trace::TraceError> {
+    opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .build()
+}
+
 /// Try to build an OpenTelemetry `TracerProvider` when `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
 ///
 /// Stores the provider in `TRACER_PROVIDER` for later shutdown and returns it.
 /// Returns `None` when the env var is absent.
 ///
-/// An `https://` endpoint is given a `ClientTlsConfig` using the platform's
-/// native root store; tonic refuses to connect to an `https://` URI when no
-/// TLS config was attached, so this must be set before `build()`. The
-/// signal-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` takes precedence
-/// here, matching the precedence the exporter itself applies when it
-/// resolves the endpoint.
+/// The signal-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` takes precedence
+/// when deciding whether the gRPC transport needs TLS, matching the
+/// precedence the exporter itself applies when it resolves the endpoint.
 ///
 /// Public so binaries that compose their own subscriber stack (e.g.
 /// `aura` in standalone mode) can register the provider before attaching
 /// an `OpenTelemetryLayer`. Subsequent calls reuse the cached provider.
 #[cfg(feature = "otel")]
 pub fn init_otel_provider() -> Option<&'static TracerProvider> {
-    use opentelemetry_otlp::WithTonicConfig;
-
     // Presence check only — the OTLP exporter reads the endpoint value itself
     let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok()?;
 
     let signal_endpoint = std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT").ok();
     let effective_endpoint = signal_endpoint.as_deref().unwrap_or(&endpoint);
 
-    let mut builder = opentelemetry_otlp::SpanExporter::builder().with_tonic();
-    if endpoint_uses_tls(effective_endpoint) {
-        builder =
-            builder.with_tls_config(tonic::transport::ClientTlsConfig::new().with_native_roots());
-    }
+    let protocol = resolve_otlp_protocol();
+    let build_result = match protocol {
+        OtlpProtocol::Grpc => build_grpc_span_exporter(effective_endpoint),
+        OtlpProtocol::HttpProtobuf => build_http_span_exporter(),
+    };
 
-    let otlp_exporter = match builder.build() {
+    let otlp_exporter = match build_result {
         Ok(exporter) => exporter,
         Err(e) => {
             eprintln!(
                 "WARNING: OTEL_EXPORTER_OTLP_ENDPOINT is set ({endpoint}) but the OTLP \
-                 exporter failed to initialize: {e}. Traces will NOT be exported."
+                 {protocol:?} exporter failed to initialize: {e}. Traces will NOT be exported."
             );
             return None;
         }
@@ -849,5 +919,18 @@ mod tests {
         assert!(endpoint_uses_tls("  HTTPS://otel.example.com:443  "));
         assert!(!endpoint_uses_tls("http://localhost:4317"));
         assert!(!endpoint_uses_tls("localhost:4317"));
+    }
+
+    #[cfg(feature = "otel")]
+    #[test]
+    fn protocol_names_parse() {
+        assert_eq!(parse_otlp_protocol("grpc"), Some(OtlpProtocol::Grpc));
+        assert_eq!(
+            parse_otlp_protocol(" HTTP/PROTOBUF "),
+            Some(OtlpProtocol::HttpProtobuf)
+        );
+        // Unsupported: no http-json feature, so the name must not be accepted.
+        assert_eq!(parse_otlp_protocol("http/json"), None);
+        assert_eq!(parse_otlp_protocol("https"), None);
     }
 }

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -77,6 +77,14 @@
 //! `mcp_tool_execution.rs`), not on Rig's `execute_tool` parent.  This is
 //! intentional: `mcp.tool_call` is the canonical TOOL span for Phoenix.
 //!
+//! ## Transport
+//!
+//! Spans are exported over OTLP/gRPC.  An `https://` endpoint is served with
+//! the platform's native root certificates; `http://` connects in plaintext.
+//! `OTEL_EXPORTER_OTLP_HEADERS` (comma-separated `key=value` pairs) is read by
+//! the OTLP exporter and attached as gRPC metadata on every export, which is
+//! how an authenticating proxy in front of the collector gets its credentials.
+//!
 //! ## Content recording
 //!
 //! When `OTEL_RECORD_CONTENT=true`, prompt/completion text and tool
@@ -270,23 +278,46 @@ fn ensure_aura_config_warnings(filter: EnvFilter) -> EnvFilter {
 // OTel provider / layer / filter (only when feature = "otel")
 // ---------------------------------------------------------------------------
 
+/// Whether an OTLP endpoint URL selects TLS.
+///
+/// Scheme comparison is case-insensitive because URI schemes are.
+#[cfg(feature = "otel")]
+fn endpoint_uses_tls(endpoint: &str) -> bool {
+    endpoint.trim().to_ascii_lowercase().starts_with("https://")
+}
+
 /// Try to build an OpenTelemetry `TracerProvider` when `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
 ///
 /// Stores the provider in `TRACER_PROVIDER` for later shutdown and returns it.
 /// Returns `None` when the env var is absent.
+///
+/// An `https://` endpoint is given a `ClientTlsConfig` using the platform's
+/// native root store; tonic refuses to connect to an `https://` URI when no
+/// TLS config was attached, so this must be set before `build()`. The
+/// signal-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` takes precedence
+/// here, matching the precedence the exporter itself applies when it
+/// resolves the endpoint.
 ///
 /// Public so binaries that compose their own subscriber stack (e.g.
 /// `aura` in standalone mode) can register the provider before attaching
 /// an `OpenTelemetryLayer`. Subsequent calls reuse the cached provider.
 #[cfg(feature = "otel")]
 pub fn init_otel_provider() -> Option<&'static TracerProvider> {
+    use opentelemetry_otlp::WithTonicConfig;
+
     // Presence check only — the OTLP exporter reads the endpoint value itself
     let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok()?;
 
-    let otlp_exporter = match opentelemetry_otlp::SpanExporter::builder()
-        .with_tonic()
-        .build()
-    {
+    let signal_endpoint = std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT").ok();
+    let effective_endpoint = signal_endpoint.as_deref().unwrap_or(&endpoint);
+
+    let mut builder = opentelemetry_otlp::SpanExporter::builder().with_tonic();
+    if endpoint_uses_tls(effective_endpoint) {
+        builder =
+            builder.with_tls_config(tonic::transport::ClientTlsConfig::new().with_native_roots());
+    }
+
+    let otlp_exporter = match builder.build() {
         Ok(exporter) => exporter,
         Err(e) => {
             eprintln!(
@@ -809,5 +840,14 @@ mod tests {
         }))
         .unwrap();
         assert!(llm_invocation_parameters(&llm).is_none());
+    }
+
+    #[cfg(feature = "otel")]
+    #[test]
+    fn tls_selected_only_for_https_endpoints() {
+        assert!(endpoint_uses_tls("https://otel.example.com:443"));
+        assert!(endpoint_uses_tls("  HTTPS://otel.example.com:443  "));
+        assert!(!endpoint_uses_tls("http://localhost:4317"));
+        assert!(!endpoint_uses_tls("localhost:4317"));
     }
 }


### PR DESCRIPTION
# Summary
Today the otel trace exporter only supports unencrypted (no TLS) endpoints, and only the `grpc` transport.

This PR adds TLS support, as well as an alternative `http/protobuf` transport.

NOTE: The commits were authored by claude, I do not have enough rust / otel / grpc experience :)
