### PR TITLE
Stamp the approval decision id at both entry points

### DIFF
--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -283,12 +283,26 @@ mod tests {
                 self.spans().iter().any(|span| span.name == name)
             }
 
+            /// The single `key` attribute on the span named `name`, or `None`
+            /// if the span carries no such attribute. Panics if the span
+            /// carries more than one — a double-stamp regression would
+            /// otherwise pass unnoticed, since `find` would silently return
+            /// only the first entry.
             fn attribute(&self, name: &str, key: &str) -> Option<String> {
-                self.spans()
+                let spans = self.spans();
+                let span = spans.iter().find(|span| span.name == name)?;
+                let matches: Vec<_> = span
+                    .attributes
                     .iter()
-                    .find(|span| span.name == name)
-                    .and_then(|span| span.attributes.iter().find(|kv| kv.key.as_str() == key))
-                    .map(|kv| kv.value.to_string())
+                    .filter(|kv| kv.key.as_str() == key)
+                    .collect();
+                assert!(
+                    matches.len() <= 1,
+                    "span {name:?} must carry at most one {key} attribute, found {}: \
+                     a regression is double-stamping the same span",
+                    matches.len(),
+                );
+                matches.first().map(|kv| kv.value.to_string())
             }
         }
 

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 use aura_config::{DecisionRouteConfig, GlobPattern, HitlConfig, ToolHeaderMappings, WebhookUrl};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
-use super::decision::{ApprovalDecision, ApprovalOutcome};
+use super::decision::{ApprovalDecision, ApprovalOutcome, DecisionId};
 use super::events;
 use super::protocol::{ApprovalDecisionWire, ApprovalRequest, ApprovalRequestWire};
 use super::registry::PendingApprovals;
@@ -197,24 +197,56 @@ pub enum DecisionRoute {
     },
 }
 
+/// Stamp `decision_id` on the current tracing span
+/// (`crate::logging::set_span_attribute`, a documented no-op without the
+/// `otel` feature).
+///
+/// Called from both [`DecisionRoute::decide_for_gate`] and
+/// [`DecisionRoute::decide`] — the two public entry points, since neither
+/// reaches the other on every path: the gate's webhook arm resolves through
+/// the client seam without ever calling `decide`, and the agent-callable
+/// `request_approval` tool calls `decide` directly, bypassing the gate
+/// entirely. Each entry point stamps exactly once: `decide_for_gate`'s
+/// conversational arm reaches the shared decision logic through the
+/// unstamped [`DecisionRoute::decide_inner`] rather than through `decide`,
+/// so nesting never produces a second stamp on the same span.
+/// `set_span_attribute` appends rather than overwrites by key, so a second
+/// stamp would add a duplicate attribute entry rather than update the
+/// existing one — this is the failure mode the single-stamp invariant
+/// avoids.
+fn stamp_decision_id(decision_id: DecisionId) {
+    crate::logging::set_span_attribute(
+        &tracing::Span::current(),
+        crate::logging::ATTR_DECISION_ID,
+        decision_id.to_string(),
+    );
+}
+
 impl DecisionRoute {
     /// Obtain a decision for a config-gated call, carrying any captured
     /// approver header overrides on the approved arm.
+    ///
+    /// The gate awaits this inline from the gated call's `execute_tool`
+    /// span, so stamping the decision id here — ahead of the route split
+    /// and of any outcome — correlates the approval with the execution it
+    /// gates on either route, decided or not.
     ///
     /// The webhook arm goes through the capture-bearing client seam
     /// ([`WebhookClient::request_approval_for_gate`]), which owns the HTTP
     /// response, so capture is filled there without signature changes;
     /// its event choreography mirrors [`Self::decide`]'s webhook arm. The
-    /// conversational arm delegates to [`Self::decide`]: that route has no
-    /// distinct identity source and never captures.
+    /// conversational arm delegates to the unstamped [`Self::decide_inner`]
+    /// (not [`Self::decide`], which would stamp a second time on this span):
+    /// that route has no distinct identity source and never captures.
     pub async fn decide_for_gate(
         &self,
         request: ApprovalRequest,
         cancel: &crate::request_cancellation::RequestCancelToken,
     ) -> Result<GateDecision, ApprovalError> {
+        stamp_decision_id(request.decision_id);
         match self {
             Self::Conversational { .. } => {
-                let outcome = self.decide(request, cancel).await?;
+                let outcome = self.decide_inner(request, cancel).await?;
                 Ok(GateDecision::without_overrides(outcome))
             }
             Self::Webhook { client, timeout } => {
@@ -222,14 +254,6 @@ impl DecisionRoute {
                 let request_id = request.request_id.clone();
                 let decision_id = request.decision_id;
                 let scope = request.scope.clone();
-
-                // Mirrors the stamp at the top of `decide`: ahead of any
-                // outcome, so the correlation holds on either route.
-                crate::logging::set_span_attribute(
-                    &tracing::Span::current(),
-                    crate::logging::ATTR_DECISION_ID,
-                    decision_id.to_string(),
-                );
 
                 approval_event_broker::publish(
                     &request_id,
@@ -262,14 +286,30 @@ impl DecisionRoute {
         }
     }
 
-    /// Obtain a decision for `request`, applying the shared semantics (deadline,
-    /// fail-closed mapping, event emission) in one place.
+    /// Obtain a decision for `request`.
     ///
-    /// Both surfaces await this inline from the gated call's `execute_tool`
-    /// span, so stamping the decision id on the current span here — ahead of
-    /// the route split and of any outcome — correlates the approval with the
-    /// execution it gates on either route, decided or not.
+    /// The agent-callable `request_approval` tool awaits this directly on
+    /// its own `execute_tool` span, never through [`Self::decide_for_gate`],
+    /// so this entry point stamps the decision id on the current span
+    /// before delegating to [`Self::decide_inner`] for the shared decision
+    /// logic (deadline, fail-closed mapping, event emission).
     pub async fn decide(
+        &self,
+        request: ApprovalRequest,
+        cancel: &crate::request_cancellation::RequestCancelToken,
+    ) -> Result<ApprovalOutcome, ApprovalError> {
+        stamp_decision_id(request.decision_id);
+        self.decide_inner(request, cancel).await
+    }
+
+    /// Obtain a decision for `request`, applying the shared semantics
+    /// (deadline, fail-closed mapping, event emission) in one place.
+    ///
+    /// Does not stamp the current span: both callers — [`Self::decide`] and
+    /// the conversational arm of [`Self::decide_for_gate`] — have already
+    /// stamped it on their own entry, so stamping here too would duplicate
+    /// the attribute on the same span.
+    async fn decide_inner(
         &self,
         request: ApprovalRequest,
         cancel: &crate::request_cancellation::RequestCancelToken,
@@ -278,12 +318,6 @@ impl DecisionRoute {
         let request_id = request.request_id.clone();
         let decision_id = request.decision_id;
         let scope = request.scope.clone();
-
-        crate::logging::set_span_attribute(
-            &tracing::Span::current(),
-            crate::logging::ATTR_DECISION_ID,
-            decision_id.to_string(),
-        );
 
         match self {
             Self::Conversational { registry, timeout } => {

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -449,4 +449,161 @@ mod tests {
             item.arguments,
         );
     }
+
+    /// Trace correlation for the agent-callable surface: `request_approval`
+    /// dispatches through [`DecisionRoute::decide`] directly, never through
+    /// the config gate's `decide_for_gate`, so this surface must stamp the
+    /// decision id on its own execution span rather than inherit one from
+    /// the gate. Mirrors the equivalent coverage for the config-gate surface
+    /// in `gate.rs`'s `decision_id_span` tests.
+    ///
+    /// Gated on `otel` — without the feature `set_span_attribute` is a
+    /// documented no-op and there is no span data to assert against.
+    #[cfg(feature = "otel")]
+    mod decision_id_span {
+        use std::future::Future;
+        use std::sync::{Arc, Mutex, MutexGuard};
+
+        use futures::future::BoxFuture;
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
+        use opentelemetry_sdk::trace::TracerProvider;
+        use tracing::Instrument;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        use super::*;
+        use crate::logging::ATTR_DECISION_ID;
+
+        /// Spans the test subscriber has exported.
+        #[derive(Debug, Clone, Default)]
+        struct CapturedSpans(Arc<Mutex<Vec<SpanData>>>);
+
+        impl CapturedSpans {
+            fn spans(&self) -> MutexGuard<'_, Vec<SpanData>> {
+                self.0.lock().expect("captured spans mutex")
+            }
+
+            fn contains(&self, name: &str) -> bool {
+                self.spans().iter().any(|span| span.name == name)
+            }
+
+            /// The single `key` attribute on the span named `name`, or `None`
+            /// if the span carries no such attribute. Panics if the span
+            /// carries more than one — a double-stamp regression would
+            /// otherwise pass unnoticed, since `find` would silently return
+            /// only the first entry.
+            fn attribute(&self, name: &str, key: &str) -> Option<String> {
+                let spans = self.spans();
+                let span = spans.iter().find(|span| span.name == name)?;
+                let matches: Vec<_> = span
+                    .attributes
+                    .iter()
+                    .filter(|kv| kv.key.as_str() == key)
+                    .collect();
+                assert!(
+                    matches.len() <= 1,
+                    "span {name:?} must carry at most one {key} attribute, found {}: \
+                     a regression is double-stamping the same span",
+                    matches.len(),
+                );
+                matches.first().map(|kv| kv.value.to_string())
+            }
+        }
+
+        impl SpanExporter for CapturedSpans {
+            fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+                self.spans().extend(batch);
+                Box::pin(std::future::ready(Ok(())))
+            }
+        }
+
+        /// Run `body` inside an `execute_tool` span — the span Rig opens
+        /// around a tool call — under a subscriber that exports to memory,
+        /// returning the body's output and the `decision_id` the exported
+        /// span carries.
+        async fn traced_as_execute_tool<T>(body: impl Future<Output = T>) -> (T, Option<String>) {
+            let captured = CapturedSpans::default();
+            let provider = TracerProvider::builder()
+                .with_simple_exporter(captured.clone())
+                .build();
+            let _guard = tracing::subscriber::set_default(
+                tracing_subscriber::registry()
+                    .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test"))),
+            );
+
+            let output = body.instrument(tracing::info_span!("execute_tool")).await;
+
+            // The registry instruments a parked approval's wake task with the
+            // same span, so the export lands once that task has released it too.
+            for _ in 0..1_000 {
+                if captured.contains("execute_tool") {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            assert!(
+                captured.contains("execute_tool"),
+                "the execute_tool span was never exported",
+            );
+
+            (output, captured.attribute("execute_tool", ATTR_DECISION_ID))
+        }
+
+        #[tokio::test]
+        async fn request_approval_tool_stamps_the_decision_id_on_the_execution_span() {
+            let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+            let bus: Arc<dyn EventBus> = Arc::new(InMemoryEventBus::new());
+            let registry = PendingApprovals::with_backend(store, bus);
+            let route = Arc::new(DecisionRoute::Conversational {
+                registry: registry.clone(),
+                timeout: std::time::Duration::from_secs(60),
+            });
+
+            let request_id = format!("req_tool_span_{}", uuid::Uuid::new_v4().simple());
+            let mut events = approval_event_broker::subscribe(&request_id).await;
+            let tool = RequestApprovalTool::new(
+                route,
+                AgentScope::Single { session_id: None },
+                request_id.clone(),
+                "test-agent".to_string(),
+            );
+            let args = RequestApprovalArgs {
+                action_description: "delete namespace".to_string(),
+                risk_rationale: "touches prod".to_string(),
+                context: None,
+                tool_call_intent: None,
+            };
+
+            let ((result, payload_id), span_id) = traced_as_execute_tool(async {
+                tokio::join!(tool.call(args), async {
+                    let event = events.recv().await.expect("requested event arrives");
+                    let id = match event {
+                        ApprovalLifecycleEvent::Requested(req) => {
+                            DecisionId::parse(&req.decision_id).expect("valid decision id")
+                        }
+                        other => panic!("expected Requested event, got {:?}", other),
+                    };
+                    registry
+                        .resolve(&id, ApprovalDecision::Approved)
+                        .await
+                        .expect("parked approval resolves");
+                    id
+                })
+            })
+            .await;
+
+            assert!(
+                result.is_ok(),
+                "an approved call must succeed: {:?}",
+                result
+            );
+            assert_eq!(
+                span_id.as_deref(),
+                Some(payload_id.to_string().as_str()),
+                "the execution span must carry the request_approval tool's decision id",
+            );
+
+            approval_event_broker::unsubscribe(&request_id).await;
+        }
+    }
 }

--- a/docs/design/hitl.md
+++ b/docs/design/hitl.md
@@ -418,11 +418,18 @@ telemetry.
 
 ## Trace correlation
 
-`DecisionRoute::decide` stamps the request's `decision_id` on the current span,
-which is the gated call's Rig `execute_tool` span: both surfaces await `decide`
-inline, and `WrappedTool` carries that span across the approval gate into the
-inner tool. One stamp, ahead of the route split, gives every approval-gated
-execution the id the payload and the lifecycle events carry:
+`DecisionRoute::decide_for_gate` and `DecisionRoute::decide` each stamp the
+request's `decision_id` on the current span, ahead of their own route split
+and of any outcome: the config gate awaits `decide_for_gate` inline from the
+gated call's Rig `execute_tool` span, and `WrappedTool` carries that span
+across the approval gate into the inner tool; the agent-callable
+`request_approval` tool awaits `decide` directly on its own `execute_tool`
+span instead of going through the gate. Neither entry point is reached
+through the other on every route — `decide_for_gate`'s webhook arm never
+calls `decide`, and `request_approval` never calls `decide_for_gate` — so
+each stamps independently rather than relying on the other to have done it.
+Stamping ahead of the split gives every approval-gated execution the id the
+payload and the lifecycle events carry:
 
 ```text
 execute_tool
@@ -431,9 +438,13 @@ execute_tool
         status = OK | ERROR
 ```
 
-A trace consumer joins the approval to the result of the action it released
-without a second reporting channel. Ungated calls never reach `decide`, so they
-carry no `decision_id`.
+On the config-gate surface, this is the gated action's own span — the approval
+joins the result of the action it released on one span, without a second
+reporting channel. On the agent-callable surface, the stamp lands on
+`request_approval`'s own execution span instead: it correlates the approval
+decision to that tool call, not to whatever separate tool call the agent goes
+on to make once the decision comes back approved. Ungated calls never reach
+`decide_for_gate` or `decide`, so they carry no `decision_id`.
 
 ## Orchestration behavior
 


### PR DESCRIPTION
#531 left two approval surfaces without a decision id on their spans: the webhook arm resolves through the client seam without calling `decide`, and the `request_approval` tool skips `decide_for_gate`. This stamps both public entries and routes the gate's conversational arm through an unstamped inner fn so no span is stamped twice.

Part of #496.


