### PR TITLE
Apply approver header overrides to the gated MCP call

### DIFF
--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -69,12 +69,15 @@ impl ApproverHeaders {
     /// Apply the overrides to an outbound request builder as per-request
     /// headers, which override the client's frozen `default_headers` for
     /// that one request only.
-    #[expect(
-        unused_variables,
-        reason = "todo!() body; filled when gate-to-wire wiring lands"
-    )]
+    ///
+    /// Whole-map application, not pair-by-pair: `RequestBuilder::header`
+    /// appends, so a name the builder already carries would end up sent
+    /// twice — the approver's identity beside the requester's. Passing the
+    /// map replaces per name, which is the discipline the lowercased keys
+    /// were established for. Default headers need no such care: `reqwest`
+    /// fills them in only where the request left the name vacant.
     pub(crate) fn apply_to(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        todo!("per-request .header(k, v) for each captured pair")
+        builder.headers(self.headers.clone())
     }
 }
 
@@ -142,15 +145,20 @@ pub enum McpTransportKind {
 
 /// Fail closed when `kind` cannot deliver per-call header overrides.
 /// Called at the execution seam only when overrides exist.
-#[expect(
-    unused_variables,
-    reason = "todo!() body; filled when gate-to-wire wiring lands"
-)]
+///
+/// The transport alone decides. An override value carrying no pairs is not
+/// "no override": the caller reached here because identity was demanded, and
+/// a transport with no per-call header channel cannot honor that demand
+/// whatever the configured map turned out to hold.
 pub(crate) fn ensure_transport_delivers_overrides(
     kind: McpTransportKind,
-    overrides: &ApproverHeaders,
+    _overrides: &ApproverHeaders,
 ) -> Result<(), OverrideApplicationError> {
-    todo!("stdio rejects overrides; http and sse accept")
+    match kind {
+        // Both HTTP send paths read the extension and apply the overrides.
+        McpTransportKind::StreamableHttp | McpTransportKind::Sse => Ok(()),
+        McpTransportKind::Stdio => Err(OverrideApplicationError::TransportUnsupported { kind }),
+    }
 }
 
 /// Extract approver overrides from an outbound client message, if the one
@@ -196,12 +204,25 @@ pub(crate) fn current_approver_overrides() -> Option<ApproverHeaders> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::collections::HashMap;
 
     use reqwest::header::HeaderValue;
 
     use super::*;
+
+    /// One captured override pair, for the seam tests that need a value of
+    /// this type without restating the capture plumbing. Construction goes
+    /// through the real capture path so a test can never hold overrides the
+    /// production path could not have produced.
+    pub(crate) fn captured_overrides(outbound: &str, value: &str) -> ApproverHeaders {
+        const RESPONSE_NAME: &str = "x-approver-source";
+        ApproverHeaders::from_captured(
+            &mappings(&[(outbound, RESPONSE_NAME)]),
+            &response(&[(RESPONSE_NAME, value)]),
+        )
+        .expect("the mapped header is present")
+    }
 
     fn mappings(pairs: &[(&str, &str)]) -> ToolHeaderMappings {
         let raw: HashMap<String, String> = pairs
@@ -291,6 +312,114 @@ mod tests {
             CaptureError::MissingHeaders {
                 names: vec!["authorization".to_owned(), "x-forwarded-user".to_owned()],
             }
+        );
+    }
+
+    /// Every captured pair lands on the request the builder produces, under
+    /// the outbound name.
+    #[test]
+    fn apply_to_sets_every_captured_pair_on_the_request() {
+        let captured = ApproverHeaders::from_captured(
+            &mappings(&[
+                ("x-forwarded-user", "x-approver-id"),
+                ("x-tenant", "x-approver-tenant"),
+            ]),
+            &response(&[("x-approver-id", "alice"), ("x-approver-tenant", "acme")]),
+        )
+        .expect("both mapped headers capture");
+
+        let request = captured
+            .apply_to(reqwest::Client::new().post("http://127.0.0.1:9/"))
+            .build()
+            .expect("the override headers are valid");
+
+        assert_eq!(request.headers().get("x-forwarded-user").unwrap(), "alice");
+        assert_eq!(request.headers().get("x-tenant").unwrap(), "acme");
+    }
+
+    /// The override REPLACES a same-named header already on the builder rather
+    /// than coexisting with it. Two identities on one request is the failure
+    /// mode this guards: `reqwest`'s per-header setter appends, so applying
+    /// pair-by-pair would leave the original value in place beside the
+    /// approver's.
+    #[test]
+    fn apply_to_replaces_a_header_already_on_the_builder() {
+        let captured = ApproverHeaders::from_captured(
+            &mappings(&[("authorization", "x-approver-token")]),
+            &response(&[("x-approver-token", "Bearer approver")]),
+        )
+        .expect("the mapped header captures");
+
+        let request = captured
+            .apply_to(
+                reqwest::Client::new()
+                    .post("http://127.0.0.1:9/")
+                    .header("authorization", "Bearer requester"),
+            )
+            .build()
+            .expect("the override headers are valid");
+
+        assert_eq!(
+            request.headers().get_all("authorization").iter().count(),
+            1,
+            "the requester's identity must not ride along beside the approver's",
+        );
+        assert_eq!(
+            request.headers().get("authorization").unwrap(),
+            "Bearer approver",
+        );
+    }
+
+    fn any_overrides() -> ApproverHeaders {
+        ApproverHeaders::from_captured(
+            &mappings(&[("x-forwarded-user", "x-approver-id")]),
+            &response(&[("x-approver-id", "alice")]),
+        )
+        .expect("test overrides capture")
+    }
+
+    /// Stdio has no per-call header channel, so a call that demands identity
+    /// cannot be delivered and must not proceed under the cached one.
+    #[test]
+    fn stdio_transport_refuses_overrides() {
+        assert_eq!(
+            ensure_transport_delivers_overrides(McpTransportKind::Stdio, &any_overrides()),
+            Err(OverrideApplicationError::TransportUnsupported {
+                kind: McpTransportKind::Stdio
+            }),
+        );
+    }
+
+    /// Both HTTP transports read the extension on their send path, so both
+    /// can deliver.
+    #[test]
+    fn http_transports_accept_overrides() {
+        let overrides = any_overrides();
+        assert_eq!(
+            ensure_transport_delivers_overrides(McpTransportKind::StreamableHttp, &overrides),
+            Ok(()),
+        );
+        assert_eq!(
+            ensure_transport_delivers_overrides(McpTransportKind::Sse, &overrides),
+            Ok(()),
+        );
+    }
+
+    /// The check keys off the transport alone. An override value with no pairs
+    /// is not "no override": identity was demanded, the configured map decided
+    /// what that means, and a transport that cannot carry headers still cannot
+    /// honor the demand.
+    #[test]
+    fn stdio_refuses_even_an_empty_override_set() {
+        let empty = ApproverHeaders::from_captured(&mappings(&[]), &HeaderMap::new())
+            .expect("an empty mapping captures nothing and succeeds");
+        assert_eq!(empty.captured_names().count(), 0);
+
+        assert_eq!(
+            ensure_transport_delivers_overrides(McpTransportKind::Stdio, &empty),
+            Err(OverrideApplicationError::TransportUnsupported {
+                kind: McpTransportKind::Stdio
+            }),
         );
     }
 

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -1970,6 +1970,171 @@ mod tests {
         scratchpad::ContextBudget::new(128_000, 0.20, 0, counter)
     }
 
+    /// Tool composition is where each MCP adaptor learns which transport it
+    /// fronts. Both the single-agent path and the orchestration worker path
+    /// reach it through `add_all_tools`, so what that function tags decides
+    /// whether a gated call can deliver approver identity or must refuse.
+    mod transport_tagging {
+        use std::collections::HashMap;
+
+        use rig::completion::{CompletionError, CompletionRequest, CompletionResponse};
+        use serde_json::json;
+
+        use super::*;
+        use crate::approver_headers::tests::captured_overrides;
+        use crate::mcp::McpManager;
+        use crate::mcp_streamable_http::McpClient;
+        use crate::mcp_streamable_http::tests::RecordingMcpServer;
+        use crate::tool_wrapper::{PreCallOutcome, ToolCallContext, ToolWrapper};
+
+        /// A completion model that exists only to satisfy the builder's type
+        /// parameter. Composition never prompts it.
+        #[derive(Clone)]
+        struct UnpromptedModel;
+
+        impl rig::completion::CompletionModel for UnpromptedModel {
+            type Response = ();
+            type StreamingResponse = ();
+            type Client = ();
+
+            fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+                Self
+            }
+
+            async fn completion(
+                &self,
+                _request: CompletionRequest,
+            ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+                unreachable!("tool composition never prompts the model")
+            }
+
+            async fn stream(
+                &self,
+                _request: CompletionRequest,
+            ) -> Result<
+                rig::streaming::StreamingCompletionResponse<Self::StreamingResponse>,
+                CompletionError,
+            > {
+                unreachable!("tool composition never prompts the model")
+            }
+        }
+
+        /// Stands in for the HITL gate: every call it wraps arrives carrying
+        /// approver identity, which is what makes the transport tag decide the
+        /// outcome.
+        struct AlwaysOverrides;
+
+        #[async_trait]
+        impl ToolWrapper for AlwaysOverrides {
+            async fn pre_call(
+                &self,
+                _args: &serde_json::Value,
+                _ctx: &ToolCallContext,
+            ) -> Result<PreCallOutcome, rig::tool::ToolError> {
+                Ok(PreCallOutcome::Proceed {
+                    overrides: Some(captured_overrides("x-forwarded-user", "alice")),
+                })
+            }
+        }
+
+        fn declared_tool(name: &str) -> rmcp::model::Tool {
+            rmcp::model::Tool::new(
+                name.to_owned(),
+                "test tool".to_owned(),
+                Arc::new(serde_json::Map::new()),
+            )
+        }
+
+        /// A manager offering the same tool name on each of the three
+        /// transports, all backed by `server` — so the only thing that can
+        /// distinguish them downstream is the tag composition gives them.
+        async fn manager_serving_all_transports(server: &RecordingMcpServer) -> McpManager {
+            let connect = async || {
+                McpClient::new(server.url.clone(), &HashMap::new())
+                    .await
+                    .expect("the loopback server completes the handshake")
+            };
+            McpManager {
+                server_info: HashMap::new(),
+                streamable_clients: HashMap::from([("http".to_owned(), connect().await)]),
+                streamable_tools: HashMap::from([(
+                    "http".to_owned(),
+                    vec![declared_tool("http_tool")],
+                )]),
+                sse_clients: HashMap::from([("sse".to_owned(), connect().await)]),
+                sse_tools: HashMap::from([("sse".to_owned(), vec![declared_tool("sse_tool")])]),
+                stdio_clients: HashMap::from([("stdio".to_owned(), connect().await)]),
+                stdio_tools: HashMap::from([(
+                    "stdio".to_owned(),
+                    vec![declared_tool("stdio_tool")],
+                )]),
+                sanitize_schemas: false,
+            }
+        }
+
+        /// Compose an agent the way a request does — gate wrapper included —
+        /// over a manager whose tools span all three transports.
+        async fn compose_agent(server: &RecordingMcpServer) -> rig::agent::Agent<UnpromptedModel> {
+            let config = AgentRuntimeConfig {
+                tool_wrapper: Some(Arc::new(AlwaysOverrides)),
+                ..Default::default()
+            };
+            let manager = Some(Arc::new(manager_serving_all_transports(server).await));
+            let state = BuilderState::Initial(rig::agent::AgentBuilder::new(UnpromptedModel));
+            Agent::add_all_tools(state, &config, &manager, Vec::new())
+                .await
+                .expect("composition succeeds")
+                .build()
+        }
+
+        /// The stdio branch must tag its adaptors `Stdio`, or a gated stdio
+        /// call would silently run under the requester's cached identity.
+        #[tokio::test]
+        async fn stdio_tools_are_tagged_so_a_gated_call_fails_closed() {
+            let server = RecordingMcpServer::start().await;
+            let agent = compose_agent(&server).await;
+
+            let error = agent
+                .tool_server_handle
+                .call_tool("stdio_tool", &json!({}).to_string())
+                .await
+                .expect_err("a gated stdio call must fail closed");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("cannot deliver approver identity"),
+                "the error must name the reason, got: {error}",
+            );
+            assert!(
+                server.tool_calls().is_empty(),
+                "the refused call must not reach any server",
+            );
+        }
+
+        /// The two HTTP branches must tag adaptors that can carry identity, so
+        /// the same gated call reaches the wire wearing the approver's header.
+        #[tokio::test]
+        async fn http_and_sse_tools_are_tagged_so_a_gated_call_delivers_identity() {
+            let server = RecordingMcpServer::start().await;
+            let agent = compose_agent(&server).await;
+
+            for tool in ["http_tool", "sse_tool"] {
+                agent
+                    .tool_server_handle
+                    .call_tool(tool, &json!({}).to_string())
+                    .await
+                    .unwrap_or_else(|e| panic!("a gated {tool} call proceeds: {e}"));
+            }
+
+            let calls = server.tool_calls();
+            assert_eq!(calls.len(), 2);
+            for call in calls {
+                assert_eq!(call.header_values("x-forwarded-user"), vec!["alice"]);
+            }
+        }
+    }
+
     #[test]
     fn scratchpad_usage_event_returns_none_when_no_activity() {
         let b = budget();

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -196,6 +196,47 @@ mod tests {
         );
     }
 
+    /// The mapping is the only path from an approval's captured identity to
+    /// the call it released; a `Proceed` that dropped the overrides would
+    /// send the gated call under the requester's identity instead.
+    #[test]
+    fn approval_result_mapping_carries_captured_overrides_into_the_call() {
+        let captured = crate::approver_headers::tests::captured_overrides("authorization", "tok");
+
+        assert_eq!(
+            approval_result_to_pre_call(Ok(GateDecision::Approved {
+                overrides: Some(captured.clone()),
+            }))
+            .unwrap(),
+            PreCallOutcome::Proceed {
+                overrides: Some(captured)
+            },
+        );
+    }
+
+    /// No decision other than approval may carry identity forward: a denial,
+    /// a timeout, a cancellation and a channel fault all stop the call, so
+    /// there is nothing to apply.
+    #[test]
+    fn only_an_approval_yields_a_proceed() {
+        for result in [
+            Ok(GateDecision::Denied { reason: None }),
+            Ok(GateDecision::TimedOut {
+                waited: Duration::from_secs(1),
+            }),
+            Ok(GateDecision::Cancelled(CancelReason::ClientDisconnected)),
+            Err(ApprovalError::BadStatus { status: 500 }),
+        ] {
+            assert!(
+                !matches!(
+                    approval_result_to_pre_call(result),
+                    Ok(PreCallOutcome::Proceed { .. })
+                ),
+                "an undecided or refused approval must never proceed",
+            );
+        }
+    }
+
     #[test]
     fn approval_result_mapping_denial_is_feedback_not_error() {
         let outcome = approval_result_to_pre_call(Ok(GateDecision::Denied {

--- a/crates/aura/src/mcp_dynamic.rs
+++ b/crates/aura/src/mcp_dynamic.rs
@@ -108,3 +108,95 @@ impl RigTool for McpToolAdaptor {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::approver_headers::{APPROVER_OVERRIDES, tests::captured_overrides};
+    use crate::mcp_streamable_http::tests::RecordingMcpServer;
+
+    /// An adaptor for `tool_name`, fronting `server`, tagged as `kind`.
+    /// The client is always a streamable-HTTP one: the tag, not the wire, is
+    /// what the override path consults, so a stdio-tagged adaptor over a
+    /// reachable server is exactly the case that must still refuse.
+    async fn adaptor_for(
+        server: &RecordingMcpServer,
+        tool_name: &str,
+        kind: McpTransportKind,
+    ) -> McpToolAdaptor {
+        let client = McpClient::new(server.url.clone(), &std::collections::HashMap::new())
+            .await
+            .expect("the loopback server completes the handshake");
+        let tool = rmcp::model::Tool::new(
+            tool_name.to_owned(),
+            "test tool".to_owned(),
+            std::sync::Arc::new(serde_json::Map::new()),
+        );
+        McpToolAdaptor::new(tool, "test-server".to_owned(), Arc::new(client), kind)
+    }
+
+    /// Identity was demanded and stdio has no way to carry it, so the call
+    /// must not run — and must not run *at all*: the refusal comes before
+    /// anything reaches the server, not after.
+    #[tokio::test]
+    async fn stdio_adaptor_refuses_a_gated_call_before_dispatch() {
+        let server = RecordingMcpServer::start().await;
+        let adaptor = adaptor_for(&server, "gated", McpTransportKind::Stdio).await;
+
+        let error = APPROVER_OVERRIDES
+            .scope(
+                Some(captured_overrides("x-forwarded-user", "alice")),
+                adaptor.call(json!({})),
+            )
+            .await
+            .expect_err("a stdio tool call carrying overrides must fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("cannot deliver approver identity"),
+            "the error must name the reason, got: {error}",
+        );
+        assert!(
+            server.tool_calls().is_empty(),
+            "the call must not reach the server",
+        );
+    }
+
+    /// The same adaptor over a transport that can carry headers reads the
+    /// task-local and threads it all the way to the wire.
+    #[tokio::test]
+    async fn http_adaptor_forwards_the_scoped_override() {
+        let server = RecordingMcpServer::start().await;
+        let adaptor = adaptor_for(&server, "gated", McpTransportKind::StreamableHttp).await;
+
+        APPROVER_OVERRIDES
+            .scope(
+                Some(captured_overrides("x-forwarded-user", "alice")),
+                adaptor.call(json!({})),
+            )
+            .await
+            .expect("an http-backed gated call proceeds");
+
+        assert_eq!(
+            server.tool_calls()[0].header_values("x-forwarded-user"),
+            vec!["alice"],
+        );
+    }
+
+    /// A stdio tool that no approval gated is untouched by any of this.
+    #[tokio::test]
+    async fn stdio_adaptor_runs_an_ungated_call() {
+        let server = RecordingMcpServer::start().await;
+        let adaptor = adaptor_for(&server, "ungated", McpTransportKind::Stdio).await;
+
+        adaptor
+            .call(json!({}))
+            .await
+            .expect("an ungated stdio call proceeds");
+
+        assert_eq!(server.tool_calls().len(), 1);
+    }
+}

--- a/crates/aura/src/mcp_sse.rs
+++ b/crates/aura/src/mcp_sse.rs
@@ -191,6 +191,94 @@ fn resolve_message_endpoint(
 mod tests {
     use super::*;
 
+    mod approver_overrides {
+        use rmcp::model::{CallToolRequestParam, ClientJsonRpcMessage, RequestId};
+
+        use super::*;
+        use crate::approver_headers::{ApproverHeaders, tests::captured_overrides};
+        use crate::mcp_streamable_http::call_tool_request;
+        use crate::mcp_streamable_http::tests::RecordingMcpServer;
+
+        /// An SSE transport aimed at `endpoint`, carrying the same frozen
+        /// identity a configured client would hold. Built by hand because
+        /// `connect` needs a live SSE stream and the send path is what is
+        /// under test.
+        fn transport_to(endpoint: &str) -> SseTransport {
+            let mut frozen = HeaderMap::new();
+            frozen.insert(
+                "authorization",
+                HeaderValue::from_static("Bearer requester"),
+            );
+            SseTransport {
+                http_client: reqwest::Client::builder()
+                    .default_headers(frozen)
+                    .build()
+                    .unwrap(),
+                message_endpoint: url::Url::parse(endpoint).unwrap(),
+                stream: None,
+            }
+        }
+
+        fn call_message(tool: &str, overrides: Option<ApproverHeaders>) -> ClientJsonRpcMessage {
+            ClientJsonRpcMessage::request(
+                call_tool_request(
+                    CallToolRequestParam {
+                        name: tool.to_owned().into(),
+                        arguments: None,
+                    },
+                    overrides,
+                ),
+                RequestId::Number(1),
+            )
+        }
+
+        /// The SSE send path reads the same extension the streamable-HTTP path
+        /// does: the override replaces the frozen identity on that one POST,
+        /// arrives once, and never appears in the JSON body.
+        #[tokio::test]
+        async fn send_applies_the_override_to_the_post_and_not_the_body() {
+            let server = RecordingMcpServer::start().await;
+            let mut transport = transport_to(&server.url);
+
+            transport
+                .send(call_message(
+                    "gated",
+                    Some(captured_overrides("authorization", "Bearer approver")),
+                ))
+                .await
+                .expect("the loopback server accepts the post");
+
+            let calls = server.tool_calls();
+            assert_eq!(calls.len(), 1);
+            assert_eq!(
+                calls[0].header_values("authorization"),
+                vec!["Bearer approver"],
+                "the requester's identity must be replaced, not joined",
+            );
+            let body = calls[0].body_text();
+            assert!(!body.contains("authorization"), "body was: {body}");
+            assert!(!body.contains("approver"), "body was: {body}");
+        }
+
+        /// A message with no extension leaves the client's own identity in
+        /// place, so an ungated call on an SSE server is unaffected.
+        #[tokio::test]
+        async fn send_without_an_extension_keeps_the_frozen_identity() {
+            let server = RecordingMcpServer::start().await;
+            let mut transport = transport_to(&server.url);
+
+            transport
+                .send(call_message("ungated", None))
+                .await
+                .expect("the loopback server accepts the post");
+
+            assert_eq!(
+                server.tool_calls()[0].header_values("authorization"),
+                vec!["Bearer requester"],
+            );
+        }
+    }
+
     #[test]
     fn test_resolve_message_endpoint_query_only() {
         let base = url::Url::parse("https://localhost/sse").unwrap();

--- a/crates/aura/src/mcp_streamable_http.rs
+++ b/crates/aura/src/mcp_streamable_http.rs
@@ -33,7 +33,7 @@ use crate::tool_event_broker::{peek_tool_call_id, publish_tool_start};
 /// request value through the transport worker and is never serialized to
 /// the wire, so one-call scoping is structural. Every `call_tool*` variant
 /// constructs its request here.
-fn call_tool_request(
+pub(crate) fn call_tool_request(
     request_param: CallToolRequestParam,
     approver_overrides: Option<ApproverHeaders>,
 ) -> ClientRequest {
@@ -635,8 +635,14 @@ impl McpClient {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
+    use std::sync::Mutex;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
     use super::*;
+    use crate::approver_headers::tests::captured_overrides;
 
     #[tokio::test]
     async fn test_in_flight_requests_tracking() {
@@ -649,5 +655,438 @@ mod tests {
 
         tracker.remove(http_id, &mcp_id).await;
         assert_eq!(tracker.get_all(http_id).await.len(), 0);
+    }
+
+    /// One HTTP request the server received, kept whole so a test can ask
+    /// both what rode in the headers and what rode in the body.
+    #[derive(Clone)]
+    pub(crate) struct RecordedRequest {
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+    }
+
+    impl RecordedRequest {
+        /// Every value sent under `name`, in arrival order. A test that asks
+        /// for the count is asking whether an override replaced a header or
+        /// merely joined it.
+        pub(crate) fn header_values(&self, name: &str) -> Vec<&str> {
+            self.headers
+                .iter()
+                .filter(|(k, _)| k.eq_ignore_ascii_case(name))
+                .map(|(_, v)| v.as_str())
+                .collect()
+        }
+
+        pub(crate) fn body_text(&self) -> String {
+            String::from_utf8_lossy(&self.body).into_owned()
+        }
+
+        /// The JSON-RPC method this request carried, or `None` for a body
+        /// that is not a JSON-RPC message.
+        fn rpc_method(&self) -> Option<String> {
+            serde_json::from_slice::<Value>(&self.body)
+                .ok()?
+                .get("method")?
+                .as_str()
+                .map(str::to_owned)
+        }
+
+        /// The tool this request asked the server to run, for correlating a
+        /// recorded request back to the call that produced it.
+        pub(crate) fn called_tool(&self) -> Option<String> {
+            serde_json::from_slice::<Value>(&self.body)
+                .ok()?
+                .get("params")?
+                .get("name")?
+                .as_str()
+                .map(str::to_owned)
+        }
+    }
+
+    /// A loopback MCP server over streamable HTTP that answers the handshake
+    /// and every tool call, and keeps each request it received.
+    ///
+    /// It exists so a test can watch what actually reaches the wire: the
+    /// approver override is applied deep inside the transport, after rmcp's
+    /// worker has taken the request value, so nothing short of the received
+    /// request proves it arrived — or, for the calls that must not carry it,
+    /// that it did not.
+    pub(crate) struct RecordingMcpServer {
+        pub(crate) url: String,
+        received: Arc<Mutex<Vec<RecordedRequest>>>,
+    }
+
+    impl RecordingMcpServer {
+        pub(crate) async fn start() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let url = format!("http://{}/mcp", listener.local_addr().unwrap());
+            let received = Arc::new(Mutex::new(Vec::new()));
+            let sink = Arc::clone(&received);
+            tokio::spawn(async move {
+                while let Ok((socket, _)) = listener.accept().await {
+                    let sink = Arc::clone(&sink);
+                    tokio::spawn(serve_one_request(socket, sink));
+                }
+            });
+            Self { url, received }
+        }
+
+        /// Snapshot of every `tools/call` the server received, oldest first.
+        pub(crate) fn tool_calls(&self) -> Vec<RecordedRequest> {
+            self.received
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|r| r.rpc_method().as_deref() == Some("tools/call"))
+                .cloned()
+                .collect()
+        }
+
+        /// The handshake request, which no approval has gated and which must
+        /// therefore carry only the identity the client was built with.
+        pub(crate) fn initialize(&self) -> RecordedRequest {
+            self.received
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|r| r.rpc_method().as_deref() == Some("initialize"))
+                .cloned()
+                .expect("the client completed a handshake")
+        }
+    }
+
+    /// The session id the handshake hands back, echoed by the client on every
+    /// later request.
+    const SESSION_ID: &str = "recording-session";
+
+    /// Read one HTTP request off `socket`, record it, answer it, and close.
+    /// Answering `connection: close` keeps the framing to one request per
+    /// connection, so the reader never has to unpick a keep-alive stream.
+    async fn serve_one_request(mut socket: TcpStream, sink: Arc<Mutex<Vec<RecordedRequest>>>) {
+        let mut buf = Vec::new();
+        let head_end = loop {
+            let mut chunk = [0u8; 4096];
+            let Ok(n) = socket.read(&mut chunk).await else {
+                return;
+            };
+            if n == 0 {
+                return;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..head_end]).into_owned();
+        let mut lines = head.lines();
+        let request_line = lines.next().unwrap_or_default().to_owned();
+        let headers: Vec<(String, String)> = lines
+            .filter_map(|line| line.split_once(':'))
+            .map(|(k, v)| (k.trim().to_owned(), v.trim().to_owned()))
+            .collect();
+        let content_length: usize = headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+            .and_then(|(_, v)| v.parse().ok())
+            .unwrap_or(0);
+        let mut body = buf[head_end + 4..].to_vec();
+        while body.len() < content_length {
+            let mut chunk = [0u8; 4096];
+            let Ok(n) = socket.read(&mut chunk).await else {
+                return;
+            };
+            if n == 0 {
+                return;
+            }
+            body.extend_from_slice(&chunk[..n]);
+        }
+
+        let http_method = request_line.split_whitespace().next().unwrap_or_default();
+        let (status, extra_headers, payload) = match http_method {
+            // rmcp opens a server-to-client stream once it has a session; 405
+            // is the documented "this server has none", which the worker
+            // absorbs instead of failing the connection.
+            "GET" => ("405 Method Not Allowed", Vec::new(), String::new()),
+            "DELETE" => ("202 Accepted", Vec::new(), String::new()),
+            _ => reply_to_rpc(&body),
+        };
+
+        sink.lock().unwrap().push(RecordedRequest { headers, body });
+
+        let mut response = format!(
+            "HTTP/1.1 {status}\r\ncontent-length: {}\r\nconnection: close\r\n",
+            payload.len()
+        );
+        if !payload.is_empty() {
+            response.push_str("content-type: application/json\r\n");
+        }
+        for (name, value) in extra_headers {
+            response.push_str(&format!("{name}: {value}\r\n"));
+        }
+        response.push_str("\r\n");
+        response.push_str(&payload);
+        socket.write_all(response.as_bytes()).await.ok();
+        socket.shutdown().await.ok();
+    }
+
+    /// Answer a JSON-RPC POST: a result for a request, a bare ack for a
+    /// notification.
+    fn reply_to_rpc(body: &[u8]) -> (&'static str, Vec<(String, String)>, String) {
+        let Ok(message) = serde_json::from_slice::<Value>(body) else {
+            return ("400 Bad Request", Vec::new(), String::new());
+        };
+        let method = message
+            .get("method")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        let Some(id) = message
+            .get("id")
+            .cloned()
+            .and_then(|id| serde_json::from_value::<RequestId>(id).ok())
+        else {
+            return ("202 Accepted", Vec::new(), String::new());
+        };
+
+        let result = match method.as_str() {
+            "initialize" => {
+                rmcp::model::ServerResult::InitializeResult(rmcp::model::InitializeResult::default())
+            }
+            "tools/call" => rmcp::model::ServerResult::CallToolResult(
+                rmcp::model::CallToolResult::success(vec![rmcp::model::Content::text("ok")]),
+            ),
+            _ => rmcp::model::ServerResult::empty(()),
+        };
+        let payload =
+            serde_json::to_string(&rmcp::model::ServerJsonRpcMessage::response(result, id))
+                .expect("server result serializes");
+        let extra_headers = if method == "initialize" {
+            vec![("mcp-session-id".to_owned(), SESSION_ID.to_owned())]
+        } else {
+            Vec::new()
+        };
+        ("200 OK", extra_headers, payload)
+    }
+
+    /// The identity frozen into the client at build time, standing in for the
+    /// original requester's forwarded headers.
+    fn requester_headers() -> HashMap<String, String> {
+        HashMap::from([("authorization".to_owned(), "Bearer requester".to_owned())])
+    }
+
+    fn no_args() -> HashMap<String, Value> {
+        HashMap::new()
+    }
+
+    /// The override rides exactly the call it was captured for: the gated
+    /// call carries it, and the very next call on the same client — the one
+    /// no approval unblocked — is back to the client's own identity.
+    #[tokio::test]
+    async fn override_rides_one_call_and_no_later_one() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        client
+            .call_tool(
+                "gated",
+                no_args(),
+                Some(captured_overrides("x-forwarded-user", "alice")),
+            )
+            .await
+            .expect("the gated call succeeds");
+        client
+            .call_tool("ungated", no_args(), None)
+            .await
+            .expect("the ungated call succeeds");
+
+        let calls = server.tool_calls();
+        assert_eq!(calls.len(), 2, "both calls reached the server");
+        assert_eq!(calls[0].header_values("x-forwarded-user"), vec!["alice"]);
+        assert!(
+            calls[1].header_values("x-forwarded-user").is_empty(),
+            "the approver's identity must not persist onto the next call",
+        );
+    }
+
+    /// The override never becomes part of the message: it rides the request
+    /// value as an extension, and the serializer emits no trace of it.
+    #[tokio::test]
+    async fn override_never_reaches_the_json_body() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        client
+            .call_tool(
+                "gated",
+                no_args(),
+                Some(captured_overrides("x-forwarded-user", "alice")),
+            )
+            .await
+            .expect("the gated call succeeds");
+
+        let body = server.tool_calls()[0].body_text();
+        assert!(!body.contains("x-forwarded-user"), "body was: {body}");
+        assert!(!body.contains("alice"), "body was: {body}");
+    }
+
+    /// The whole point of the frozen-header problem: the approver's value must
+    /// stand in place of the requester's on the gated call, not beside it.
+    #[tokio::test]
+    async fn override_replaces_the_clients_frozen_identity_for_that_call_only() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        client
+            .call_tool(
+                "gated",
+                no_args(),
+                Some(captured_overrides("authorization", "Bearer approver")),
+            )
+            .await
+            .expect("the gated call succeeds");
+        client
+            .call_tool("ungated", no_args(), None)
+            .await
+            .expect("the ungated call succeeds");
+
+        let calls = server.tool_calls();
+        assert_eq!(
+            calls[0].header_values("authorization"),
+            vec!["Bearer approver"],
+            "the requester's identity must be replaced, not joined",
+        );
+        assert_eq!(
+            calls[1].header_values("authorization"),
+            vec!["Bearer requester"],
+        );
+        assert_eq!(
+            server.initialize().header_values("authorization"),
+            vec!["Bearer requester"],
+            "the handshake predates any approval",
+        );
+    }
+
+    /// Two gated calls in flight on one client keep their own identities.
+    /// Scoping is structural — each override rides its own request value —
+    /// and this is the test that would catch a regression to shared state.
+    #[tokio::test]
+    async fn concurrent_gated_calls_keep_their_own_identity() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        let (first, second) = tokio::join!(
+            client.call_tool(
+                "for_alice",
+                no_args(),
+                Some(captured_overrides("x-forwarded-user", "alice")),
+            ),
+            client.call_tool(
+                "for_bob",
+                no_args(),
+                Some(captured_overrides("x-forwarded-user", "bob")),
+            ),
+        );
+        first.expect("alice's call succeeds");
+        second.expect("bob's call succeeds");
+
+        let calls = server.tool_calls();
+        assert_eq!(calls.len(), 2);
+        for call in calls {
+            let expected = match call.called_tool().as_deref() {
+                Some("for_alice") => "alice",
+                Some("for_bob") => "bob",
+                other => panic!("unexpected tool call {other:?}"),
+            };
+            assert_eq!(call.header_values("x-forwarded-user"), vec![expected]);
+        }
+    }
+
+    /// The tracked branch is the one production takes under the web server;
+    /// it must deliver identity the same way the untracked branch does.
+    #[tokio::test]
+    async fn tracked_call_carries_the_override_like_the_untracked_one() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        client
+            .call_tool_tracked(
+                "gated",
+                no_args(),
+                "http-req-1",
+                Some(captured_overrides("x-forwarded-user", "alice")),
+            )
+            .await
+            .expect("the tracked gated call succeeds");
+
+        assert_eq!(
+            server.tool_calls()[0].header_values("x-forwarded-user"),
+            vec!["alice"],
+        );
+    }
+
+    /// `set_current_request` selects the tracked branch, so this is the same
+    /// entry point a gated call takes in the server and the branch choice must
+    /// not decide whether identity is delivered.
+    #[tokio::test]
+    async fn call_tool_delivers_the_override_on_either_branch() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        client
+            .call_tool(
+                "untracked",
+                no_args(),
+                Some(captured_overrides("x-forwarded-user", "alice")),
+            )
+            .await
+            .expect("the untracked call succeeds");
+
+        client.set_current_request("http-req-1").await;
+        client
+            .call_tool(
+                "tracked",
+                no_args(),
+                Some(captured_overrides("x-forwarded-user", "bob")),
+            )
+            .await
+            .expect("the tracked call succeeds");
+
+        let calls = server.tool_calls();
+        assert_eq!(calls[0].header_values("x-forwarded-user"), vec!["alice"]);
+        assert_eq!(calls[1].header_values("x-forwarded-user"), vec!["bob"]);
+    }
+
+    /// A call no approval gated must reach the server carrying nothing extra —
+    /// neither an override header nor a stale one from an earlier call.
+    #[tokio::test]
+    async fn ungated_call_carries_no_override() {
+        let server = RecordingMcpServer::start().await;
+        let client = McpClient::new(server.url.clone(), &requester_headers())
+            .await
+            .expect("the loopback server completes the handshake");
+
+        client
+            .call_tool("ungated", no_args(), None)
+            .await
+            .expect("the ungated call succeeds");
+
+        let call = &server.tool_calls()[0];
+        assert!(call.header_values("x-forwarded-user").is_empty());
+        assert_eq!(
+            call.header_values("authorization"),
+            vec!["Bearer requester"]
+        );
     }
 }

--- a/crates/aura/src/tool_wrapper.rs
+++ b/crates/aura/src/tool_wrapper.rs
@@ -1141,4 +1141,77 @@ mod tests {
             "wrappers after the first rejection must not run"
         );
     }
+
+    /// Composition is a value-loss seam: it builds its own `Proceed`, so the
+    /// gate's captured identity survives only if aggregation carries it.
+    mod composed_overrides {
+        use super::*;
+        use crate::approver_headers::tests::captured_overrides;
+
+        struct Produces(&'static str);
+
+        #[async_trait]
+        impl ToolWrapper for Produces {
+            async fn pre_call(
+                &self,
+                _a: &Value,
+                _c: &ToolCallContext,
+            ) -> Result<PreCallOutcome, ToolError> {
+                Ok(PreCallOutcome::Proceed {
+                    overrides: Some(captured_overrides("x-forwarded-user", self.0)),
+                })
+            }
+        }
+
+        struct Passive;
+
+        #[async_trait]
+        impl ToolWrapper for Passive {
+            async fn pre_call(
+                &self,
+                _a: &Value,
+                _c: &ToolCallContext,
+            ) -> Result<PreCallOutcome, ToolError> {
+                Ok(PreCallOutcome::Proceed { overrides: None })
+            }
+        }
+
+        async fn compose(wrappers: Vec<Arc<dyn ToolWrapper>>) -> Result<PreCallOutcome, ToolError> {
+            ComposedWrapper::new(wrappers)
+                .pre_call(&serde_json::json!({}), &ToolCallContext::new("t"))
+                .await
+        }
+
+        #[tokio::test]
+        async fn the_single_producers_identity_survives_its_passive_neighbours() {
+            let outcome = compose(vec![
+                Arc::new(Passive),
+                Arc::new(Produces("alice")),
+                Arc::new(Passive),
+            ])
+            .await
+            .expect("one producer composes cleanly");
+
+            assert_eq!(
+                outcome,
+                PreCallOutcome::Proceed {
+                    overrides: Some(captured_overrides("x-forwarded-user", "alice")),
+                },
+            );
+        }
+
+        /// Two producers would make wrapper order decide whose identity the
+        /// call runs under. The call fails instead.
+        #[tokio::test]
+        async fn two_producers_fail_the_call_rather_than_pick_one() {
+            let error = compose(vec![Arc::new(Produces("alice")), Arc::new(Produces("bob"))])
+                .await
+                .expect_err("two producers must not resolve to either identity");
+
+            assert!(
+                error.to_string().contains("conflicting approver identity"),
+                "the error must name the conflict, got: {error}",
+            );
+        }
+    }
 }


### PR DESCRIPTION
The delivery half: captured overrides ride the rmcp request extension onto exactly one outbound request on the http-streamable and SSE transports. The override replaces the frozen client identity for that call only. A gated stdio call carrying overrides fails closed. Wire-level tests drive a recording loopback server through the real request-construction site.