### PR TITLE
chore: switch release profile to thin lto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ license = "Apache-2.0"
 repository = "https://github.com/mezmo/aura"
 
 [profile.release]
-lto = "fat"
+# prefer thin lto until runtime performance warrants optimizations
+lto = "thin"
 codegen-units = 1
 strip = "symbols"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
   }
 
   options {
-    timeout time: 1, unit: 'HOURS'
+    timeout time: 90, unit: 'MINUTES'
     timestamps()
     ansiColor 'xterm'
     // On main, don't abort: a release build pushes a [skip ci] version commit


### PR DESCRIPTION
Fat lto was aggresively increasing our compile times and caused Jenkins to timeout. Switch to thin lto since runtime performance is neither benchmarked nor a concern.

Bump the Jenkins timeout to 1.5 hours as we are routinely getting close to the current 1 hour limit