### PR TITLE
feat(orchestration): emit tool_call_executing once a call clears its gates

### DIFF
--- a/crates/aura-events/src/orchestration.rs
+++ b/crates/aura-events/src/orchestration.rs
@@ -77,6 +77,7 @@ pub mod event_names {
     pub const SYNTHESIZING: &str = "aura.orchestrator.synthesizing";
     pub const WORKER_REASONING: &str = "aura.orchestrator.worker_reasoning";
     pub const TOOL_CALL_STARTED: &str = "aura.orchestrator.tool_call_started";
+    pub const TOOL_CALL_EXECUTING: &str = "aura.orchestrator.tool_call_executing";
     pub const TOOL_CALL_COMPLETED: &str = "aura.orchestrator.tool_call_completed";
     pub const PHASE_STARTED: &str = "aura.orchestrator.phase_started";
     pub const PHASE_COMPLETED: &str = "aura.orchestrator.phase_completed";
@@ -196,11 +197,24 @@ pub enum OrchestrationStreamEvent {
         #[serde(flatten)]
         context: EventContext,
     },
+    /// Emitted once a tool call has cleared every pre-call gate (e.g. HITL
+    /// approval) and is running. `ToolCallStarted` precedes any gate.
+    ToolCallExecuting {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        task_id: Option<usize>,
+        tool_call_id: String,
+        tool_name: String,
+        worker_id: String,
+        #[serde(flatten)]
+        context: EventContext,
+    },
     /// Emitted when a tool call completes within a worker task.
     ToolCallCompleted {
         #[serde(skip_serializing_if = "Option::is_none")]
         task_id: Option<usize>,
         tool_call_id: String,
+        tool_name: String,
+        worker_id: String,
         success: bool,
         duration_ms: u64,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -241,6 +255,7 @@ impl OrchestrationStreamEvent {
             Self::Synthesizing { .. } => event_names::SYNTHESIZING,
             Self::WorkerReasoning { .. } => event_names::WORKER_REASONING,
             Self::ToolCallStarted { .. } => event_names::TOOL_CALL_STARTED,
+            Self::ToolCallExecuting { .. } => event_names::TOOL_CALL_EXECUTING,
             Self::ToolCallCompleted { .. } => event_names::TOOL_CALL_COMPLETED,
             Self::PhaseStarted { .. } => event_names::PHASE_STARTED,
             Self::PhaseCompleted { .. } => event_names::PHASE_COMPLETED,
@@ -411,9 +426,28 @@ impl OrchestrationStreamEvent {
         }
     }
 
+    pub fn tool_call_executing(
+        task_id: Option<usize>,
+        tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        worker_id: impl Into<String>,
+        context: EventContext,
+    ) -> Self {
+        Self::ToolCallExecuting {
+            task_id,
+            tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            worker_id: worker_id.into(),
+            context,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
     pub fn tool_call_completed(
         task_id: Option<usize>,
         tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        worker_id: impl Into<String>,
         success: bool,
         duration_ms: u64,
         result: Option<String>,
@@ -422,6 +456,8 @@ impl OrchestrationStreamEvent {
         Self::ToolCallCompleted {
             task_id,
             tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            worker_id: worker_id.into(),
             success,
             duration_ms,
             result,

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -1349,16 +1349,39 @@ fn handle_orchestrator_event(
                 event_context,
             )
         }
+        OrchestratorEvent::ToolCallExecuting {
+            task_id,
+            tool_call_id,
+            tool_name,
+            worker_id,
+        } => {
+            tracing::debug!(
+                "Orchestrator: task {:?} tool call executing - {} ({})",
+                task_id,
+                tool_name,
+                tool_call_id
+            );
+            OrchestrationStreamEvent::tool_call_executing(
+                *task_id,
+                tool_call_id,
+                tool_name,
+                worker_id,
+                event_context,
+            )
+        }
         OrchestratorEvent::ToolCallCompleted {
             task_id,
             tool_call_id,
+            tool_name,
+            worker_id,
             success,
             duration_ms,
             result,
         } => {
             tracing::debug!(
-                "Orchestrator: task {:?} tool call completed - {} (success={}) in {}ms",
+                "Orchestrator: task {:?} tool call completed - {} ({}) (success={}) in {}ms",
                 task_id,
+                tool_name,
                 tool_call_id,
                 success,
                 duration_ms
@@ -1366,6 +1389,8 @@ fn handle_orchestrator_event(
             OrchestrationStreamEvent::tool_call_completed(
                 *task_id,
                 tool_call_id,
+                tool_name,
+                worker_id,
                 *success,
                 *duration_ms,
                 maybe_truncate(result, config.tool_result_max_length),

--- a/crates/aura/src/orchestration/events.rs
+++ b/crates/aura/src/orchestration/events.rs
@@ -161,12 +161,31 @@ pub enum OrchestratorEvent {
         /// Arguments passed to the tool
         arguments: serde_json::Value,
     },
+    /// A tool call has cleared every pre-call gate and is running.
+    ///
+    /// `ToolCallStarted` is emitted when the call is requested, before a
+    /// HITL gate can hold or deny it; this is the first event that means
+    /// the tool is actually executing.
+    ToolCallExecuting {
+        /// Task ID the tool call belongs to (None if ID couldn't be parsed)
+        task_id: Option<usize>,
+        /// Unique identifier for this tool call
+        tool_call_id: String,
+        /// Name of the tool being called
+        tool_name: String,
+        /// ID of the worker or orchestrator that called the tool
+        worker_id: String,
+    },
     /// A tool call has completed within a worker task.
     ToolCallCompleted {
         /// Task ID the tool call belongs to (None if ID couldn't be parsed)
         task_id: Option<usize>,
         /// The tool call ID this result corresponds to
         tool_call_id: String,
+        /// Name of the tool that was called
+        tool_name: String,
+        /// ID of the worker or orchestrator that called the tool
+        worker_id: String,
         /// Whether the tool call succeeded
         success: bool,
         /// How long the call took in milliseconds

--- a/crates/aura/src/orchestration/observer_wrapper.rs
+++ b/crates/aura/src/orchestration/observer_wrapper.rs
@@ -26,7 +26,8 @@ fn generate_tool_call_id(task_id: usize, tool_name: &str) -> String {
 /// Tool wrapper that emits events to a `ToolCallObserver`.
 ///
 /// This wrapper provides real-time visibility into tool execution by emitting
-/// `ToolEvent::CallStarted` when a tool begins execution and
+/// `ToolEvent::CallStarted` when a tool call is requested,
+/// `ToolEvent::CallExecuting` once it has cleared every pre-call gate, and
 /// `ToolEvent::CallCompleted` when it finishes.
 ///
 /// Events are emitted to a broadcast channel that the orchestrator can
@@ -42,6 +43,19 @@ pub struct ObserverWrapper {
 impl ObserverWrapper {
     pub fn new(observer: ToolCallObserver, task_id: usize) -> Self {
         Self { observer, task_id }
+    }
+}
+
+/// The tool call ID this wrapper stashed in `transform_args`, from either the
+/// wrapper's own extracted object or the array `ComposedWrapper` collects.
+fn observer_tool_call_id(extracted: Option<&Value>) -> Option<&str> {
+    let v = extracted?;
+    if let Some(arr) = v.as_array() {
+        arr.iter()
+            .find_map(|item| item.get("observer_tool_call_id"))
+            .and_then(|v| v.as_str())
+    } else {
+        v.get("observer_tool_call_id").and_then(|v| v.as_str())
     }
 }
 
@@ -80,6 +94,17 @@ impl ToolWrapper for ObserverWrapper {
         error
     }
 
+    fn on_execute(&self, ctx: &ToolCallContext, extracted: Option<&Value>) {
+        let Some(tool_call_id) = observer_tool_call_id(extracted) else {
+            return;
+        };
+        self.observer.emit(ToolEvent::call_executing(
+            tool_call_id,
+            &ctx.tool_name,
+            &ctx.tool_initiator_id,
+        ));
+    }
+
     async fn on_complete(
         &self,
         ctx: &ToolCallContext,
@@ -87,34 +112,34 @@ impl ToolWrapper for ObserverWrapper {
         result: Result<&str, &str>,
         duration_ms: u64,
     ) {
-        // Extract tool_call_id from the extracted data
-        let tool_call_id = extracted
-            .and_then(|v| {
-                // Handle both direct object and array from ComposedWrapper
-                if let Some(arr) = v.as_array() {
-                    // Find the object with observer_tool_call_id
-                    arr.iter()
-                        .find_map(|item| item.get("observer_tool_call_id"))
-                        .and_then(|v| v.as_str())
-                } else {
-                    v.get("observer_tool_call_id").and_then(|v| v.as_str())
-                }
-            })
-            .unwrap_or_else(|| {
-                // Fallback: generate a new ID (shouldn't happen in normal flow)
-                tracing::warn!(
-                    "observer_tool_call_id not found in extracted data for {}",
-                    ctx.tool_name
-                );
-                "unknown"
-            });
+        let tool_call_id = observer_tool_call_id(extracted).unwrap_or_else(|| {
+            // Fallback: generate a new ID (shouldn't happen in normal flow)
+            tracing::warn!(
+                "observer_tool_call_id not found in extracted data for {}",
+                ctx.tool_name
+            );
+            "unknown"
+        });
 
         // Emit CallCompleted event (full output — truncation happens at SSE handler layer)
         let event = match result {
-            Ok(output) => ToolEvent::call_completed_success(tool_call_id, output, duration_ms),
+            Ok(output) => ToolEvent::call_completed_success(
+                tool_call_id,
+                &ctx.tool_name,
+                &ctx.tool_initiator_id,
+                output,
+                duration_ms,
+            ),
             Err(err) => {
                 let retry_hint = RetryHint::from_error_message(err);
-                ToolEvent::call_completed_error(tool_call_id, err, Some(retry_hint), duration_ms)
+                ToolEvent::call_completed_error(
+                    tool_call_id,
+                    &ctx.tool_name,
+                    &ctx.tool_initiator_id,
+                    err,
+                    Some(retry_hint),
+                    duration_ms,
+                )
             }
         };
 
@@ -217,7 +242,24 @@ mod tests {
             _ => panic!("Expected CallStarted event"),
         }
 
-        // Call on_complete (should emit CallCompleted)
+        // Call on_execute (should emit CallExecuting for the same call)
+        wrapper.on_execute(&ctx, result.extracted.as_ref());
+
+        let event = rx.recv().await.unwrap();
+        match event {
+            ToolEvent::CallExecuting {
+                tool_call_id,
+                tool_name,
+                tool_initiator_id,
+            } => {
+                assert!(tool_call_id.contains("task42"));
+                assert_eq!(tool_name, "test_tool");
+                assert_eq!(tool_initiator_id, "worker");
+            }
+            _ => panic!("Expected CallExecuting event"),
+        }
+
+        // Call on_complete (should emit CallCompleted carrying the tool identity)
         wrapper
             .on_complete(&ctx, result.extracted.as_ref(), Ok("success"), 100)
             .await;
@@ -225,15 +267,29 @@ mod tests {
         let event = rx.recv().await.unwrap();
         match event {
             ToolEvent::CallCompleted {
+                tool_name,
+                tool_initiator_id,
                 duration_ms,
                 result,
                 ..
             } => {
+                assert_eq!(tool_name, "test_tool");
+                assert_eq!(tool_initiator_id, "worker");
                 assert_eq!(duration_ms, 100);
                 assert!(result.is_success());
             }
             _ => panic!("Expected CallCompleted event"),
         }
+    }
+
+    #[test]
+    fn test_on_execute_without_extracted_emits_nothing() {
+        let (observer, rx) = ToolCallObserver::new(8);
+        let wrapper = ObserverWrapper::new(observer, 0);
+
+        wrapper.on_execute(&ToolCallContext::new("test_tool"), None);
+
+        assert!(rx.is_empty());
     }
 
     #[tokio::test]

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -235,8 +235,20 @@ fn tool_event_to_orchestrator_event(
             worker_id: tool_initiator_id,
             arguments,
         },
+        crate::tool_call_observer::ToolEvent::CallExecuting {
+            tool_call_id,
+            tool_name,
+            tool_initiator_id,
+        } => OrchestratorEvent::ToolCallExecuting {
+            task_id: extract_task_id(&tool_call_id),
+            tool_call_id,
+            tool_name,
+            worker_id: tool_initiator_id,
+        },
         crate::tool_call_observer::ToolEvent::CallCompleted {
             tool_call_id,
+            tool_name,
+            tool_initiator_id,
             result,
             duration_ms,
         } => {
@@ -248,6 +260,8 @@ fn tool_event_to_orchestrator_event(
             OrchestratorEvent::ToolCallCompleted {
                 task_id: extract_task_id(&tool_call_id),
                 tool_call_id,
+                tool_name,
+                worker_id: tool_initiator_id,
                 success,
                 duration_ms,
                 result: result_str,
@@ -256,12 +270,22 @@ fn tool_event_to_orchestrator_event(
     }
 }
 
-/// Forward a `ToolCallStarted` event for a non-MCP tool the worker
-/// `ObserverWrapper` does not cover: skills, orchestration operations, and
-/// scratchpad tools when enabled (see [`scratchpad::should_forward_tool_event`]).
-/// Records the start instant so the completion can report a duration. No-op
-/// without an event channel. Used by both `stream_and_forward` (workers) and
-/// `stream_and_collect` (coordinator) so skill use surfaces in both roles.
+/// What [`forward_internal_tool_started`] records per call so the matching
+/// completion can report a duration and carry the tool identity.
+struct InternalToolStart {
+    at: std::time::Instant,
+    tool_name: String,
+    worker_id: String,
+}
+
+/// Forward `ToolCallStarted` and `ToolCallExecuting` events for a non-MCP tool
+/// the worker `ObserverWrapper` does not cover: skills, orchestration
+/// operations, and scratchpad tools when enabled (see
+/// [`scratchpad::should_forward_tool_event`]). These tools pass through no
+/// pre-call gate, so both events are emitted back to back. Records the start
+/// so the completion can report a duration. No-op without an event channel.
+/// Used by both `stream_and_forward` (workers) and `stream_and_collect`
+/// (coordinator) so skill use surfaces in both roles.
 async fn forward_internal_tool_started(
     event_tx: Option<&tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>>,
     task_id: Option<usize>,
@@ -269,20 +293,37 @@ async fn forward_internal_tool_started(
     tool_call_id: &str,
     tool_name: &str,
     raw_arguments: &str,
-    starts: &mut std::collections::HashMap<String, std::time::Instant>,
+    starts: &mut std::collections::HashMap<String, InternalToolStart>,
 ) {
     let Some(tx) = event_tx else { return };
     let tool_call_id = tool_call_id.to_string();
-    starts.insert(tool_call_id.clone(), std::time::Instant::now());
+    starts.insert(
+        tool_call_id.clone(),
+        InternalToolStart {
+            at: std::time::Instant::now(),
+            tool_name: tool_name.to_string(),
+            worker_id: worker_id.to_string(),
+        },
+    );
     let arguments = serde_json::from_str(raw_arguments).unwrap_or_else(|_| serde_json::json!({}));
     let _ = tx
         .send(Ok(StreamItem::OrchestratorEvent(
             OrchestratorEvent::ToolCallStarted {
                 task_id,
-                tool_call_id,
+                tool_call_id: tool_call_id.clone(),
                 tool_name: tool_name.to_string(),
                 worker_id: worker_id.to_string(),
                 arguments,
+            },
+        )))
+        .await;
+    let _ = tx
+        .send(Ok(StreamItem::OrchestratorEvent(
+            OrchestratorEvent::ToolCallExecuting {
+                task_id,
+                tool_call_id,
+                tool_name: tool_name.to_string(),
+                worker_id: worker_id.to_string(),
             },
         )))
         .await;
@@ -296,7 +337,7 @@ async fn forward_internal_tool_completed(
     task_id: Option<usize>,
     tool_call_id: &str,
     result: &str,
-    starts: &mut std::collections::HashMap<String, std::time::Instant>,
+    starts: &mut std::collections::HashMap<String, InternalToolStart>,
 ) {
     let Some(start) = starts.remove(tool_call_id) else {
         return;
@@ -311,8 +352,10 @@ async fn forward_internal_tool_completed(
             OrchestratorEvent::ToolCallCompleted {
                 task_id,
                 tool_call_id: tool_call_id.to_string(),
+                tool_name: start.tool_name,
+                worker_id: start.worker_id,
                 success,
-                duration_ms: start.elapsed().as_millis() as u64,
+                duration_ms: start.at.elapsed().as_millis() as u64,
                 result: result.to_string(),
             },
         )))
@@ -1040,7 +1083,7 @@ impl Orchestrator {
         // ToolResult can report a duration. Membership also gates completion:
         // only IDs we started get completed, so MCP tools (covered by
         // ObserverWrapper) are never double-emitted.
-        let mut internal_tool_starts: HashMap<String, std::time::Instant> = HashMap::new();
+        let mut internal_tool_starts: HashMap<String, InternalToolStart> = HashMap::new();
 
         // Two guarded phases per iteration, so the body (its sends and the
         // decision-ready branch's inner `next()`) runs under the deadline
@@ -1327,7 +1370,7 @@ impl Orchestrator {
             // The coordinator is not ObserverWrapped, so forward the same non-MCP
             // tool calls a worker does (skills, orchestration operations), attributed
             // to the main agent.
-            let mut internal_tool_starts: HashMap<String, std::time::Instant> = HashMap::new();
+            let mut internal_tool_starts: HashMap<String, InternalToolStart> = HashMap::new();
 
             // Same two-phase guarded shape as `stream_and_forward`; see the
             // rationale there, including why new_disarmed() rather than new().

--- a/crates/aura/src/orchestration/stream_events.rs
+++ b/crates/aura/src/orchestration/stream_events.rs
@@ -10,7 +10,8 @@
 //! - `aura.orchestrator.task_completed` - Worker finished task (success/failure)
 //! - `aura.orchestrator.iteration_complete` - Plan-execute-continue cycle done
 //! - `aura.orchestrator.synthesizing` - Consolidating task results for coordinator decision
-//! - `aura.orchestrator.tool_call_started` - Worker tool execution began
+//! - `aura.orchestrator.tool_call_started` - Worker requested a tool call (before any gate)
+//! - `aura.orchestrator.tool_call_executing` - Tool call cleared every gate and is running
 //! - `aura.orchestrator.tool_call_completed` - Worker tool execution finished
 //!
 //! # Separation from Base Events
@@ -74,6 +75,7 @@ pub mod event_names {
     pub const SYNTHESIZING: &str = "aura.orchestrator.synthesizing";
     pub const WORKER_REASONING: &str = "aura.orchestrator.worker_reasoning";
     pub const TOOL_CALL_STARTED: &str = "aura.orchestrator.tool_call_started";
+    pub const TOOL_CALL_EXECUTING: &str = "aura.orchestrator.tool_call_executing";
     pub const TOOL_CALL_COMPLETED: &str = "aura.orchestrator.tool_call_completed";
 }
 
@@ -174,11 +176,24 @@ pub enum OrchestrationStreamEvent {
         #[serde(flatten)]
         context: EventContext,
     },
+    /// Emitted once a tool call has cleared every pre-call gate (e.g. HITL
+    /// approval) and is running. `ToolCallStarted` precedes any gate.
+    ToolCallExecuting {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        task_id: Option<usize>,
+        tool_call_id: String,
+        tool_name: String,
+        worker_id: String,
+        #[serde(flatten)]
+        context: EventContext,
+    },
     /// Emitted when a tool call completes within a worker task.
     ToolCallCompleted {
         #[serde(skip_serializing_if = "Option::is_none")]
         task_id: Option<usize>,
         tool_call_id: String,
+        tool_name: String,
+        worker_id: String,
         #[serde(flatten)]
         outcome: CompletionOutcome,
         #[serde(flatten)]
@@ -200,6 +215,7 @@ impl OrchestrationStreamEvent {
             Self::Synthesizing { .. } => event_names::SYNTHESIZING,
             Self::WorkerReasoning { .. } => event_names::WORKER_REASONING,
             Self::ToolCallStarted { .. } => event_names::TOOL_CALL_STARTED,
+            Self::ToolCallExecuting { .. } => event_names::TOOL_CALL_EXECUTING,
             Self::ToolCallCompleted { .. } => event_names::TOOL_CALL_COMPLETED,
         }
     }
@@ -375,10 +391,30 @@ impl OrchestrationStreamEvent {
         }
     }
 
+    /// Create a ToolCallExecuting event.
+    pub fn tool_call_executing(
+        task_id: Option<usize>,
+        tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        worker_id: impl Into<String>,
+        context: EventContext,
+    ) -> Self {
+        Self::ToolCallExecuting {
+            task_id,
+            tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            worker_id: worker_id.into(),
+            context,
+        }
+    }
+
     /// Create a ToolCallCompleted event.
+    #[allow(clippy::too_many_arguments)]
     pub fn tool_call_completed(
         task_id: Option<usize>,
         tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        worker_id: impl Into<String>,
         success: bool,
         duration_ms: u64,
         result: Option<String>,
@@ -387,6 +423,8 @@ impl OrchestrationStreamEvent {
         Self::ToolCallCompleted {
             task_id,
             tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            worker_id: worker_id.into(),
             outcome: CompletionOutcome {
                 success,
                 duration_ms,
@@ -572,10 +610,29 @@ mod tests {
     }
 
     #[test]
+    fn test_format_sse_tool_call_executing() {
+        let event = OrchestrationStreamEvent::tool_call_executing(
+            Some(0),
+            "call_1",
+            "mean",
+            "statistics",
+            test_ctx(),
+        );
+        let sse = event.format_sse();
+
+        assert!(sse.starts_with(&format!("event: {}\n", event_names::TOOL_CALL_EXECUTING)));
+        assert!(sse.contains("\"tool_call_id\":\"call_1\""));
+        assert!(sse.contains("\"tool_name\":\"mean\""));
+        assert!(sse.contains("\"worker_id\":\"statistics\""));
+    }
+
+    #[test]
     fn test_format_sse_tool_call_completed_with_result() {
         let event = OrchestrationStreamEvent::tool_call_completed(
             Some(0),
             "call_1",
+            "mean",
+            "statistics",
             true,
             42,
             Some("30.0".to_string()),
@@ -584,6 +641,8 @@ mod tests {
         let sse = event.format_sse();
 
         assert!(sse.starts_with(&format!("event: {}\n", event_names::TOOL_CALL_COMPLETED)));
+        assert!(sse.contains("\"tool_name\":\"mean\""));
+        assert!(sse.contains("\"worker_id\":\"statistics\""));
         assert!(sse.contains("\"result\":\"30.0\""));
         assert!(sse.contains("\"success\":true"));
     }

--- a/crates/aura/src/tool_call_observer.rs
+++ b/crates/aura/src/tool_call_observer.rs
@@ -62,10 +62,28 @@ pub enum ToolEvent {
         timestamp: Instant,
     },
 
+    /// A tool call has passed every pre-call gate and is about to run.
+    ///
+    /// `CallStarted` fires when the model asks for the call; a gated call
+    /// can still be held or denied after that. This is the first event
+    /// that means the tool is executing.
+    CallExecuting {
+        /// The tool call ID being executed
+        tool_call_id: String,
+        /// Name of the tool being called
+        tool_name: String,
+        /// The ID of the orchestrator or worker that initiated the tool call
+        tool_initiator_id: String,
+    },
+
     /// A tool call has completed (success or failure).
     CallCompleted {
         /// The tool call ID this result corresponds to
         tool_call_id: String,
+        /// Name of the tool that was called
+        tool_name: String,
+        /// The ID of the orchestrator or worker that initiated the tool call
+        tool_initiator_id: String,
         /// The outcome of the tool call
         result: ToolOutcome,
         /// How long the call took in milliseconds
@@ -90,14 +108,31 @@ impl ToolEvent {
         }
     }
 
+    /// Create a new CallExecuting event.
+    pub fn call_executing(
+        tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        tool_initiator_id: impl Into<String>,
+    ) -> Self {
+        Self::CallExecuting {
+            tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            tool_initiator_id: tool_initiator_id.into(),
+        }
+    }
+
     /// Create a successful CallCompleted event.
     pub fn call_completed_success(
         tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        tool_initiator_id: impl Into<String>,
         result: impl Into<String>,
         duration_ms: u64,
     ) -> Self {
         Self::CallCompleted {
             tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            tool_initiator_id: tool_initiator_id.into(),
             result: ToolOutcome::Success(result.into()),
             duration_ms,
         }
@@ -106,12 +141,16 @@ impl ToolEvent {
     /// Create a failed CallCompleted event.
     pub fn call_completed_error(
         tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        tool_initiator_id: impl Into<String>,
         message: impl Into<String>,
         retry_hint: Option<RetryHint>,
         duration_ms: u64,
     ) -> Self {
         Self::CallCompleted {
             tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            tool_initiator_id: tool_initiator_id.into(),
             result: ToolOutcome::Error {
                 message: message.into(),
                 retry_hint,
@@ -366,7 +405,9 @@ mod tests {
 
         assert_eq!(observer.subscriber_count(), 2);
 
-        observer.emit(ToolEvent::call_completed_success("call_1", "result", 100));
+        observer.emit(ToolEvent::call_completed_success(
+            "call_1", "search", "worker", "result", 100,
+        ));
 
         let event1 = rx1.recv().await.unwrap();
         let event2 = rx2.recv().await.unwrap();
@@ -375,13 +416,16 @@ mod tests {
         match (event1, event2) {
             (
                 ToolEvent::CallCompleted {
-                    tool_call_id: id1, ..
+                    tool_call_id: id1,
+                    tool_name: name1,
+                    ..
                 },
                 ToolEvent::CallCompleted {
                     tool_call_id: id2, ..
                 },
             ) => {
                 assert_eq!(id1, "call_1");
+                assert_eq!(name1, "search");
                 assert_eq!(id2, "call_1");
             }
             _ => panic!("Expected CallCompleted events"),

--- a/crates/aura/src/tool_wrapper.rs
+++ b/crates/aura/src/tool_wrapper.rs
@@ -349,6 +349,17 @@ pub trait ToolWrapper: Send + Sync {
         Ok(PreCallOutcome::Proceed { overrides: None })
     }
 
+    /// Hook called once the call is committed to run: after every
+    /// `pre_call` returned `Proceed`, immediately before the inner tool
+    /// is invoked. Not called when `validate_args` or `pre_call` rejects
+    /// or short-circuits, so this is the first point at which a call is
+    /// known to execute — a gated call reaches it only after approval.
+    ///
+    /// # Arguments
+    /// * `ctx` - Context about the current tool call
+    /// * `extracted` - Data extracted during `transform_args`
+    fn on_execute(&self, _ctx: &ToolCallContext, _extracted: Option<&Value>) {}
+
     /// Async hook called after tool completion (success or failure).
     ///
     /// Use this for async side effects like:
@@ -569,6 +580,8 @@ where
                 }
             };
 
+            wrapper.on_execute(&ctx, extracted.as_ref());
+
             // Call inner tool in a spawned task to isolate panics.
             // Propagate the current span so mcp.tool_call nests under execute_tool.
             let inner_clone = inner.clone();
@@ -786,6 +799,12 @@ impl ToolWrapper for ComposedWrapper {
             }
         }
         Ok(PreCallOutcome::Proceed { overrides })
+    }
+
+    fn on_execute(&self, ctx: &ToolCallContext, extracted: Option<&Value>) {
+        for wrapper in &self.wrappers {
+            wrapper.on_execute(ctx, extracted);
+        }
     }
 
     async fn transform_output(
@@ -1091,6 +1110,59 @@ mod tests {
         assert!(
             !ran.load(Ordering::SeqCst),
             "inner tool must not run when pre_call short-circuits"
+        );
+    }
+
+    struct RecordExecute(Arc<std::sync::atomic::AtomicBool>);
+
+    #[async_trait]
+    impl ToolWrapper for RecordExecute {
+        fn on_execute(&self, _ctx: &ToolCallContext, _extracted: Option<&Value>) {
+            self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn on_execute_runs_after_pre_call_proceeds() {
+        use std::sync::atomic::Ordering;
+
+        let executed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let composed = ComposedWrapper::new(vec![
+            Arc::new(RecordExecute(executed.clone())) as Arc<dyn ToolWrapper>
+        ]);
+        let wrapped = WrappedTool::new(
+            RecordingInner {
+                ran: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            },
+            Arc::new(composed) as Arc<dyn ToolWrapper>,
+        );
+
+        wrapped.call(serde_json::json!({})).await.unwrap();
+
+        assert!(executed.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn on_execute_skipped_when_pre_call_short_circuits() {
+        use std::sync::atomic::Ordering;
+
+        let executed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let composed = ComposedWrapper::new(vec![
+            Arc::new(ShortCircuitPreCall) as Arc<dyn ToolWrapper>,
+            Arc::new(RecordExecute(executed.clone())) as Arc<dyn ToolWrapper>,
+        ]);
+        let wrapped = WrappedTool::new(
+            RecordingInner {
+                ran: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            },
+            Arc::new(composed) as Arc<dyn ToolWrapper>,
+        );
+
+        wrapped.call(serde_json::json!({})).await.unwrap();
+
+        assert!(
+            !executed.load(Ordering::SeqCst),
+            "on_execute must not run for a call the gate short-circuited"
         );
     }
 


### PR DESCRIPTION
Orchestration emits `aura.orchestrator.tool_call_started` when a worker requests a call — before the HITL gate — and nothing further until completion, so a stream consumer cannot tell a running call from one parked for approval or denied. Single-agent mode already distinguishes the two (`tool_requested`, then `tool_start` from the MCP transport).

This adds a `ToolWrapper::on_execute` hook, invoked after every `pre_call` returned `Proceed` and before the inner tool runs, and has `ObserverWrapper` emit from it. The orchestrator forwards it as `aura.orchestrator.tool_call_executing` (`task_id`, `tool_call_id`, `tool_name`, `worker_id`); internal non-MCP tools, which pass through no gate, emit it straight after their start event. `tool_call_completed` now also carries `tool_name` and `worker_id`, so a completion can be labelled without a consumer-side map of open calls.

Additive only: existing events, names, and fields are unchanged. The CLI ignores the new event name until it chooses to use it (e.g. to flip a task header from pending to executing).

Motivation: sre-bot renders tool activity into Slack and currently holds every orchestration start event until an approval outcome or completion proves the call ran; with this event that state goes away.