### PR TITLE
fix(streaming): classify mcp-returned tool errors as failures

### DIFF
--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -1555,6 +1555,51 @@ mod tests {
         );
     }
 
+    /// An MCP server's error reaches `handle_tool_result` with the prefix
+    /// `aura::mcp_response` applies, and must be reported as a failure rather
+    /// than a successful result carrying the error text.
+    #[test]
+    fn test_handle_tool_result_reports_mcp_error_as_failure() {
+        let config = StreamConfig::new(true, false, ToolResultMode::Aura, 0);
+        let ctx = TurnContext {
+            completion_id: "test-123".to_string(),
+            model_str: "gpt-4".to_string(),
+            created_timestamp: 1234567890,
+            max_tokens: None,
+            agent_context: AgentContext::single_agent(),
+            correlation: CorrelationContext::new("test-session", None),
+        };
+
+        let mut state = TurnState::new();
+        state
+            .tool_call_map
+            .insert("call_abc123".to_string(), ("list_files".to_string(), 0));
+
+        let tool_result = ToolResult {
+            id: "call_abc123".to_string(),
+            call_id: None,
+            result: "Tool returned an error: 401 Unauthorized".to_string(),
+        };
+
+        let output: String = handle_tool_result(&config, &ctx, &mut state, &tool_result)
+            .iter()
+            .filter_map(|b| std::str::from_utf8(b).ok())
+            .collect();
+
+        assert!(
+            output.contains(event_names::TOOL_COMPLETE),
+            "expected an aura.tool_complete event, got: {output}"
+        );
+        assert!(
+            output.contains(r#""success":false"#),
+            "MCP error must report success:false, got: {output}"
+        );
+        assert!(
+            output.contains("401 Unauthorized"),
+            "error message must survive into the event, got: {output}"
+        );
+    }
+
     #[test]
     fn test_is_context_overflow_error_openai_style() {
         assert!(is_context_overflow_error("context_length_exceeded"));

--- a/crates/aura-web-server/src/streaming/types.rs
+++ b/crates/aura-web-server/src/streaming/types.rs
@@ -260,9 +260,11 @@ pub use openai::{
     MessageRole, ToolCallChunk,
 };
 
-/// Error prefix patterns from Rig's tool error handling.
+/// Error prefix patterns from Rig's tool error handling. The first is also
+/// `MCP_ERROR_PREFIX` in `aura::mcp_response`; both must stay in step with
+/// `McpToolError` in rig's `tool/mod.rs`.
 const ERROR_PREFIXES: &[(&str, &str)] = &[
-    ("Tool returned error: ", "ToolError"),
+    ("Tool returned an error: ", "ToolError"),
     ("Tool execution failed: ", "ExecutionError"),
     ("Tool not found: ", "NotFoundError"),
     ("Invalid tool arguments: ", "ArgumentError"),
@@ -403,7 +405,7 @@ mod tests {
 
     #[test]
     fn test_detect_tool_error_failure() {
-        let status = detect_tool_error("Tool returned error: Connection refused");
+        let status = detect_tool_error("Tool returned an error: Connection refused");
         match status {
             ToolResultStatus::Error(err) => {
                 assert_eq!(err.error_type(), "ToolError");


### PR DESCRIPTION
ERROR_PREFIXES carried "Tool returned error: ", which nothing emits. Rig's McpToolError and aura::mcp_response both produce "Tool returned an error: ", so every MCP error fell through to Success and aura.tool_complete reported success: true with the error text in the result field.