### PR TITLE
fix(config): validate memory_dir writability at startup

### DIFF
--- a/crates/aura-config/Cargo.toml
+++ b/crates/aura-config/Cargo.toml
@@ -28,5 +28,5 @@ regex = { workspace = true }
 # Glob matching for HITL tool-name patterns
 globset = "0.4"
 
-[dev-dependencies]
+# Directory perms validation
 tempfile = "3"

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -336,6 +336,16 @@ impl Config {
         self.agent.alias.as_deref().unwrap_or(&self.agent.name)
     }
 
+    /// Resolve the effective persistence directory: top-level `memory_dir`,
+    /// or `[orchestration.artifacts].memory_dir` as a legacy fallback.
+    pub fn effective_memory_dir(&self) -> Option<&str> {
+        self.memory_dir.as_deref().or_else(|| {
+            self.orchestration
+                .as_ref()
+                .and_then(|o| o.artifacts.memory_dir.as_deref())
+        })
+    }
+
     /// Validate the configuration
     pub fn validate(&self) -> Result<(), crate::ConfigError> {
         validate_llm_api_key(&self.agent.llm, "agent.llm")?;
@@ -418,6 +428,32 @@ impl Config {
         Ok(())
     }
 
+    /// Validate that the effective `memory_dir` (if set) is writable.
+    ///
+    /// Creates the directory if it doesn't exist, then probes writability with
+    /// a temporary file. The probe file is removed afterward on a best-effort
+    /// basis.
+    ///
+    /// This is not part of the validate() method because it is not side effect
+    /// free.
+    pub fn validate_memory_dir_writable(&self) -> Result<(), crate::ConfigError> {
+        let Some(dir) = self.effective_memory_dir() else {
+            return Ok(());
+        };
+
+        let path = std::path::Path::new(dir);
+
+        std::fs::create_dir_all(path).map_err(|e| {
+            crate::ConfigError::Validation(format!("Cannot create memory_dir '{dir}': {e}"))
+        })?;
+
+        tempfile::NamedTempFile::new_in(path).map_err(|e| {
+            crate::ConfigError::Validation(format!("memory_dir '{dir}' is not writable: {e}"))
+        })?;
+
+        Ok(())
+    }
+
     /// When scratchpad is enabled on the agent or any worker, require a
     /// `memory_dir` (top-level, with legacy fallback to
     /// `[orchestration.artifacts].memory_dir`) and a `context_window` on each
@@ -440,11 +476,7 @@ impl Config {
             return Ok(());
         }
 
-        let effective_memory_dir = self.memory_dir.as_deref().or_else(|| {
-            self.orchestration
-                .as_ref()
-                .and_then(|o| o.artifacts.memory_dir.as_deref())
-        });
+        let effective_memory_dir = self.effective_memory_dir();
         if effective_memory_dir.is_none() {
             return Err(crate::ConfigError::Validation(
                 "Scratchpad enabled but top-level `memory_dir` is not set".to_string(),

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -37,8 +37,11 @@ fn load_single_config<P: AsRef<Path>>(path: P) -> Result<Config, ConfigError> {
     let contents = fs::read_to_string(path)?;
     let resolved = resolve_env_vars(&contents)?;
     check_legacy_top_level_llm(&resolved)?;
+
     let config: Config = toml::from_str(&resolved)?;
     config.validate()?;
+    config.validate_memory_dir_writable()?;
+
     Ok(config)
 }
 
@@ -136,4 +139,92 @@ pub fn load_config_from_str(contents: &str) -> Result<Config, ConfigError> {
     let config: Config = toml::from_str(&resolved)?;
     config.validate()?;
     Ok(config)
+}
+
+#[cfg(test)]
+mod load_config_tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_config(dir: &TempDir, name: &str, contents: &str) -> std::path::PathBuf {
+        let path = dir.path().join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        path
+    }
+
+    fn minimal_toml(extra: &str) -> String {
+        format!(
+            r#"
+{extra}
+[agent]
+name = "Test"
+system_prompt = "p"
+[agent.llm]
+provider = "openai"
+api_key = "test-key"
+model = "gpt-4o"
+"#
+        )
+    }
+
+    #[test]
+    fn load_config_no_memory_dir_passes() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, "agent.toml", &minimal_toml(""));
+        load_config(path).expect("config without memory_dir should load");
+    }
+
+    #[test]
+    fn load_config_writable_memory_dir_passes() {
+        let dir = TempDir::new().unwrap();
+        let memory_dir = dir.path().join("memory");
+        let toml = minimal_toml(&format!(
+            r#"memory_dir = "{}"
+"#,
+            memory_dir.display()
+        ));
+        let path = write_config(&dir, "agent.toml", &toml);
+        load_config(&path).expect("config with writable memory_dir should load");
+        assert!(
+            memory_dir.exists(),
+            "memory_dir should have been created by load_config"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn load_config_unwritable_memory_dir_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let memory_dir = dir.path().join("locked");
+        std::fs::create_dir_all(&memory_dir).unwrap();
+        std::fs::set_permissions(&memory_dir, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+        // Root ignores permission bits — skip rather than fail the assertion.
+        let probe = memory_dir.join(".aura-startup-probe");
+        if std::fs::write(&probe, b"probe").is_ok() {
+            let _ = std::fs::remove_file(&probe);
+            std::fs::set_permissions(&memory_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+            return;
+        }
+
+        let toml = minimal_toml(&format!(
+            r#"memory_dir = "{}"
+"#,
+            memory_dir.display()
+        ));
+        let path = write_config(&dir, "agent.toml", &toml);
+        let err = load_config(&path).expect_err("unwritable memory_dir should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not writable") || msg.contains("Permission denied"),
+            "error should describe the write failure: {msg}"
+        );
+
+        // Restore permissions so TempDir cleanup succeeds.
+        std::fs::set_permissions(&memory_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
 }


### PR DESCRIPTION
## Summary

Closes #493

If `memory_dir` is configured but unwritable, aura previously only discovered this at runtime, surfacing a confusing provider error to the user rather than a clear permission failure.

## Changes

- **`Config::effective_memory_dir()`** — new public method on `Config` that resolves the effective persistence directory (top-level `memory_dir` wins, `[orchestration.artifacts].memory_dir` as legacy fallback). Eliminates the duplication that existed inside `validate_scratchpad()`.

- **`validate_memory_dir_writable()`** — new private function in `load_config` that creates the directory if absent, then probes writability with a temporary file. Returns a `ConfigError::Validation` with the path and OS error on failure.

- **`load_config()`** — now calls `validate_memory_dir_writable()` for every loaded config after parsing. Both the web server and CLI standalone mode go through `load_config()`, so neither can start with a bad `memory_dir`.

`load_config_from_str()` is intentionally left without the check — it is the test-only path and its callers supply literal strings, not real filesystem paths.

## Testing

Three new unit tests in `load_config_tests`:
- `load_config_no_memory_dir_passes` — no `memory_dir` set, no filesystem check performed
- `load_config_writable_memory_dir_passes` — writable temp dir, directory is created and check passes
- `load_config_unwritable_memory_dir_fails` — read-only directory, returns error containing "not writable" or "Permission denied"