### PR TITLE
fix(orchestration): accept the reasoning field on wait_for calls

### DIFF
--- a/crates/aura/src/orchestration/tools/wait_for.rs
+++ b/crates/aura/src/orchestration/tools/wait_for.rs
@@ -37,6 +37,13 @@ pub struct WaitForArgs {
     pub poll_sec: Option<u64>,
     #[serde(default)]
     pub max_wait_sec: Option<u64>,
+    /// The persistence wrapper teaches worker models to attach
+    /// `_aura_reasoning` to every call, so it arrives here too even though
+    /// this tool sits outside the wrapper. Accepted and ignored — same
+    /// contract as `request_approval` — so the strict parse rejects only
+    /// genuinely unknown fields.
+    #[serde(default, rename = "_aura_reasoning")]
+    pub aura_reasoning: Option<String>,
 }
 
 /// Wire form of the probe.
@@ -1231,6 +1238,23 @@ mod tests {
             "poll_secs": 3,
         }));
         assert!(result.is_err());
+    }
+
+    /// Worker models attach the persistence wrapper's reasoning field to
+    /// every tool call; a wait_for call carrying it must parse rather than
+    /// bounce back to the model as an unknown-field error.
+    #[test]
+    fn aura_reasoning_is_accepted_and_ignored() {
+        let args = serde_json::from_value::<WaitForArgs>(serde_json::json!({
+            "probe": { "tool": "t", "args": {} },
+            "until": { "matches": "x" },
+            "_aura_reasoning": "watching the rollout settle",
+        }))
+        .expect("the reasoning field must not fail the call");
+        assert_eq!(
+            args.aura_reasoning.as_deref(),
+            Some("watching the rollout settle")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Worker agents see `_aura_reasoning` on every schema the persistence wrapper wraps, so they attach it to their tool calls as a matter of course. `wait_for` is registered on workers outside that wrapper (`orchestrator.rs`, `build_worker_provider_agent`) with a `deny_unknown_fields` parse, so a call carrying the field bounces back to the model instead of running:

```
WARN rig::agent::prompt_request::streaming: Error while calling tool: Toolset error: ToolCallError: ToolCallError: JsonError: unknown field `_aura_reasoning`, expected one of `probe`, `until`, `poll_sec`, `max_wait_sec`
```

Seen in a live dev deployment during post-remediation verification — the step `wait_for` exists for. The model usually retries without the field, so the cost is a wasted bounce per run; a model that doesn't retry skips its recovery check.

Accept and ignore the field (`#[serde(default, rename = "_aura_reasoning")]`), the same contract `request_approval` already applies to it. Genuinely unknown fields still fail the parse, and the existing `unknown_top_level_field_fails_wire_deserialization` test pins that.