### PR TITLE
feat(otel): fix empty assistant content 400, enrich phoenix span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3757,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.28.0"
-source = "git+https://github.com/mezmo/rig.git?rev=e6f008eaf555733d93368c9dd174d1d61d7d096d#e6f008eaf555733d93368c9dd174d1d61d7d096d"
+source = "git+https://github.com/mezmo/rig.git?rev=5b0238a1d74e1d7c68034384b69e17f62890d517#5b0238a1d74e1d7c68034384b69e17f62890d517"
 dependencies = [
  "as-any",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mezmo/aura"
 
 [workspace.dependencies]
-rig-core = { git = "https://github.com/mezmo/rig.git", rev = "e6f008eaf555733d93368c9dd174d1d61d7d096d", default-features = false, features = ["rmcp", "reqwest-rustls"] }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "5b0238a1d74e1d7c68034384b69e17f62890d517", default-features = false, features = ["rmcp", "reqwest-rustls"] }
 # Pinned to exact versions compatible with our rig-core 0.28.x fork.
 # Newer versions pull in rig-core 0.31+ which is semver-incompatible with the fork.
 rig-bedrock = "=0.3.10"
@@ -96,5 +96,5 @@ http = "1.0"
 
 # Patch rig-core to use the fork with streaming hook + span propagation fix
 [patch.crates-io]
-rig-core = { git = "https://github.com/mezmo/rig.git", rev = "e6f008eaf555733d93368c9dd174d1d61d7d096d" }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "5b0238a1d74e1d7c68034384b69e17f62890d517" }
 

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -280,6 +280,7 @@ impl DirectBackend {
             max_tokens: None,
             stream: Some(true),
             metadata: None,
+            user: None,
             tools: web_tools,
         }
     }
@@ -358,6 +359,7 @@ impl DirectBackend {
             max_tokens: None,
             stream: Some(false),
             metadata: None,
+            user: None,
             tools: None,
         };
 

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -231,6 +231,14 @@ pub struct RequestSetup {
     pub has_client_tools: bool,
     /// Request id (`req_…`) shared by the agent build and the completion stream.
     pub request_id: String,
+    /// OpenAI-compatible `user` field, for the `user.id` span attribute.
+    pub user_id: Option<String>,
+    /// Request `metadata` serialized as a JSON object string, for the
+    /// `metadata` span attribute.
+    pub metadata_json: Option<String>,
+    /// MCP tool schemas for the `llm.tools.{i}.tool.json_schema` span
+    /// attributes.
+    pub tools_json: Vec<String>,
 }
 
 /// Extract query, chat history, and build agent -- shared across both code paths.
@@ -288,47 +296,59 @@ pub async fn prepare_request(
         .map(|tools| tools.iter().map(aura::builder::ClientTool::from).collect());
 
     // Build the appropriate agent type based on orchestration config
-    let streaming_agent: Arc<dyn StreamingAgent> = if config.orchestration_enabled() {
-        // Orchestration path: build via streaming agent builder (returns Orchestrator).
-        // Client tools are filtered per-coordinator/per-worker inside the orchestrator.
-        let builder = RigBuilder::new(config.clone(), data.pending_approvals.clone())
-            .with_hitl_hmac(data.hitl_webhook_hmac.clone());
-        builder
-            .build_streaming_agent_with_headers(
-                Some(req_headers_map),
-                Some(chat_session_id.to_string()),
-                client_tools_vec.clone(),
-                Some(request_id.clone()),
-            )
-            .await
-            .map_err(|e| {
-                error!("Failed to build streaming agent: {}", e);
-                PrepareError::Internal(format!("Failed to build streaming agent: {e}"))
-            })?
-    } else {
-        // Standard path: build Agent with optional additional tools and client tools.
-        // Only attach client tools if the agent opted in via [agent].enable_client_tools.
-        let client_tools = if config.agent.enable_client_tools {
-            req.tools.as_deref()
+    let (streaming_agent, tools_json): (Arc<dyn StreamingAgent>, Vec<String>) =
+        if config.orchestration_enabled() {
+            // Orchestration path: build via streaming agent builder (returns Orchestrator).
+            // Client tools are filtered per-coordinator/per-worker inside the orchestrator.
+            let builder = RigBuilder::new(config.clone(), data.pending_approvals.clone())
+                .with_hitl_hmac(data.hitl_webhook_hmac.clone());
+            let agent = builder
+                .build_streaming_agent_with_headers(
+                    Some(req_headers_map),
+                    Some(chat_session_id.to_string()),
+                    client_tools_vec.clone(),
+                    Some(request_id.clone()),
+                )
+                .await
+                .map_err(|e| {
+                    error!("Failed to build streaming agent: {}", e);
+                    PrepareError::Internal(format!("Failed to build streaming agent: {e}"))
+                })?;
+            // Worker spans carry their own filtered tool lists.
+            (agent, Vec::new())
         } else {
-            None
+            // Standard path: build Agent with optional additional tools and client tools.
+            // Only attach client tools if the agent opted in via [agent].enable_client_tools.
+            let client_tools = if config.agent.enable_client_tools {
+                req.tools.as_deref()
+            } else {
+                None
+            };
+            let agent = build_agent_for_request(
+                &config,
+                req_headers_map,
+                additional_tools,
+                client_tools,
+                request_id.clone(),
+                chat_session_id.to_string(),
+                data,
+            )
+            .await?;
+            let tools_json = agent.otel_llm_tools();
+            (agent as Arc<dyn StreamingAgent>, tools_json)
         };
-        build_agent_for_request(
-            &config,
-            req_headers_map,
-            additional_tools,
-            client_tools,
-            request_id.clone(),
-            chat_session_id.to_string(),
-            data,
-        )
-        .await? as Arc<dyn StreamingAgent>
-    };
 
     let (provider, model) = streaming_agent.get_provider_info();
     let model_str = format!("{provider}/{model}");
     let completion_id = format!("chatcmpl-{}", Uuid::new_v4());
     let created_timestamp = Utc::now().timestamp() as u64;
+
+    let user_id = req.user.clone().filter(|u| !u.is_empty());
+    let metadata_json = req
+        .metadata
+        .as_ref()
+        .filter(|m| !m.is_empty())
+        .and_then(|m| serde_json::to_string(m).ok());
 
     Ok(RequestSetup {
         query,
@@ -341,6 +361,9 @@ pub async fn prepare_request(
         chat_session_id: chat_session_id.to_string(),
         has_client_tools,
         request_id,
+        user_id,
+        metadata_json,
+        tools_json,
     })
 }
 
@@ -501,6 +524,9 @@ pub async fn execute_completion(
     let _resource_guard =
         RequestResourceGuard::new(config.request_id.clone(), config.pending_approvals.clone());
 
+    let invocation_parameters = aura::logging::llm_invocation_parameters(&setup.config.agent.llm);
+    let orchestration_enabled = setup.config.orchestration_enabled();
+
     // Destructure to move chat_history instead of cloning
     let RequestSetup {
         query,
@@ -513,6 +539,9 @@ pub async fn execute_completion(
         chat_session_id,
         has_client_tools: _,
         request_id: _,
+        user_id,
+        metadata_json,
+        tools_json,
     } = setup;
 
     // Orchestration spawns inside `stream_with_timeout`, so SSE side-channel
@@ -549,12 +578,14 @@ pub async fn execute_completion(
         request_id: config.request_id.clone(),
         session_id: chat_session_id.clone(),
         query: config.query_for_otel,
-        identity_id: String::new(),
+        user_id,
+        metadata_json,
+        invocation_parameters,
+        tools_json,
         message_count: config.message_count,
-        usage_state: usage_state.clone(),
         response_content: config.response_content,
         system_prompt: streaming_agent.system_prompt().map(str::to_string),
-        is_orchestration: streaming_agent.is_orchestration(),
+        orchestration_enabled,
     };
     otel_ctx.record_input();
 
@@ -1279,6 +1310,7 @@ mod tests {
             max_tokens: None,
             stream,
             metadata: None,
+            user: None,
             tools: None,
         }
     }
@@ -1401,6 +1433,9 @@ mod tests {
             chat_session_id: "cs-test".to_string(),
             has_client_tools: false,
             request_id: request_id.clone(),
+            user_id: None,
+            metadata_json: None,
+            tools_json: vec![],
         };
         let config = CompletionConfig {
             request_id,

--- a/crates/aura-web-server/src/streaming/otel.rs
+++ b/crates/aura-web-server/src/streaming/otel.rs
@@ -7,7 +7,7 @@
 //! - [`StreamOtelContext::record_input`] — called at span start
 //! - [`StreamOtelContext::record_output`] — called after the stream ends
 
-use aura::{ResponseContent, UsageState};
+use aura::ResponseContent;
 
 use super::StreamTermination;
 
@@ -25,21 +25,20 @@ pub struct StreamOtelContext {
     pub request_id: String,
     pub session_id: String,
     pub query: String,
-    /// Identity from request headers (currently unused).
-    pub identity_id: String,
+    /// OpenAI-compatible `user` field from the request.
+    pub user_id: Option<String>,
+    /// Request `metadata` map serialized as a JSON object string.
+    pub metadata_json: Option<String>,
+    /// `llm.invocation_parameters` JSON for the effective LLM config.
+    pub invocation_parameters: Option<String>,
+    /// MCP tool schemas for `llm.tools.{i}.tool.json_schema`.
+    pub tools_json: Vec<String>,
     pub message_count: usize,
-    pub usage_state: UsageState,
     pub response_content: ResponseContent,
     /// Assembled system prompt sent to the provider.
     pub system_prompt: Option<String>,
-    /// True when the streaming agent is an orchestrator. Orchestration emits
-    /// per-phase LLM spans (`orchestration.planning`, `orchestration.worker`,
-    /// `orchestration.synthesis`, `orchestration.evaluation`) that each carry
-    /// their own `llm.token_count.*` attributes. Recording the aggregate on
-    /// the parent `agent.stream` span on top of that double-counts in
-    /// Phoenix's rollup, so `record_output` skips the token write here and
-    /// lets Phoenix sum the descendants.
-    pub is_orchestration: bool,
+    /// Whether the request is served by the multi-agent orchestrator.
+    pub orchestration_enabled: bool,
 }
 
 impl StreamOtelContext {
@@ -53,33 +52,47 @@ impl StreamOtelContext {
         }
         aura::logging::set_span_attribute(&span, "http.request_id", self.request_id.clone());
         aura::logging::set_span_attribute(&span, "session.id", self.session_id.clone());
-        if !self.identity_id.is_empty() {
-            aura::logging::set_span_attribute(&span, "identity.id", self.identity_id.clone());
+        aura::logging::set_span_attribute(
+            &span,
+            aura::logging::ATTR_AURA_VERSION,
+            aura::logging::AURA_VERSION,
+        );
+        aura::logging::set_span_attribute(
+            &span,
+            aura::logging::ATTR_AURA_MODE,
+            if self.orchestration_enabled {
+                "orchestration"
+            } else {
+                "single-agent"
+            },
+        );
+        if let Some(user_id) = &self.user_id {
+            aura::logging::set_span_attribute(&span, aura::logging::ATTR_USER_ID, user_id.clone());
+        }
+        if let Some(metadata) = &self.metadata_json {
+            aura::logging::set_span_attribute(
+                &span,
+                aura::logging::ATTR_METADATA,
+                metadata.clone(),
+            );
+        }
+        if let Some(params) = &self.invocation_parameters {
+            aura::logging::set_llm_invocation_parameters(&span, params);
+        }
+        if !self.tools_json.is_empty() {
+            aura::logging::set_llm_tools(&span, &self.tools_json);
         }
         aura::logging::set_span_attribute(&span, "message_count", self.message_count as i64);
     }
 
     /// Record output-side OTel attributes on the current span after the stream ends.
     ///
-    /// Captures token usage, response content (if available), and termination status.
+    /// Captures response content (if available) and termination status. Token
+    /// usage is not recorded here: each `agent.turn` child span carries its
+    /// own per-call usage (recorded by the Rig fork), and Phoenix's rollup
+    /// sums those descendants — an aggregate on this span would double-count.
     pub fn record_output(&self, termination: &StreamTermination) {
         let span = tracing::Span::current();
-        // In orchestration mode, per-phase spans already carry their own
-        // `llm.token_count.*` attributes; recording the aggregate on the parent
-        // `agent.stream` span would double-count under Phoenix's rollup.
-        if !self.is_orchestration {
-            let (prompt_tokens, completion_tokens, total_tokens) =
-                self.usage_state.get_final_usage();
-            let tool_completion_tokens = self.usage_state.get_tool_completion_tokens();
-            aura::logging::set_token_usage(
-                &span,
-                prompt_tokens,
-                completion_tokens,
-                total_tokens,
-                tool_completion_tokens,
-            );
-        }
-
         // Record response content for OpenInference/Phoenix visibility
         if let Some(content) = self.response_content.get() {
             aura::logging::set_output_attributes(&span, &content);

--- a/crates/aura-web-server/src/types.rs
+++ b/crates/aura-web-server/src/types.rs
@@ -227,6 +227,10 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     pub metadata: Option<HashMap<String, String>>,
 
+    /// OpenAI-compatible end-user identifier.
+    #[serde(default)]
+    pub user: Option<String>,
+
     /// Client-side tool definitions. Per-agent opt-in via
     /// `[agent].enable_client_tools` and `[orchestration.worker.<name>].enable_client_tools`
     /// in TOML; tools are filtered with the matching `client_tool_filter`.

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -151,6 +151,8 @@ pub struct Agent {
     /// Assembled system prompt handed to the provider builder
     /// (preamble + skill catalog, etc.).
     pub(crate) system_prompt: String,
+    /// `llm.invocation_parameters` JSON for OTel spans.
+    pub(crate) invocation_parameters: Option<String>,
 }
 
 impl Agent {
@@ -432,6 +434,7 @@ impl Agent {
 
         // Extract model name for logging
         let model_name = config.llm.model_name().to_string();
+        let (llm_provider, _) = config.llm.model_info();
 
         let mut system_prompt = config.effective_preamble().to_string();
         if let Some(catalog) = render_skill_catalog(&config.agent.skills) {
@@ -472,7 +475,12 @@ impl Agent {
 
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
-                agent_builder = agent_builder.preamble(&system_prompt);
+                agent_builder = agent_builder
+                    .name(&config.agent.name)
+                    .provider_name(llm_provider)
+                    .model_name(&model_name)
+                    .preamble(&system_prompt);
+
                 if let Some(temp) = temperature {
                     agent_builder = agent_builder.temperature(*temp);
                 }
@@ -538,7 +546,12 @@ impl Agent {
 
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
-                agent_builder = agent_builder.preamble(&system_prompt);
+                agent_builder = agent_builder
+                    .name(&config.agent.name)
+                    .provider_name(llm_provider)
+                    .model_name(&model_name)
+                    .preamble(&system_prompt);
+
                 if let Some(temp) = temperature {
                     agent_builder = agent_builder.temperature(*temp);
                 }
@@ -603,7 +616,12 @@ impl Agent {
 
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
-                agent_builder = agent_builder.preamble(&system_prompt);
+                agent_builder = agent_builder
+                    .name(&config.agent.name)
+                    .provider_name(llm_provider)
+                    .model_name(&model_name)
+                    .preamble(&system_prompt);
+
                 if let Some(temp) = temperature {
                     agent_builder = agent_builder.temperature(*temp);
                 }
@@ -652,7 +670,12 @@ impl Agent {
                 let completion_model = client.completion_model(model);
 
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
-                agent_builder = agent_builder.preamble(&system_prompt);
+                agent_builder = agent_builder
+                    .name(&config.agent.name)
+                    .provider_name(llm_provider)
+                    .model_name(&model_name)
+                    .preamble(&system_prompt);
+
                 if let Some(temp) = temperature {
                     agent_builder = agent_builder.temperature(*temp);
                 }
@@ -696,7 +719,12 @@ impl Agent {
 
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
-                agent_builder = agent_builder.preamble(&system_prompt);
+                agent_builder = agent_builder
+                    .name(&config.agent.name)
+                    .provider_name(llm_provider)
+                    .model_name(&model_name)
+                    .preamble(&system_prompt);
+
                 if let Some(temp) = temperature {
                     agent_builder = agent_builder.temperature(*temp);
                 }
@@ -744,7 +772,12 @@ impl Agent {
                 let completion_model = client.completion_model(model);
 
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
-                agent_builder = agent_builder.preamble(&system_prompt);
+                agent_builder = agent_builder
+                    .name(&config.agent.name)
+                    .provider_name(llm_provider)
+                    .model_name(&model_name)
+                    .preamble(&system_prompt);
+
                 if let Some(temp) = temperature {
                     agent_builder = agent_builder.temperature(*temp);
                 }
@@ -787,6 +820,7 @@ impl Agent {
             client_tool_names,
             turn_nudge,
             system_prompt,
+            invocation_parameters: crate::logging::llm_invocation_parameters(&config.llm),
         })
     }
 
@@ -1144,6 +1178,7 @@ impl Agent {
             query,
             &self.system_prompt,
         );
+        self.record_llm_call_attributes(&span);
 
         let stream = self.stream_prompt(query).await;
         let result = self.collect_stream_response(stream).await;
@@ -1169,11 +1204,23 @@ impl Agent {
             query,
             &self.system_prompt,
         );
+        self.record_llm_call_attributes(&span);
 
         let stream = self.stream_chat(query, chat_history).await;
         let result = self.collect_stream_response(stream).await;
         record_completion_result(&span, &result);
         result
+    }
+
+    /// Record invocation parameters and the advertised tool schemas on a span.
+    fn record_llm_call_attributes(&self, span: &tracing::Span) {
+        if let Some(params) = &self.invocation_parameters {
+            crate::logging::set_llm_invocation_parameters(span, params);
+        }
+        let tools = self.otel_llm_tools();
+        if !tools.is_empty() {
+            crate::logging::set_llm_tools(span, &tools);
+        }
     }
 
     /// Internal: Collect a stream into a CompletionResponse.
@@ -1526,6 +1573,20 @@ impl Agent {
     pub fn mcp_manager(&self) -> Option<&McpManager> {
         self.mcp_manager.as_deref()
     }
+
+    /// MCP tool schemas serialized for the `llm.tools.{i}.tool.json_schema`
+    /// span attributes. Empty when no MCP manager is configured.
+    pub fn otel_llm_tools(&self) -> Vec<String> {
+        self.mcp_manager
+            .as_ref()
+            .map(|m| m.tool_schemas_json(None))
+            .unwrap_or_default()
+    }
+
+    /// `llm.invocation_parameters` JSON for OTel spans.
+    pub fn otel_invocation_parameters(&self) -> Option<&str> {
+        self.invocation_parameters.as_deref()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1568,7 +1629,9 @@ fn record_input_attributes(
     crate::logging::set_system_prompt_attribute(span, system_prompt);
 }
 
-/// Record completion result fields (usage, content, status) on the span via OTel API.
+/// Record completion result fields (content, status) on the span via OTel API.
+/// Token usage lives on the nested `agent.turn` spans (recorded by the Rig
+/// fork), which Phoenix rolls up and prices.
 fn record_completion_result(
     span: &tracing::Span,
     result: &Result<
@@ -1578,13 +1641,6 @@ fn record_completion_result(
 ) {
     match result {
         Ok(response) => {
-            crate::logging::set_token_usage(
-                span,
-                response.usage.input_tokens,
-                response.usage.output_tokens,
-                response.usage.total_tokens,
-                0, // no per-tool breakdown in non-streaming path
-            );
             crate::logging::set_output_attributes(span, &response.content);
             crate::logging::set_span_ok(span);
         }

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -20,18 +20,19 @@
 //! `agent.stream` is created as a **root span** (`parent: None`) so that
 //! Phoenix sees it as the trace root.  I/O attributes (`input.value`,
 //! `output.value`, `user.id`, `session.id`, `metadata`) always live on this
-//! span. Token counts live here in **single-agent mode only**; in
-//! **orchestration mode** they live on the per-phase child spans
-//! (`orchestration.planning`, `orchestration.worker`,
-//! `orchestration.synthesis`, `orchestration.evaluation`) so Phoenix's
-//! rollup shows the accurate aggregate without double-counting the parent.
+//! span. Token counts live on the `agent.turn` spans only: the Rig fork
+//! records per-call model identifiers and usage there, Phoenix prices those
+//! LLM-kind spans (`openinference_exporter::infer_span_kind`), and every
+//! aggregate — per worker, per phase, per trace — is Phoenix's rollup of
+//! the turns. No Aura-owned span records token counts, so nothing
+//! double-counts.
 //!
 //! ### Single-agent mode
 //!
 //! ```text
-//! agent.stream (AGENT, ROOT)        <- Phoenix root span, lives for full stream duration
-//!   ├── user.id, session.id, metadata, input.value, output.value, tokens
-//!   └── agent.turn (LLM)           <- from Rig fork (reuses agent.stream as parent)
+//! agent.stream (LLM, ROOT)          <- Phoenix root span, lives for full stream duration
+//!   ├── user.id, session.id, metadata, input.value, output.value
+//!   └── agent.turn (LLM)           <- from Rig fork; carries model + per-call tokens
 //!       ├── execute_tool (TOOL)     <- from Rig (no error status — see below)
 //!       │   └── mcp.tool_call (TOOL) <- from Aura, canonical tool span with error status
 //!       └── execute_tool (TOOL)
@@ -41,12 +42,12 @@
 //! ### Orchestration mode
 //!
 //! ```text
-//! agent.stream (AGENT, ROOT)
+//! agent.stream (LLM, ROOT)
 //!   └── orchestration (CHAIN)                   <- full orchestration lifecycle
-//!         ├── orchestration.planning (CHAIN)     <- coordinator routing/planning
+//!         ├── orchestration.planning (LLM)         <- coordinator routing/planning
 //!         │   └── agent.turn (LLM) → ...
 //!         └── orchestration.iteration (CHAIN)    <- per plan-execute-continue cycle
-//!             └── orchestration.worker (AGENT)   <- per worker task
+//!             └── orchestration.worker (LLM)       <- per worker task
 //!                 └── agent.turn (LLM) → execute_tool → mcp.tool_call
 //! ```
 //!
@@ -105,16 +106,30 @@ static TRACER_PROVIDER: OnceLock<TracerProvider> = OnceLock::new();
 
 /// LLM provider identifier (e.g. "openai", "anthropic").
 pub const ATTR_LLM_SYSTEM: &str = "llm.system";
+/// LLM hosting provider (e.g. "openai", "bedrock").
+pub const ATTR_LLM_PROVIDER: &str = "llm.provider";
 /// Model name (e.g. "gpt-4o").
 pub const ATTR_LLM_MODEL_NAME: &str = "llm.model_name";
 /// Prompt / input token count.
 pub const ATTR_LLM_TOKEN_PROMPT: &str = "llm.token_count.prompt";
 /// Completion / output token count.
 pub const ATTR_LLM_TOKEN_COMPLETION: &str = "llm.token_count.completion";
-/// Total token count (prompt + completion).
-pub const ATTR_LLM_TOKEN_TOTAL: &str = "llm.token_count.total";
-/// Completion tokens spent generating tool call JSON (subset of completion).
-pub const ATTR_LLM_TOKEN_TOOL_COMPLETION: &str = "llm.token_count.tool_completion";
+/// LLM call parameters (temperature, max_tokens, …) as a JSON object string.
+pub const ATTR_LLM_INVOCATION_PARAMETERS: &str = "llm.invocation_parameters";
+/// End-user identifier from the request.
+pub const ATTR_USER_ID: &str = "user.id";
+/// Caller-supplied request metadata as a JSON object string.
+pub const ATTR_METADATA: &str = "metadata";
+/// Aura release that produced the trace.
+pub const ATTR_AURA_VERSION: &str = "aura.version";
+/// Aura workspace version.
+pub const AURA_VERSION: &str = env!("CARGO_PKG_VERSION");
+/// Serving path: "orchestration" or "single-agent".
+pub const ATTR_AURA_MODE: &str = "aura.mode";
+/// Prompt template with placeholders, before variable substitution.
+pub const ATTR_LLM_PROMPT_TEMPLATE: &str = "llm.prompt_template.template";
+/// Prompt template variables as a JSON object string.
+pub const ATTR_LLM_PROMPT_TEMPLATE_VARIABLES: &str = "llm.prompt_template.variables";
 /// Assembled system prompt sent to the provider (preamble + skill catalog,
 /// etc.), as an OTel GenAI array of typed parts.
 pub const ATTR_GEN_AI_SYSTEM_INSTRUCTIONS: &str = "gen_ai.system_instructions";
@@ -284,11 +299,19 @@ pub fn init_otel_provider() -> Option<&'static TracerProvider> {
     let exporter = crate::openinference_exporter::OpenInferenceExporter::new(otlp_exporter);
 
     let service_name = std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| "aura".to_string());
+    // Phoenix routes traces to a project solely by the
+    // `openinference.project.name` resource attribute (its OTLP receiver
+    // ignores `service.name`); without it, traces land in Phoenix's
+    // default project.
+    let project_name =
+        std::env::var("PHOENIX_PROJECT_NAME").unwrap_or_else(|_| service_name.clone());
 
     let provider = TracerProvider::builder()
         .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
         .with_resource(opentelemetry_sdk::Resource::new(vec![
             opentelemetry::KeyValue::new("service.name", service_name),
+            opentelemetry::KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
+            opentelemetry::KeyValue::new("openinference.project.name", project_name),
         ]))
         .build();
 
@@ -440,11 +463,22 @@ pub fn set_span_ok(span: &tracing::Span) {
     let _ = span;
 }
 
-/// Mark the span status as error with a message. No-op when the `otel` feature is disabled.
+/// Mark the span status as error with a message, and attach an OTel
+/// `exception` span event carrying `exception.message` — the shape Phoenix
+/// renders on failed spans. No-op when the `otel` feature is disabled.
 #[cfg(feature = "otel")]
 pub fn set_span_error(span: &tracing::Span, msg: impl Into<String>) {
     use tracing_opentelemetry::OpenTelemetrySpanExt;
-    span.set_status(opentelemetry::trace::Status::error(msg.into()));
+    let msg = msg.into();
+    // The tracing-opentelemetry layer rewrites an `error`-only event (no
+    // message field) into a span event named `exception`. Fired before
+    // `set_status` so the clean message below overrides the Debug-formatted
+    // status the layer derives from the event.
+    {
+        let _guard = span.enter();
+        tracing::error!(error = msg.as_str());
+    }
+    span.set_status(opentelemetry::trace::Status::error(msg));
 }
 
 /// Mark the span status as error with a message. No-op when the `otel` feature is disabled.
@@ -458,10 +492,15 @@ pub fn set_span_error(span: &tracing::Span, _msg: impl Into<String>) {
 // ---------------------------------------------------------------------------
 
 /// Record LLM provider and model identifiers on a span.
+///
+/// Sets both `llm.system` and `llm.provider` to the same provider string:
+/// Phoenix cost tracking matches `llm.provider` + `llm.model_name` against
+/// its pricing table, while `llm.system` is what its UI displays.
 #[cfg(feature = "otel")]
 pub fn set_llm_identifiers(span: &tracing::Span, provider: &str, model: &str) {
     use tracing_opentelemetry::OpenTelemetrySpanExt;
     span.set_attribute(ATTR_LLM_SYSTEM, provider.to_string());
+    span.set_attribute(ATTR_LLM_PROVIDER, provider.to_string());
     span.set_attribute(ATTR_LLM_MODEL_NAME, model.to_string());
 }
 
@@ -470,35 +509,113 @@ pub fn set_llm_identifiers(span: &tracing::Span, _provider: &str, _model: &str) 
     let _ = span;
 }
 
-/// Record token usage counters on a span.
-///
-/// `tool_completion` is the subset of `completion` spent generating tool call JSON.
-/// Only recorded when non-zero to avoid noise on single-turn (no-tool) interactions.
+/// Build the `llm.invocation_parameters` JSON object string for an LLM config
+/// (temperature, max_tokens, and any additional params). Returns `None` when
+/// the config sets no call parameters.
+pub fn llm_invocation_parameters(llm: &aura_config::LlmConfig) -> Option<String> {
+    let mut map = serde_json::Map::new();
+    if let Some(t) = llm.temperature() {
+        map.insert("temperature".into(), t.into());
+    }
+    if let Some(m) = llm.max_tokens() {
+        map.insert("max_tokens".into(), m.into());
+    }
+    if let Some(serde_json::Value::Object(extra)) = llm.additional_params() {
+        map.extend(extra);
+    }
+    if map.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(map).to_string())
+    }
+}
+
+/// Record LLM invocation parameters (a JSON object string) on a span.
 #[cfg(feature = "otel")]
-pub fn set_token_usage(
-    span: &tracing::Span,
-    prompt: u64,
-    completion: u64,
-    total: u64,
-    tool_completion: u64,
-) {
+pub fn set_llm_invocation_parameters(span: &tracing::Span, params_json: &str) {
     use tracing_opentelemetry::OpenTelemetrySpanExt;
-    span.set_attribute(ATTR_LLM_TOKEN_PROMPT, prompt as i64);
-    span.set_attribute(ATTR_LLM_TOKEN_COMPLETION, completion as i64);
-    span.set_attribute(ATTR_LLM_TOKEN_TOTAL, total as i64);
-    if tool_completion > 0 {
-        span.set_attribute(ATTR_LLM_TOKEN_TOOL_COMPLETION, tool_completion as i64);
+    span.set_attribute(ATTR_LLM_INVOCATION_PARAMETERS, params_json.to_string());
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn set_llm_invocation_parameters(span: &tracing::Span, _params_json: &str) {
+    let _ = span;
+}
+
+/// Record the prompt template and its variables on a span.
+///
+/// The template (static text with `%%VAR%%` placeholders, no request
+/// content) is always recorded; the variables carry request content, so
+/// they follow the content-recording rules (`OTEL_RECORD_CONTENT` gate
+/// plus truncation), mirroring `input.value`.
+#[cfg(feature = "otel")]
+pub fn set_llm_prompt_template(span: &tracing::Span, template: &str, variables: &[(&str, &str)]) {
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    span.set_attribute(ATTR_LLM_PROMPT_TEMPLATE, template.to_string());
+    if should_record_content() {
+        let map: serde_json::Map<String, serde_json::Value> = variables
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), truncate_for_otel(v).into()))
+            .collect();
+        span.set_attribute(
+            ATTR_LLM_PROMPT_TEMPLATE_VARIABLES,
+            serde_json::Value::Object(map).to_string(),
+        );
     }
 }
 
 #[cfg(not(feature = "otel"))]
-pub fn set_token_usage(
-    span: &tracing::Span,
-    _prompt: u64,
-    _completion: u64,
-    _total: u64,
-    _tool_completion: u64,
-) {
+pub fn set_llm_prompt_template(span: &tracing::Span, _template: &str, _variables: &[(&str, &str)]) {
+    let _ = span;
+}
+
+/// Record the tool schemas advertised to the model as OpenInference
+/// `llm.tools.{i}.tool.json_schema` attributes.
+#[cfg(feature = "otel")]
+pub fn set_llm_tools(span: &tracing::Span, schemas: &[String]) {
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    for (i, schema) in schemas.iter().enumerate() {
+        span.set_attribute(format!("llm.tools.{i}.tool.json_schema"), schema.clone());
+    }
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn set_llm_tools(span: &tracing::Span, _schemas: &[String]) {
+    let _ = span;
+}
+
+/// A retrieved document for [`set_retrieval_documents`].
+pub struct RetrievedDocument<'a> {
+    pub content: &'a str,
+    pub score: f64,
+    pub metadata: Option<&'a serde_json::Value>,
+}
+
+/// Record retrieved documents as OpenInference `retrieval.documents.{i}.*`
+/// attributes. Scores are always recorded; content and metadata only when
+/// content recording is enabled (`OTEL_RECORD_CONTENT`).
+#[cfg(feature = "otel")]
+pub fn set_retrieval_documents(span: &tracing::Span, docs: &[RetrievedDocument<'_>]) {
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    for (i, doc) in docs.iter().enumerate() {
+        span.set_attribute(format!("retrieval.documents.{i}.document.score"), doc.score);
+        if should_record_content() {
+            span.set_attribute(
+                format!("retrieval.documents.{i}.document.content"),
+                truncate_for_otel(doc.content),
+            );
+            if let Some(meta) = doc.metadata {
+                span.set_attribute(
+                    format!("retrieval.documents.{i}.document.metadata"),
+                    meta.to_string(),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn set_retrieval_documents(span: &tracing::Span, _docs: &[RetrievedDocument<'_>]) {
     let _ = span;
 }
 
@@ -665,5 +782,32 @@ mod tests {
         let json = system_instructions_json("You are a helpful assistant.");
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed[0]["content"], "You are a helpful assistant.");
+    }
+
+    #[test]
+    fn llm_invocation_parameters_serializes_call_params() {
+        let llm: aura_config::LlmConfig = serde_json::from_value(serde_json::json!({
+            "provider": "openai",
+            "api_key": "k",
+            "model": "gpt-4o",
+            "temperature": 0.2,
+            "max_tokens": 512,
+        }))
+        .unwrap();
+        let params = llm_invocation_parameters(&llm).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&params).unwrap();
+        assert_eq!(parsed["temperature"], 0.2);
+        assert_eq!(parsed["max_tokens"], 512);
+    }
+
+    #[test]
+    fn llm_invocation_parameters_none_when_unset() {
+        let llm: aura_config::LlmConfig = serde_json::from_value(serde_json::json!({
+            "provider": "openai",
+            "api_key": "k",
+            "model": "gpt-4o",
+        }))
+        .unwrap();
+        assert!(llm_invocation_parameters(&llm).is_none());
     }
 }

--- a/crates/aura/src/mcp.rs
+++ b/crates/aura/src/mcp.rs
@@ -1147,6 +1147,33 @@ impl McpManager {
             .chain(self.stdio_tools.values().flat_map(|tools| tools.iter()))
     }
 
+    /// Serialize tool definitions as OpenAI-style function schemas, for the
+    /// OpenInference `llm.tools.{i}.tool.json_schema` span attributes.
+    ///
+    /// `filter` narrows by glob patterns (worker `mcp_filter` semantics);
+    /// `None` includes every tool.
+    pub fn tool_schemas_json(&self, filter: Option<&[String]>) -> Vec<String> {
+        self.tool_definitions_iter()
+            .filter(|tool| match filter {
+                None => true,
+                Some(patterns) => patterns
+                    .iter()
+                    .any(|p| crate::config::glob_match(p, &tool.name)),
+            })
+            .map(|tool| {
+                serde_json::json!({
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": tool.input_schema,
+                    }
+                })
+                .to_string()
+            })
+            .collect()
+    }
+
     /// Returns a `server_name → tool_names` map for all transports.
     ///
     /// Used by the scratchpad layer to resolve per-server `min_tokens`

--- a/crates/aura/src/openinference_exporter.rs
+++ b/crates/aura/src/openinference_exporter.rs
@@ -2,7 +2,7 @@
 //!
 //! Wraps an OTLP `SpanExporter` to add [OpenInference] attributes before
 //! export. This ensures Phoenix correctly classifies spans (LLM, TOOL,
-//! AGENT, CHAIN) and displays token counts, model names, and
+//! RETRIEVER, CHAIN) and displays token counts, model names, and
 //! structured messages in its UI.
 //!
 //! ## Dual-source attribute design
@@ -20,9 +20,9 @@
 //! [OpenInference]: https://github.com/Arize-ai/openinference/tree/main/spec
 
 use crate::logging::{
-    ATTR_GEN_AI_SYSTEM_INSTRUCTIONS, ATTR_INPUT_VALUE, ATTR_LLM_MODEL_NAME, ATTR_LLM_SYSTEM,
-    ATTR_LLM_TOKEN_COMPLETION, ATTR_LLM_TOKEN_PROMPT, ATTR_OUTPUT_VALUE, ATTR_TOOL_NAME,
-    ATTR_TOOL_PARAMETERS,
+    ATTR_GEN_AI_SYSTEM_INSTRUCTIONS, ATTR_INPUT_VALUE, ATTR_LLM_MODEL_NAME, ATTR_LLM_PROVIDER,
+    ATTR_LLM_SYSTEM, ATTR_LLM_TOKEN_COMPLETION, ATTR_LLM_TOKEN_PROMPT, ATTR_OUTPUT_VALUE,
+    ATTR_TOOL_NAME, ATTR_TOOL_PARAMETERS,
 };
 use futures::future::BoxFuture;
 use opentelemetry::{KeyValue, StringValue, Value};
@@ -106,19 +106,37 @@ impl<E: SpanExporter + Send + Sync + 'static> SpanExporter for OpenInferenceExpo
 // ---------------------------------------------------------------------------
 
 /// Map a span name to an OpenInference span kind.
+///
+/// Phoenix computes cost only for LLM-kind spans with a non-empty
+/// `llm.model_name` (`should_calculate_span_cost` in the Phoenix server).
+/// The `agent.turn` spans are the cost anchors: the Rig fork records
+/// per-call model identifiers and token usage on them, and Phoenix rolls
+/// those descendants up per worker / per trace. Aura's agent-level spans
+/// also export as LLM so Phoenix renders their `llm.tools.*` and
+/// `llm.invocation_parameters` attributes in its LLM span view; they carry
+/// model identifiers but no token counts, so only the turns contribute
+/// cost.
 fn infer_span_kind(name: &str) -> &'static str {
     match name {
-        // Rig LLM-level spans (agent.turn is LLM so Phoenix renders Output Messages)
+        // Rig LLM-level spans (agent.turn carries per-call model + usage)
         "chat" | "chat_streaming" | "agent.turn" => "LLM",
         // Tool execution spans
         "execute_tool" | "mcp.tool_call" => "TOOL",
-        // Aura agent orchestration (worker is an autonomous agent with its own LLM + tools)
-        "agent.stream" | "agent.prompt" | "agent.chat" | "orchestration.worker" => "AGENT",
-        // Aura chain / entry-point spans + orchestration phases
+        // Vector store searches carry `retrieval.documents.*` attributes
+        "vector.search" => "RETRIEVER",
+        // Aura agent-level spans: the streaming root, the non-streaming
+        // entry points, and the orchestration coordinator/worker phases —
+        // each records the tools and invocation parameters it advertises
+        // to the model (see the doc comment above)
+        "agent.stream"
+        | "agent.prompt"
+        | "agent.chat"
+        | "orchestration.planning"
+        | "orchestration.worker" => "LLM",
+        // Aura chain / entry-point spans + orchestration lifecycle
         "chat_completions"
         | "streaming_completion"
         | "orchestration"
-        | "orchestration.planning"
         | "orchestration.iteration" => "CHAIN",
         // Safe default
         _ => "CHAIN",
@@ -153,6 +171,7 @@ fn transform_span(mut span: SpanData) -> SpanData {
         match key {
             "gen_ai.system" | "gen_ai.provider.name" => {
                 extra_attrs.push(KeyValue::new(ATTR_LLM_SYSTEM, kv.value.clone()));
+                extra_attrs.push(KeyValue::new(ATTR_LLM_PROVIDER, kv.value.clone()));
             }
             "gen_ai.request.model" => {
                 extra_attrs.push(KeyValue::new(ATTR_LLM_MODEL_NAME, kv.value.clone()));
@@ -181,8 +200,8 @@ fn transform_span(mut span: SpanData) -> SpanData {
             }
             // The system prompt has no OpenInference attribute of its own, so
             // it becomes leading `system` entries in `llm.input_messages`.
-            // Ungated by span kind: Aura records it on `agent.stream` (AGENT)
-            // and the `orchestration.*` (CHAIN/AGENT) spans, never on an LLM one.
+            // Ungated by span kind: any span that records a system prompt
+            // translates the same way.
             ATTR_GEN_AI_SYSTEM_INSTRUCTIONS => {
                 deferred_system_instructions = parse_system_instructions(&kv.value.to_string());
             }
@@ -558,13 +577,30 @@ mod tests {
         assert_eq!(infer_span_kind("chat_streaming"), "LLM");
         assert_eq!(infer_span_kind("execute_tool"), "TOOL");
         assert_eq!(infer_span_kind("mcp.tool_call"), "TOOL");
-        assert_eq!(infer_span_kind("agent.stream"), "AGENT");
-        assert_eq!(infer_span_kind("agent.prompt"), "AGENT");
-        assert_eq!(infer_span_kind("agent.chat"), "AGENT");
+        assert_eq!(infer_span_kind("vector.search"), "RETRIEVER");
+        assert_eq!(infer_span_kind("agent.stream"), "LLM");
+        assert_eq!(infer_span_kind("agent.prompt"), "LLM");
+        assert_eq!(infer_span_kind("agent.chat"), "LLM");
         assert_eq!(infer_span_kind("agent.turn"), "LLM");
+        assert_eq!(infer_span_kind("orchestration.planning"), "LLM");
+        assert_eq!(infer_span_kind("orchestration.worker"), "LLM");
         assert_eq!(infer_span_kind("chat_completions"), "CHAIN");
         assert_eq!(infer_span_kind("streaming_completion"), "CHAIN");
+        assert_eq!(infer_span_kind("orchestration"), "CHAIN");
+        assert_eq!(infer_span_kind("orchestration.iteration"), "CHAIN");
         assert_eq!(infer_span_kind("unknown_span"), "CHAIN");
+    }
+
+    /// `transform_span` stamps the kind attribute on the streaming root.
+    #[test]
+    fn test_agent_stream_kind_attribute() {
+        let without_tokens = transform_span(make_span("agent.stream", vec![]));
+        assert_eq!(
+            find_attr(&without_tokens, "openinference.span.kind")
+                .unwrap()
+                .to_string(),
+            "LLM"
+        );
     }
 
     /// Verify gen_ai.* LLM attributes are translated to OpenInference equivalents,
@@ -572,7 +608,8 @@ mod tests {
     #[test]
     fn test_translates_llm_attributes() {
         use crate::logging::{
-            ATTR_LLM_MODEL_NAME, ATTR_LLM_SYSTEM, ATTR_LLM_TOKEN_COMPLETION, ATTR_LLM_TOKEN_PROMPT,
+            ATTR_LLM_MODEL_NAME, ATTR_LLM_PROVIDER, ATTR_LLM_SYSTEM, ATTR_LLM_TOKEN_COMPLETION,
+            ATTR_LLM_TOKEN_PROMPT,
         };
 
         let span = make_span(
@@ -592,6 +629,10 @@ mod tests {
             "openai"
         );
         assert_eq!(
+            find_attr(&result, "llm.provider").unwrap().to_string(),
+            "openai"
+        );
+        assert_eq!(
             find_attr(&result, "llm.model_name").unwrap().to_string(),
             "gpt-4"
         );
@@ -600,6 +641,7 @@ mod tests {
 
         // Keys match logging.rs constants (drift guard)
         assert!(find_attr(&result, ATTR_LLM_SYSTEM).is_some());
+        assert!(find_attr(&result, ATTR_LLM_PROVIDER).is_some());
         assert!(find_attr(&result, ATTR_LLM_MODEL_NAME).is_some());
         assert!(find_attr(&result, ATTR_LLM_TOKEN_PROMPT).is_some());
         assert!(find_attr(&result, ATTR_LLM_TOKEN_COMPLETION).is_some());
@@ -949,11 +991,11 @@ mod tests {
 
     /// A single instruction part becomes a leading `system` message, and the
     /// raw GenAI key is stripped like every other translated `gen_ai.*` key.
-    /// AGENT kind matters: Aura records the prompt on non-LLM spans.
+    /// Uses a CHAIN span: the translation is ungated by span kind.
     #[test]
     fn test_system_instructions_translate_to_input_messages() {
         let span = make_span(
-            "agent.stream",
+            "orchestration",
             vec![
                 KeyValue::new("gen_ai.system", "openai"),
                 KeyValue::new(
@@ -1208,7 +1250,7 @@ mod tests {
         // input.messages only expanded on LLM spans
         let messages = r#"[{"role":"user","content":"hello"}]"#;
         let span = make_span(
-            "agent.stream",
+            "orchestration",
             vec![KeyValue::new("gen_ai.input.messages", messages)],
         );
         assert!(find_attr(&transform_span(span), "llm.input_messages.0.message.role").is_none());
@@ -1464,6 +1506,10 @@ mod pipeline_tests {
 
         // Translated LLM attributes
         assert_eq!(find_attr(chat, "llm.system").unwrap().to_string(), "openai");
+        assert_eq!(
+            find_attr(chat, "llm.provider").unwrap().to_string(),
+            "openai"
+        );
         assert_eq!(
             find_attr(chat, "llm.model_name").unwrap().to_string(),
             "gpt-4"

--- a/crates/aura/src/orchestration/factory.rs
+++ b/crates/aura/src/orchestration/factory.rs
@@ -147,10 +147,6 @@ impl StreamingAgent for OrchestratorFactory {
         self.agent_config.llm.model_info()
     }
 
-    fn is_orchestration(&self) -> bool {
-        true
-    }
-
     async fn stream(
         &self,
         query: &str,

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -586,6 +586,13 @@ impl Orchestrator {
         let mut worker_config = self.agent_config.clone();
         let worker_cfg = worker_name.and_then(|name| self.config.workers.get(name));
 
+        // Named workers report their own agent name (Rig stamps it on turn
+        // spans as `gen_ai.agent.name`); the generic worker keeps the base
+        // agent's name.
+        if let Some(name) = worker_name {
+            worker_config.agent.name = name.to_string();
+        }
+
         // Resolve per-worker LLM override (falls back to [agent.llm] when absent)
         if let Some(override_llm) = worker_cfg.and_then(|w| w.llm.as_ref()) {
             worker_config.llm = override_llm.clone();
@@ -922,6 +929,7 @@ impl Orchestrator {
             client_tool_names: Default::default(),
             turn_nudge,
             system_prompt: preamble.clone(),
+            invocation_parameters: crate::logging::llm_invocation_parameters(&worker_config.llm),
         };
 
         Ok(AgentWithPreamble {
@@ -1469,6 +1477,12 @@ impl Orchestrator {
             &tracing::Span::current(),
             &coordinator_state.preamble,
         );
+        // The coordinator always runs on [agent.llm] (see `create_coordinator`).
+        let (provider, model) = self.agent_config.llm.model_info();
+        crate::logging::set_llm_identifiers(&tracing::Span::current(), provider, model);
+        if let Some(params) = crate::logging::llm_invocation_parameters(&self.agent_config.llm) {
+            crate::logging::set_llm_invocation_parameters(&tracing::Span::current(), &params);
+        }
 
         for attempt in 1..=max_correction_attempts {
             // Clear any stale routing decision
@@ -1524,16 +1538,7 @@ impl Orchestrator {
                 )
                 .await
             {
-                Ok(r) => {
-                    crate::logging::set_token_usage(
-                        &tracing::Span::current(),
-                        r.usage.input_tokens,
-                        r.usage.output_tokens,
-                        r.usage.total_tokens,
-                        0,
-                    );
-                    r
-                }
+                Ok(r) => r,
                 Err(e) if is_context_overflow_error(e.as_ref()) => {
                     let suggestion = context_overflow_suggestion("planning");
                     return Err(
@@ -2105,15 +2110,20 @@ Assign tasks to the worker whose tools best match the required operations."#,
     /// Build a Rig agent with the given completion model and coordinator tools.
     ///
     /// Shared helper that eliminates per-provider duplication in `create_coordinator`.
+    #[allow(clippy::too_many_arguments)]
     fn build_agent_with_tools<M: rig::completion::CompletionModel + Send + Sync>(
         completion_model: M,
         preamble: &str,
         temperature: Option<f64>,
         additional_params: Option<serde_json::Value>,
         max_tokens: Option<u64>,
+        provider_name: &str,
+        model_name: &str,
         tools: CoordinatorTools,
     ) -> rig::agent::Agent<M> {
         let mut builder = rig::agent::AgentBuilder::new(completion_model);
+        builder = builder.name("coordinator");
+        builder = builder.provider_name(provider_name).model_name(model_name);
         builder = builder.preamble(preamble);
         if let Some(temp) = temperature {
             builder = builder.temperature(temp);
@@ -2322,6 +2332,9 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 client_tool_names: Default::default(),
                 turn_nudge: None,
                 system_prompt: preamble.clone(),
+                invocation_parameters: crate::logging::llm_invocation_parameters(
+                    &self.agent_config.llm,
+                ),
             },
             preamble,
             escalation_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -2341,6 +2354,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         max_tokens: Option<u64>,
         tools: CoordinatorTools,
     ) -> Result<ProviderAgent, Box<dyn std::error::Error + Send + Sync>> {
+        let (llm_provider, llm_model) = self.agent_config.llm.model_info();
         match &self.agent_config.llm {
             LlmConfig::OpenAI {
                 api_key,
@@ -2376,6 +2390,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     temperature,
                     combined_params,
                     max_tokens,
+                    llm_provider,
+                    llm_model,
                     tools,
                 )))
             }
@@ -2400,6 +2416,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     temperature,
                     additional_params,
                     max_tokens,
+                    llm_provider,
+                    llm_model,
                     tools,
                 )))
             }
@@ -2432,6 +2450,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     temperature,
                     additional_params,
                     max_tokens,
+                    llm_provider,
+                    llm_model,
                     tools,
                 )))
             }
@@ -2456,6 +2476,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     temperature,
                     additional_params,
                     max_tokens,
+                    llm_provider,
+                    llm_model,
                     tools,
                 )))
             }
@@ -2475,6 +2497,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     temperature,
                     additional_params,
                     max_tokens,
+                    llm_provider,
+                    llm_model,
                     tools,
                 )))
             }
@@ -2499,6 +2523,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     temperature,
                     additional_params,
                     max_tokens,
+                    llm_provider,
+                    llm_model,
                     tools,
                 )))
             }
@@ -2517,6 +2543,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
     ) -> Result<(ProviderAgent, String), Box<dyn std::error::Error + Send + Sync>> {
         let preamble = worker_config.effective_preamble();
         let temperature = worker_config.llm.temperature();
+        let (llm_provider, llm_model) = worker_config.llm.model_info();
         let shared_mcp: Option<Arc<McpManager>> = self.mcp_manager.clone();
 
         // Box<dyn ToolDyn> is not Clone, so each provider arm constructs its own instance.
@@ -2552,6 +2579,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     .completions_api()
                     .completion_model(model);
                 let mut builder = rig::agent::AgentBuilder::new(cm);
+                builder = builder.name(&worker_config.agent.name);
+                builder = builder.provider_name(llm_provider).model_name(llm_model);
                 builder = builder.preamble(preamble);
                 if let Some(temp) = temperature {
                     builder = builder.temperature(temp);
@@ -2597,6 +2626,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     .map_err(|e| format!("Failed to build Anthropic worker: {}", e))?
                     .completion_model(model);
                 let mut builder = rig::agent::AgentBuilder::new(cm);
+                builder = builder.name(&worker_config.agent.name);
+                builder = builder.provider_name(llm_provider).model_name(llm_model);
                 builder = builder.preamble(preamble);
                 if let Some(temp) = temperature {
                     builder = builder.temperature(temp);
@@ -2638,6 +2669,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 ))
                 .completion_model(model);
                 let mut builder = rig::agent::AgentBuilder::new(cm);
+                builder = builder.name(&worker_config.agent.name);
+                builder = builder.provider_name(llm_provider).model_name(llm_model);
                 builder = builder.preamble(preamble);
                 if let Some(temp) = temperature {
                     builder = builder.temperature(temp);
@@ -2671,6 +2704,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     .map_err(|e| format!("Failed to build Gemini worker: {}", e))?
                     .completion_model(model);
                 let mut builder = rig::agent::AgentBuilder::new(cm);
+                builder = builder.name(&worker_config.agent.name);
+                builder = builder.provider_name(llm_provider).model_name(llm_model);
                 builder = builder.preamble(preamble);
                 if let Some(temp) = temperature {
                     builder = builder.temperature(temp);
@@ -2698,6 +2733,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     .map_err(|e| format!("Failed to build Ollama worker: {}", e))?
                     .completion_model(model);
                 let mut builder = rig::agent::AgentBuilder::new(cm);
+                builder = builder.name(&worker_config.agent.name);
+                builder = builder.provider_name(llm_provider).model_name(llm_model);
                 builder = builder.preamble(preamble);
                 if let Some(temp) = temperature {
                     builder = builder.temperature(temp);
@@ -2730,6 +2767,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     .map_err(|e| format!("Failed to build OpenRouter worker: {}", e))?
                     .completion_model(model);
                 let mut builder = rig::agent::AgentBuilder::new(cm);
+                builder = builder.name(&worker_config.agent.name);
+                builder = builder.provider_name(llm_provider).model_name(llm_model);
                 builder = builder.preamble(preamble);
                 if let Some(temp) = temperature {
                     builder = builder.temperature(temp);
@@ -3065,6 +3104,24 @@ Assign tasks to the worker whose tools best match the required operations."#,
             if let Some(name) = worker_name {
                 span.record("orchestration.worker", *name);
             }
+            // Same effective-LLM resolution as `create_worker`; recorded here
+            // (not there) so retries don't append duplicate attributes.
+            let worker_cfg = worker_name.and_then(|name| self.config.workers.get(name));
+            let effective_llm = worker_cfg
+                .and_then(|w| w.llm.as_ref())
+                .unwrap_or(&self.agent_config.llm);
+            let (provider, model) = effective_llm.model_info();
+            crate::logging::set_llm_identifiers(&span, provider, model);
+            if let Some(params) = crate::logging::llm_invocation_parameters(effective_llm) {
+                crate::logging::set_llm_invocation_parameters(&span, &params);
+            }
+            if let Some(mcp) = &self.mcp_manager {
+                let filter = worker_cfg.and_then(|w| w.mcp_filter.as_deref());
+                let tools = mcp.tool_schemas_json(filter);
+                if !tools.is_empty() {
+                    crate::logging::set_llm_tools(&span, &tools);
+                }
+            }
         }
 
         // Build the base worker prompt once — reused across retry attempts
@@ -3077,13 +3134,16 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 context: &context_str,
                 your_task: task_description,
             });
+        crate::logging::set_llm_prompt_template(
+            &tracing::Span::current(),
+            super::templates::WORKER_TASK_PROMPT_TEMPLATE,
+            &[
+                ("CONTEXT", context_str.as_str()),
+                ("YOUR_TASK", task_description),
+            ],
+        );
 
         let start_time = std::time::Instant::now();
-        let mut last_usage = rig::completion::Usage {
-            input_tokens: 0,
-            output_tokens: 0,
-            total_tokens: 0,
-        };
         let mut last_raw_response = String::new();
         let mut last_error: Option<Box<dyn std::error::Error + Send + Sync>> = None;
         let mut actual_attempts: usize = 0;
@@ -3177,13 +3237,6 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 }
             }
 
-            // Track per-attempt usage for span metrics.
-            // Cumulative usage_state is now updated eagerly per TurnUsage inside
-            // stream_and_forward, so failed attempts also contribute.
-            if let Ok(ref response) = stream_result {
-                last_usage = response.usage;
-            }
-
             // Detect context overflow and other errors — don't retry hard errors
             let result = match stream_result {
                 Ok(r) => Ok(r.content),
@@ -3216,11 +3269,6 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     match structured {
                         Some(output) => {
                             let duration_ms = start_time.elapsed().as_millis() as u64;
-                            self.set_worker_span_usage(
-                                last_usage.input_tokens,
-                                last_usage.output_tokens,
-                                last_usage.total_tokens,
-                            );
                             self.persist_worker_execution(
                                 task_id,
                                 task_description,
@@ -3249,11 +3297,6 @@ Assign tasks to the worker whose tools best match the required operations."#,
                                 attempt
                             );
                             let duration_ms = start_time.elapsed().as_millis() as u64;
-                            self.set_worker_span_usage(
-                                last_usage.input_tokens,
-                                last_usage.output_tokens,
-                                last_usage.total_tokens,
-                            );
                             self.persist_worker_execution(
                                 task_id,
                                 task_description,
@@ -3289,11 +3332,6 @@ Assign tasks to the worker whose tools best match the required operations."#,
 
         // All attempts exhausted or hard error occurred
         let duration_ms = start_time.elapsed().as_millis() as u64;
-        self.set_worker_span_usage(
-            last_usage.input_tokens,
-            last_usage.output_tokens,
-            last_usage.total_tokens,
-        );
         if let Some(ref e) = last_error {
             self.persist_worker_execution(
                 task_id,
@@ -3327,13 +3365,6 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 structured_output: None,
             })
         }
-    }
-
-    /// Set token usage metrics on the current orchestration.worker span.
-    /// usage_state is already updated per-attempt in the retry loop.
-    fn set_worker_span_usage(&self, input: u64, output: u64, total: u64) {
-        let span = tracing::Span::current();
-        crate::logging::set_token_usage(&span, input, output, total, 0);
     }
 
     /// Persist a single worker execution attempt to the journal and persistence store.

--- a/crates/aura/src/rag_tools.rs
+++ b/crates/aura/src/rag_tools.rs
@@ -4,7 +4,7 @@ use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
-use tracing::{debug, info, warn};
+use tracing::{Instrument, debug, info, warn};
 
 /// Macro to create unique vector search tool structs for each vector store
 macro_rules! create_vector_search_tool {
@@ -68,6 +68,9 @@ macro_rules! create_vector_search_tool {
             }
 
             async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+                let span = tracing::info_span!("vector.search", "vector.store" = Self::NAME);
+                crate::logging::set_input_attributes(&span, &args.query);
+
                 info!(
                     "🔍 Searching vector store: '{}' (limit: {}, min_score: {})",
                     args.query, args.limit, args.min_score
@@ -76,6 +79,7 @@ macro_rules! create_vector_search_tool {
                 let search_results = self
                     .vector_store
                     .search(&args.query, args.limit)
+                    .instrument(span.clone())
                     .await?;
 
                 // Filter by minimum score if specified
@@ -83,6 +87,16 @@ macro_rules! create_vector_search_tool {
                     .into_iter()
                     .filter(|result| result.score >= args.min_score)
                     .collect();
+
+                let documents: Vec<crate::logging::RetrievedDocument<'_>> = filtered_results
+                    .iter()
+                    .map(|r| crate::logging::RetrievedDocument {
+                        content: &r.content,
+                        score: r.score as f64,
+                        metadata: r.metadata.as_ref(),
+                    })
+                    .collect();
+                crate::logging::set_retrieval_documents(&span, &documents);
 
                 let results_count = filtered_results.len();
 

--- a/crates/aura/src/streaming.rs
+++ b/crates/aura/src/streaming.rs
@@ -140,19 +140,6 @@ pub trait StreamingAgent: Send + Sync {
         Vec::new()
     }
 
-    /// Whether this agent is an orchestrator (emits per-phase LLM spans).
-    ///
-    /// Returned `true` by the multi-agent `OrchestratorFactory`. The web-server
-    /// streaming handler uses this to suppress the total token write on the
-    /// root `agent.stream` span, because each phase (`orchestration.planning`,
-    /// `orchestration.worker`, `orchestration.synthesis`,
-    /// `orchestration.evaluation`) already carries its own `set_token_usage`
-    /// attributes. Letting Phoenix roll those descendants up is the accurate
-    /// aggregate; also recording the total on the parent double-counts.
-    fn is_orchestration(&self) -> bool {
-        false
-    }
-
     /// The assembled system prompt sent to the provider, if this agent has a
     /// single static one.
     ///

--- a/crates/aura/src/vector_dynamic.rs
+++ b/crates/aura/src/vector_dynamic.rs
@@ -4,7 +4,7 @@ use rig::completion::ToolDefinition;
 use rig::tool::Tool as RigTool;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::{debug, info};
+use tracing::{Instrument, debug, info};
 
 use crate::{error::BuilderError, vector_store::VectorStoreManager};
 
@@ -113,6 +113,9 @@ impl RigTool for DynamicVectorSearchTool {
         let store_name = self.store_name.clone();
         let vector_store = self.vector_store.clone();
 
+        let span = tracing::info_span!("vector.search", "vector.store" = %store_name);
+        crate::logging::set_input_attributes(&span, &args.query);
+
         info!(
             "🔍 Searching vector store '{}' (query: '{}', limit: {}, min_score: {}, filters: {})",
             store_name,
@@ -122,29 +125,43 @@ impl RigTool for DynamicVectorSearchTool {
             args.label_filters.len()
         );
 
-        let search_results = if !args.label_filters.is_empty() {
-            info!(
-                "   Applying {} label filter(s): {:?}",
-                args.label_filters.len(),
-                args.label_filters
-            );
-            let filter_map = args
-                .label_filters
-                .iter()
-                .map(|kv| (kv.key.clone(), parse_value_str(&kv.value)))
-                .collect();
-            vector_store
-                .search_with_filter(&args.query, args.limit, filter_map)
-                .await?
-        } else {
-            vector_store.search(&args.query, args.limit).await?
-        };
+        let search_results = async {
+            if !args.label_filters.is_empty() {
+                info!(
+                    "   Applying {} label filter(s): {:?}",
+                    args.label_filters.len(),
+                    args.label_filters
+                );
+                let filter_map = args
+                    .label_filters
+                    .iter()
+                    .map(|kv| (kv.key.clone(), parse_value_str(&kv.value)))
+                    .collect();
+                vector_store
+                    .search_with_filter(&args.query, args.limit, filter_map)
+                    .await
+            } else {
+                vector_store.search(&args.query, args.limit).await
+            }
+        }
+        .instrument(span.clone())
+        .await?;
 
         // Filter by minimum score if specified
         let filtered_results: Vec<_> = search_results
             .into_iter()
             .filter(|result| result.score >= args.min_score)
             .collect();
+
+        let documents: Vec<crate::logging::RetrievedDocument<'_>> = filtered_results
+            .iter()
+            .map(|r| crate::logging::RetrievedDocument {
+                content: &r.content,
+                score: r.score as f64,
+                metadata: r.metadata.as_ref(),
+            })
+            .collect();
+        crate::logging::set_retrieval_documents(&span, &documents);
 
         let results_count = filtered_results.len();
 


### PR DESCRIPTION
Reasoning models that call a tool without emitting any text produced an assistant message with an empty content array, which OpenAI rejects with a 400 `empty_array`. Retries re-sent the same history, so the run failed deterministically and reached the user as a tooling error instead of an answer.

Pin rig-core to the merged `mezmo` head, which omits assistant content when it is empty. The workspace dependency and the `[patch.crates-io]` entry have to move together or the build resolves two rig versions. The same bump carries the http_client stream-open retries and the turn-span attributes below.

Phoenix prices a span only when it is LLM-kind and carries both `llm.model_name` and token counts. Aura recorded aggregate token counts on its own spans, which forced a choice between pricing the root span or the per-phase spans, and risked double-counting once Phoenix rolled the descendants up.

Take token counts off Aura's spans entirely. The rig fork now records provider, model, and per-call usage on each `agent.turn` span, making the turns the single cost anchor: every aggregate — per worker, per phase, per trace — is Phoenix's rollup of them.

- pass provider and model to every `AgentBuilder` — the six single-agent provider arms, the coordinator, and each worker — so turn spans identify the model that actually ran them, and per-worker LLM overrides price at their own rate.
- drop `set_token_usage` and its call sites: the planning span, the worker spans, the streaming root, and the non-streaming completion path. `is_orchestration` and `StreamOtelContext::usage_state` existed only to arbitrate which span held the aggregate, so they go with it.

Aura's agent-level spans (`agent.stream`, `agent.prompt`, `agent.chat`, `orchestration.planning`, `orchestration.worker`) still export as LLM so Phoenix renders the tools and invocation parameters they advertise. Carrying no token counts, they price at zero and leave the turn rollup intact. `infer_span_kind` no longer inspects attributes, only the span name.

Phoenix also reads a set of OpenInference attributes Aura never emitted, leaving its UI showing "Unnamed Agent" and empty panes. Fill them in:

- `llm.provider` beside `llm.system`, since the pricing table matches on provider and model together.
- agent names on every span that creates an agent.
- `user.id` from a new OpenAI-compatible `user` request field, and `metadata` from the request's metadata map.
- `llm.invocation_parameters` from the effective LLM config, and `llm.tools.{i}.tool.json_schema` from the MCP schemas each agent advertises, filtered per worker.
- `llm.prompt_template.*` on worker spans, showing the task template beside the values filled into it. The variables carry request content, so they follow the `OTEL_RECORD_CONTENT` gate and the usual truncation; the template itself is static and always recorded.
- `retrieval.documents.{i}.*` on vector searches, which now export as RETRIEVER spans.
- `aura.version` and `aura.mode` on the streaming root, so traces filter by release and by serving path, plus `service.version` on the tracer resource.
- `openinference.project.name`, from `PHOENIX_PROJECT_NAME`. Phoenix routes traces to a project by that resource attribute alone and ignores `service.name`, so without it everything lands in the default project.
- an `exception` span event carrying `exception.message` on every error, which is the shape Phoenix's exception view reads.

Dashboards and alerts should be checked before this ships: `llm.token_count.total` and `llm.token_count.tool_completion` are no longer emitted on Aura spans. Per-turn prompt and completion counts on `agent.turn` replace them.