### PR TITLE
feat(governance): add catalog sync command for MCP tool discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "ulid",
  "url",
  "uuid",
 ]
@@ -5164,6 +5165,16 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "web-time",
+]
 
 [[package]]
 name = "unicase"

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -139,6 +139,11 @@ impl DirectBackend {
         &self.config_path
     }
 
+    /// Access to the loaded configs.
+    pub fn configs(&self) -> &[aura_config::Config] {
+        &self.app_state.configs
+    }
+
     /// Return `true` if any loaded config enables client-side tools.
     ///
     /// A config qualifies when it is single-agent (orchestration disabled)

--- a/crates/aura-cli/src/cli.rs
+++ b/crates/aura-cli/src/cli.rs
@@ -21,6 +21,24 @@ pub enum Command {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<std::ffi::OsString>,
     },
+
+    /// Governance operations for MCP tool catalog management.
+    Governance {
+        #[command(subcommand)]
+        action: GovernanceAction,
+    },
+}
+
+/// Governance subcommand actions.
+#[derive(clap::Subcommand, Debug)]
+pub enum GovernanceAction {
+    /// Discover all MCP tools and POST a catalog snapshot to the configured
+    /// governance webhook. This command is standalone-mode only.
+    Sync {
+        /// Path to TOML agent config file (defaults to config.toml).
+        #[arg(long = "config")]
+        config_path: Option<String>,
+    },
 }
 
 /// Aura CLI — interactive chat completions REPL
@@ -141,7 +159,7 @@ pub fn check_standalone_flag() {
     let pass_through = std::env::args().any(|a| {
         matches!(
             a.as_str(),
-            "--help" | "-h" | "--version" | "-V" | "init" | "webserver"
+            "--help" | "-h" | "--version" | "-V" | "init" | "webserver" | "governance"
         )
     });
     if pass_through {

--- a/crates/aura-cli/src/governance.rs
+++ b/crates/aura-cli/src/governance.rs
@@ -1,0 +1,93 @@
+//! CLI governance subcommand handlers.
+
+use anyhow::{Context, Result, bail};
+use std::time::Duration;
+
+use crate::cli::GovernanceAction;
+
+/// Run a governance action.
+///
+/// Governance commands require standalone mode (they need to load TOML configs
+/// directly). HTTP mode is not supported.
+pub fn run(action: &GovernanceAction) -> Result<()> {
+    match action {
+        GovernanceAction::Sync { config_path } => run_sync(config_path.as_deref()),
+    }
+}
+
+/// Run the `governance sync` command.
+///
+/// Discovers MCP tools from all configs and POSTs a catalog snapshot to the
+/// governance webhook. Outputs a JSON DeliveryReport on success.
+fn run_sync(config_path: Option<&str>) -> Result<()> {
+    #[cfg(not(feature = "standalone-cli"))]
+    {
+        _ = config_path;
+        bail!(
+            "governance sync requires standalone mode (the standalone-cli feature)\n\n\
+             This build of aura cannot load agent configs directly. Rebuild with \
+             the standalone-cli feature (enabled by default) to use governance commands."
+        );
+    }
+
+    #[cfg(feature = "standalone-cli")]
+    {
+        // Load .env so {{ env.* }} references resolve
+        dotenvy::dotenv().ok();
+        if let Some(cfg) = config_path
+            && let Some(dir) = std::path::Path::new(cfg).parent()
+        {
+            dotenvy::from_path(dir.join(".env")).ok();
+        }
+
+        let config_path = config_path.unwrap_or("config.toml");
+        let configs = aura_config::load_config(config_path)
+            .with_context(|| format!("failed to load config from {config_path}"))?;
+
+        if configs.is_empty() {
+            bail!("no agent configs found in {config_path}");
+        }
+
+        // Find the first config with governance.catalog configured
+        let (gov_config, _target_config) = configs
+            .iter()
+            .find_map(|cfg| {
+                cfg.governance
+                    .as_ref()
+                    .and_then(|g| g.catalog.as_ref())
+                    .map(|gc| (gc, cfg))
+            })
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "governance catalog webhook not configured\n\n\
+                     Add a [governance.catalog] section to your config:\n\n\
+                     [governance.catalog]\n\
+                     url = \"https://example.com/catalog\"\n\
+                     timeout_secs = 30  # optional, defaults to 30"
+                )
+            })?;
+
+        // Build the catalog and deliver it
+        let rt = tokio::runtime::Runtime::new()?;
+        let result = rt.block_on(async {
+            // Build the catalog envelope from all configs
+            let timeout = Duration::from_secs(gov_config.timeout_secs);
+            let envelope = aura::governance::build_catalog_multi(&configs, None, timeout).await;
+
+            // Deliver to webhook
+            aura::governance::deliver(gov_config, &envelope, None).await
+        });
+
+        match result {
+            Ok(report) => {
+                // Output JSON report to stdout
+                let json = serde_json::to_string_pretty(&report)?;
+                println!("{json}");
+                Ok(())
+            }
+            Err(e) => {
+                bail!("governance sync failed: {e}");
+            }
+        }
+    }
+}

--- a/crates/aura-cli/src/lib.rs
+++ b/crates/aura-cli/src/lib.rs
@@ -4,6 +4,7 @@ pub mod backend;
 pub mod cli;
 pub mod config;
 pub mod event_names;
+pub mod governance;
 pub mod init;
 pub mod logging;
 pub mod oneshot;

--- a/crates/aura-cli/src/main.rs
+++ b/crates/aura-cli/src/main.rs
@@ -24,6 +24,9 @@ fn main() -> Result<()> {
         }
         #[cfg(feature = "webserver")]
         Some(aura_cli::cli::Command::Webserver { args }) => return aura_cli::webserver::run(args),
+        Some(aura_cli::cli::Command::Governance { action }) => {
+            return aura_cli::governance::run(action);
+        }
         None => {}
     }
 

--- a/crates/aura-cli/src/repl/governance.rs
+++ b/crates/aura-cli/src/repl/governance.rs
@@ -1,0 +1,129 @@
+//! `/governance` — MCP tool catalog sync command for governance webhooks.
+//!
+//! Standalone-mode only. HTTP mode returns a clear error message.
+
+use super::registry::CommandContext;
+use crate::theme::{AuraStyle, Themed};
+use crate::ui::prompt::redraw_input_frame;
+
+/// Handle the `/governance` slash command.
+pub(crate) fn handle_governance(ctx: &mut CommandContext, args: &str) {
+    match args.trim() {
+        "sync" => handle_sync(ctx),
+        "" => {
+            println!("Usage: /governance sync\n");
+            println!(
+                "The sync command discovers all MCP tools and sends a catalog \
+                 snapshot to the configured governance webhook."
+            );
+        }
+        other => {
+            println!(
+                "Unknown /governance subcommand: {other}\n\
+                 Run /governance sync to send the MCP tool catalog."
+            );
+        }
+    }
+    redraw_input_frame();
+}
+
+/// Handle the `/governance sync` command.
+fn handle_sync(ctx: &mut CommandContext) {
+    #[cfg(not(feature = "standalone-cli"))]
+    {
+        _ = ctx;
+        println!(
+            "{}\n\n\
+             Governance commands require standalone mode. This build of aura \
+             is HTTP-only and cannot load agent configs directly.\n\n\
+             Rebuild with the standalone-cli feature (enabled by default) or \
+             use the `aura governance sync` CLI command from a standalone build.",
+            "Error: standalone mode required".themed(AuraStyle::Error)
+        );
+        return;
+    }
+
+    #[cfg(feature = "standalone-cli")]
+    {
+        use crate::backend::Backend;
+        use std::time::Duration;
+
+        // Check if we're in standalone mode
+        let Backend::Direct(direct) = ctx.backend else {
+            println!(
+                "{}\n\n\
+                 Governance commands are only available in standalone mode.\n\
+                 Use the `aura governance sync` CLI command instead.",
+                "Error: HTTP mode not supported".themed(AuraStyle::Error)
+            );
+            return;
+        };
+
+        // Get the configs from the backend
+        let configs = direct.configs();
+
+        // Find the first config with governance.catalog configured
+        let gov_config = configs
+            .iter()
+            .find_map(|cfg| cfg.governance.as_ref().and_then(|g| g.catalog.as_ref()));
+
+        let Some(gov_config) = gov_config else {
+            println!(
+                "{}\n\n\
+                 No governance catalog webhook is configured. Add a \
+                 [governance.catalog] section to your config:\n\n\
+                 [governance.catalog]\n\
+                 url = \"https://example.com/catalog\"\n\
+                 timeout_secs = 30  # optional, defaults to 30",
+                "Error: webhook not configured".themed(AuraStyle::Error)
+            );
+            return;
+        };
+
+        println!("{}", "Discovering MCP tools...".themed(AuraStyle::Muted));
+
+        let result = ctx.rt.block_on(async {
+            let timeout = Duration::from_secs(gov_config.timeout_secs);
+            let envelope = aura::governance::build_catalog_multi(configs, None, timeout).await;
+
+            println!(
+                "{} {} agent(s), {} server(s)",
+                "Catalog built:".themed(AuraStyle::Muted),
+                envelope.agents.len(),
+                envelope
+                    .agents
+                    .iter()
+                    .map(|a| a.mcp_servers.len())
+                    .sum::<usize>()
+            );
+
+            println!("{}", "Sending to webhook...".themed(AuraStyle::Muted));
+
+            aura::governance::deliver(gov_config, &envelope, None).await
+        });
+
+        match result {
+            Ok(report) => {
+                println!(
+                    "\n{} (HTTP {})",
+                    "Catalog sync successful".themed(AuraStyle::Success),
+                    report.status_code
+                );
+                println!(
+                    "  Event ID: {}",
+                    report.event_id.as_str().themed(AuraStyle::Identifier)
+                );
+                println!("  Agents:   {}", report.agents_count);
+                println!("  Servers:  {}", report.servers_count);
+                println!("  Tools:    {}", report.tools_count);
+            }
+            Err(e) => {
+                println!(
+                    "\n{}\n{}",
+                    "Catalog sync failed".themed(AuraStyle::Error),
+                    e.to_string().themed(AuraStyle::Muted)
+                );
+            }
+        }
+    }
+}

--- a/crates/aura-cli/src/repl/mod.rs
+++ b/crates/aura-cli/src/repl/mod.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod conversations;
+pub mod governance;
 pub mod history;
 pub mod input_reader;
 pub mod r#loop;

--- a/crates/aura-cli/src/repl/registry.rs
+++ b/crates/aura-cli/src/repl/registry.rs
@@ -193,6 +193,14 @@ pub(crate) const COMMANDS: &[Command] = &[
         validate: None,
         mid_stream: MidStream::Defer,
     },
+    Command {
+        name: "/governance",
+        description: "Sync MCP tool catalog to governance webhook",
+        usage_hint: Some("sync"),
+        handler: cmd_governance,
+        validate: Some(validate_governance),
+        mid_stream: MidStream::Defer,
+    },
 ];
 
 /// Look up a command by its exact, fully-resolved name.
@@ -311,6 +319,21 @@ fn cmd_mcp(ctx: &mut CommandContext, args: &str) -> CommandOutcome {
 fn cmd_telemetry(ctx: &mut CommandContext, args: &str) -> CommandOutcome {
     commands::handle_telemetry(args, ctx.telemetry);
     CommandOutcome::Handled
+}
+
+fn cmd_governance(ctx: &mut CommandContext, args: &str) -> CommandOutcome {
+    super::governance::handle_governance(ctx, args);
+    CommandOutcome::Handled
+}
+
+fn validate_governance(input: &str) -> bool {
+    let args = input
+        .trim()
+        .strip_prefix("/governance")
+        .unwrap_or("")
+        .trim();
+    // Require the "sync" sub-verb
+    args == "sync"
 }
 
 /// Block Enter while a command's argument is still ambiguous against the live

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -28,6 +28,9 @@ pub struct Config {
     /// it; presence of the table is the enable bit.
     #[serde(default)]
     pub hitl: Option<HitlConfig>,
+    /// Governance subsystem configuration.
+    #[serde(default)]
+    pub governance: Option<GovernanceConfig>,
 }
 
 /// Reasoning effort level for GPT-5 models
@@ -1541,4 +1544,50 @@ impl<'de> Deserialize<'de> for GlobPattern {
         let source = String::deserialize(deserializer)?;
         Self::new(source).map_err(serde::de::Error::custom)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Governance configuration
+// ---------------------------------------------------------------------------
+//
+// The `[governance]` table configures catalog-sync webhooks for MCP tool
+// discovery snapshots. These are declarative DTOs — the runtime domain
+// lives in `aura::governance`.
+
+/// `[governance]` config table.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GovernanceConfig {
+    /// Catalog-sync webhook configuration.
+    #[serde(default)]
+    pub catalog: Option<CatalogWebhookConfig>,
+}
+
+/// `[governance.catalog]` webhook configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogWebhookConfig {
+    /// The webhook URL to POST catalog snapshots to.
+    pub url: WebhookUrl,
+    /// Request timeout in seconds (default 30s).
+    #[serde(default = "default_catalog_timeout_secs")]
+    pub timeout_secs: u64,
+    /// Static headers to include with every request.
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+    /// Outbound header name → inbound request header name mapping.
+    #[serde(default)]
+    pub headers_from_request: HashMap<String, String>,
+    /// HMAC signing configuration.
+    #[serde(default)]
+    pub hmac: Option<CatalogHmacConfig>,
+}
+
+/// `[governance.catalog.hmac]` HMAC signing configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogHmacConfig {
+    /// The primary HMAC secret for signing requests.
+    pub secret: String,
+}
+
+fn default_catalog_timeout_secs() -> u64 {
+    30
 }

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -756,6 +756,7 @@ mod tests {
             tools: None,
             orchestration: None,
             hitl: None,
+            governance: None,
             agent: aura_config::AgentConfig {
                 name: name.to_owned(),
                 alias: alias.map(str::to_owned),

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1366,6 +1366,7 @@ mod tests {
             tools: None,
             orchestration: None,
             hitl: None,
+            governance: None,
             agent: aura_config::AgentConfig {
                 name: "test-agent".to_string(),
                 ..aura_config::AgentConfig::default()

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -67,6 +67,9 @@ regex = "1"
 async-stream = "0.3"
 strum = { workspace = true }
 
+# Event ID generation for governance catalog sync
+ulid = "1"
+
 # Tokenization for scratchpad context budget
 tiktoken-rs = "0.9.1"
 # Exact local Gemini tokenizer (embeds the Gemma 3 SentencePiece model)

--- a/crates/aura/src/governance/client.rs
+++ b/crates/aura/src/governance/client.rs
@@ -1,0 +1,240 @@
+//! Governance catalog webhook delivery.
+//!
+//! Handles POSTing the catalog envelope to the configured webhook, including
+//! optional HMAC signing. Follows the same patterns as HITL webhook delivery.
+
+use aura_config::CatalogWebhookConfig;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::Duration;
+
+use super::envelope::CatalogEnvelope;
+use crate::hitl::{PrimarySecret, SigningContext, Tolerance, WebhookHmac};
+
+/// Maximum time to wait for a TCP connection before failing.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Errors that can occur during catalog delivery.
+#[derive(Debug, thiserror::Error)]
+pub enum DeliveryError {
+    #[error("governance webhook transport error: {0}")]
+    Transport(String),
+    #[error("governance webhook returned status {status}: {body}")]
+    BadStatus { status: u16, body: String },
+    #[error("governance webhook HMAC signing failed: {0}")]
+    Signing(String),
+    #[error("governance webhook HMAC misconfigured: {0}")]
+    Misconfigured(String),
+    #[error("governance catalog webhook not configured")]
+    NotConfigured,
+}
+
+/// Result of a successful catalog delivery.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DeliveryReport {
+    /// The event ID that was delivered.
+    pub event_id: String,
+    /// HTTP status code from the webhook.
+    pub status_code: u16,
+    /// Response body from the webhook (truncated if large).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_body: Option<String>,
+    /// Number of agents in the catalog.
+    pub agents_count: usize,
+    /// Total number of MCP servers across all agents.
+    pub servers_count: usize,
+    /// Total number of tools across all connected servers.
+    pub tools_count: usize,
+}
+
+/// Deliver a catalog envelope to the configured governance webhook.
+///
+/// If HMAC signing is configured, the request is signed with the context
+/// `catalog-sync:{event_id}`. The function returns a `DeliveryReport` on
+/// success or a `DeliveryError` on failure.
+pub async fn deliver(
+    config: &CatalogWebhookConfig,
+    envelope: &CatalogEnvelope,
+    req_headers: Option<&HashMap<String, String>>,
+) -> Result<DeliveryReport, DeliveryError> {
+    let client = build_client();
+    let headers = resolve_headers(&config.headers, &config.headers_from_request, req_headers);
+    let timeout = Duration::from_secs(config.timeout_secs);
+
+    // Build HMAC signer if configured
+    let hmac = build_hmac(config)?;
+
+    // Serialize the envelope
+    let body = serde_json::to_vec(envelope).expect("catalog envelope serializes");
+
+    // Build the request
+    let mut request = client
+        .post(config.url.as_str())
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .timeout(timeout);
+
+    // Apply operator headers
+    for (name, value) in headers.iter() {
+        request = request.header(name.clone(), value.clone());
+    }
+
+    // Sign if configured
+    if let Some(hmac) = &hmac {
+        let context = SigningContext::new(&format!("catalog-sync:{}", envelope.event_id))
+            .expect("event_id renders as dot-free ASCII");
+        let signed = hmac
+            .sign(&context, &body)
+            .map_err(|e| DeliveryError::Signing(e.to_string()))?;
+        for (name, value) in signed.into_pairs() {
+            request = request.header(name, value);
+        }
+    }
+
+    // Send the request
+    let response = request
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| DeliveryError::Transport(e.to_string()))?;
+
+    let status = response.status();
+    let status_code = status.as_u16();
+
+    // Read response body
+    let response_body = response
+        .text()
+        .await
+        .ok()
+        .map(|s| truncate_response(&s, 1024));
+
+    if !status.is_success() {
+        return Err(DeliveryError::BadStatus {
+            status: status_code,
+            body: response_body.unwrap_or_default(),
+        });
+    }
+
+    // Calculate stats
+    let agents_count = envelope.agents.len();
+    let servers_count: usize = envelope.agents.iter().map(|a| a.mcp_servers.len()).sum();
+    let tools_count: usize = envelope
+        .agents
+        .iter()
+        .flat_map(|a| &a.mcp_servers)
+        .filter_map(|s| s.tools.as_ref())
+        .map(|t| t.len())
+        .sum();
+
+    Ok(DeliveryReport {
+        event_id: envelope.event_id.clone(),
+        status_code,
+        response_body,
+        agents_count,
+        servers_count,
+        tools_count,
+    })
+}
+
+/// Build the reqwest client for webhook calls.
+fn build_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .build()
+        .expect("reqwest client builder only fails on TLS backend init")
+}
+
+/// Resolve operator-configured headers into a validated `HeaderMap`.
+fn resolve_headers(
+    static_headers: &HashMap<String, String>,
+    headers_from_request: &HashMap<String, String>,
+    req_headers: Option<&HashMap<String, String>>,
+) -> HeaderMap {
+    let empty = HashMap::new();
+    let req_headers = req_headers.unwrap_or(&empty);
+
+    let mut resolved: HashMap<String, String> = static_headers
+        .iter()
+        .map(|(k, v)| (k.to_lowercase(), v.clone()))
+        .collect();
+
+    let resolved_count = crate::rig_builder::apply_request_header_mappings(
+        &mut resolved,
+        headers_from_request,
+        req_headers,
+    );
+    if resolved_count > 0 {
+        tracing::info!(
+            "Governance catalog webhook: resolved {resolved_count} header(s) from request"
+        );
+    }
+
+    let mut header_map = HeaderMap::new();
+    for (key, value) in &resolved {
+        match (
+            HeaderName::from_bytes(key.as_bytes()),
+            HeaderValue::from_str(value),
+        ) {
+            (Ok(name), Ok(val)) => {
+                header_map.insert(name, val);
+            }
+            _ => {
+                tracing::warn!(
+                    "Skipping invalid governance webhook header '{}' (failed to convert)",
+                    key
+                );
+            }
+        }
+    }
+    header_map
+}
+
+/// Build the HMAC signer from config if configured.
+fn build_hmac(config: &CatalogWebhookConfig) -> Result<Option<WebhookHmac>, DeliveryError> {
+    let Some(hmac_config) = &config.hmac else {
+        return Ok(None);
+    };
+
+    // Validate plaintext URL with HMAC
+    if config.url.as_str().starts_with("http://") {
+        return Err(DeliveryError::Misconfigured(format!(
+            "governance webhook url {} uses plaintext http:// while an HMAC secret is configured; \
+             use https://",
+            config.url.as_str()
+        )));
+    }
+
+    // Build the HMAC configuration
+    let primary = PrimarySecret::new(hmac_config.secret.as_bytes());
+    let hmac = WebhookHmac::new(primary, None, Tolerance::default())
+        .map_err(|e| DeliveryError::Misconfigured(e.to_string()))?;
+
+    Ok(Some(hmac))
+}
+
+/// Truncate a response body for logging.
+fn truncate_response(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}... (truncated)", &s[..max_len])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_response_leaves_short_strings() {
+        assert_eq!(truncate_response("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_response_truncates_long_strings() {
+        let long = "a".repeat(2000);
+        let result = truncate_response(&long, 1024);
+        assert!(result.ends_with("... (truncated)"));
+        assert!(result.len() < 1100);
+    }
+}

--- a/crates/aura/src/governance/envelope.rs
+++ b/crates/aura/src/governance/envelope.rs
@@ -1,0 +1,536 @@
+//! Governance catalog envelope types.
+//!
+//! These types form the JSON payload POSTed to the governance webhook.
+//! They are intentionally distinct from the `aura-events` types used by
+//! `GET /aura/info`: the governance wire format prioritizes a flat,
+//! explicit structure suitable for ingestion by external governance systems.
+
+use aura_config::{Config, McpServerConfig};
+use aura_events::{McpToolAnnotations, McpToolOverview};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Top-level envelope for the catalog sync webhook payload.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct CatalogEnvelope {
+    /// Event type identifier.
+    pub event: String,
+    /// Schema version.
+    pub version: String,
+    /// Unique event identifier (format: `cat_<ULID>`).
+    pub event_id: String,
+    /// ISO 8601 timestamp when the event was emitted.
+    pub emitted_at: String,
+    /// AURA process version.
+    pub aura_version: String,
+    /// Catalog entries for each agent.
+    pub agents: Vec<AgentCatalogEntry>,
+}
+
+impl CatalogEnvelope {
+    /// Generate a new unique event ID.
+    pub fn generate_event_id() -> String {
+        format!("cat_{}", ulid::Ulid::new())
+    }
+}
+
+/// Catalog entry for a single agent.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct AgentCatalogEntry {
+    /// Agent identifier (from config).
+    pub id: String,
+    /// Agent name (from config).
+    pub name: String,
+    /// Agent description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// LLM model name.
+    pub model: String,
+    /// Flat array of MCP server reports, sorted by name.
+    pub mcp_servers: Vec<McpServerReport>,
+}
+
+/// Report for a single MCP server with connection status.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct McpServerReport {
+    /// Server name (from config).
+    pub name: String,
+    /// Transport type: `"http_streamable"`, `"sse"`, or `"stdio"`.
+    pub transport: String,
+    /// URL for http_streamable/sse transports (origin only, no credentials).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Command basename for stdio transport.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    /// Server description from config.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Connection status.
+    pub status: ServerStatus,
+    /// Failure message (present iff `status == ServerStatus::Failed`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_message: Option<String>,
+    /// Discovered tools (present iff `status == ServerStatus::Connected`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<McpToolReport>>,
+}
+
+impl McpServerReport {
+    /// Create a report for a connected server.
+    pub fn connected(
+        name: String,
+        transport: String,
+        url: Option<String>,
+        command: Option<String>,
+        description: Option<String>,
+        tools: Vec<McpToolReport>,
+    ) -> Self {
+        Self {
+            name,
+            transport,
+            url,
+            command,
+            description,
+            status: ServerStatus::Connected,
+            failure_message: None,
+            tools: Some(tools),
+        }
+    }
+
+    /// Create a report for a failed server.
+    pub fn failed(
+        name: String,
+        transport: String,
+        url: Option<String>,
+        command: Option<String>,
+        description: Option<String>,
+        failure_message: String,
+    ) -> Self {
+        Self {
+            name,
+            transport,
+            url,
+            command,
+            description,
+            status: ServerStatus::Failed,
+            failure_message: Some(failure_message),
+            tools: None,
+        }
+    }
+
+    /// Create a report for a server that was not attempted.
+    pub fn not_attempted(
+        name: String,
+        transport: String,
+        url: Option<String>,
+        command: Option<String>,
+        description: Option<String>,
+    ) -> Self {
+        Self {
+            name,
+            transport,
+            url,
+            command,
+            description,
+            status: ServerStatus::NotAttempted,
+            failure_message: None,
+            tools: None,
+        }
+    }
+}
+
+/// Connection status for an MCP server.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServerStatus {
+    Connected,
+    Failed,
+    NotAttempted,
+}
+
+impl From<&crate::mcp::ConnectionStatus> for ServerStatus {
+    fn from(status: &crate::mcp::ConnectionStatus) -> Self {
+        match status {
+            crate::mcp::ConnectionStatus::Connected => Self::Connected,
+            crate::mcp::ConnectionStatus::Failed(_) => Self::Failed,
+            crate::mcp::ConnectionStatus::NotAttempted => Self::NotAttempted,
+        }
+    }
+}
+
+/// Tool report mirroring `McpToolOverview` but using snake_case field names.
+///
+/// The governance format uses snake_case throughout for consistency; the
+/// `McpToolOverview` type uses camelCase to match the MCP spec.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct McpToolReport {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_schema: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<McpToolAnnotations>,
+}
+
+impl From<McpToolOverview> for McpToolReport {
+    fn from(tool: McpToolOverview) -> Self {
+        Self {
+            name: tool.name,
+            title: tool.title,
+            description: tool.description,
+            input_schema: tool.input_schema,
+            output_schema: tool.output_schema,
+            annotations: tool.annotations,
+        }
+    }
+}
+
+impl From<&rmcp::model::Tool> for McpToolReport {
+    fn from(tool: &rmcp::model::Tool) -> Self {
+        Self {
+            name: tool.name.to_string(),
+            title: tool.title.clone(),
+            description: tool.description.as_ref().map(|d| d.to_string()),
+            input_schema: Some(serde_json::Value::Object((*tool.input_schema).clone())),
+            output_schema: tool
+                .output_schema
+                .as_ref()
+                .map(|schema| serde_json::Value::Object((**schema).clone())),
+            annotations: tool
+                .annotations
+                .as_ref()
+                .map(|annotations| McpToolAnnotations {
+                    title: annotations.title.clone(),
+                    read_only_hint: annotations.read_only_hint,
+                    destructive_hint: annotations.destructive_hint,
+                    idempotent_hint: annotations.idempotent_hint,
+                    open_world_hint: annotations.open_world_hint,
+                }),
+        }
+    }
+}
+
+/// Build a catalog envelope for the given config by discovering MCP tools.
+///
+/// This function connects to all configured MCP servers, discovers their
+/// tools, and builds a complete catalog snapshot. Servers that fail to
+/// connect are included with their failure status and message.
+pub async fn build_catalog(
+    config: &Config,
+    req_headers: Option<&HashMap<String, String>>,
+    timeout: Duration,
+) -> CatalogEnvelope {
+    build_catalog_multi(std::slice::from_ref(config), req_headers, timeout).await
+}
+
+/// Build a catalog envelope for multiple configs by discovering MCP tools.
+///
+/// Each config becomes an agent entry in the catalog. Servers that fail to
+/// connect are included with their failure status and message.
+pub async fn build_catalog_multi(
+    configs: &[Config],
+    req_headers: Option<&HashMap<String, String>>,
+    timeout: Duration,
+) -> CatalogEnvelope {
+    let mut agents = Vec::with_capacity(configs.len());
+
+    for config in configs {
+        let mut mcp_config = config.mcp.clone();
+        if let Some(mcp) = mcp_config.as_mut() {
+            crate::rig_builder::resolve_mcp_headers_in(mcp, req_headers);
+        }
+
+        let mcp_servers = discover_mcp_servers(&mcp_config, timeout).await;
+
+        agents.push(AgentCatalogEntry {
+            id: config.agent_id().to_owned(),
+            name: config.agent.name.clone(),
+            description: config.agent.description.clone(),
+            model: config.agent.llm.model_info().1.to_owned(),
+            mcp_servers,
+        });
+    }
+
+    CatalogEnvelope {
+        event: "mcp_catalog".to_string(),
+        version: "1".to_string(),
+        event_id: CatalogEnvelope::generate_event_id(),
+        emitted_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        aura_version: env!("CARGO_PKG_VERSION").to_string(),
+        agents,
+    }
+}
+
+/// Discover MCP servers and their tools, returning a flat list sorted by name.
+async fn discover_mcp_servers(
+    mcp_config: &Option<aura_config::McpConfig>,
+    timeout: Duration,
+) -> Vec<McpServerReport> {
+    let Some(mcp_config) = mcp_config else {
+        return Vec::new();
+    };
+
+    let manager = match tokio::time::timeout(
+        timeout,
+        crate::mcp::McpManager::initialize_from_config(mcp_config),
+    )
+    .await
+    {
+        Ok(Ok(manager)) => manager,
+        Ok(Err(e)) => {
+            tracing::warn!("MCP tool discovery for governance catalog failed: {e}");
+            // Return servers from config with NotAttempted status
+            return servers_from_config_only(mcp_config);
+        }
+        Err(_) => {
+            tracing::warn!(
+                "MCP tool discovery for governance catalog timed out after {}s",
+                timeout.as_secs()
+            );
+            // Return servers from config with NotAttempted status
+            return servers_from_config_only(mcp_config);
+        }
+    };
+
+    // Build server reports from the manager's discovery results
+    let mut servers: Vec<McpServerReport> = manager
+        .server_info
+        .iter()
+        .map(|(name, info)| {
+            let server_config = mcp_config.servers.get(name);
+            let (url, command) = server_config.map(extract_endpoint).unwrap_or((None, None));
+
+            match &info.status {
+                crate::mcp::ConnectionStatus::Connected => {
+                    // Collect tools for this server
+                    let tools = manager
+                        .streamable_tools
+                        .get(name)
+                        .or_else(|| manager.sse_tools.get(name))
+                        .or_else(|| manager.stdio_tools.get(name))
+                        .map(|tools| tools.iter().map(McpToolReport::from).collect())
+                        .unwrap_or_default();
+
+                    McpServerReport::connected(
+                        name.clone(),
+                        info.transport.clone(),
+                        url,
+                        command,
+                        info.description.clone(),
+                        tools,
+                    )
+                }
+                crate::mcp::ConnectionStatus::Failed(reason) => McpServerReport::failed(
+                    name.clone(),
+                    info.transport.clone(),
+                    url,
+                    command,
+                    info.description.clone(),
+                    reason.clone(),
+                ),
+                crate::mcp::ConnectionStatus::NotAttempted => McpServerReport::not_attempted(
+                    name.clone(),
+                    info.transport.clone(),
+                    url,
+                    command,
+                    info.description.clone(),
+                ),
+            }
+        })
+        .collect();
+
+    // Sort by name for deterministic output
+    servers.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // Close all MCP connections
+    manager
+        .cancel_and_close_all("governance-catalog", "catalog sync completed")
+        .await;
+
+    servers
+}
+
+/// Build server reports from config only (when discovery fails entirely).
+fn servers_from_config_only(mcp_config: &aura_config::McpConfig) -> Vec<McpServerReport> {
+    let mut servers: Vec<McpServerReport> = mcp_config
+        .servers
+        .iter()
+        .map(|(name, config)| {
+            let transport = transport_label(config).to_string();
+            let (url, command) = extract_endpoint(config);
+            let description = extract_description(config);
+
+            McpServerReport::not_attempted(name.clone(), transport, url, command, description)
+        })
+        .collect();
+
+    servers.sort_by(|a, b| a.name.cmp(&b.name));
+    servers
+}
+
+/// Extract the transport label from an MCP server config.
+fn transport_label(config: &McpServerConfig) -> &'static str {
+    match config {
+        McpServerConfig::HttpStreamable { .. } => "http_streamable",
+        McpServerConfig::Sse { .. } => "sse",
+        McpServerConfig::Stdio { .. } => "stdio",
+    }
+}
+
+/// Extract the endpoint (url or command) from an MCP server config.
+/// URLs are sanitized to origin-only (no path, query, or credentials).
+/// Commands are sanitized to basename only.
+fn extract_endpoint(config: &McpServerConfig) -> (Option<String>, Option<String>) {
+    match config {
+        McpServerConfig::HttpStreamable { url, .. } | McpServerConfig::Sse { url, .. } => {
+            (Some(sanitize_url(url)), None)
+        }
+        McpServerConfig::Stdio { cmd, .. } => {
+            // cmd is a Vec<String> where the first element is the command
+            let command = cmd.first().map(|c| command_basename(c));
+            (None, command)
+        }
+    }
+}
+
+/// Extract the description from an MCP server config.
+fn extract_description(config: &McpServerConfig) -> Option<String> {
+    match config {
+        McpServerConfig::HttpStreamable { description, .. }
+        | McpServerConfig::Sse { description, .. }
+        | McpServerConfig::Stdio { description, .. } => description.clone(),
+    }
+}
+
+/// Sanitize a URL to origin-only (scheme + host + port).
+fn sanitize_url(url: &str) -> String {
+    url::Url::parse(url)
+        .map(|u| u.origin().unicode_serialization())
+        .unwrap_or_else(|_| url.to_string())
+}
+
+/// Extract the basename from a command path.
+fn command_basename(command: &str) -> String {
+    std::path::Path::new(command)
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| command.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_status_serializes_to_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ServerStatus::Connected).unwrap(),
+            r#""connected""#
+        );
+        assert_eq!(
+            serde_json::to_string(&ServerStatus::Failed).unwrap(),
+            r#""failed""#
+        );
+        assert_eq!(
+            serde_json::to_string(&ServerStatus::NotAttempted).unwrap(),
+            r#""not_attempted""#
+        );
+    }
+
+    #[test]
+    fn connected_server_has_tools_no_failure_message() {
+        let report = McpServerReport::connected(
+            "test".to_string(),
+            "http_streamable".to_string(),
+            Some("https://example.com".to_string()),
+            None,
+            None,
+            vec![],
+        );
+
+        assert_eq!(report.status, ServerStatus::Connected);
+        assert!(report.failure_message.is_none());
+        assert!(report.tools.is_some());
+
+        // Verify JSON output has no failure_message field
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(!json.contains("failure_message"));
+    }
+
+    #[test]
+    fn failed_server_has_failure_message_no_tools() {
+        let report = McpServerReport::failed(
+            "test".to_string(),
+            "sse".to_string(),
+            Some("https://example.com".to_string()),
+            None,
+            None,
+            "connection refused".to_string(),
+        );
+
+        assert_eq!(report.status, ServerStatus::Failed);
+        assert_eq!(
+            report.failure_message,
+            Some("connection refused".to_string())
+        );
+        assert!(report.tools.is_none());
+
+        // Verify JSON output has failure_message but no tools
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(json.contains("failure_message"));
+        assert!(!json.contains("\"tools\""));
+    }
+
+    #[test]
+    fn not_attempted_server_has_neither_failure_nor_tools() {
+        let report = McpServerReport::not_attempted(
+            "test".to_string(),
+            "stdio".to_string(),
+            None,
+            Some("some-cmd".to_string()),
+            None,
+        );
+
+        assert_eq!(report.status, ServerStatus::NotAttempted);
+        assert!(report.failure_message.is_none());
+        assert!(report.tools.is_none());
+
+        // Verify JSON output has neither failure_message nor tools
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(!json.contains("failure_message"));
+        assert!(!json.contains("\"tools\""));
+    }
+
+    #[test]
+    fn event_id_has_correct_prefix() {
+        let id = CatalogEnvelope::generate_event_id();
+        assert!(id.starts_with("cat_"));
+        assert!(id.len() > 4); // cat_ + ULID
+    }
+
+    #[test]
+    fn sanitize_url_extracts_origin() {
+        assert_eq!(
+            sanitize_url("https://user:pass@example.com:8080/path?query=1"),
+            "https://example.com:8080"
+        );
+        assert_eq!(
+            sanitize_url("http://localhost:3000/mcp"),
+            "http://localhost:3000"
+        );
+    }
+
+    #[test]
+    fn command_basename_extracts_filename() {
+        assert_eq!(command_basename("/usr/local/bin/some-mcp"), "some-mcp");
+        assert_eq!(command_basename("./node_modules/.bin/mcp"), "mcp");
+        assert_eq!(command_basename("uvx"), "uvx");
+    }
+}

--- a/crates/aura/src/governance/mod.rs
+++ b/crates/aura/src/governance/mod.rs
@@ -1,0 +1,40 @@
+//! Governance subsystem: catalog-sync webhooks for MCP tool discovery.
+//!
+//! The `/governance sync` command (CLI/REPL) discovers all configured MCP
+//! servers, collects their tool catalogs, and POSTs a single bundled snapshot
+//! to a configured webhook. This is standalone-mode only — no HTTP endpoint.
+//!
+//! ## Wire format
+//!
+//! The envelope is a JSON object with:
+//! - `event`: always `"mcp_catalog"`
+//! - `version`: schema version (currently `"1"`)
+//! - `event_id`: unique identifier (format: `cat_<ULID>`)
+//! - `emitted_at`: ISO 8601 timestamp
+//! - `aura_version`: the AURA process version
+//! - `agents`: array of agent catalog entries
+//!
+//! Each agent entry contains:
+//! - `id`: agent identifier (from config)
+//! - `name`: agent name (from config)
+//! - `description`: optional agent description
+//! - `model`: the LLM model name
+//! - `mcp_servers`: flat array of MCP server reports, sorted by name
+//!
+//! Each MCP server report contains:
+//! - `name`: server name
+//! - `transport`: `"http_streamable"`, `"sse"`, or `"stdio"`
+//! - `url` or `command`: transport-specific endpoint
+//! - `description`: optional server description
+//! - `status`: `"connected"`, `"failed"`, or `"not_attempted"`
+//! - `failure_message`: present iff `status == "failed"`
+//! - `tools`: present iff `status == "connected"`
+
+mod client;
+mod envelope;
+
+pub use client::{DeliveryError, DeliveryReport, deliver};
+pub use envelope::{
+    AgentCatalogEntry, CatalogEnvelope, McpServerReport, McpToolReport, ServerStatus,
+    build_catalog, build_catalog_multi,
+};

--- a/crates/aura/src/hitl/mod.rs
+++ b/crates/aura/src/hitl/mod.rs
@@ -49,7 +49,7 @@ pub use route::{
     validate_webhook_signing_config,
 };
 pub use signing::{
-    SIGNATURE_HEADER, SignedHeaders, SigningContext, TIMESTAMP_HEADER, VerificationError,
-    VerifiedBody, WebhookHmac, authorize_ingress,
+    PrimarySecret, SIGNATURE_HEADER, SignedHeaders, SigningContext, TIMESTAMP_HEADER, Tolerance,
+    VerificationError, VerifiedBody, WebhookHmac, authorize_ingress,
 };
 pub use tool::{RequestApprovalArgs, RequestApprovalTool};

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -14,6 +14,7 @@ pub mod env_flags;
 pub mod error;
 pub mod fallback_tool_parser;
 pub mod fallback_tool_stream;
+pub mod governance;
 pub mod hitl;
 pub mod inactivity;
 pub mod logging;
@@ -56,9 +57,9 @@ pub use config::{AgentRuntimeConfig, SessionId, ToolContextFactory};
 // Pure config types are owned by `aura-config` and re-exported here for
 // ergonomic consumption (`aura::LlmConfig`, etc.).
 pub use aura_config::{
-    AgentConfig, AgentSettings, EmbeddingConfig, LlmConfig, McpConfig, McpServerConfig,
-    ReasoningEffort, SkillConfig, TodoToolsConfig, ToolsConfig, VectorStoreConfig, VectorStoreType,
-    glob_match, lenient_int,
+    AgentConfig, AgentSettings, CatalogHmacConfig, CatalogWebhookConfig, EmbeddingConfig,
+    GovernanceConfig, LlmConfig, McpConfig, McpServerConfig, ReasoningEffort, SkillConfig,
+    TodoToolsConfig, ToolsConfig, VectorStoreConfig, VectorStoreType, glob_match, lenient_int,
 };
 pub use error::{BuilderError, BuilderResult};
 pub use orchestration::tools::{


### PR DESCRIPTION
## Summary

Implements `/governance sync` (REPL) and `aura governance sync` (CLI) to discover all MCP tools and POST a catalog snapshot to a configured governance webhook. Standalone-mode only — no HTTP endpoint.

Fixes #599

## Changes

### Configuration (`aura-config`)
- Add `[governance.catalog]` config section with:
  - `url` - webhook endpoint
  - `timeout_secs` - request timeout (default 30s)
  - `headers` - static headers with env var interpolation
  - `headers_from_request` - header forwarding mappings
  - `hmac` - optional HMAC signing config (reuses HITL pattern)

### Core Library (`aura`)
- Add `aura::governance` module:
  - `envelope.rs` - `CatalogEnvelope`, `AgentEntry`, `McpServerEntry`, `ToolEntry` types
  - `client.rs` - `CatalogClient` for webhook delivery with HMAC signing
  - `mod.rs` - `build_catalog_multi()` to build envelope from multiple configs

### CLI (`aura-cli`)
- Add `aura governance sync` subcommand (standalone mode only)
- Add `/governance sync` REPL slash command
- HTTP mode returns explicit "governance commands are only supported in standalone mode" error

## Wire Format

```json
{
  "event": "mcp_catalog",
  "version": "1",
  "event_id": "cat_01HXXX...",
  "emitted_at": "2026-08-26T14:15:22Z",
  "aura_version": "0.2.7",
  "agents": [{
    "id": "prod-sre",
    "name": "SRE Agent",
    "model": "gpt-4o",
    "mcp_servers": [{
      "name": "kubernetes",
      "transport": "http_streamable",
      "url": "https://example.com",
      "status": "connected",
      "tools": [{ "name": "list_pods", ... }]
    }]
  }]
}
```

## Testing

```sh
cargo +nightly fmt --check        # ✓
cargo clippy --all-targets --all-features -- --deny warnings  # ✓
cargo nextest run --all-targets   # 1991 tests passed
```