### PR TITLE
fix(openai): bump rig version to fix 400 on GPT models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3757,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.28.0"
-source = "git+https://github.com/mezmo/rig.git?rev=e6f008eaf555733d93368c9dd174d1d61d7d096d#e6f008eaf555733d93368c9dd174d1d61d7d096d"
+source = "git+https://github.com/mezmo/rig.git?rev=49ba5f78b322efb83730ecff4fc4d04f2056d9b9#49ba5f78b322efb83730ecff4fc4d04f2056d9b9"
 dependencies = [
  "as-any",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mezmo/aura"
 
 [workspace.dependencies]
-rig-core = { git = "https://github.com/mezmo/rig.git", rev = "e6f008eaf555733d93368c9dd174d1d61d7d096d", default-features = false, features = ["rmcp", "reqwest-rustls"] }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "49ba5f78b322efb83730ecff4fc4d04f2056d9b9", default-features = false, features = ["rmcp", "reqwest-rustls"] }
 # Pinned to exact versions compatible with our rig-core 0.28.x fork.
 # Newer versions pull in rig-core 0.31+ which is semver-incompatible with the fork.
 rig-bedrock = "=0.3.10"
@@ -96,5 +96,5 @@ http = "1.0"
 
 # Patch rig-core to use the fork with streaming hook + span propagation fix
 [patch.crates-io]
-rig-core = { git = "https://github.com/mezmo/rig.git", rev = "e6f008eaf555733d93368c9dd174d1d61d7d096d" }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "49ba5f78b322efb83730ecff4fc4d04f2056d9b9" }
 


### PR DESCRIPTION
Reasoning models that call a tool without emitting any text produced an assistant message with an empty content array, which OpenAI rejects with a 400 `empty_array`. Retries re-sent the same history, so the run failed deterministically and reached the user as a tooling error instead of an answer.

Pin rig-core to the merged `mezmo` head, which omits assistant content when it is empty. The workspace dependency and the `[patch.crates-io]` entry have to move together or the build resolves two rig versions.