### PR TITLE
feat(hitl): send requesting agent name on webhook approvals

### DIFF
--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -1005,8 +1005,14 @@ mod tests {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ApprovalOriginWire {
-    ConfigGate { matched_pattern: String },
-    AgentRequested { reason: String },
+    ConfigGate {
+        matched_pattern: String,
+    },
+    AgentRequested {
+        reason: String,
+        #[serde(default)]
+        agent_name: String,
+    },
 }
 
 /// Which agent surface is asking for approval.

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -344,6 +344,7 @@ impl Agent {
                 hitl.route.clone(),
                 scope,
                 request_id,
+                config_owned.agent.name.clone(),
             ));
         }
 

--- a/crates/aura/src/hitl/decision.rs
+++ b/crates/aura/src/hitl/decision.rs
@@ -113,7 +113,11 @@ pub enum ApprovalOrigin {
     /// glob that fired.
     ConfigGate { matched_pattern: String },
     /// The agent called `request_approval` itself.
-    AgentRequested { reason: String },
+    AgentRequested {
+        reason: String,
+        /// `[agent].name` of the config that built this agent.
+        agent_name: String,
+    },
 }
 
 /// Typestate for a parked call awaiting its decision.

--- a/crates/aura/src/hitl/events.rs
+++ b/crates/aura/src/hitl/events.rs
@@ -131,9 +131,12 @@ fn origin_to_wire(origin: &ApprovalOrigin) -> ApprovalOriginWire {
         ApprovalOrigin::ConfigGate { matched_pattern } => ApprovalOriginWire::ConfigGate {
             matched_pattern: matched_pattern.clone(),
         },
-        ApprovalOrigin::AgentRequested { reason } => ApprovalOriginWire::AgentRequested {
-            reason: reason.clone(),
-        },
+        ApprovalOrigin::AgentRequested { reason, agent_name } => {
+            ApprovalOriginWire::AgentRequested {
+                reason: reason.clone(),
+                agent_name: agent_name.clone(),
+            }
+        }
     }
 }
 

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -786,6 +786,7 @@ mod tests {
             },
             origin: ApprovalOrigin::AgentRequested {
                 reason: "deleting prod ns".to_string(),
+                agent_name: "sre-assistant".to_string(),
             },
             items: vec![],
         };
@@ -802,6 +803,7 @@ mod tests {
         // task is flattened to task_id/worker siblings, not a nested object.
         assert!(value["scope"].get("task").is_none());
         assert_eq!(value["origin"]["kind"], "agent_requested");
+        assert_eq!(value["origin"]["agent_name"], "sre-assistant");
         // regression guard: no externally-tagged domain variant keys.
         assert!(value["scope"].get("Worker").is_none());
         assert!(value["origin"].get("AgentRequested").is_none());
@@ -842,6 +844,7 @@ mod tests {
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::AgentRequested {
                 reason: "touches prod".to_string(),
+                agent_name: "test-agent".to_string(),
             },
             items: vec![ApprovalItem {
                 tool_name: "request_approval".to_string(),
@@ -868,6 +871,7 @@ mod tests {
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::AgentRequested {
                 reason: "touches prod".to_string(),
+                agent_name: "test-agent".to_string(),
             },
             items: vec![ApprovalItem {
                 tool_name: "request_approval".to_string(),
@@ -920,6 +924,7 @@ mod tests {
             "conv-req-1",
             ApprovalOrigin::AgentRequested {
                 reason: "test".into(),
+                agent_name: "test-agent".to_string(),
             },
         );
         let decision_id = request.decision_id;
@@ -1001,6 +1006,7 @@ mod tests {
             "conv-req-3",
             ApprovalOrigin::AgentRequested {
                 reason: "test".into(),
+                agent_name: "test-agent".to_string(),
             },
         );
         let decision_id = request.decision_id;
@@ -1065,6 +1071,7 @@ mod tests {
             "conv-req-backstop",
             ApprovalOrigin::AgentRequested {
                 reason: "test".into(),
+                agent_name: "test-agent".to_string(),
             },
         );
         let decision_id = request.decision_id;
@@ -1097,6 +1104,7 @@ mod tests {
             "conv-req-4",
             ApprovalOrigin::AgentRequested {
                 reason: "test".into(),
+                agent_name: "test-agent".to_string(),
             },
         );
         let cancel = crate::request_cancellation::RequestCancelToken::unbound();

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -27,15 +27,22 @@ pub struct RequestApprovalTool {
     route: Arc<DecisionRoute>,
     scope: AgentScope,
     request_id: String,
+    agent_name: String,
 }
 
 impl RequestApprovalTool {
     #[must_use]
-    pub fn new(route: Arc<DecisionRoute>, scope: AgentScope, request_id: String) -> Self {
+    pub fn new(
+        route: Arc<DecisionRoute>,
+        scope: AgentScope,
+        request_id: String,
+        agent_name: String,
+    ) -> Self {
         Self {
             route,
             scope,
             request_id,
+            agent_name,
         }
     }
 }
@@ -142,6 +149,7 @@ impl Tool for RequestApprovalTool {
             scope: self.scope.clone(),
             origin: ApprovalOrigin::AgentRequested {
                 reason: args.risk_rationale.clone(),
+                agent_name: self.agent_name.clone(),
             },
             items: vec![ApprovalItem {
                 tool_name: Self::NAME.to_string(),
@@ -301,6 +309,7 @@ mod tests {
             route.clone(),
             AgentScope::Single { session_id: None },
             request_id.clone(),
+            "test-agent".to_string(),
         );
 
         // Subscribe before the call so the Requested event is captured.

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -791,6 +791,7 @@ impl Orchestrator {
                 hitl.route.clone(),
                 scope,
                 request_id,
+                self.agent_config.agent.name.clone(),
             ));
         }
 

--- a/crates/aura/src/session_store/record.rs
+++ b/crates/aura/src/session_store/record.rs
@@ -57,8 +57,14 @@ pub enum ScopeRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum OriginRecord {
-    ConfigGate { matched_pattern: String },
-    AgentRequested { reason: String },
+    ConfigGate {
+        matched_pattern: String,
+    },
+    AgentRequested {
+        reason: String,
+        #[serde(default)]
+        agent_name: String,
+    },
 }
 
 /// Storage form of a recorded [`ApprovalDecision`].
@@ -192,8 +198,9 @@ impl From<&ApprovalOrigin> for OriginRecord {
             ApprovalOrigin::ConfigGate { matched_pattern } => OriginRecord::ConfigGate {
                 matched_pattern: matched_pattern.clone(),
             },
-            ApprovalOrigin::AgentRequested { reason } => OriginRecord::AgentRequested {
+            ApprovalOrigin::AgentRequested { reason, agent_name } => OriginRecord::AgentRequested {
                 reason: reason.clone(),
+                agent_name: agent_name.clone(),
             },
         }
     }
@@ -205,7 +212,9 @@ impl From<OriginRecord> for ApprovalOrigin {
             OriginRecord::ConfigGate { matched_pattern } => {
                 ApprovalOrigin::ConfigGate { matched_pattern }
             }
-            OriginRecord::AgentRequested { reason } => ApprovalOrigin::AgentRequested { reason },
+            OriginRecord::AgentRequested { reason, agent_name } => {
+                ApprovalOrigin::AgentRequested { reason, agent_name }
+            }
         }
     }
 }
@@ -274,6 +283,7 @@ mod tests {
             },
             ApprovalOrigin::AgentRequested {
                 reason: "risky".to_string(),
+                agent_name: "ops-agent".to_string(),
             },
         ));
     }
@@ -296,6 +306,7 @@ mod tests {
             AgentScope::Single { session_id: None },
             ApprovalOrigin::AgentRequested {
                 reason: "r".to_string(),
+                agent_name: "test-agent".to_string(),
             },
         ));
         let json = serde_json::to_value(&record).unwrap();


### PR DESCRIPTION
Add agent_name to the ApprovalOrigin::AgentRequested wire, domain, and storage shapes so an approval webhook receiver can attribute an agent-requested (request_approval tool) approval to the config that produced it. The value is [agent].name of the config building the agent (the coordinator's config in orchestration mode); the per-worker name is unchanged and still carried by AgentScopeWire::Worker::worker.

ConfigGate origins are untouched. This is an additive wire change, so PROTOCOL_VERSION is not bumped; agent_name carries #[serde(default)] on the wire and storage record types so older payloads and already-persisted approval records without the field stay parseable.

Fixes #494