### PR TITLE
test: consolidate mock streaming agents into MockAgent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,10 +359,14 @@ dependencies = [
 name = "aura-test-utils"
 version = "0.2.5"
 dependencies = [
+ "async-trait",
+ "aura",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/aura-test-utils/Cargo.toml
+++ b/crates/aura-test-utils/Cargo.toml
@@ -5,7 +5,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
+aura = { path = "../aura" }
 tokio = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+async-trait = "0.1"
+futures = "0.3"
+tokio-util = "0.7"

--- a/crates/aura-test-utils/src/lib.rs
+++ b/crates/aura-test-utils/src/lib.rs
@@ -1,5 +1,6 @@
 //! Shared test utilities for aura integration tests.
 
+pub mod mock_agent;
 pub mod sse;
 
 use std::future::Future;

--- a/crates/aura-test-utils/src/mock_agent.rs
+++ b/crates/aura-test-utils/src/mock_agent.rs
@@ -1,0 +1,134 @@
+//! A [`StreamingAgent`] for tests that need an agent without a provider.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use aura::{Message, StreamError, StreamItem, StreamingAgent, UsageState};
+use futures::stream::{self, BoxStream};
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+type StartHook = Arc<dyn Fn(String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+
+pub struct MockAgent {
+    on_stream_start: Option<StartHook>,
+}
+
+impl MockAgent {
+    /// Yields nothing and never ends.
+    pub fn pending() -> Self {
+        Self {
+            on_stream_start: None,
+        }
+    }
+
+    /// Awaited before either entry point produces its stream, and passed that
+    /// call's `request_id`.
+    pub fn on_stream_start<F, Fut>(mut self, hook: F) -> Self
+    where
+        F: Fn(String) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_stream_start = Some(Arc::new(move |request_id| Box::pin(hook(request_id))));
+        self
+    }
+
+    async fn start(&self, request_id: &str) -> BoxStream<'static, Result<StreamItem, StreamError>> {
+        if let Some(hook) = &self.on_stream_start {
+            hook(request_id.to_string()).await;
+        }
+        Box::pin(stream::pending())
+    }
+}
+
+#[async_trait]
+impl StreamingAgent for MockAgent {
+    fn get_provider_info(&self) -> (&str, &str) {
+        ("test", "fake")
+    }
+
+    async fn stream(
+        &self,
+        _query: &str,
+        _chat_history: Vec<Message>,
+        _cancel_token: CancellationToken,
+        request_id: &str,
+    ) -> Result<BoxStream<'static, Result<StreamItem, StreamError>>, StreamError> {
+        Ok(self.start(request_id).await)
+    }
+
+    async fn stream_with_timeout(
+        &self,
+        _query: &str,
+        _chat_history: Vec<Message>,
+        _timeout: Duration,
+        request_id: &str,
+    ) -> (
+        BoxStream<'static, Result<StreamItem, StreamError>>,
+        watch::Sender<bool>,
+        UsageState,
+    ) {
+        let stream = self.start(request_id).await;
+        let (cancel_tx, _cancel_rx) = watch::channel(false);
+        (stream, cancel_tx, UsageState::new())
+    }
+
+    async fn cancel_and_close_mcp(&self, _request_id: &str, _reason: &str) -> usize {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[tokio::test]
+    async fn a_pending_agent_never_yields() {
+        let agent = MockAgent::pending();
+        let mut stream = agent
+            .stream("q", vec![], CancellationToken::new(), "req_1")
+            .await
+            .expect("mock stream should start");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), stream.next())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn the_start_hook_runs_before_both_entry_points_stream() {
+        for entry_point in ["stream", "stream_with_timeout"] {
+            let ran = Arc::new(AtomicBool::new(false));
+            let flag = Arc::clone(&ran);
+            let agent = MockAgent::pending().on_stream_start(move |request_id| {
+                let flag = Arc::clone(&flag);
+                async move {
+                    assert_eq!(request_id, "req_1");
+                    flag.store(true, Ordering::SeqCst);
+                }
+            });
+
+            if entry_point == "stream" {
+                let _ = agent
+                    .stream("q", vec![], CancellationToken::new(), "req_1")
+                    .await
+                    .expect("mock stream should start");
+            } else {
+                let _ = agent
+                    .stream_with_timeout("q", vec![], Duration::from_secs(1), "req_1")
+                    .await;
+            }
+
+            assert!(
+                ran.load(Ordering::SeqCst),
+                "hook should run for {entry_point}"
+            );
+        }
+    }
+}

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -716,6 +716,7 @@ mod tests {
     use crate::a2a::SharedTaskStore;
     use crate::streaming::ToolResultMode;
     use crate::types::{ActiveRequestTracker, AppState};
+    use aura_test_utils::mock_agent::MockAgent;
 
     fn make_executor(
         configs: Vec<aura_config::Config>,
@@ -840,52 +841,6 @@ mod tests {
         assert_eq!(result.map(|c| c.agent.name), Some("B".to_owned()));
     }
 
-    /// Stand-in for a built agent, only ever parked in the cancel map.
-    struct IdleAgent;
-
-    #[async_trait::async_trait]
-    impl StreamingAgent for IdleAgent {
-        fn get_provider_info(&self) -> (&str, &str) {
-            ("test", "idle")
-        }
-
-        async fn stream(
-            &self,
-            _query: &str,
-            _chat_history: Vec<aura::Message>,
-            _cancel_token: CancellationToken,
-            _request_id: &str,
-        ) -> Result<
-            futures_util::stream::BoxStream<'static, Result<aura::StreamItem, aura::StreamError>>,
-            aura::StreamError,
-        > {
-            Ok(Box::pin(futures_util::stream::pending()))
-        }
-
-        async fn stream_with_timeout(
-            &self,
-            _query: &str,
-            _chat_history: Vec<aura::Message>,
-            _timeout: std::time::Duration,
-            _request_id: &str,
-        ) -> (
-            futures_util::stream::BoxStream<'static, Result<aura::StreamItem, aura::StreamError>>,
-            tokio::sync::watch::Sender<bool>,
-            aura::UsageState,
-        ) {
-            let (cancel_tx, _cancel_rx) = tokio::sync::watch::channel(false);
-            (
-                Box::pin(futures_util::stream::pending()),
-                cancel_tx,
-                aura::UsageState::new(),
-            )
-        }
-
-        async fn cancel_and_close_mcp(&self, _request_id: &str, _reason: &str) -> usize {
-            0
-        }
-    }
-
     /// A consumer that stops polling after a terminal event drops the
     /// execution generator mid-body, so the entry and the registry
     /// registration have to be released by the guard rather than by cleanup
@@ -906,7 +861,7 @@ mod tests {
             task_id.clone(),
             TaskCancelEntry {
                 token: CancellationToken::new(),
-                agent: Arc::new(IdleAgent),
+                agent: Arc::new(MockAgent::pending()),
                 request_id: request_id.clone(),
             },
         );

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1342,12 +1342,10 @@ fn error_response(
 mod tests {
     use super::*;
     use crate::types::{ChatMessage, ChatMessageFunctionCall, ChatMessageToolCall, Role};
-    use async_trait::async_trait;
-    use futures::stream::{self, BoxStream};
+    use aura_test_utils::mock_agent::MockAgent;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
-    use tokio::sync::watch;
     use tokio_util::sync::CancellationToken;
 
     fn msg(role: Role, content: &str) -> ChatMessage {
@@ -1437,74 +1435,32 @@ mod tests {
         validate_hitl_delivery_mode(&config, &req).unwrap();
     }
 
-    struct StartupApprovalPublisher {
-        published: Arc<AtomicBool>,
-    }
-
-    #[async_trait]
-    impl StreamingAgent for StartupApprovalPublisher {
-        fn get_provider_info(&self) -> (&str, &str) {
-            ("test", "fake")
-        }
-
-        async fn stream(
-            &self,
-            _query: &str,
-            _chat_history: Vec<aura::Message>,
-            _cancel_token: CancellationToken,
-            _request_id: &str,
-        ) -> Result<
-            BoxStream<'static, Result<aura::StreamItem, aura::StreamError>>,
-            aura::StreamError,
-        > {
-            Ok(Box::pin(stream::pending()))
-        }
-
-        async fn stream_with_timeout(
-            &self,
-            _query: &str,
-            _chat_history: Vec<aura::Message>,
-            _timeout: Duration,
-            request_id: &str,
-        ) -> (
-            BoxStream<'static, Result<aura::StreamItem, aura::StreamError>>,
-            watch::Sender<bool>,
-            aura::UsageState,
-        ) {
-            let event = aura::ApprovalLifecycleEvent::Requested(aura_events::ApprovalRequested {
-                decision_id: aura::hitl::DecisionId::generate().to_string(),
-                tool_name: "dangerous_apply".to_string(),
-                origin: aura_events::ApprovalOriginWire::ConfigGate {
-                    matched_pattern: "dangerous_*".to_string(),
-                    agent_name: "test-agent".to_string(),
-                },
-                scope: aura_events::AgentScopeWire::Single { session_id: None },
-            });
-            self.published.store(
-                aura::approval_event_broker::publish(request_id, event).await,
-                Ordering::SeqCst,
-            );
-
-            let (cancel_tx, _cancel_rx) = watch::channel(false);
-            (
-                Box::pin(stream::pending()),
-                cancel_tx,
-                aura::UsageState::new(),
-            )
-        }
-
-        async fn cancel_and_close_mcp(&self, _request_id: &str, _reason: &str) -> usize {
-            0
-        }
-    }
-
     #[tokio::test]
     async fn sse_approval_subscription_exists_before_stream_startup() {
         let request_id = format!("req_test_{}", Uuid::new_v4().simple());
         let published = Arc::new(AtomicBool::new(false));
-        let agent: Arc<dyn StreamingAgent> = Arc::new(StartupApprovalPublisher {
-            published: Arc::clone(&published),
-        });
+        let agent: Arc<dyn StreamingAgent> = Arc::new(MockAgent::pending().on_stream_start({
+            let published = Arc::clone(&published);
+            move |request_id| {
+                let published = Arc::clone(&published);
+                async move {
+                    let event =
+                        aura::ApprovalLifecycleEvent::Requested(aura_events::ApprovalRequested {
+                            decision_id: aura::hitl::DecisionId::generate().to_string(),
+                            tool_name: "dangerous_apply".to_string(),
+                            origin: aura_events::ApprovalOriginWire::ConfigGate {
+                                matched_pattern: "dangerous_*".to_string(),
+                                agent_name: "test-agent".to_string(),
+                            },
+                            scope: aura_events::AgentScopeWire::Single { session_id: None },
+                        });
+                    published.store(
+                        aura::approval_event_broker::publish(&request_id, event).await,
+                        Ordering::SeqCst,
+                    );
+                }
+            }
+        }));
         let setup = RequestSetup {
             query: "trigger approval".to_string(),
             chat_history: vec![],

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -1831,56 +1831,9 @@ mod tests {
 
     mod inactivity {
         use super::*;
-        use async_trait::async_trait;
-        use aura::streaming::StreamingAgent;
-        use futures_util::stream::BoxStream;
+        use aura_test_utils::mock_agent::MockAgent;
         use std::sync::Arc;
         use tokio_util::sync::CancellationToken;
-
-        struct NoopAgent;
-
-        #[async_trait]
-        impl StreamingAgent for NoopAgent {
-            fn get_provider_info(&self) -> (&str, &str) {
-                ("test", "fake")
-            }
-
-            async fn stream(
-                &self,
-                _query: &str,
-                _chat_history: Vec<aura::Message>,
-                _cancel_token: CancellationToken,
-                _request_id: &str,
-            ) -> Result<
-                BoxStream<'static, Result<aura::StreamItem, aura::StreamError>>,
-                aura::StreamError,
-            > {
-                Ok(Box::pin(futures_util::stream::pending()))
-            }
-
-            async fn stream_with_timeout(
-                &self,
-                _query: &str,
-                _chat_history: Vec<aura::Message>,
-                _timeout: Duration,
-                _request_id: &str,
-            ) -> (
-                BoxStream<'static, Result<aura::StreamItem, aura::StreamError>>,
-                watch::Sender<bool>,
-                aura::UsageState,
-            ) {
-                let (cancel_tx, _) = watch::channel(false);
-                (
-                    Box::pin(futures_util::stream::pending()),
-                    cancel_tx,
-                    aura::UsageState::new(),
-                )
-            }
-
-            async fn cancel_and_close_mcp(&self, _request_id: &str, _reason: &str) -> usize {
-                0
-            }
-        }
 
         /// Event senders must outlive the loop: a closed channel's `recv()`
         /// arm is permanently ready with `None`, which starves paused time.
@@ -1900,7 +1853,7 @@ mod tests {
             (
                 StreamingCallbacks {
                     request_id: "req_inactivity_test".to_string(),
-                    agent: Arc::new(NoopAgent),
+                    agent: Arc::new(MockAgent::pending()),
                     tool_event_rx,
                     progress_rx,
                     tool_usage_rx,


### PR DESCRIPTION
Replaces IdleAgent, NoopAgent and StartupApprovalPublisher with one mock in aura-test-utils.

Ref: #575