### PR TITLE
Header forwarding audit span, integration suite, and docs

### DIFF
--- a/.makefiles/aura.mk
+++ b/.makefiles/aura.mk
@@ -262,3 +262,29 @@ test-integration-session-store-local: $(REPORT_DIR) ## Start an ephemeral Valkey
 	test_exit=$$?; \
 	docker stop $(VALKEY_TEST_NAME) >/dev/null 2>&1 || true; \
 	exit $$test_exit
+
+# --- HITL header-forwarding integration tests (needs only mock-mcp; each ---
+# --- test case spawns and tears down its own aura-web-server) ---
+
+.PHONY:test-integration-hitl-local
+test-integration-hitl-local: $(REPORT_DIR) ## Start mock-mcp, run HITL header-forwarding integration tests, then cleanup
+	@echo "Starting mock-mcp for HITL header-forwarding testing..."
+	docker compose -f compose/base.yml -f compose/dev.yml up -d --build --force-recreate mock-mcp
+	@echo "Waiting for mock-mcp to be healthy..."
+	@timeout=90; while [ $$timeout -gt 0 ]; do \
+		mcp_status=$$(docker compose -f compose/base.yml -f compose/dev.yml ps mock-mcp --format '{{.Health}}' 2>/dev/null); \
+		if [ "$$mcp_status" = "healthy" ]; then \
+			echo "✅ mock-mcp is healthy"; \
+			break; \
+		fi; \
+		echo "Waiting... mock-mcp: $$mcp_status ($$timeout s remaining)"; \
+		sleep 2; \
+		timeout=$$((timeout - 2)); \
+	done; \
+	if [ "$$mcp_status" != "healthy" ]; then echo "❌ Timeout waiting for mock-mcp"; docker compose -f compose/base.yml -f compose/dev.yml down; exit 1; fi
+	@echo "Running HITL header-forwarding integration tests..."
+	@trap 'docker compose -f compose/base.yml -f compose/dev.yml down; exit 130' INT TERM; \
+	cargo test --package aura-web-server --features integration-hitl-header-forwarding --test hitl_header_forwarding_tests --no-fail-fast -- --test-threads=1; \
+	test_exit=$$?; \
+	docker compose -f compose/base.yml -f compose/dev.yml down; \
+	exit $$test_exit

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -130,6 +130,12 @@ make test-integration-stdio-local
 # no other infra and no LLM key). To use an existing Redis/Valkey instead,
 # set AURA_TEST_REDIS_URL and run the cargo command directly.
 make test-integration-session-store-local
+
+# HITL header-forwarding tests (local only; needs mock-mcp up, same as the
+# base suite, but each test case spawns and tears down its own
+# aura-web-server against a generated per-case config, so there is no
+# separate -up/-down aura-web-server step).
+make test-integration-hitl-local
 ```
 
 Integration tests run single-threaded (`--test-threads=1`) due to LLM API rate limits.
@@ -150,6 +156,7 @@ Integration tests run single-threaded (`--test-threads=1`) due to LLM API rate l
 | `integration-orchestration-sre` | SRE orchestration (requires k8s-sre-mcp server config)   |
 | `integration-scratchpad`        | Scratchpad (separate from parent `integration`; requires scratchpad-test-mcp server config) |
 | `integration-session-store`     | Redis/Valkey session store (separate from parent `integration`; requires a live Redis/Valkey via `AURA_TEST_REDIS_URL`) |
+| `integration-hitl-header-forwarding` | HITL approver header forwarding (separate from parent `integration`; a gated `echo_headers` would break the base suite's ungated calls to the same tool, so each test spawns its own aura-web-server) |
 | `integration-vector`            | Vector store / RAG (requires external Qdrant)            |
 
 Example, run only the streaming tests:

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -99,6 +99,13 @@ impl DirectBackend {
             if let Some(hitl) = &config.hitl {
                 aura::hitl::validate_webhook_signing_config(hitl, hitl_webhook_hmac.as_ref())
                     .context("Invalid HITL webhook configuration")?;
+                aura::hitl::warn_on_cleartext_capture(hitl);
+                // The CLI's tracing subscriber is a no-op unless `log_file`
+                // is set, so the warning rides stderr as well — silent by
+                // default here would contradict the posture the ADR records.
+                if let Some(warning) = aura::hitl::cleartext_capture_warning(hitl) {
+                    eprintln!("warning: {warning}");
+                }
             }
         }
 

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -1406,8 +1406,7 @@ pub enum DecisionRouteConfig {
         headers_from_request: HashMap<String, String>,
         /// Outbound MCP header name → webhook approval-response header name.
         /// Non-empty opts gated calls into approver identity forwarding.
-        /// Validated at parse (see [`ToolHeaderMappings`]); the validated
-        /// map is carried but not consumed until capture wiring lands.
+        /// Validated at parse; see [`ToolHeaderMappings`].
         #[serde(default, skip_serializing_if = "ToolHeaderMappings::is_empty")]
         tool_headers_from_response: ToolHeaderMappings,
     },

--- a/crates/aura-web-server/Cargo.toml
+++ b/crates/aura-web-server/Cargo.toml
@@ -81,6 +81,14 @@ integration-scratchpad = []  # scratchpad_test
 # `AURA_TEST_REDIS_URL` in tests/redis_session_store_test.rs)
 integration-session-store = ["session-store-redis"]  # redis_session_store_test
 
+# HITL approver header forwarding (separate - a `require_approval` glob on
+# `echo_headers` would gate every call the base header_forwarding_tests.rs
+# suite makes to the same tool, so this suite builds its own aura-web-server
+# per test case against the shared mock-mcp fixture instead of the one
+# compose/base.yml starts). See hitl_header_forwarding_tests.rs for the run
+# recipe.
+integration-hitl-header-forwarding = []  # hitl_header_forwarding_tests
+
 [dev-dependencies]
 tokio-test = "0.4"
 reqwest = { workspace = true }

--- a/crates/aura-web-server/src/server.rs
+++ b/crates/aura-web-server/src/server.rs
@@ -404,7 +404,10 @@ async fn run(args: ServerArgs) -> std::io::Result<()> {
         )
     })?;
     // With a secret configured, a plaintext webhook URL fails at boot rather
-    // than on the first approval request.
+    // than on the first approval request. Cleartext response-header capture
+    // (a usable, unsigned configuration) warns here too, once per config —
+    // not from `WebhookClient` construction, which runs fresh on every
+    // request that builds an agent.
     for config in configs_arc.iter() {
         if let Some(hitl) = &config.hitl {
             aura::hitl::validate_webhook_signing_config(hitl, ingress_hmac.as_ref()).map_err(
@@ -416,6 +419,7 @@ async fn run(args: ServerArgs) -> std::io::Result<()> {
                     )
                 },
             )?;
+            aura::hitl::warn_on_cleartext_capture(hitl);
         }
     }
 

--- a/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
+++ b/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
@@ -1,0 +1,660 @@
+#![cfg(feature = "integration-hitl-header-forwarding")]
+
+//! Integration tests for HITL approver header forwarding (aura#496).
+//!
+//! Proves the override path end to end, through a real approval webhook and
+//! a real gated MCP call, over the actual `/v1/chat/completions` path —
+//! everything the unit suites cover only seam by seam.
+//!
+//! # Why this suite runs its own server
+//!
+//! `header_forwarding_tests.rs` shares one already-running `aura-web-server`
+//! and one `test-config.toml` with every other `integration-*` suite. A
+//! `require_approval` glob on `echo_headers` would gate every call that
+//! shared server makes to the tool, including that suite's — there is no way
+//! to scope `[hitl]` to a subset of calls on one running config. So each
+//! test here builds its own `aura-web-server` child process against its own
+//! generated config, on its own port, and tears it down when the test ends.
+//! All instances share the one `mock-mcp` fixture `header_forwarding_tests.rs`
+//! already depends on.
+//!
+//! # Run recipe
+//!
+//! 1. Start the shared MCP fixture (the same one `header_forwarding_tests.rs`
+//!    needs): `docker compose -f compose/base.yml -f compose/dev.yml up -d
+//!    mock-mcp`. Its FastMCP server must be reachable at
+//!    `${MCP_MOCK_HOST:-127.0.0.1}:9999`.
+//! 2. Export `OPENAI_API_KEY` (each generated config resolves
+//!    `{{ env.OPENAI_API_KEY }}`, exactly like `test-config.toml`).
+//! 3. `cargo test -p aura-web-server --features integration-hitl-header-forwarding`.
+//!    Cargo builds `aura-web-server` as a side effect (via
+//!    `CARGO_BIN_EXE_aura-web-server`); each test spawns it fresh, waits on
+//!    `/health`, drives one chat completion, and kills it on drop.
+//!
+//! No docker image, compose overlay, or Makefile target is needed beyond
+//! step 1's existing `mock-mcp` service.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::process::{Child, Command};
+
+const CHAT_TIMEOUT: Duration = Duration::from_secs(90);
+const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// A dedicated aura-web-server, spawned fresh per test case
+// ---------------------------------------------------------------------------
+
+/// A freshly spawned `aura-web-server`, bound to its own port and reading a
+/// config generated for exactly one test case. Killed and its config file
+/// removed on drop.
+struct AuraServer {
+    port: u16,
+    child: Child,
+    config_path: PathBuf,
+    /// Accumulated stderr, drained continuously so the child's pipe never
+    /// blocks; read back to explain a health-check timeout.
+    stderr_log: Arc<Mutex<String>>,
+}
+
+impl AuraServer {
+    fn base_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+
+    /// Spawn `aura-web-server` (built as a side effect of this test binary,
+    /// via `CARGO_BIN_EXE_aura-web-server`) against `config_toml`, and wait
+    /// until it answers `/health`. `free_port`'s bind-then-drop leaves a
+    /// window for something else to grab the port before the child binds it;
+    /// one retry on a fresh port covers that without masking a genuine
+    /// startup failure, which still panics on the second attempt.
+    async fn start(config_toml: &str) -> Self {
+        match Self::try_start(config_toml).await {
+            Ok(server) => server,
+            Err(failed) => {
+                let log = failed.stderr_log.lock().expect("stderr log mutex").clone();
+                eprintln!(
+                    "aura-web-server on port {} never answered /health within {HEALTH_TIMEOUT:?}; \
+                     retrying once on a fresh port. stderr:\n{log}",
+                    failed.port
+                );
+                failed.stop().await;
+                match Self::try_start(config_toml).await {
+                    Ok(server) => server,
+                    Err(failed) => {
+                        let log = failed.stderr_log.lock().expect("stderr log mutex").clone();
+                        let port = failed.port;
+                        failed.stop().await;
+                        panic!(
+                            "aura-web-server never answered /health, on a fresh port either; \
+                             last tried port {port}; stderr:\n{log}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// One spawn-and-wait attempt. `Err` carries the (still-running) server
+    /// so the caller can log its stderr and stop it before retrying.
+    async fn try_start(config_toml: &str) -> Result<Self, Self> {
+        let port = free_port();
+        let config_path =
+            std::env::temp_dir().join(format!("aura-hitl-test-{}.toml", uuid::Uuid::new_v4()));
+        std::fs::write(&config_path, config_toml).expect("write generated test config");
+
+        let mut child = Command::new(env!("CARGO_BIN_EXE_aura-web-server"))
+            .env("CONFIG_PATH", &config_path)
+            .env("HOST", "127.0.0.1")
+            .env("PORT", port.to_string())
+            .env("RUST_LOG", "warn")
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn aura-web-server (did `cargo build -p aura-web-server` succeed?)");
+
+        let stderr_log = Arc::new(Mutex::new(String::new()));
+        let stderr = child.stderr.take().expect("stderr was piped");
+        let log_sink = Arc::clone(&stderr_log);
+        tokio::spawn(async move {
+            let mut lines = tokio::io::BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let mut log = log_sink.lock().expect("stderr log mutex");
+                log.push_str(&line);
+                log.push('\n');
+            }
+        });
+
+        let server = Self {
+            port,
+            child,
+            config_path,
+            stderr_log,
+        };
+        if server.is_healthy_within(HEALTH_TIMEOUT).await {
+            Ok(server)
+        } else {
+            Err(server)
+        }
+    }
+
+    async fn is_healthy_within(&self, timeout: Duration) -> bool {
+        let client = reqwest::Client::new();
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Ok(resp) = client
+                .get(format!("{}/health", self.base_url()))
+                .send()
+                .await
+                && resp.status().is_success()
+            {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+
+    /// Kill the child and await its exit, reaping the process, then remove
+    /// its generated config file. Call this explicitly at the end of a
+    /// test; `Drop`'s `start_kill` is only the fallback for a test that
+    /// panics before reaching it, since a non-blocking kill on drop cannot
+    /// await the reap.
+    async fn stop(mut self) {
+        let _ = self.child.kill().await;
+        let _ = std::fs::remove_file(&self.config_path);
+    }
+}
+
+impl Drop for AuraServer {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+        let _ = std::fs::remove_file(&self.config_path);
+    }
+}
+
+/// An OS-assigned free port, read and released before the caller uses it.
+/// The bind-then-drop race is the standard tolerance for test-local ports.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+// ---------------------------------------------------------------------------
+// A hand-rolled mock webhook approver
+// ---------------------------------------------------------------------------
+
+/// How the mock approver answers every decision request it receives for the
+/// life of one test.
+#[derive(Clone, Copy)]
+enum ApproverReply {
+    /// Approve and return one extra response header, for capture.
+    ApproveWithHeader {
+        name: &'static str,
+        value: &'static str,
+    },
+    /// Approve with no extra headers — the mapped header (if any) is missing.
+    ApproveBare,
+    /// Deny every request.
+    Deny,
+}
+
+/// An in-process webhook approver bound to a loopback port, answering every
+/// POST it receives the same way for the life of the test. Mirrors the
+/// one-shot receiver idiom in `hitl::route`'s `webhook_signing` tests, minus
+/// the one-shot restriction: a chat turn may retry or the harness may want
+/// more than one decision, so this loops `accept`.
+struct MockApprover {
+    url: String,
+    hits: Arc<AtomicUsize>,
+}
+
+impl MockApprover {
+    async fn start(reply: ApproverReply) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock approver");
+        let url = format!("http://{}/decision", listener.local_addr().unwrap());
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hit_sink = Arc::clone(&hits);
+        tokio::spawn(async move {
+            while let Ok((socket, _)) = listener.accept().await {
+                // Counted on accept, before the decision is served: a test
+                // asserting `hits() == 0` is asserting the gate never even
+                // opened a connection, not that a slow reply raced the
+                // assertion.
+                hit_sink.fetch_add(1, Ordering::SeqCst);
+                serve_one_decision(socket, reply).await;
+            }
+        });
+        Self { url, hits }
+    }
+
+    /// How many decision requests this approver has accepted so far. The
+    /// direct proof that a call did, or did not, consult the route at all —
+    /// stronger than inferring it from the reply's shape.
+    fn hits(&self) -> usize {
+        self.hits.load(Ordering::SeqCst)
+    }
+}
+
+/// Read one HTTP request off `socket` and answer it per `reply`. Ignores the
+/// request body: which decision to hand back is fixed per test, not derived
+/// from the payload.
+async fn serve_one_decision(mut socket: tokio::net::TcpStream, reply: ApproverReply) {
+    let mut buf = Vec::new();
+    let head_end = loop {
+        let mut chunk = [0u8; 4096];
+        let Ok(n) = socket.read(&mut chunk).await else {
+            return;
+        };
+        if n == 0 {
+            return;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+            break pos;
+        }
+    };
+    let head = String::from_utf8_lossy(&buf[..head_end]).into_owned();
+    let content_length: usize = head
+        .lines()
+        .filter_map(|line| line.split_once(':'))
+        .find(|(name, _)| name.trim().eq_ignore_ascii_case("content-length"))
+        .and_then(|(_, value)| value.trim().parse().ok())
+        .unwrap_or(0);
+    let mut body = buf[head_end + 4..].to_vec();
+    while body.len() < content_length {
+        let mut chunk = [0u8; 4096];
+        let Ok(n) = socket.read(&mut chunk).await else {
+            return;
+        };
+        if n == 0 {
+            return;
+        }
+        body.extend_from_slice(&chunk[..n]);
+    }
+
+    let (payload, extra_header) = match reply {
+        ApproverReply::ApproveWithHeader { name, value } => {
+            (json!({"approved": true}).to_string(), Some((name, value)))
+        }
+        ApproverReply::ApproveBare => (json!({"approved": true}).to_string(), None),
+        ApproverReply::Deny => (
+            json!({"approved": false, "reason": "integration test denial"}).to_string(),
+            None,
+        ),
+    };
+
+    let mut response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n",
+        payload.len()
+    );
+    if let Some((name, value)) = extra_header {
+        response.push_str(&format!("{name}: {value}\r\n"));
+    }
+    response.push_str("\r\n");
+    response.push_str(&payload);
+    socket.write_all(response.as_bytes()).await.ok();
+    socket.shutdown().await.ok();
+}
+
+// ---------------------------------------------------------------------------
+// Generated config
+// ---------------------------------------------------------------------------
+
+/// The shared mock-mcp fixture's URL — the same server
+/// `header_forwarding_tests.rs` depends on, honoring the same `MCP_MOCK_HOST`
+/// override for container-network runs.
+fn mcp_url() -> String {
+    let host = std::env::var("MCP_MOCK_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    format!("http://{host}:9999/mcp")
+}
+
+/// A minimal single-agent config: one MCP server with a frozen static
+/// `Authorization` header (standing in for the pre-approval requester
+/// identity, as `test-config.toml` does for the base suite), plus whatever
+/// `[hitl]` table the caller supplies.
+fn config_toml(mcp_url: &str, frozen_authorization: &str, hitl_toml: &str) -> String {
+    format!(
+        r#"
+[mcp]
+sanitize_schemas = true
+
+[mcp.servers.mock_test_server]
+transport = "http_streamable"
+url = "{mcp_url}"
+description = "Mock MCP server for HITL header-forwarding integration tests"
+
+[mcp.servers.mock_test_server.headers]
+Authorization = "{frozen_authorization}"
+
+[agent]
+name = "HITL Header Forwarding Test Assistant"
+alias = "test-assistant"
+system_prompt = """
+You are a test assistant. Call tools immediately when requested, with no
+explanation, confirmation, or promise to call them later.
+
+If a tool call succeeds, reply with only its raw output - no commentary.
+
+If a tool call returns an error, reply with only the exact error message
+text - no apology, no extra commentary.
+
+AVAILABLE TOOLS (from mock_test_server):
+- echo_headers: Return HTTP headers as JSON (no params)
+"""
+turn_depth = 3
+
+[agent.llm]
+provider = "openai"
+api_key = "{{{{ env.OPENAI_API_KEY }}}}"
+model = "gpt-5.1"
+temperature = 0.0
+
+{hitl_toml}
+"#
+    )
+}
+
+/// `[hitl]` gating `echo_headers`, routed to `approver_url`.
+/// `tool_headers_from_response` is present when `with_map` is true (cases 1-3)
+/// and absent when false (case 4, legacy behavior).
+fn gated_hitl_toml(approver_url: &str, with_map: bool) -> String {
+    let mapping = if with_map {
+        r#"tool_headers_from_response = { "authorization" = "x-approver-token" }"#
+    } else {
+        ""
+    };
+    format!(
+        r#"
+[hitl]
+require_approval = ["echo_headers"]
+
+[hitl.route]
+mode = "webhook"
+url = "{approver_url}"
+{mapping}
+"#
+    )
+}
+
+/// `[hitl]` present and pointed at a real (denying) approver, but its glob
+/// matches no tool this suite calls — proves an unmatched call never
+/// consults the route at all.
+fn ungated_hitl_toml(approver_url: &str) -> String {
+    format!(
+        r#"
+[hitl]
+require_approval = ["not_a_real_tool_*"]
+
+[hitl.route]
+mode = "webhook"
+url = "{approver_url}"
+tool_headers_from_response = {{ "authorization" = "x-approver-token" }}
+"#
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Chat helpers
+// ---------------------------------------------------------------------------
+
+async fn send_chat(server: &AuraServer, prompt: &str) -> Value {
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("{}/v1/chat/completions", server.base_url()))
+        .json(&json!({
+            "model": "test-assistant",
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": false,
+            "metadata": {
+                "account_id": "test-account",
+                "chat_session_id": format!("hitl-test-{}", uuid::Uuid::new_v4())
+            }
+        }))
+        .timeout(CHAT_TIMEOUT)
+        .send()
+        .await
+        .expect("chat completion request reaches the server");
+
+    assert_eq!(
+        response.status(),
+        200,
+        "expected 200 OK from /v1/chat/completions"
+    );
+    response.json().await.expect("response body is valid JSON")
+}
+
+fn assistant_text(response_json: &Value) -> &str {
+    response_json["choices"][0]["message"]["content"]
+        .as_str()
+        .expect("response carries assistant message content")
+}
+
+/// The first `{...}` JSON object embedded in `text`, if any — mirrors
+/// `header_forwarding_tests.rs`'s extraction of the `echo_headers` JSON blob
+/// out of the model's prose.
+fn extract_json_object(text: &str) -> Option<Value> {
+    // The assistant relays the tool output in whatever quoting it fancies:
+    // bare, wrapped as a JSON string literal, or with the headers JSON
+    // stringified inside a `result` field - sometimes several layers deep.
+    // Unwrap until an object with plain fields remains.
+    if let Ok(Value::String(inner)) = serde_json::from_str::<Value>(text.trim()) {
+        return extract_json_object(&inner);
+    }
+    let start = text.find('{')?;
+    let end = text.rfind('}')?;
+    let mut value: Value = serde_json::from_str(&text[start..=end]).ok()?;
+    while let Some(inner) = value.get("result").and_then(Value::as_str) {
+        match serde_json::from_str::<Value>(inner) {
+            Ok(unwrapped) => value = unwrapped,
+            Err(_) => break,
+        }
+    }
+    Some(value)
+}
+
+// ---------------------------------------------------------------------------
+// Cases (spec Phase 3)
+// ---------------------------------------------------------------------------
+
+/// Case 1: an approved decision carrying the mapped header replaces the
+/// frozen requester identity on the one gated call.
+#[tokio::test]
+async fn override_forwarded_to_the_gated_call() {
+    let approver = MockApprover::start(ApproverReply::ApproveWithHeader {
+        name: "x-approver-token",
+        value: "Bearer approver-issued-identity",
+    })
+    .await;
+    let server = AuraServer::start(&config_toml(
+        &mcp_url(),
+        "Bearer legacy-frozen-identity",
+        &gated_hitl_toml(&approver.url, true),
+    ))
+    .await;
+
+    let response = send_chat(
+        &server,
+        "Call the echo_headers tool now and reply with only its raw JSON output.",
+    )
+    .await;
+    let headers = extract_json_object(assistant_text(&response)).unwrap_or_else(|| {
+        panic!(
+            "the assistant relays the echo_headers JSON output; got: {:?}",
+            assistant_text(&response)
+        )
+    });
+
+    assert_eq!(
+        headers.get("authorization").and_then(Value::as_str),
+        Some("Bearer approver-issued-identity"),
+        "the approver's identity must replace the frozen requester identity, got: {headers}"
+    );
+    assert_eq!(
+        approver.hits(),
+        1,
+        "exactly one decision request for the one gated call"
+    );
+    server.stop().await;
+}
+
+/// Case 2: an approved decision missing the mapped header fails the gated
+/// call closed; the error names the header, never any value.
+#[tokio::test]
+async fn missing_mapped_header_fails_the_call_by_name_only() {
+    let approver = MockApprover::start(ApproverReply::ApproveBare).await;
+    let server = AuraServer::start(&config_toml(
+        &mcp_url(),
+        "Bearer legacy-frozen-identity",
+        &gated_hitl_toml(&approver.url, true),
+    ))
+    .await;
+
+    let response = send_chat(
+        &server,
+        "Call the echo_headers tool now. If it returns an error, reply with \
+         only the exact error message text.",
+    )
+    .await;
+    let text = assistant_text(&response);
+
+    assert!(
+        text.to_lowercase().contains("authorization"),
+        "the error must name the missing header, got: {text}"
+    );
+    assert!(
+        !text.contains("legacy-frozen-identity"),
+        "the error must never leak a header value, got: {text}"
+    );
+    assert_eq!(
+        approver.hits(),
+        1,
+        "exactly one decision request for the one gated call"
+    );
+    server.stop().await;
+}
+
+/// Case 3: a denial short-circuits before the inner tool ever runs — the
+/// assistant sees the denial text, never a real headers echo.
+#[tokio::test]
+async fn denial_short_circuits_before_the_tool_runs() {
+    let approver = MockApprover::start(ApproverReply::Deny).await;
+    let server = AuraServer::start(&config_toml(
+        &mcp_url(),
+        "Bearer legacy-frozen-identity",
+        &gated_hitl_toml(&approver.url, true),
+    ))
+    .await;
+
+    let response = send_chat(
+        &server,
+        "Call the echo_headers tool now and reply with only its exact output.",
+    )
+    .await;
+    let text = assistant_text(&response);
+
+    assert!(
+        text.to_lowercase().contains("denial") || text.to_lowercase().contains("blocked"),
+        "the assistant must relay the denial, got: {text}"
+    );
+    assert!(
+        extract_json_object(text).is_none(),
+        "a denied call must never reach the tool and echo real headers, got: {text}"
+    );
+    assert_eq!(
+        approver.hits(),
+        1,
+        "exactly one decision request for the one gated call"
+    );
+    server.stop().await;
+}
+
+/// Case 4: an approval with no `tool_headers_from_response` configured
+/// proceeds exactly as it did before this feature — no override anywhere.
+#[tokio::test]
+async fn approval_with_no_configured_map_proceeds_with_no_override() {
+    let approver = MockApprover::start(ApproverReply::ApproveBare).await;
+    let server = AuraServer::start(&config_toml(
+        &mcp_url(),
+        "Bearer legacy-frozen-identity",
+        &gated_hitl_toml(&approver.url, false),
+    ))
+    .await;
+
+    let response = send_chat(
+        &server,
+        "Call the echo_headers tool now and reply with only its raw JSON output.",
+    )
+    .await;
+    let headers = extract_json_object(assistant_text(&response)).unwrap_or_else(|| {
+        panic!(
+            "an approval with no map still proceeds and echoes the real headers; got: {:?}",
+            assistant_text(&response)
+        )
+    });
+
+    assert_eq!(
+        headers.get("authorization").and_then(Value::as_str),
+        Some("Bearer legacy-frozen-identity"),
+        "with no tool_headers_from_response configured, the call keeps the frozen \
+         identity, got: {headers}"
+    );
+    assert_eq!(
+        approver.hits(),
+        1,
+        "exactly one decision request for the one gated call"
+    );
+    server.stop().await;
+}
+
+/// Case 5: `[hitl]` is configured, but the glob does not match this tool —
+/// the call never consults the route, so a denying approver never fires.
+#[tokio::test]
+async fn a_tool_the_glob_does_not_match_is_unaffected() {
+    let approver = MockApprover::start(ApproverReply::Deny).await;
+    let server = AuraServer::start(&config_toml(
+        &mcp_url(),
+        "Bearer legacy-frozen-identity",
+        &ungated_hitl_toml(&approver.url),
+    ))
+    .await;
+
+    let response = send_chat(
+        &server,
+        "Call the echo_headers tool now and reply with only its raw JSON output.",
+    )
+    .await;
+    let headers = extract_json_object(assistant_text(&response)).unwrap_or_else(|| {
+        panic!(
+            "a tool the glob does not match runs with no approval step at all; got: {:?}",
+            assistant_text(&response)
+        )
+    });
+
+    assert_eq!(
+        headers.get("authorization").and_then(Value::as_str),
+        Some("Bearer legacy-frozen-identity"),
+        "an unmatched call must carry no approver override, got: {headers}"
+    );
+    assert_eq!(
+        approver.hits(),
+        0,
+        "a call the glob does not match must never consult the approver at all"
+    );
+    server.stop().await;
+}

--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -313,6 +313,17 @@ pub(crate) mod tests {
                 names: vec!["authorization".to_owned(), "x-forwarded-user".to_owned()],
             }
         );
+
+        // The event-level audit signal: the Display text names every missing
+        // header and carries no value, including the one response value that
+        // did arrive (for the header that was present).
+        let message = err.to_string();
+        assert_eq!(
+            message,
+            "approver identity capture failed: response missing mapped headers \
+             [\"authorization\", \"x-forwarded-user\"]"
+        );
+        assert!(!message.contains("acme"), "message was: {message}");
     }
 
     /// Every captured pair lands on the request the builder produces, under

--- a/crates/aura/src/hitl/mod.rs
+++ b/crates/aura/src/hitl/mod.rs
@@ -46,7 +46,7 @@ pub use protocol::{ApprovalDecisionWire, ApprovalItem, ApprovalRequest, PROTOCOL
 pub use registry::{ParkedApproval, PendingApprovals, ResolveError};
 pub use route::{
     ApprovalError, DecisionRoute, HitlRuntime, PlaintextWebhookUrlError, WebhookClient,
-    validate_webhook_signing_config,
+    validate_webhook_signing_config, warn_on_cleartext_capture,
 };
 pub use signing::{
     SIGNATURE_HEADER, SignedHeaders, SigningContext, TIMESTAMP_HEADER, VerificationError,

--- a/crates/aura/src/hitl/mod.rs
+++ b/crates/aura/src/hitl/mod.rs
@@ -46,7 +46,7 @@ pub use protocol::{ApprovalDecisionWire, ApprovalItem, ApprovalRequest, PROTOCOL
 pub use registry::{ParkedApproval, PendingApprovals, ResolveError};
 pub use route::{
     ApprovalError, DecisionRoute, HitlRuntime, PlaintextWebhookUrlError, WebhookClient,
-    validate_webhook_signing_config, warn_on_cleartext_capture,
+    cleartext_capture_warning, validate_webhook_signing_config, warn_on_cleartext_capture,
 };
 pub use signing::{
     SIGNATURE_HEADER, SignedHeaders, SigningContext, TIMESTAMP_HEADER, VerificationError,

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -494,14 +494,13 @@ fn resolve_webhook_headers(
     header_map
 }
 
-/// The webhook route's egress signing state, plus the fail-closed state an
-/// unusable route configuration lands in.
+/// HMAC signing state for the webhook route.
 enum EgressSigning {
     /// Unsigned egress.
     Disabled,
     /// Signed egress under the configured HMAC secret.
     Enabled(WebhookHmac),
-    /// An unusable route configuration, with the reason.
+    /// An unusable signing configuration, with the reason.
     Misconfigured(String),
 }
 
@@ -579,36 +578,36 @@ impl WebhookClient {
         signing: EgressSigning,
         tool_header_mappings: ToolHeaderMappings,
     ) -> Self {
-        // Two ways a plaintext url makes the route unusable, both fail closed
-        // for the life of the client. A plaintext response channel defeats
-        // response-leg verification, so http:// with a secret configured is
-        // itself a misconfiguration (DESIGN.md §4, Route A). Captured
-        // approver headers are credentials the gated call then presents as
-        // identity, so carrying them back over cleartext exposes them to the
-        // network whether or not the decision itself is signed. Neither check
-        // exempts loopback: the url is operator config, not a test fixture.
-        let signing = if url.as_str().starts_with("http://") {
-            match signing {
-                EgressSigning::Enabled(_) => EgressSigning::Misconfigured(format!(
+        // A plaintext response channel would defeat response-leg verification,
+        // so http:// with a secret configured is itself a misconfiguration
+        // (DESIGN.md §4, Route A).
+        let signing = match signing {
+            EgressSigning::Enabled(_) if url.as_str().starts_with("http://") => {
+                EgressSigning::Misconfigured(format!(
                     "webhook url {} uses plaintext http:// while an HMAC secret is configured; \
                      use https://",
                     url.as_str()
-                )),
-                _ if !tool_header_mappings.is_empty() => EgressSigning::Misconfigured(format!(
-                    "webhook url {} uses plaintext http:// while tool_headers_from_response is \
-                     configured; use https://",
-                    url.as_str()
-                )),
-                other => other,
+                ))
             }
-        } else {
-            signing
+            other => other,
         };
         if let EgressSigning::Misconfigured(reason) = &signing {
             tracing::error!(
                 reason,
-                "HITL webhook route misconfigured; every approval request on this route \
+                "HITL webhook HMAC misconfigured; every approval request on this route \
                  will fail closed"
+            );
+        }
+        // Capture over cleartext stays usable — TLS is often terminated ahead
+        // of this process (trusted gateway, service-to-service), which the url
+        // alone cannot distinguish from an exposed hop — but it is never
+        // silent.
+        if !tool_header_mappings.is_empty() && !url.as_str().starts_with("https://") {
+            tracing::warn!(
+                url = url.as_str(),
+                "HITL webhook route captures approver response headers over cleartext http, so \
+                 this route's tool_headers_from_response values are readable by any network \
+                 observer; intended for trusted-gateway or service-to-service deployments"
             );
         }
         Self {
@@ -1785,11 +1784,12 @@ mod tests {
             );
         }
 
-        /// Captured approver headers are credentials travelling back from the
-        /// approver, so a cleartext approval channel must fail closed for
-        /// them on its own — with no HMAC secret anywhere in the config.
+        /// Capture does not require https: TLS may be terminated ahead of the
+        /// process (trusted gateway, service-to-service), so a cleartext url
+        /// with mappings builds a usable unsigned route. Only the HMAC-secret
+        /// rule rejects plaintext, and it is unchanged by capture.
         #[test]
-        fn from_config_rejects_capture_over_plaintext_url() {
+        fn from_config_allows_capture_over_plaintext_url() {
             use super::super::HitlRuntime;
 
             let pending = crate::hitl::PendingApprovals::new();
@@ -1800,13 +1800,10 @@ mod tests {
                 None,
                 None,
             );
-            match signing_of(&plaintext) {
-                EgressSigning::Misconfigured(reason) => assert!(
-                    reason.contains("tool_headers_from_response"),
-                    "the reason must name the capture config: {reason}"
-                ),
-                _ => panic!("plaintext http:// with capture must fail closed"),
-            }
+            assert!(
+                matches!(signing_of(&plaintext), EgressSigning::Disabled),
+                "plaintext http:// with capture and no secret must stay usable"
+            );
 
             let secure = HitlRuntime::from_config(
                 &webhook_config("https://approvals.example.com/aura", user_mapping()),
@@ -1819,8 +1816,6 @@ mod tests {
                 "https:// with capture and no secret is a usable unsigned route"
             );
 
-            // Without capture configured, plaintext stays allowed for an
-            // unsigned route — this guard adds no new restriction there.
             let legacy = HitlRuntime::from_config(
                 &webhook_config(
                     "http://approvals.example.com/aura",
@@ -1830,7 +1825,72 @@ mod tests {
                 None,
                 None,
             );
-            assert!(matches!(signing_of(&legacy), EgressSigning::Disabled));
+            assert!(
+                matches!(signing_of(&legacy), EgressSigning::Disabled),
+                "plaintext http:// without capture is unchanged"
+            );
+
+            // The HMAC-secret rule is the one that still rejects plaintext,
+            // and capture being configured does not soften it.
+            let signed_plaintext = HitlRuntime::from_config(
+                &webhook_config("http://approvals.example.com/aura", user_mapping()),
+                &pending,
+                Some(&test_hmac()),
+                None,
+            );
+            assert!(
+                matches!(
+                    signing_of(&signed_plaintext),
+                    EgressSigning::Misconfigured(_)
+                ),
+                "plaintext http:// with a secret must still fail closed"
+            );
+        }
+
+        /// Cleartext capture is allowed but never silent: constructing the
+        /// route warns, naming the risk and the url.
+        #[test]
+        fn capture_over_plaintext_url_warns_at_construction() {
+            use std::sync::Arc;
+
+            let buf = Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(buf.clone())
+                .with_max_level(tracing::Level::WARN)
+                .with_ansi(false)
+                .finish();
+
+            let pending = crate::hitl::PendingApprovals::new();
+            tracing::subscriber::with_default(subscriber, || {
+                let _ = super::super::HitlRuntime::from_config(
+                    &webhook_config("http://approvals.example.com/aura", user_mapping()),
+                    &pending,
+                    None,
+                    None,
+                );
+                // An https route with the same mappings must stay quiet, so
+                // the warning is attributable to the cleartext url alone.
+                let _ = super::super::HitlRuntime::from_config(
+                    &webhook_config("https://approvals.example.com/aura", user_mapping()),
+                    &pending,
+                    None,
+                    None,
+                );
+            });
+
+            let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
+            assert!(
+                log.contains("cleartext http"),
+                "the warning must name the risk, got log: {log}"
+            );
+            assert!(
+                log.contains("http://approvals.example.com/aura"),
+                "the warning must name the url, got log: {log}"
+            );
+            assert!(
+                !log.contains("https://approvals.example.com/aura"),
+                "an https route must not warn, got log: {log}"
+            );
         }
 
         #[tokio::test]

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -598,18 +598,9 @@ impl WebhookClient {
                  will fail closed"
             );
         }
-        // Capture over cleartext stays usable — TLS is often terminated ahead
-        // of this process (trusted gateway, service-to-service), which the url
-        // alone cannot distinguish from an exposed hop — but it is never
-        // silent.
-        if !tool_header_mappings.is_empty() && !url.as_str().starts_with("https://") {
-            tracing::warn!(
-                url = url.as_str(),
-                "HITL webhook route captures approver response headers over cleartext http, so \
-                 this route's tool_headers_from_response values are readable by any network \
-                 observer; intended for trusted-gateway or service-to-service deployments"
-            );
-        }
+        // The cleartext-capture warning does not live here: `HitlRuntime::from_config`
+        // (and so this constructor) runs once per request, not once at startup.
+        // `warn_on_cleartext_capture` below is the boot-time seam for it.
         Self {
             client,
             url,
@@ -842,6 +833,51 @@ pub fn validate_webhook_signing_config(
             })
         }
         DecisionRouteConfig::Webhook { .. } | DecisionRouteConfig::Conversational { .. } => Ok(()),
+    }
+}
+
+/// Boot-time warning: a webhook route with `tool_headers_from_response`
+/// configured over plain `http://` is usable (`validate_webhook_signing_config`
+/// above covers the one case that still fails closed, an HMAC secret over
+/// plaintext) but exposes captured approver credentials to any network
+/// observer between here and the webhook. Call this once per `[hitl]`
+/// config at startup, alongside `validate_webhook_signing_config` — never
+/// from [`WebhookClient`] construction, which runs fresh per request via
+/// `HitlRuntime::from_config` and would turn one misconfiguration into a
+/// warning per chat request.
+pub fn warn_on_cleartext_capture(config: &HitlConfig) {
+    let DecisionRouteConfig::Webhook {
+        url,
+        tool_headers_from_response,
+        ..
+    } = &config.route
+    else {
+        return;
+    };
+    if tool_headers_from_response.is_empty() || url.as_str().starts_with("https://") {
+        return;
+    }
+    tracing::warn!(
+        origin = %redact_to_origin(url.as_str()),
+        "HITL webhook route captures approver response headers over cleartext http, so \
+         this route's tool_headers_from_response values are readable by any network \
+         observer; intended for trusted-gateway or service-to-service deployments"
+    );
+}
+
+/// `scheme://host[:port]` of `url`, dropping userinfo, path, query, and
+/// fragment — the parts of a webhook URL a log line must never carry,
+/// since a webhook URL may embed a token in any of them.
+fn redact_to_origin(url: &str) -> String {
+    let (scheme, rest) = url.split_once("://").unwrap_or(("", url));
+    let authority = &rest[..rest.find(['/', '?', '#']).unwrap_or(rest.len())];
+    let host_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if scheme.is_empty() {
+        host_port.to_string()
+    } else {
+        format!("{scheme}://{host_port}")
     }
 }
 
@@ -1847,10 +1883,13 @@ mod tests {
             );
         }
 
-        /// Cleartext capture is allowed but never silent: constructing the
-        /// route warns, naming the risk and the url.
+        /// Construction (`HitlRuntime::from_config`, and so `WebhookClient`
+        /// construction) runs once per chat request, not once at startup —
+        /// so it must never warn on cleartext capture itself, or every
+        /// request on the route would repeat the warning.
+        /// [`warn_on_cleartext_capture`] is the boot-time seam for it.
         #[test]
-        fn capture_over_plaintext_url_warns_at_construction() {
+        fn capture_over_plaintext_url_stays_silent_at_construction() {
             use std::sync::Arc;
 
             let buf = Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
@@ -1868,14 +1907,37 @@ mod tests {
                     None,
                     None,
                 );
-                // An https route with the same mappings must stay quiet, so
-                // the warning is attributable to the cleartext url alone.
-                let _ = super::super::HitlRuntime::from_config(
-                    &webhook_config("https://approvals.example.com/aura", user_mapping()),
-                    &pending,
-                    None,
-                    None,
-                );
+            });
+
+            let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
+            assert!(log.is_empty(), "construction must not log, got: {log}");
+        }
+
+        /// The boot-time warning names the risk and the webhook's origin,
+        /// but never the userinfo, path, or query a webhook URL may carry —
+        /// any of which can hold a secret. An https route with the same
+        /// mappings stays quiet, so the warning is attributable to the
+        /// cleartext scheme alone.
+        #[test]
+        fn warn_on_cleartext_capture_warns_once_and_redacts_the_url() {
+            use std::sync::Arc;
+
+            let buf = Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(buf.clone())
+                .with_max_level(tracing::Level::WARN)
+                .with_ansi(false)
+                .finish();
+
+            tracing::subscriber::with_default(subscriber, || {
+                super::super::warn_on_cleartext_capture(&webhook_config(
+                    "http://token:secret@approvals.example.com:8443/aura/hook?key=shh",
+                    user_mapping(),
+                ));
+                super::super::warn_on_cleartext_capture(&webhook_config(
+                    "https://approvals.example.com/aura",
+                    user_mapping(),
+                ));
             });
 
             let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
@@ -1884,12 +1946,46 @@ mod tests {
                 "the warning must name the risk, got log: {log}"
             );
             assert!(
-                log.contains("http://approvals.example.com/aura"),
-                "the warning must name the url, got log: {log}"
+                log.contains("http://approvals.example.com:8443"),
+                "the warning must name the origin, got log: {log}"
             );
+            for secret in ["token", "secret", "aura/hook", "key=shh"] {
+                assert!(
+                    !log.contains(secret),
+                    "the warning must never carry userinfo, path, or query, got: {log}"
+                );
+            }
             assert!(
-                !log.contains("https://approvals.example.com/aura"),
+                !log.contains("https://approvals.example.com"),
                 "an https route must not warn, got log: {log}"
+            );
+        }
+
+        /// An absent or empty `tool_headers_from_response` map is the
+        /// legacy path: no capture, so no exposure to warn about, over
+        /// either scheme.
+        #[test]
+        fn warn_on_cleartext_capture_is_quiet_with_no_map() {
+            use std::sync::Arc;
+
+            let buf = Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(buf.clone())
+                .with_max_level(tracing::Level::WARN)
+                .with_ansi(false)
+                .finish();
+
+            tracing::subscriber::with_default(subscriber, || {
+                super::super::warn_on_cleartext_capture(&webhook_config(
+                    "http://approvals.example.com/aura",
+                    aura_config::ToolHeaderMappings::default(),
+                ));
+            });
+
+            let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
+            assert!(
+                log.is_empty(),
+                "no map means nothing to warn about, got: {log}"
             );
         }
 

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -846,23 +846,34 @@ pub fn validate_webhook_signing_config(
 /// `HitlRuntime::from_config` and would turn one misconfiguration into a
 /// warning per chat request.
 pub fn warn_on_cleartext_capture(config: &HitlConfig) {
+    if let Some(warning) = cleartext_capture_warning(config) {
+        tracing::warn!("{warning}");
+    }
+}
+
+/// The cleartext-capture warning for `config`, rendered as a message so a
+/// binary whose default tracing subscriber is silent (aura-cli without
+/// `log_file`) can print it on a channel it actually owns, such as stderr.
+/// `None` for every configuration [`warn_on_cleartext_capture`] stays quiet
+/// for; the message carries the redacted origin, never the full URL.
+pub fn cleartext_capture_warning(config: &HitlConfig) -> Option<String> {
     let DecisionRouteConfig::Webhook {
         url,
         tool_headers_from_response,
         ..
     } = &config.route
     else {
-        return;
+        return None;
     };
     if tool_headers_from_response.is_empty() || url.as_str().starts_with("https://") {
-        return;
+        return None;
     }
-    tracing::warn!(
-        origin = %redact_to_origin(url.as_str()),
-        "HITL webhook route captures approver response headers over cleartext http, so \
+    Some(format!(
+        "HITL webhook route {} captures approver response headers over cleartext http, so \
          this route's tool_headers_from_response values are readable by any network \
-         observer; intended for trusted-gateway or service-to-service deployments"
-    );
+         observer; intended for trusted-gateway or service-to-service deployments",
+        redact_to_origin(url.as_str())
+    ))
 }
 
 /// `scheme://host[:port]` of `url`, dropping userinfo, path, query, and
@@ -1958,6 +1969,54 @@ mod tests {
             assert!(
                 !log.contains("https://approvals.example.com"),
                 "an https route must not warn, got log: {log}"
+            );
+        }
+
+        /// The rendered warning carries the redacted origin so a binary can
+        /// print it on a channel tracing does not reach, and it keeps the
+        /// same redaction the traced event holds: userinfo, path, and query
+        /// never appear.
+        #[test]
+        fn cleartext_capture_warning_redacts_the_url() {
+            let warning = super::super::cleartext_capture_warning(&webhook_config(
+                "http://token:secret@approvals.example.com:8443/aura/hook?key=shh",
+                user_mapping(),
+            ))
+            .expect("a mapped cleartext route must warn");
+
+            assert!(
+                warning.contains("http://approvals.example.com:8443"),
+                "the warning must name the origin, got: {warning}"
+            );
+            for secret in ["token", "secret", "aura/hook", "key=shh"] {
+                assert!(
+                    !warning.contains(secret),
+                    "the warning must never carry userinfo, path, or query, got: {warning}"
+                );
+            }
+        }
+
+        /// The quiet cases match [`warn_on_cleartext_capture`]: an https
+        /// route and an empty (legacy) mapping both return `None`, so the
+        /// stderr channel a binary opens stays silent exactly when the
+        /// traced one does.
+        #[test]
+        fn cleartext_capture_warning_is_none_when_quiet() {
+            assert!(
+                super::super::cleartext_capture_warning(&webhook_config(
+                    "https://approvals.example.com/aura",
+                    user_mapping(),
+                ))
+                .is_none(),
+                "an https route must not warn"
+            );
+            assert!(
+                super::super::cleartext_capture_warning(&webhook_config(
+                    "http://approvals.example.com/aura",
+                    aura_config::ToolHeaderMappings::default(),
+                ))
+                .is_none(),
+                "an empty mapping is the legacy path and must not warn"
             );
         }
 

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -267,12 +267,16 @@ where
     }
 }
 
-/// Ensure aura_config warnings are always visible regardless of RUST_LOG setting.
+/// Keep operational warnings visible regardless of RUST_LOG setting.
 ///
-/// This is important for operational warnings like duplicate skill detection
-/// that should never be silently filtered.
-fn ensure_aura_config_warnings(filter: EnvFilter) -> EnvFilter {
-    filter.add_directive("aura_config=warn".parse().unwrap())
+/// This is important for warnings that must never be silently filtered:
+/// `aura_config` (duplicate skill detection) and `aura::hitl` (the
+/// cleartext-capture exposure warning), both of which the default
+/// per-binary `info` filter would otherwise drop.
+fn ensure_operational_warnings(filter: EnvFilter) -> EnvFilter {
+    filter
+        .add_directive("aura_config=warn".parse().unwrap())
+        .add_directive("aura::hitl=warn".parse().unwrap())
 }
 
 // ---------------------------------------------------------------------------
@@ -523,7 +527,7 @@ pub fn init_logging(debug: bool, verbose: bool, binary_name: &str) {
         // Default: Only binary-specific info level logging on console
         let console_filter = EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| format!("{binary_name}=info").into());
-        let console_filter = ensure_aura_config_warnings(console_filter);
+        let console_filter = ensure_operational_warnings(console_filter);
 
         let registry =
             tracing_subscriber::registry().with(fmt::layer().with_filter(console_filter));
@@ -857,6 +861,60 @@ pub async fn shutdown_tracer() {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Minimal tracing-capture facility (same shape as the one in
+    /// `hitl::route` tests): a shared buffer that implements `io::Write` by
+    /// reference, so `Arc<CapturedLog>` satisfies `tracing_subscriber`'s
+    /// `MakeWriter`, and a filter's real select/not-select behavior is
+    /// observable without touching the global subscriber.
+    struct CapturedLog(std::sync::Mutex<Vec<u8>>);
+
+    impl std::io::Write for &CapturedLog {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// The default console filter is `{binary}=info` plus the operational
+    /// directives; under EnvFilter semantics an unmatched target is silent,
+    /// so without the `aura::hitl=warn` directive the cleartext-capture
+    /// warning would never reach a default-mode console. Warn-level events
+    /// from that subtree must pass while its info-level noise stays dropped.
+    #[test]
+    fn default_console_filter_still_shows_hitl_warnings() {
+        use std::sync::Arc;
+
+        let buf = Arc::new(CapturedLog(std::sync::Mutex::new(Vec::new())));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(buf.clone())
+            .with_env_filter(ensure_operational_warnings(EnvFilter::new(
+                "aura-web-server=info",
+            )))
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::warn!(
+                target: "aura::hitl::route",
+                "cleartext capture warning under a default filter"
+            );
+            tracing::info!(target: "aura::hitl::route", "info noise stays filtered");
+        });
+
+        let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
+        assert!(
+            log.contains("cleartext capture warning under a default filter"),
+            "the hitl warning must survive the default filter, got log: {log}"
+        );
+        assert!(
+            !log.contains("info noise stays filtered"),
+            "the directive is warn-level, not a blanket enable, got log: {log}"
+        );
+    }
 
     /// A prompt longer than `OTEL_CONTENT_MAX_LENGTH` must still serialize to
     /// valid JSON — truncating the finished JSON instead of the content would

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -154,11 +154,15 @@ pub const ATTR_TOOL_RESULT: &str = "tool.result";
 pub const ATTR_TOOL_RESULT_LENGTH: &str = "tool.result.length";
 pub const ATTR_TOOL_CANCELLED: &str = "tool.cancelled";
 
-// HITL attribute (used by `hitl::route`)
+// HITL attributes (used by `hitl::route` and `mcp_tool_execution`)
 
 /// Handle of the human approval decision gating a tool call — the same
 /// `decision_id` the approval payload and lifecycle events carry.
 pub const ATTR_DECISION_ID: &str = "decision_id";
+
+/// Comma-separated, sorted outbound header NAMES an approver override
+/// applied to a gated MCP call — never their values.
+pub const ATTR_APPLIED_HEADERS: &str = "applied_headers";
 
 // --- Content recording configuration ---
 

--- a/crates/aura/src/mcp_tool_execution.rs
+++ b/crates/aura/src/mcp_tool_execution.rs
@@ -43,6 +43,18 @@ fn record_tool_call_input(span: &tracing::Span, args: &Value) {
     }
 }
 
+/// Record the outbound header NAMES an approver override applies to this
+/// call, sorted and comma-joined, never the values. Absent from the span
+/// when the call carries no override.
+fn record_applied_headers(
+    span: &tracing::Span,
+    overrides: &crate::approver_headers::ApproverHeaders,
+) {
+    let mut names: Vec<&str> = overrides.captured_names().collect();
+    names.sort_unstable();
+    crate::logging::set_span_attribute(span, crate::logging::ATTR_APPLIED_HEADERS, names.join(","));
+}
+
 /// Record tool call result attributes on the current span.
 ///
 /// On success: result length, status OK, and (when content recording is
@@ -106,6 +118,9 @@ pub async fn execute_mcp_tool(
 
     // OTel: record input attributes
     record_tool_call_input(&span, &args);
+    if let Some(overrides) = approver_overrides.as_ref() {
+        record_applied_headers(&span, overrides);
+    }
 
     // Log tool call initiation
     info!(
@@ -269,5 +284,172 @@ mod tests {
         assert!(bounded.contains("[tool error truncated:"));
         // The leading context (where categorization keywords live) survives.
         assert!(bounded.starts_with("Tool execution failed:"));
+    }
+
+    /// Trace correlation: a gated call's `mcp.tool_call` span carries the
+    /// captured override's header NAMES, never their values, and an
+    /// ungated call's span carries neither.
+    ///
+    /// Gated on `otel` — without the feature `set_span_attribute` is a
+    /// documented no-op and there is no span data to assert against.
+    #[cfg(feature = "otel")]
+    mod applied_headers_span {
+        use std::sync::{Arc, Mutex, MutexGuard};
+
+        use futures::future::BoxFuture;
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
+        use opentelemetry_sdk::trace::TracerProvider;
+        use serde_json::json;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        use aura_config::ToolHeaderMappings;
+        use reqwest::header::{HeaderMap as ReqwestHeaderMap, HeaderName, HeaderValue};
+
+        use super::*;
+        use crate::logging::ATTR_APPLIED_HEADERS;
+        use crate::mcp_streamable_http::tests::RecordingMcpServer;
+
+        /// Captured overrides for `pairs`, given in whatever order the
+        /// caller likes — the loopback response headers are keyed
+        /// `x-response-<outbound>` so the capture step (case-insensitive
+        /// lookup by mapped name) is exercised the same way production
+        /// capture is, rather than hand-building the type directly.
+        fn captured_overrides_for(
+            pairs: &[(&str, &str)],
+        ) -> crate::approver_headers::ApproverHeaders {
+            let mapping: std::collections::HashMap<String, String> = pairs
+                .iter()
+                .map(|(outbound, _)| (outbound.to_string(), format!("x-response-{outbound}")))
+                .collect();
+            let mut response = ReqwestHeaderMap::new();
+            for (outbound, value) in pairs {
+                response.insert(
+                    HeaderName::from_bytes(format!("x-response-{outbound}").as_bytes()).unwrap(),
+                    HeaderValue::from_str(value).unwrap(),
+                );
+            }
+            crate::approver_headers::ApproverHeaders::from_captured(
+                &ToolHeaderMappings::try_from(mapping).expect("test mapping is valid config"),
+                &response,
+            )
+            .expect("every mapped header is present")
+        }
+
+        /// Spans the test subscriber has exported.
+        #[derive(Debug, Clone, Default)]
+        struct CapturedSpans(Arc<Mutex<Vec<SpanData>>>);
+
+        impl CapturedSpans {
+            fn spans(&self) -> MutexGuard<'_, Vec<SpanData>> {
+                self.0.lock().expect("captured spans mutex")
+            }
+
+            fn contains(&self, name: &str) -> bool {
+                self.spans().iter().any(|span| span.name == name)
+            }
+
+            /// The single `key` attribute on the span named `name`, or `None`
+            /// if the span carries no such attribute. Panics if the span
+            /// carries more than one — a double-stamp regression would
+            /// otherwise pass unnoticed, since `find` would silently return
+            /// only the first entry.
+            fn attribute(&self, name: &str, key: &str) -> Option<String> {
+                let spans = self.spans();
+                let span = spans.iter().find(|span| span.name == name)?;
+                let matches: Vec<_> = span
+                    .attributes
+                    .iter()
+                    .filter(|kv| kv.key.as_str() == key)
+                    .collect();
+                assert!(
+                    matches.len() <= 1,
+                    "span {name:?} must carry at most one {key} attribute, found {}: \
+                     a regression is double-stamping the same span",
+                    matches.len(),
+                );
+                matches.first().map(|kv| kv.value.to_string())
+            }
+        }
+
+        impl SpanExporter for CapturedSpans {
+            fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+                self.spans().extend(batch);
+                Box::pin(std::future::ready(Ok(())))
+            }
+        }
+
+        /// Run `execute_mcp_tool` under a subscriber that exports to memory,
+        /// returning the `applied_headers` attribute its `mcp.tool_call`
+        /// span carries. `#[tracing::instrument]` on `execute_mcp_tool`
+        /// opens the span itself, so no outer instrumentation is needed.
+        async fn applied_headers_on_call(
+            client: &McpClient,
+            overrides: Option<crate::approver_headers::ApproverHeaders>,
+        ) -> Option<String> {
+            let captured = CapturedSpans::default();
+            let provider = TracerProvider::builder()
+                .with_simple_exporter(captured.clone())
+                .build();
+            let _guard = tracing::subscriber::set_default(
+                tracing_subscriber::registry()
+                    .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test"))),
+            );
+
+            execute_mcp_tool(client, "gated", json!({}), overrides)
+                .await
+                .expect("the call succeeds");
+
+            assert!(
+                captured.contains("mcp.tool_call"),
+                "the mcp.tool_call span was never exported",
+            );
+            captured.attribute("mcp.tool_call", ATTR_APPLIED_HEADERS)
+        }
+
+        /// A gated call carrying an override stamps its captured names,
+        /// sorted and comma-joined, on the execution span — never a value.
+        /// Configured out of alphabetical order (`x-tenant` before
+        /// `authorization`), so a joined-but-unsorted regression would
+        /// produce `"x-tenant,authorization"` and this test would catch it.
+        #[tokio::test]
+        async fn gated_call_stamps_the_applied_header_names_never_values() {
+            let server = RecordingMcpServer::start().await;
+            let client = McpClient::new(server.url.clone(), &HashMap::new())
+                .await
+                .expect("the loopback server completes the handshake");
+
+            let overrides = captured_overrides_for(&[
+                ("x-tenant", "acme"),
+                ("authorization", "Bearer approver-secret"),
+            ]);
+            let attribute = applied_headers_on_call(&client, Some(overrides)).await;
+
+            assert_eq!(
+                attribute.as_deref(),
+                Some("authorization,x-tenant"),
+                "the span must name every applied header, sorted",
+            );
+            for value in ["acme", "Bearer approver-secret", "approver-secret"] {
+                assert!(
+                    !attribute.as_deref().unwrap().contains(value),
+                    "the span must never carry a header value, got: {attribute:?}",
+                );
+            }
+        }
+
+        /// A call no approval gated carries no override, so its span records
+        /// no `applied_headers` attribute at all.
+        #[tokio::test]
+        async fn ungated_call_records_no_applied_headers() {
+            let server = RecordingMcpServer::start().await;
+            let client = McpClient::new(server.url.clone(), &HashMap::new())
+                .await
+                .expect("the loopback server completes the handshake");
+
+            let attribute = applied_headers_on_call(&client, None).await;
+
+            assert_eq!(attribute, None);
+        }
     }
 }

--- a/docs/adr/2026-08-13-approver-identity-forwarding.md
+++ b/docs/adr/2026-08-13-approver-identity-forwarding.md
@@ -1,0 +1,178 @@
+<!-- markdownlint-disable MD033 -->
+# Forward the webhook approver's identity to the gated MCP call
+
+- Status: **accepted**
+- Deciders: Mike Shearer
+- Date: 2026-08-13
+
+Technical Story: [#496](https://github.com/mezmo/aura/issues/496)
+
+## Context and Problem Statement
+
+MCP client headers are resolved once per inbound chat request, at agent-build
+time: the completions handler flattens the inbound `HeaderMap`, overlays it
+per `headers_from_request` config, and the MCP client bakes the result into
+its default headers. Identity is frozen before the LLM emits any tool call,
+and before any HITL approval exists.
+
+When a human approves a gated tool call, the downstream MCP call still
+executes under the original requester's frozen identity, not the approver's.
+An operator who wants the approver's own credentials (or a context header
+naming them) on the call they just authorized has no way to get it there.
+
+## Decision Drivers
+
+- Forwarding **MUST** be config-selectable: an operator may map real auth
+  material (`Authorization`) or context headers, since the security posture
+  has to be designed to the auth worst case.
+- The override **MUST** be scoped to exactly the one gated call the approval
+  releases. Every tool execution re-enters `pre_call` and the gate mints a
+  fresh `DecisionId` per call, so a retry **MUST** re-gate and re-capture
+  rather than reuse a prior decision's identity; no reuse store exists.
+- A missing or invalid captured header **MUST** fail the call closed, naming
+  the affected header names and never a value, rather than silently
+  substituting or dropping identity.
+- The route-wide `ApprovalOutcome`, shared with the agent-callable
+  `request_approval` surface, **MUST NOT** gain a credential-holding path —
+  that surface has no consumer for captured headers.
+- Delivery **MUST NOT** require a fork or upgrade of the pinned `rmcp` client
+  library.
+
+## Considered Options
+
+Delivering a per-call header override through to the outbound MCP POST,
+verified against pinned `rmcp` 0.12.0:
+
+- Parameter threading a header override into `post_message`'s signature —
+  rejected: the signature belongs to a trait `rmcp` owns.
+- A task-local read inside the transport worker — rejected: the worker task
+  is spawned once at connect time, before any gated call exists, so nothing
+  scoped per call is visible to it.
+- `PeerRequestOptions.meta` — rejected: the hand-written wire serializer
+  extracts only the `Meta` extension onto the request; a header override
+  placed there would still need a second, undocumented channel to become an
+  HTTP header, and nothing reads `meta` for that purpose today.
+- An ephemeral per-call MCP client, built fresh under the approver's headers —
+  rejected: roughly 4 extra round trips per gated call, and it loses
+  manager-driven cancellation, `tool_start`/progress events, and leaks
+  sessions on an unretried `DELETE`.
+- A sidecar proxy that rewrites headers in flight — rejected: the proxy's own
+  URL is frozen the same way the MCP client's headers are today, so it
+  degenerates into a persistent, body-inspecting proxy that re-derives the
+  same call-to-approval correlation problem out of process.
+- **The `rmcp` request-extension side-channel — chosen.** `rmcp::model::Request`
+  carries an http-crate-style typed `Extensions` map, `Clone + Send + Sync +
+  'static` bound, that rides the request value intact through
+  `Peer::send_request_with_option`, the transport channel, and the worker
+  into `post_message`, which receives the message by value.
+
+## Decision Outcome
+
+Chosen option: **the rmcp request-extension side-channel, webhook route
+only.**
+
+A `#[derive(Clone)] ApproverHeaders(HeaderMap)` (redacting `Debug`) is
+inserted into a request's extensions at every `call_tool*` construction site
+when the gate released an override, and read back at the two send points
+that own an outbound POST: `CustomHttpClient::post_message` (HTTP-streamable)
+and aura's own `SseTransport::send`. Both apply the override as per-request
+headers, which `reqwest` uses to replace the client's frozen default header
+for that one request only — the JSON body never carries it, and the
+serializer emits no trace of it, because the hand-written wire serializer
+extracts only the `Meta` extension. One-call scoping is structural: the
+extension rides on the one request value, so there is no keyed map, no
+cleanup step, and no cross-call leakage under concurrency.
+
+Only the webhook decision route captures. The conversational route's
+decision also arrives on its own request (`POST
+/v1/approvals/{decision_id}`), which carries its own caller headers — but in
+this system's deployment model that caller is the session holder already on
+the stream, not a distinct identity source, so forwarding it would forward
+nothing new. Excluding it is a deliberate scope choice, recorded here as
+such. Capture is further conditioned
+on the approval's origin: the webhook client captures response headers only
+when the request that raised it came from the config gate
+(`ApprovalOrigin::ConfigGate`), never from the agent-callable
+`request_approval` surface ([#306](https://github.com/mezmo/aura/issues/306)),
+because that surface's route-wide `ApprovalOutcome` has no consumer for
+credentials it would otherwise hold with nowhere to go.
+
+Capture fails closed: when `tool_headers_from_response` is non-empty and the
+approved response is missing a mapped header, the approval resolves to an
+error naming every missing header — never a value. A malformed value cannot
+reach capture at all: values are read from the parsed response's header map,
+which admits only valid HTTP header values. A denied, timed-out, or cancelled
+decision captures nothing, because there is no decision to capture from.
+Every non-webhook, non-approved, or non-`ConfigGate` path produces no
+override, which the unit suite proves directly rather than by omission.
+
+Stdio fails closed on a gated call that carries an override. The tool
+adaptor is tagged with its transport kind at construction; stdio has no
+per-call header channel, so a gated call demanding identity is refused
+before dispatch, and the cached identity never runs the call in its place.
+
+Capture does not require `https://`. A cleartext webhook route with
+`tool_headers_from_response` configured is usable and unsigned, because TLS
+termination ahead of the process (a trusted gateway, service-to-service) is
+a legitimate topology. It is never silent: startup logs one warning per
+`[hitl]` config naming the exposure (scheme and host only, never path,
+query, or userinfo), at the same boot-time seam as the HMAC-signing check —
+not at webhook-client construction, which happens fresh on every request
+that builds an agent. The one rule that still rejects plaintext is unchanged
+and independent of capture: an HMAC secret configured over `http://` is a
+misconfiguration and fails at boot.
+
+Audit is names-only. `execute_mcp_tool` stamps the applied header names,
+sorted and joined, on the `mcp.tool_call` span as `applied_headers`; a
+capture failure's own error text is the event-level signal, naming every
+affected header. Under fail-closed semantics a capture-success stamp would
+be degenerate (success always equals the configured key set), so no
+`aura-events` wire type or CLI deserializer changes. This contract covers
+only the audit fields this feature emits — a tool that echoes the header it
+received puts the forwarded value into its own recorded result the same
+way any tool call's output is recorded, feature or no feature.
+
+### Positive Consequences
+
+- No `rmcp` fork and no version bump: the extension mechanism already exists
+  in the pinned client library, unused until this feature reads it.
+- One-call scoping needs no bookkeeping — no keyed map, no expiry, no cleanup
+  — because it is structural to how the extension rides the request value.
+- HTTP-streamable and SSE share one insertion pattern and one read pattern,
+  so a third HTTP-shaped transport would only need the same read hook added
+  at its own send point.
+- Audit stays cheap: a span attribute and an existing error path, no new
+  wire type.
+
+### Negative Consequences
+
+- Stdio cannot deliver a per-call header at all, so a gated stdio call that
+  carries an override fails closed rather than degrading — an operator who
+  gates a stdio tool and also configures forwarding gets a hard failure, not
+  a partial success.
+- The read point sits inside a trait method whose signature `rmcp` owns; a
+  future upgrade past the pinned version (already flagged: upstream 0.16.0
+  changes `post_message`'s shape) requires re-verifying the extension is
+  still readable there before the bump lands, not after.
+- Cleartext capture is allowed with only a boot-time log warning, not a hard
+  rejection. An operator who does not watch boot logs can run a
+  credential-forwarding route over plaintext without noticing.
+- Conversational-route forwarding does not exist. A deployment whose
+  approver is the attended operator on the stream has no forwarding path
+  today; nothing here builds toward one; extending it would need this
+  design's premise re-examined, not just a config addition.
+- `request_approval` ([#306](https://github.com/mezmo/aura/issues/306)) never
+  forwards identity either, so the two approval surfaces are not symmetric:
+  an operator who assumes agent-requested approvals behave like config-gated
+  ones will find no override on that path.
+
+## Links
+
+- Design and implementation note: [docs/design/hitl.md](../design/hitl.md)
+  (approver header forwarding section)
+- Extends [2026-06-16-hitl-approval-architecture](2026-06-16-hitl-approval-architecture.md)
+  (the dual-channel routing and fail-closed lifecycle this decision builds on)
+- Implements [#496](https://github.com/mezmo/aura/issues/496)
+- Leaves open [#306](https://github.com/mezmo/aura/issues/306) (the
+  `request_approval` agent-callable surface never captures)
+- RFC 2119: <https://www.rfc-editor.org/rfc/rfc2119>

--- a/docs/design/hitl.md
+++ b/docs/design/hitl.md
@@ -446,6 +446,121 @@ decision to that tool call, not to whatever separate tool call the agent goes
 on to make once the decision comes back approved. Ungated calls never reach
 `decide_for_gate` or `decide`, so they carry no `decision_id`.
 
+## Approver header forwarding
+
+Companion to the ADR [2026-08-13-approver-identity-forwarding](../adr/2026-08-13-approver-identity-forwarding.md).
+
+MCP client headers are resolved once, at agent-build time, before any
+approval exists — so a gated tool call executes under the original
+requester's identity even after a human approves it. `tool_headers_from_response`
+lets an operator substitute the approver's identity onto that one gated
+call instead.
+
+### Config shape
+
+```toml
+[hitl.route]
+mode = "webhook"
+url = "https://approvals.example.com/hook"
+headers_from_request = { "authorization" = "authorization" }   # PR #490, unrelated
+# outbound MCP header name -> webhook response header name
+tool_headers_from_response = { "authorization" = "x-approver-token" }
+```
+
+`#[serde(default)]`; absent or an empty map is the pre-existing behavior,
+unchanged. Every outbound name is lowercased at parse — the same discipline
+`resolve_mcp_headers` already applies to static headers — so a captured
+override replaces the frozen value on the wire rather than coexisting with
+it. Parse also rejects a duplicate outbound name after lowercasing and any
+name from the transport-owned reserved set (`content-type`, `accept`,
+`mcp-session-id`, `host`, `content-length`, `transfer-encoding`), so a
+mapping can never corrupt MCP framing or session routing.
+
+### Fail-closed contract
+
+Capture runs only for an approved webhook decision whose origin is the
+config gate (`ApprovalOrigin::ConfigGate`) — never for the `request_approval`
+agent-callable surface, which stays credential-free by construction
+([#306](https://github.com/mezmo/aura/issues/306)). When
+`tool_headers_from_response` is non-empty:
+
+- Every mapped outbound name must resolve to a present response header, read
+  case-insensitively and taking the first value on a repeat. One missing
+  name fails the whole capture.
+- A malformed value cannot reach capture: values are read from the parsed
+  response's header map, which admits only valid HTTP header values.
+- A capture failure resolves the approval to an error: the gated call fails
+  with a message naming every missing header, never a value.
+- A denied, timed-out, or cancelled decision captures nothing, because there
+  is no decision to capture from.
+
+An absent or empty map is the legacy path: an approved call proceeds under
+the requester's frozen identity, exactly as it did before this feature.
+
+### The https question
+
+Capture does not require `https://`. A webhook route with
+`tool_headers_from_response` configured over plain `http://` is usable and
+unsigned — a deployment that terminates TLS ahead of the process (a trusted
+gateway, service-to-service) is a legitimate topology this does not reject —
+but it is never silent: server startup logs one warning per `[hitl]` config
+naming the exposure, alongside the boot-time HMAC-signing check
+(`warn_on_cleartext_capture`, called next to `validate_webhook_signing_config`).
+The webhook client itself, rebuilt on every request that builds an agent,
+never logs this warning; only the boot-time call does, and the log line
+carries the webhook's scheme and host only, never its path, query, or
+userinfo. The one rule `https://` still enforces is unchanged and
+independent of capture: an HMAC secret configured over `http://` is a
+misconfiguration and fails closed at boot.
+
+### Transport support
+
+The override rides the outbound `rmcp::model::Request` as a typed extension;
+only the transports that read it back before serializing can deliver it:
+
+- **HTTP-streamable and SSE**: both send paths read the extension and apply
+  it as a per-request header, which replaces the client's frozen default
+  header for that one request only. The override never reaches the JSON
+  body — the hand-written wire serializer extracts only the `Meta`
+  extension, so anything else placed in `Extensions` never reaches the wire
+  as data.
+- **Stdio**: the tool adaptor is tagged with its transport kind at
+  construction. A gated stdio call that carries an override fails closed
+  before dispatch — identity was demanded and stdio has no per-call header
+  channel to deliver it.
+
+### One-call scoping
+
+The override rides the one request value the gate released, inserted into
+that request's `Extensions` map and read back by the transport before the
+outbound POST. There is no keyed map and nothing to clean up: every tool
+execution re-enters `pre_call` and the gate mints a fresh `DecisionId` per
+call, so an LLM- or orchestration-initiated retry re-gates, fires a fresh
+webhook approval, and captures fresh response headers rather than reusing a
+prior decision's identity.
+
+### Application-time audit
+
+`execute_mcp_tool` (`crates/aura/src/mcp_tool_execution.rs`) stamps the
+outbound header NAMES an override applied — sorted, comma-joined, never the
+values — on the `mcp.tool_call` span as `applied_headers`, present only when
+the call carried an override. Event-level audit is the capture failure's own
+error text: a missing header fails the approval with a message naming
+every affected header, which is what both a caller and the trace see.
+No `aura-events` wire type changes: under fail-closed semantics a capture
+success stamp would be degenerate (success always equals the configured key
+set), so the existing `Errored` outcome already carries the full audit
+signal.
+
+The names-only contract covers this feature's own audit fields — the span
+attribute and the capture-failure error text. It does not extend to a
+gated tool's own output: a tool whose result echoes the header it received
+(as `echo_headers` does, by design, for testing) puts the forwarded value
+into that tool's recorded result the same way any tool call's output is
+recorded, whether or not an override applied. Forwarding credentials to a
+tool that echoes them back makes the value visible wherever tool results
+are recorded.
+
 ## Orchestration behavior
 
 Workers share the parent's request id, so `approval_pending` events from a parked

--- a/docs/design/hitl.md
+++ b/docs/design/hitl.md
@@ -503,9 +503,11 @@ Capture does not require `https://`. A webhook route with
 `tool_headers_from_response` configured over plain `http://` is usable and
 unsigned — a deployment that terminates TLS ahead of the process (a trusted
 gateway, service-to-service) is a legitimate topology this does not reject —
-but it is never silent: server startup logs one warning per `[hitl]` config
-naming the exposure, alongside the boot-time HMAC-signing check
-(`warn_on_cleartext_capture`, called next to `validate_webhook_signing_config`).
+but it is never silent: each binary's startup logs one warning per `[hitl]`
+config naming the exposure, alongside the boot-time HMAC-signing check
+(`warn_on_cleartext_capture`, called next to `validate_webhook_signing_config`;
+the standalone CLI additionally prints the warning to stderr, because its
+default tracing subscriber is a no-op without `log_file`).
 The webhook client itself, rebuilt on every request that builds an agent,
 never logs this warning; only the boot-time call does, and the log line
 carries the webhook's scheme and host only, never its path, query, or


### PR DESCRIPTION
Three closers for the feature: the cleartext-capture rule softens from reject to a boot-time warning since TLS can terminate outside the process; the gated call's `mcp.tool_call` span gets the applied override names, never values; and the first hitl integration suite lands behind its own feature flag with a make target against the mock fixture. The transport and route-scope decisions are recorded as an ADR.

Part of #496.


