### PR TITLE
fix(orchestration): number planning phase artifacts by phase index

### DIFF
--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -1453,6 +1453,7 @@ impl Orchestrator {
         chat_history: &[rig::completion::Message],
         coordinator_state: &mut CoordinatorState,
         previous: Option<&IterationContext>,
+        phase_index: usize,
         event_tx: Option<&tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>>,
     ) -> Result<(PlanningResponse, String, String), StreamError> {
         let max_correction_attempts = self.config.max_plan_parse_retries;
@@ -1596,7 +1597,7 @@ impl Orchestrator {
                 {
                     let persistence = self.persistence.lock().await;
                     if let Err(e) = persistence
-                        .write_planning_phase(&prompt, &response_text)
+                        .write_planning_phase(phase_index, &prompt, &response_text)
                         .await
                     {
                         tracing::warn!("Failed to persist planning phase: {}", e);
@@ -1639,7 +1640,7 @@ impl Orchestrator {
             {
                 let persistence = self.persistence.lock().await;
                 if let Err(e) = persistence
-                    .write_planning_phase(&prompt, &response_text)
+                    .write_planning_phase(phase_index, &prompt, &response_text)
                     .await
                 {
                     tracing::warn!("Failed to persist planning phase: {}", e);
@@ -3666,6 +3667,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 &chat_history,
                 &mut coordinator_state,
                 None,
+                0,
                 Some(&event_tx),
             )
             .await?;
@@ -4029,6 +4031,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 chat_history,
                 coordinator_state,
                 Some(&post_execute_ctx),
+                1,
                 Some(event_tx),
             )
             .await;

--- a/crates/aura/src/orchestration/persistence.rs
+++ b/crates/aura/src/orchestration/persistence.rs
@@ -519,7 +519,16 @@ impl ExecutionPersistence {
     }
 
     /// Write planning phase artifacts (coordinator prompt/response).
-    pub async fn write_planning_phase(&self, prompt: &str, response: &str) -> io::Result<PathBuf> {
+    ///
+    /// `phase_index` distinguishes multiple coordinator calls within one
+    /// iteration (e.g. `0` for initial planning, `1` for the post-execution
+    /// continuation decision) so successive calls don't overwrite one another.
+    pub async fn write_planning_phase(
+        &self,
+        phase_index: usize,
+        prompt: &str,
+        response: &str,
+    ) -> io::Result<PathBuf> {
         if !self.enabled {
             return Ok(PathBuf::new());
         }
@@ -527,8 +536,16 @@ impl ExecutionPersistence {
         let iter_path = self.iteration_path();
         fs::create_dir_all(&iter_path).await?;
 
-        fs::write(iter_path.join("planning.prompt.txt"), prompt).await?;
-        fs::write(iter_path.join("planning.response.txt"), response).await?;
+        fs::write(
+            iter_path.join(format!("planning.{phase_index}.prompt.txt")),
+            prompt,
+        )
+        .await?;
+        fs::write(
+            iter_path.join(format!("planning.{phase_index}.response.txt")),
+            response,
+        )
+        .await?;
 
         Ok(iter_path)
     }
@@ -1217,6 +1234,79 @@ mod tests {
         assert_eq!(persistence.current_iteration(), 1);
         assert_eq!(persistence.start_new_iteration(), 2);
         assert_eq!(persistence.current_iteration(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_write_planning_phase_indexed_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut persistence = ExecutionPersistence::new(temp_dir.path().join("memory"), None)
+            .await
+            .unwrap();
+
+        // Two coordinator phases in the same iteration must not overwrite
+        // one another.
+        persistence
+            .write_planning_phase(0, "initial-prompt", "initial-response")
+            .await
+            .unwrap();
+        persistence
+            .write_planning_phase(1, "continuation-prompt", "continuation-response")
+            .await
+            .unwrap();
+
+        let iter1 = persistence.iteration_path();
+        assert_eq!(
+            tokio::fs::read_to_string(iter1.join("planning.0.prompt.txt"))
+                .await
+                .unwrap(),
+            "initial-prompt",
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(iter1.join("planning.0.response.txt"))
+                .await
+                .unwrap(),
+            "initial-response",
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(iter1.join("planning.1.prompt.txt"))
+                .await
+                .unwrap(),
+            "continuation-prompt",
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(iter1.join("planning.1.response.txt"))
+                .await
+                .unwrap(),
+            "continuation-response",
+        );
+
+        // The legacy unindexed filenames must not appear.
+        assert!(!iter1.join("planning.prompt.txt").exists());
+        assert!(!iter1.join("planning.response.txt").exists());
+
+        // A new iteration gets its own directory, so `phase_index = 0` starts
+        // fresh without colliding with the previous iteration's files.
+        persistence.start_new_iteration();
+        persistence
+            .write_planning_phase(0, "iter2-prompt", "iter2-response")
+            .await
+            .unwrap();
+
+        let iter2 = persistence.iteration_path();
+        assert_ne!(iter1, iter2);
+        assert_eq!(
+            tokio::fs::read_to_string(iter2.join("planning.0.prompt.txt"))
+                .await
+                .unwrap(),
+            "iter2-prompt",
+        );
+        // Previous iteration's artifacts remain intact.
+        assert_eq!(
+            tokio::fs::read_to_string(iter1.join("planning.0.prompt.txt"))
+                .await
+                .unwrap(),
+            "initial-prompt",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
plan_with_routing() runs at least twice per orchestration iteration (initial plan creation, then post-execution continuation decision), and each call wrote the same planning.prompt.txt / planning.response.txt under the iteration directory. The second call overwrote the first, destroying the prompt/response that actually produced the plan and leaving only the post-execution decision artifacts for debugging.

Thread a phase_index parameter from run_orchestration and run_iteration through plan_with_routing() to write_planning_phase(), so artifacts are written as planning.<phase_index>.prompt.txt / planning.<phase_index>.response.txt. Initial planning uses phase 0 and the post-execution continuation uses phase 1, so both survive side by side under the same iteration directory. plan.json is unchanged.

Downstream tooling that scrapes run directories for the previous planning.prompt.txt / planning.response.txt filenames needs to be updated for the new indexed layout.

Fixes: #183