### PR TITLE
feat(hitl): include agent_name in config_gate origin

### DIFF
--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -1007,6 +1007,8 @@ mod tests {
 pub enum ApprovalOriginWire {
     ConfigGate {
         matched_pattern: String,
+        #[serde(default)]
+        agent_name: String,
     },
     AgentRequested {
         reason: String,

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1476,6 +1476,7 @@ mod tests {
                 tool_name: "dangerous_apply".to_string(),
                 origin: aura_events::ApprovalOriginWire::ConfigGate {
                     matched_pattern: "dangerous_*".to_string(),
+                    agent_name: "test-agent".to_string(),
                 },
                 scope: aura_events::AgentScopeWire::Single { session_id: None },
             });
@@ -2428,6 +2429,7 @@ url = "http://127.0.0.1:9"
                 scope: aura::hitl::AgentScope::Single { session_id: None },
                 origin: aura::hitl::ApprovalOrigin::ConfigGate {
                     matched_pattern: "test_*".into(),
+                    agent_name: "test-agent".to_string(),
                 },
                 items: vec![],
             };
@@ -2635,6 +2637,7 @@ url = "http://127.0.0.1:9"
                 scope: aura::hitl::AgentScope::Single { session_id: None },
                 origin: aura::hitl::ApprovalOrigin::ConfigGate {
                     matched_pattern: "test_*".into(),
+                    agent_name: "test-agent".to_string(),
                 },
                 items: vec![],
             };

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -2219,6 +2219,7 @@ mod tests {
                                 arguments: serde_json::json!({}),
                                 origin: aura_events::ApprovalOriginWire::ConfigGate {
                                     matched_pattern: "dangerous_*".into(),
+                                    agent_name: "test-agent".into(),
                                 },
                                 scope: aura_events::AgentScopeWire::Single { session_id: None },
                                 expires_at: "2026-01-01T00:00:00Z".into(),

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -343,6 +343,7 @@ fn make_parked(request_id: &str, ttl: Duration) -> ParkedApproval {
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: "kubectl_*".to_string(),
+                agent_name: "test-agent".to_string(),
             },
             items: vec![ApprovalItem {
                 tool_name: "kubectl_delete".to_string(),

--- a/crates/aura/src/approval_event_broker.rs
+++ b/crates/aura/src/approval_event_broker.rs
@@ -140,6 +140,7 @@ mod tests {
             tool_name: "dangerous_apply".to_owned(),
             origin: ApprovalOriginWire::ConfigGate {
                 matched_pattern: "dangerous_*".to_owned(),
+                agent_name: "test-agent".to_owned(),
             },
             scope: AgentScopeWire::Single { session_id: None },
         })

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -333,6 +333,7 @@ impl Agent {
                     hitl.route.clone(),
                     scope.clone(),
                     request_id.clone(),
+                    config_owned.agent.name.clone(),
                 ));
             config_owned.tool_wrapper = Some(match config_owned.tool_wrapper.take() {
                 Some(existing) => Arc::new(crate::tool_wrapper::ComposedWrapper::new(vec![

--- a/crates/aura/src/hitl/decision.rs
+++ b/crates/aura/src/hitl/decision.rs
@@ -111,7 +111,11 @@ pub enum AgentScope {
 pub enum ApprovalOrigin {
     /// A configured glob matched the tool call; carries the display form of the
     /// glob that fired.
-    ConfigGate { matched_pattern: String },
+    ConfigGate {
+        matched_pattern: String,
+        /// `[agent].name` of the config that built this agent.
+        agent_name: String,
+    },
     /// The agent called `request_approval` itself.
     AgentRequested {
         reason: String,

--- a/crates/aura/src/hitl/events.rs
+++ b/crates/aura/src/hitl/events.rs
@@ -128,8 +128,12 @@ pub fn completed_error(
 
 fn origin_to_wire(origin: &ApprovalOrigin) -> ApprovalOriginWire {
     match origin {
-        ApprovalOrigin::ConfigGate { matched_pattern } => ApprovalOriginWire::ConfigGate {
+        ApprovalOrigin::ConfigGate {
+            matched_pattern,
+            agent_name,
+        } => ApprovalOriginWire::ConfigGate {
             matched_pattern: matched_pattern.clone(),
+            agent_name: agent_name.clone(),
         },
         ApprovalOrigin::AgentRequested { reason, agent_name } => {
             ApprovalOriginWire::AgentRequested {

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -30,6 +30,8 @@ pub struct HitlApprovalWrapper {
     scope: AgentScope,
     /// Global request id, for SSE event routing.
     request_id: String,
+    /// `[agent].name` of the config that built this agent.
+    agent_name: String,
 }
 
 impl HitlApprovalWrapper {
@@ -39,12 +41,14 @@ impl HitlApprovalWrapper {
         route: Arc<DecisionRoute>,
         scope: AgentScope,
         request_id: String,
+        agent_name: String,
     ) -> Self {
         Self {
             patterns,
             route,
             scope,
             request_id,
+            agent_name,
         }
     }
 
@@ -80,6 +84,7 @@ impl ToolWrapper for HitlApprovalWrapper {
             scope: self.scope.clone(),
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: matched.to_string(),
+                agent_name: self.agent_name.clone(),
             },
             items: vec![ApprovalItem {
                 tool_name: ctx.tool_name.clone(),
@@ -141,6 +146,7 @@ mod tests {
             }),
             AgentScope::Single { session_id: None },
             "t".into(),
+            "test-agent".to_string(),
         );
         assert_eq!(wrapper.matched_pattern("kubectl_apply"), Some("kubectl_*"));
         assert_eq!(wrapper.matched_pattern("request_approval"), None);
@@ -165,6 +171,7 @@ mod tests {
             }),
             AgentScope::Single { session_id: None },
             "req-test".into(),
+            "test-agent".to_string(),
         );
         let args = serde_json::json!({});
 
@@ -458,6 +465,7 @@ mod tests {
                 Arc::new(route),
                 AgentScope::Single { session_id: None },
                 request_id.to_string(),
+                "test-agent".to_string(),
             );
             (
                 WrappedTool::new(inner, Arc::new(gate) as Arc<dyn ToolWrapper>),

--- a/crates/aura/src/hitl/registry.rs
+++ b/crates/aura/src/hitl/registry.rs
@@ -354,6 +354,7 @@ mod tests {
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: "test_*".to_string(),
+                agent_name: "test-agent".to_string(),
             },
             items: vec![ApprovalItem {
                 tool_name: "test_tool".to_string(),

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -740,6 +740,7 @@ mod tests {
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: "shell*".to_string(),
+                agent_name: "sre-assistant".to_string(),
             },
             items: vec![ApprovalItem {
                 tool_name: "shell_exec".to_string(),
@@ -760,6 +761,7 @@ mod tests {
         assert!(value["scope"].get("session_id").is_none());
         assert_eq!(value["origin"]["kind"], "config_gate");
         assert_eq!(value["origin"]["matched_pattern"], "shell*");
+        assert_eq!(value["origin"]["agent_name"], "sre-assistant");
         // regression guard: the externally-tagged domain variant keys must not appear.
         assert!(value["scope"].get("Single").is_none());
         assert!(value["origin"].get("ConfigGate").is_none());
@@ -818,6 +820,7 @@ mod tests {
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: "kubectl_*".to_string(),
+                agent_name: "test-agent".to_string(),
             },
             items: vec![ApprovalItem {
                 tool_name: "kubectl_delete".to_string(),
@@ -961,6 +964,7 @@ mod tests {
             "conv-req-2",
             ApprovalOrigin::ConfigGate {
                 matched_pattern: "rm_*".into(),
+                agent_name: "test-agent".to_string(),
             },
         );
         let decision_id = request.decision_id;
@@ -1135,6 +1139,7 @@ mod tests {
             &request_id,
             ApprovalOrigin::ConfigGate {
                 matched_pattern: "dangerous_*".into(),
+                agent_name: "test-agent".to_string(),
             },
         );
         let decision_id = request.decision_id;
@@ -1208,6 +1213,7 @@ mod tests {
                 scope: AgentScope::Single { session_id: None },
                 origin: ApprovalOrigin::ConfigGate {
                     matched_pattern: "dangerous_*".into(),
+                    agent_name: "test-agent".to_string(),
                 },
                 items: vec![],
             }
@@ -1563,6 +1569,7 @@ mod tests {
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: "dangerous_*".into(),
+                agent_name: "test-agent".to_string(),
             },
             items: vec![ApprovalItem {
                 tool_name: "dangerous_apply".into(),
@@ -1912,6 +1919,7 @@ mod tests {
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: "dangerous_*".into(),
+                agent_name: "test-agent".to_string(),
             },
             items: vec![ApprovalItem {
                 tool_name: "dangerous_apply".into(),

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -785,13 +785,14 @@ impl Orchestrator {
                 hitl.route.clone(),
                 scope.clone(),
                 request_id.clone(),
+                worker_config.agent.name.clone(),
             ));
             wrappers.insert(0, gate);
             worker_config.hitl_request_approval_tool = Some(crate::hitl::RequestApprovalTool::new(
                 hitl.route.clone(),
                 scope,
                 request_id,
-                self.agent_config.agent.name.clone(),
+                worker_config.agent.name.clone(),
             ));
         }
 

--- a/crates/aura/src/orchestration/persistence_wrapper.rs
+++ b/crates/aura/src/orchestration/persistence_wrapper.rs
@@ -1459,6 +1459,7 @@ mod tests {
             route,
             scope,
             request_id.clone(),
+            "test-agent".to_string(),
         ));
         let persistence: Arc<dyn ToolWrapper> = Arc::new(test_wrapper(Arc::new(Mutex::new(
             ExecutionPersistence::disabled(),

--- a/crates/aura/src/session_store/memory.rs
+++ b/crates/aura/src/session_store/memory.rs
@@ -196,6 +196,7 @@ mod tests {
                 scope: AgentScope::Single { session_id: None },
                 origin: ApprovalOrigin::ConfigGate {
                     matched_pattern: "test_*".to_string(),
+                    agent_name: "test-agent".to_string(),
                 },
                 items: vec![ApprovalItem {
                     tool_name: "test_tool".to_string(),

--- a/crates/aura/src/session_store/record.rs
+++ b/crates/aura/src/session_store/record.rs
@@ -59,6 +59,8 @@ pub enum ScopeRecord {
 pub enum OriginRecord {
     ConfigGate {
         matched_pattern: String,
+        #[serde(default)]
+        agent_name: String,
     },
     AgentRequested {
         reason: String,
@@ -195,8 +197,12 @@ impl TryFrom<ScopeRecord> for AgentScope {
 impl From<&ApprovalOrigin> for OriginRecord {
     fn from(origin: &ApprovalOrigin) -> Self {
         match origin {
-            ApprovalOrigin::ConfigGate { matched_pattern } => OriginRecord::ConfigGate {
+            ApprovalOrigin::ConfigGate {
+                matched_pattern,
+                agent_name,
+            } => OriginRecord::ConfigGate {
                 matched_pattern: matched_pattern.clone(),
+                agent_name: agent_name.clone(),
             },
             ApprovalOrigin::AgentRequested { reason, agent_name } => OriginRecord::AgentRequested {
                 reason: reason.clone(),
@@ -209,9 +215,13 @@ impl From<&ApprovalOrigin> for OriginRecord {
 impl From<OriginRecord> for ApprovalOrigin {
     fn from(record: OriginRecord) -> Self {
         match record {
-            OriginRecord::ConfigGate { matched_pattern } => {
-                ApprovalOrigin::ConfigGate { matched_pattern }
-            }
+            OriginRecord::ConfigGate {
+                matched_pattern,
+                agent_name,
+            } => ApprovalOrigin::ConfigGate {
+                matched_pattern,
+                agent_name,
+            },
             OriginRecord::AgentRequested { reason, agent_name } => {
                 ApprovalOrigin::AgentRequested { reason, agent_name }
             }
@@ -269,6 +279,7 @@ mod tests {
             },
             ApprovalOrigin::ConfigGate {
                 matched_pattern: "kubectl_*".to_string(),
+                agent_name: "test-agent".to_string(),
             },
         ));
     }
@@ -296,6 +307,7 @@ mod tests {
             },
             ApprovalOrigin::ConfigGate {
                 matched_pattern: "*".to_string(),
+                agent_name: "test-agent".to_string(),
             },
         ));
     }


### PR DESCRIPTION
## Summary

Extends the config-gate approval origin with the same `agent_name`
attribution already carried by agent-requested approvals (#494), so a
config-gate `request_approval` payload can also be traced back to the
config that raised it.

## Changes

- `ApprovalOrigin::ConfigGate` (domain), `ApprovalOriginWire::ConfigGate`
  (wire), and `OriginRecord::ConfigGate` (persisted storage) all gain a
  required `agent_name: String` field, matching the treatment already
  applied to the `AgentRequested` variant.
- `HitlApprovalWrapper` — the sole production constructor of
  `ConfigGate` origins — now carries the config's `[agent].name` and
  stamps it onto every gate-raised approval request.
- Both production call sites (`Agent::new` in `builder.rs` and
  `Orchestrator::create_worker`) pass `agent.name` through, right next
  to the identical argument already passed to `RequestApprovalTool::new`.
- All existing test constructions of `ConfigGate` across `aura` and
  `aura-web-server` updated; added `agent_name` wire-shape assertions
  in `hitl/route.rs`.

## Compatibility

Additive wire and storage change — `agent_name` carries
`#[serde(default)]` on the wire (`aura-events`) and storage
(`OriginRecord`) types, so older webhook payloads and already-persisted
approval records without the field stay parseable.
`PROTOCOL_VERSION` is not bumped.

## Validation

- `cargo build --workspace --all-targets` — clean
- `cargo +nightly fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` (run unsandboxed since several HITL webhook
  tests bind local TCP listeners for mock servers) — 992/992 passing in
  `aura`, 0 failures workspace-wide

Fixes #494
