### PR TITLE
ci(release): bake version into homebrew formula urls

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -113,8 +113,8 @@ authenticates it, so it verifies the API key and the target repository.
 bump-homebrew-tap.sh [--dry-run] <version>
 ```
 
-Rewrites the `version` and `sha256` fields in each `Formula/*.rb` of
-`mezmo/homebrew-tap` and pushes to `main`.
+Rewrites the version tag in each `url` and the matching `sha256` in every
+`Formula/*.rb` of `mezmo/homebrew-tap`, and pushes to `main`.
 
 | Switch | Default | Effect |
 | --- | --- | --- |

--- a/scripts/bump-homebrew-tap.sh
+++ b/scripts/bump-homebrew-tap.sh
@@ -55,8 +55,8 @@ cd "${WORKDIR}/tap"
 for f in Formula/*.rb; do
   awk -v ver="${VERSION}" -v ck="${CHECKSUMS}" -v have="${HAVE_CHECKSUMS}" -v dry="${DRY_RUN}" '
     BEGIN { if (have) while ((getline l < ck) > 0) { n = split(l, a, /  +/); sums[a[2]] = a[1] } }
-    /^[[:space:]]*version "/ { sub(/"[^"]+"/, "\"" ver "\""); print; next }
     /^[[:space:]]*url "/ {
+      sub(/\/v[0-9][^\/"]*\//, "/v" ver "/")
       m = split($0, p, "/"); asset = p[m]; sub(/".*/, "", asset); pend = asset; print; next
     }
     pend != "" && /sha256 "/ {


### PR DESCRIPTION
Homebrew reads a formula's version off its url, and now flags a `version` field that agrees with it as redundant, failing `brew audit` on the tap.