### PR TITLE
feat(governance): add core config and catalog envelope types 

### DIFF
--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -28,6 +28,9 @@ pub struct Config {
     /// it; presence of the table is the enable bit.
     #[serde(default)]
     pub hitl: Option<HitlConfig>,
+    /// Governance integration for catalog sync and policy endpoints.
+    #[serde(default)]
+    pub governance: Option<GovernanceConfig>,
 }
 
 /// Reasoning effort level for GPT-5 models
@@ -1588,4 +1591,45 @@ impl<'de> Deserialize<'de> for GlobPattern {
         let source = String::deserialize(deserializer)?;
         Self::new(source).map_err(serde::de::Error::custom)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Governance configuration
+// ---------------------------------------------------------------------------
+
+/// `[governance]` config table for catalog sync and policy integration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GovernanceConfig {
+    /// Catalog webhook configuration for MCP tool discovery sync.
+    pub catalog: Option<CatalogWebhookConfig>,
+}
+
+/// `[governance.catalog]` webhook configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogWebhookConfig {
+    /// Webhook endpoint URL (must start with http:// or https://).
+    pub url: WebhookUrl,
+    /// Request timeout in seconds (default: 30).
+    #[serde(default = "default_catalog_timeout_secs")]
+    pub timeout_secs: u64,
+    /// Static headers with environment variable interpolation.
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+    /// Outbound header name → inbound request header name mapping.
+    #[serde(default)]
+    pub headers_from_request: HashMap<String, String>,
+    /// Optional HMAC signing configuration.
+    #[serde(default)]
+    pub hmac: Option<CatalogHmacConfig>,
+}
+
+fn default_catalog_timeout_secs() -> u64 {
+    30
+}
+
+/// `[governance.catalog.hmac]` HMAC signing configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogHmacConfig {
+    /// Primary HMAC secret (minimum 32 bytes). Supports env var interpolation.
+    pub secret: String,
 }

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -756,6 +756,7 @@ mod tests {
             tools: None,
             orchestration: None,
             hitl: None,
+            governance: None,
             agent: aura_config::AgentConfig {
                 name: name.to_owned(),
                 alias: alias.map(str::to_owned),

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1366,6 +1366,7 @@ mod tests {
             tools: None,
             orchestration: None,
             hitl: None,
+            governance: None,
             agent: aura_config::AgentConfig {
                 name: "test-agent".to_string(),
                 ..aura_config::AgentConfig::default()

--- a/crates/aura/src/governance/client.rs
+++ b/crates/aura/src/governance/client.rs
@@ -1,0 +1,117 @@
+//! HTTP client for sending catalog snapshots to the governance webhook.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use aura_config::CatalogWebhookConfig;
+use reqwest::header::{CONTENT_TYPE, HeaderMap};
+use tracing::info;
+
+use super::envelope::CatalogEnvelope;
+use crate::hitl::{SigningContext, WebhookHmac};
+
+/// Maximum time to wait for a TCP connection before failing.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Errors that can occur while sending a catalog to the governance webhook.
+#[derive(Debug, thiserror::Error)]
+pub enum CatalogError {
+    #[error("catalog webhook transport error: {0}")]
+    Transport(String),
+    #[error("catalog webhook returned status {status}: {body}")]
+    BadStatus { status: u16, body: String },
+    #[error("catalog webhook HMAC signing failed: {0}")]
+    Signing(String),
+    #[error("catalog serialization failed: {0}")]
+    Serialization(String),
+}
+
+/// HTTP client for the governance catalog webhook.
+pub struct CatalogClient {
+    client: reqwest::Client,
+    url: String,
+    timeout: Duration,
+    headers: HeaderMap,
+    hmac: Option<WebhookHmac>,
+}
+
+impl CatalogClient {
+    /// Build a catalog client from config.
+    ///
+    /// `req_headers` is the inbound request headers for `headers_from_request`
+    /// resolution. Pass `None` in CLI standalone mode.
+    pub fn from_config(
+        config: &CatalogWebhookConfig,
+        req_headers: Option<&HashMap<String, String>>,
+    ) -> Result<Self, CatalogError> {
+        let client = reqwest::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .build()
+            .expect("reqwest client builder only fails on TLS backend init");
+
+        let headers = crate::webhook_utils::resolve_headers(
+            &config.headers,
+            &config.headers_from_request,
+            req_headers,
+        );
+        let hmac = crate::webhook_utils::build_hmac_from_secret(
+            config.hmac.as_ref().map(|c| c.secret.as_str()),
+        )
+        .map_err(|e| CatalogError::Signing(e.to_string()))?;
+        let timeout = Duration::from_secs(config.timeout_secs);
+
+        Ok(Self {
+            client,
+            url: config.url.as_str().to_string(),
+            timeout,
+            headers,
+            hmac,
+        })
+    }
+
+    /// Send a catalog envelope to the governance webhook.
+    pub async fn send(&self, envelope: &CatalogEnvelope) -> Result<(), CatalogError> {
+        let body =
+            serde_json::to_vec(envelope).map_err(|e| CatalogError::Serialization(e.to_string()))?;
+
+        let mut request = self
+            .client
+            .post(&self.url)
+            .timeout(self.timeout)
+            .headers(self.headers.clone())
+            .header(CONTENT_TYPE, "application/json");
+
+        // Add HMAC signature if configured
+        if let Some(hmac) = &self.hmac {
+            let context = SigningContext::new(&format!("catalog-sync:{}", envelope.event_id))
+                .map_err(|e| CatalogError::Signing(e.to_string()))?;
+            let signed = hmac
+                .sign(&context, &body)
+                .map_err(|e| CatalogError::Signing(e.to_string()))?;
+            for (name, value) in signed.into_pairs() {
+                request = request.header(name, value);
+            }
+        }
+
+        let response = request
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| CatalogError::Transport(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<failed to read body>".to_string());
+            return Err(CatalogError::BadStatus {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        info!(url = %self.url, event_id = %envelope.event_id, "Catalog sync successful");
+        Ok(())
+    }
+}

--- a/crates/aura/src/governance/envelope.rs
+++ b/crates/aura/src/governance/envelope.rs
@@ -1,0 +1,616 @@
+//! Catalog envelope types for governance webhook payloads.
+
+use crate::mcp::McpManager;
+use anyhow::anyhow;
+use aura_config::Config;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const MCP_CATALOG_EVENT_NAME: &str = "mcp_catalog";
+const MCP_CATALOG_ENVELOPE_VERSION: &str = "1";
+
+/// Wire envelope for the MCP catalog sync event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogEnvelope {
+    /// Event type identifier.
+    pub event: &'static str,
+    /// Schema version for forward compatibility.
+    pub version: &'static str,
+    /// Unique event ID (UUID v1).
+    pub event_id: String,
+    /// ISO 8601 timestamp when the event was emitted.
+    pub emitted_at: DateTime<Utc>,
+    /// AURA version that generated this catalog.
+    pub aura_version: String,
+    /// Agent entries with their MCP server configurations and tools.
+    pub agent: AgentEntry,
+}
+
+/// Agent entry in the catalog envelope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentEntry {
+    /// Agent identifier (from config).
+    pub id: String,
+    /// Human-readable agent name.
+    pub name: String,
+    /// LLM model identifier.
+    pub model: String,
+    /// MCP servers configured for this agent.
+    pub mcp_servers: Vec<McpServerEntry>,
+}
+
+/// MCP server entry with connection status and discovered tools.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServerEntry {
+    /// Server name (config key).
+    pub name: String,
+    /// Transport type: `http_streamable`, `sse`, or `stdio`.
+    pub transport: String,
+    /// Connection status.
+    pub status: McpServerStatus,
+    /// Failure message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_message: Option<String>,
+    /// Discovered tools from this server.
+    pub tools: Vec<ToolEntry>,
+}
+
+impl TryFrom<&aura_events::McpServerStatus> for McpServerEntry {
+    type Error = anyhow::Error;
+    fn try_from(value: &aura_events::McpServerStatus) -> anyhow::Result<Self> {
+        Ok(Self {
+            name: value.server_name.clone(),
+            transport: value.transport.clone(),
+            status: McpServerStatus::try_from(value.status.as_str())?,
+            failure_message: value.reason.clone(),
+            tools: vec![],
+        })
+    }
+}
+
+/// Connection status for an MCP server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpServerStatus {
+    Connected,
+    Failed,
+    NotAttempted,
+}
+
+impl TryFrom<&str> for McpServerStatus {
+    type Error = anyhow::Error;
+    fn try_from(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "connected" => Ok(McpServerStatus::Connected),
+            "failed" => Ok(McpServerStatus::Failed),
+            "not_attempted" => Ok(McpServerStatus::NotAttempted),
+            _ => Err(anyhow!("unsupported MCP server status string: {value}")),
+        }
+    }
+}
+
+/// Tool entry with full schema information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolEntry {
+    /// Tool name.
+    pub name: String,
+    /// Tool description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// JSON Schema for tool input parameters.
+    pub input_schema: serde_json::Value,
+}
+
+impl From<&rmcp::model::Tool> for ToolEntry {
+    fn from(value: &rmcp::model::Tool) -> Self {
+        Self {
+            name: value.name.to_string(),
+            description: value.description.as_ref().map(|d| d.to_string()),
+            input_schema: value.schema_as_json_value(),
+        }
+    }
+}
+
+/// Build a catalog envelope from a single config and its MCP manager.
+///
+/// This is the single-agent path used when only one config is loaded.
+pub async fn build_catalog(config: &aura_config::Config) -> Option<CatalogEnvelope> {
+    if let Some(mcp_config) = &config.mcp
+        && let Ok(manager) = McpManager::initialize_from_config(mcp_config).await
+    {
+        let server_entries = build_server_entries(&manager);
+        let agent = build_agent_entry(config, server_entries);
+        let event_id = Uuid::new_v4().to_string();
+        let emitted_at = Utc::now();
+        let aura_version = env!("CARGO_PKG_VERSION").to_string();
+        return Some(CatalogEnvelope {
+            event: MCP_CATALOG_EVENT_NAME,
+            version: MCP_CATALOG_ENVELOPE_VERSION,
+            event_id,
+            emitted_at,
+            aura_version,
+            agent,
+        });
+    }
+    None
+}
+
+/// Build an agent entry from a config and its MCP manager.
+fn build_agent_entry(config: &Config, mcp_servers: Vec<McpServerEntry>) -> AgentEntry {
+    // Use alias as id if set, otherwise fall back to name
+    let id = config
+        .agent
+        .alias
+        .clone()
+        .unwrap_or_else(|| config.agent.name.clone());
+    let name = config.agent.name.clone();
+    let model = config.agent.llm.model_name().to_string();
+
+    AgentEntry {
+        id,
+        name,
+        model,
+        mcp_servers,
+    }
+}
+
+/// Build MCP server entries from config and runtime state.
+fn build_server_entries(mcp_manager: &McpManager) -> Vec<McpServerEntry> {
+    let mut res = vec![];
+    for server in &mcp_manager.server_status_snapshot() {
+        let mut e = McpServerEntry::try_from(server).unwrap();
+        e.tools = mcp_manager
+            .get_tool_definition_by_server(&server.server_name)
+            .iter()
+            .map(ToolEntry::from)
+            .collect();
+        res.push(e);
+    }
+
+    // Sort by server name for deterministic output
+    res.sort_by(|a, b| a.name.cmp(&b.name));
+    res
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::{ConnectionStatus, ServerInfo};
+    use std::borrow::Cow;
+    use std::sync::Arc;
+
+    // -----------------------------------------------------------------
+    // Fixtures
+    // -----------------------------------------------------------------
+
+    fn tool_fixture(name: &str, description: Option<&str>) -> rmcp::model::Tool {
+        rmcp::model::Tool {
+            name: Cow::Owned(name.to_string()),
+            title: None,
+            description: description.map(|d| Cow::Owned(d.to_string())),
+            input_schema: Arc::new(serde_json::Map::from_iter(vec![(
+                "type".to_string(),
+                serde_json::json!("object"),
+            )])),
+            output_schema: None,
+            annotations: None,
+            icons: None,
+            meta: None,
+        }
+    }
+
+    fn server_info_fixture(name: &str, transport: &str, status: ConnectionStatus) -> ServerInfo {
+        ServerInfo {
+            name: name.to_string(),
+            description: None,
+            tools_count: 0,
+            status,
+            transport: transport.to_string(),
+        }
+    }
+
+    /// Minimal agent config: only `[agent]`/`[agent.llm]`, plus caller-supplied
+    /// extra agent fields (e.g. `alias = "..."`) and extra top-level sections
+    /// (e.g. `[mcp.servers.dead]`).
+    fn agent_config_toml(
+        name: &str,
+        extra_agent_fields: &str,
+        extra_sections: &str,
+    ) -> aura_config::Config {
+        aura_config::load_config_from_str(&format!(
+            r#"
+[agent]
+name = "{name}"
+system_prompt = "p"
+{extra_agent_fields}
+[agent.llm]
+provider = "openai"
+model = "gpt-4o"
+api_key = "k"
+{extra_sections}
+"#
+        ))
+        .unwrap_or_else(|e| panic!("config should parse: {e}"))
+    }
+
+    // -----------------------------------------------------------------
+    // McpServerStatus::try_from(&str)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn server_status_try_from_str_parses_all_variants() {
+        assert_eq!(
+            McpServerStatus::try_from("connected").unwrap(),
+            McpServerStatus::Connected
+        );
+        assert_eq!(
+            McpServerStatus::try_from("failed").unwrap(),
+            McpServerStatus::Failed
+        );
+        assert_eq!(
+            McpServerStatus::try_from("not_attempted").unwrap(),
+            McpServerStatus::NotAttempted
+        );
+    }
+
+    #[test]
+    fn server_status_try_from_str_rejects_unknown_value() {
+        assert!(McpServerStatus::try_from("connecting").is_err());
+    }
+
+    #[test]
+    fn server_status_try_from_str_is_case_sensitive() {
+        // The wire status comes from aura_events::McpServerStatus.status, which
+        // is always lowercased by its producer; the match must not accept
+        // near-miss casing as if it were normalized.
+        assert!(McpServerStatus::try_from("Connected").is_err());
+        assert!(McpServerStatus::try_from("CONNECTED").is_err());
+        assert!(McpServerStatus::try_from("Failed").is_err());
+        assert!(McpServerStatus::try_from("Not_Attempted").is_err());
+    }
+
+    #[test]
+    fn server_status_try_from_str_rejects_empty_string() {
+        assert!(McpServerStatus::try_from("").is_err());
+    }
+
+    #[test]
+    fn server_status_try_from_str_rejects_surrounding_whitespace() {
+        // No trimming: a value with incidental whitespace must not silently match.
+        assert!(McpServerStatus::try_from(" connected").is_err());
+        assert!(McpServerStatus::try_from("connected ").is_err());
+        assert!(McpServerStatus::try_from("connected\n").is_err());
+    }
+
+    #[test]
+    fn server_status_try_from_str_rejects_near_miss_separators() {
+        // Guards the underscore convention specifically: a hyphen or missing
+        // separator must not be treated as equivalent to "not_attempted".
+        assert!(McpServerStatus::try_from("not-attempted").is_err());
+        assert!(McpServerStatus::try_from("notattempted").is_err());
+    }
+
+    #[test]
+    fn server_status_try_from_str_error_message_names_the_offending_value() {
+        let err = McpServerStatus::try_from("connecting").unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("connecting"),
+            "error must name the offending value for triage, got: {message}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // McpServerEntry: TryFrom<&aura_events::McpServerStatus>
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn server_entry_from_connected_status_has_no_failure_message() {
+        let status = aura_events::McpServerStatus {
+            server_name: "kubernetes".to_string(),
+            transport: "http_streamable".to_string(),
+            status: "connected".to_string(),
+            tools_count: 3,
+            reason: None,
+        };
+
+        let entry = McpServerEntry::try_from(&status).unwrap();
+        assert_eq!(entry.name, "kubernetes");
+        assert_eq!(entry.transport, "http_streamable");
+        assert_eq!(entry.status, McpServerStatus::Connected);
+        assert_eq!(entry.failure_message, None);
+        assert!(
+            entry.tools.is_empty(),
+            "tools are attached later by build_server_entries, not by this conversion"
+        );
+    }
+
+    #[test]
+    fn server_entry_from_failed_status_carries_failure_message() {
+        let status = aura_events::McpServerStatus {
+            server_name: "pagerduty".to_string(),
+            transport: "sse".to_string(),
+            status: "failed".to_string(),
+            tools_count: 0,
+            reason: Some("connection refused".to_string()),
+        };
+
+        let entry = McpServerEntry::try_from(&status).unwrap();
+        assert_eq!(entry.status, McpServerStatus::Failed);
+        assert_eq!(entry.failure_message.as_deref(), Some("connection refused"));
+    }
+
+    #[test]
+    fn server_entry_from_not_attempted_status_has_no_failure_message() {
+        let status = aura_events::McpServerStatus {
+            server_name: "unused".to_string(),
+            transport: "stdio".to_string(),
+            status: "not_attempted".to_string(),
+            tools_count: 0,
+            reason: None,
+        };
+
+        let entry = McpServerEntry::try_from(&status).unwrap();
+        assert_eq!(entry.status, McpServerStatus::NotAttempted);
+        assert_eq!(entry.failure_message, None);
+    }
+
+    #[test]
+    fn server_entry_from_unrecognized_status_string_errs() {
+        let status = aura_events::McpServerStatus {
+            server_name: "weird".to_string(),
+            transport: "http_streamable".to_string(),
+            status: "connecting".to_string(),
+            tools_count: 0,
+            reason: None,
+        };
+
+        assert!(McpServerEntry::try_from(&status).is_err());
+    }
+
+    // -----------------------------------------------------------------
+    // ToolEntry: From<&rmcp::model::Tool>
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn tool_entry_from_tool_maps_name_description_and_schema() {
+        let tool = tool_fixture("list_pods", Some("List pods in a namespace"));
+
+        let entry = ToolEntry::from(&tool);
+        assert_eq!(entry.name, "list_pods");
+        assert_eq!(
+            entry.description.as_deref(),
+            Some("List pods in a namespace")
+        );
+        assert_eq!(entry.input_schema.get("type").unwrap(), "object");
+    }
+
+    #[test]
+    fn tool_entry_from_tool_without_description_is_none() {
+        let tool = tool_fixture("no_desc", None);
+
+        let entry = ToolEntry::from(&tool);
+        assert_eq!(entry.description, None);
+    }
+
+    // -----------------------------------------------------------------
+    // Serialization: skip_serializing_if / rename_all behavior
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn mcp_server_entry_omits_failure_message_field_when_none() {
+        let entry = McpServerEntry {
+            name: "kubernetes".to_string(),
+            transport: "http_streamable".to_string(),
+            status: McpServerStatus::Connected,
+            failure_message: None,
+            tools: vec![],
+        };
+
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            !json.contains("failure_message"),
+            "failure_message must be omitted, not null, when None: {json}"
+        );
+    }
+
+    #[test]
+    fn mcp_server_entry_includes_failure_message_field_when_some() {
+        let entry = McpServerEntry {
+            name: "pagerduty".to_string(),
+            transport: "sse".to_string(),
+            status: McpServerStatus::Failed,
+            failure_message: Some("connection refused".to_string()),
+            tools: vec![],
+        };
+
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("\"failure_message\":\"connection refused\""));
+    }
+
+    #[test]
+    fn tool_entry_omits_description_field_when_none() {
+        let entry = ToolEntry {
+            name: "no_desc".to_string(),
+            description: None,
+            input_schema: serde_json::json!({}),
+        };
+
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(!json.contains("description"));
+    }
+
+    #[test]
+    fn mcp_server_status_serializes_to_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&McpServerStatus::Connected).unwrap(),
+            "\"connected\""
+        );
+        assert_eq!(
+            serde_json::to_string(&McpServerStatus::Failed).unwrap(),
+            "\"failed\""
+        );
+        assert_eq!(
+            serde_json::to_string(&McpServerStatus::NotAttempted).unwrap(),
+            "\"not_attempted\""
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // build_agent_entry
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn build_agent_entry_uses_alias_as_id_when_set() {
+        let config = agent_config_toml("sre-agent", "alias = \"prod-sre\"", "");
+        let entry = build_agent_entry(&config, vec![]);
+        assert_eq!(entry.id, "prod-sre");
+        assert_eq!(entry.name, "sre-agent");
+        assert_eq!(entry.model, "gpt-4o");
+    }
+
+    #[test]
+    fn build_agent_entry_falls_back_to_name_when_alias_unset() {
+        let config = agent_config_toml("sre-agent", "", "");
+        let entry = build_agent_entry(&config, vec![]);
+        assert_eq!(entry.id, "sre-agent");
+        assert_eq!(entry.name, "sre-agent");
+    }
+
+    #[test]
+    fn build_agent_entry_carries_through_mcp_servers_unchanged() {
+        let config = agent_config_toml("sre-agent", "", "");
+        let servers = vec![McpServerEntry {
+            name: "kubernetes".to_string(),
+            transport: "http_streamable".to_string(),
+            status: McpServerStatus::Connected,
+            failure_message: None,
+            tools: vec![],
+        }];
+
+        let entry = build_agent_entry(&config, servers);
+        assert_eq!(entry.mcp_servers.len(), 1);
+        assert_eq!(entry.mcp_servers[0].name, "kubernetes");
+    }
+
+    // -----------------------------------------------------------------
+    // build_server_entries
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn build_server_entries_empty_manager_yields_empty_vec() {
+        let manager = McpManager::with_sanitization(true);
+        assert!(build_server_entries(&manager).is_empty());
+    }
+
+    #[test]
+    fn build_server_entries_attaches_tools_from_matching_transport_map() {
+        let mut manager = McpManager::with_sanitization(true);
+        manager.server_info.insert(
+            "kubernetes".to_string(),
+            server_info_fixture("kubernetes", "http_streamable", ConnectionStatus::Connected),
+        );
+        manager.streamable_tools.insert(
+            "kubernetes".to_string(),
+            vec![tool_fixture("list_pods", None)],
+        );
+
+        let entries = build_server_entries(&manager);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "kubernetes");
+        assert_eq!(entries[0].transport, "http_streamable");
+        assert_eq!(entries[0].status, McpServerStatus::Connected);
+        assert_eq!(entries[0].tools.len(), 1);
+        assert_eq!(entries[0].tools[0].name, "list_pods");
+    }
+
+    #[test]
+    fn build_server_entries_finds_tools_regardless_of_which_transport_map_holds_them() {
+        // A server's tools live in whichever transport-keyed map matches its
+        // transport; build_server_entries must find them via any of the three.
+        let mut manager = McpManager::with_sanitization(true);
+        manager.server_info.insert(
+            "legacy".to_string(),
+            server_info_fixture("legacy", "sse", ConnectionStatus::Connected),
+        );
+        manager.sse_tools.insert(
+            "legacy".to_string(),
+            vec![tool_fixture("legacy_tool", None)],
+        );
+
+        let entries = build_server_entries(&manager);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].tools[0].name, "legacy_tool");
+    }
+
+    #[test]
+    fn build_server_entries_failed_server_has_no_tools_and_carries_reason() {
+        let mut manager = McpManager::with_sanitization(true);
+        manager.server_info.insert(
+            "pagerduty".to_string(),
+            server_info_fixture(
+                "pagerduty",
+                "sse",
+                ConnectionStatus::Failed("connection refused".to_string()),
+            ),
+        );
+
+        let entries = build_server_entries(&manager);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].status, McpServerStatus::Failed);
+        assert_eq!(
+            entries[0].failure_message.as_deref(),
+            Some("connection refused")
+        );
+        assert!(entries[0].tools.is_empty());
+    }
+
+    #[test]
+    fn build_server_entries_sorted_by_name_regardless_of_insertion_order() {
+        let mut manager = McpManager::with_sanitization(true);
+        for name in ["zeta", "alpha", "mu"] {
+            manager.server_info.insert(
+                name.to_string(),
+                server_info_fixture(name, "stdio", ConnectionStatus::NotAttempted),
+            );
+        }
+
+        let entries = build_server_entries(&manager);
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "mu", "zeta"]);
+    }
+
+    // -----------------------------------------------------------------
+    // build_catalog
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn build_catalog_skips_configs_without_an_mcp_table() {
+        let config = agent_config_toml("solo", "", "");
+        let envelope = build_catalog(&config).await;
+        // Current behavior: a config with no [mcp] table produces no catalog
+        // entry at all (build_catalog only pushes when config.mcp is Some).
+        assert!(envelope.is_none());
+    }
+
+    #[tokio::test]
+    async fn build_catalog_reports_a_failed_server_for_an_unreachable_mcp_server() {
+        let config = agent_config_toml(
+            "sre-agent",
+            "",
+            "[mcp.servers.dead]\ntransport = \"http_streamable\"\nurl = \"http://127.0.0.1:9/mcp\"\n",
+        );
+
+        let envelope = build_catalog(&config).await.unwrap();
+        assert_eq!(envelope.agent.id, "sre-agent");
+        assert_eq!(envelope.agent.model, "gpt-4o");
+        assert_eq!(envelope.agent.mcp_servers.len(), 1);
+        assert_eq!(envelope.agent.mcp_servers[0].name, "dead");
+        assert_eq!(
+            envelope.agent.mcp_servers[0].status,
+            McpServerStatus::Failed
+        );
+        assert!(envelope.agent.mcp_servers[0].tools.is_empty());
+    }
+}

--- a/crates/aura/src/governance/mod.rs
+++ b/crates/aura/src/governance/mod.rs
@@ -1,0 +1,13 @@
+//! Governance integration for MCP tool catalog sync.
+//!
+//! This module provides the ability to discover all MCP tools from configured
+//! servers and send a catalog snapshot to a governance webhook for policy
+//! management and auditing.
+
+mod client;
+mod envelope;
+
+pub use client::CatalogClient;
+pub use envelope::{
+    AgentEntry, CatalogEnvelope, McpServerEntry, McpServerStatus, ToolEntry, build_catalog,
+};

--- a/crates/aura/src/hitl/mod.rs
+++ b/crates/aura/src/hitl/mod.rs
@@ -49,7 +49,7 @@ pub use route::{
     cleartext_capture_warning, validate_webhook_signing_config, warn_on_cleartext_capture,
 };
 pub use signing::{
-    SIGNATURE_HEADER, SignedHeaders, SigningContext, TIMESTAMP_HEADER, VerificationError,
-    VerifiedBody, WebhookHmac, authorize_ingress,
+    ConfigError, PrimarySecret, SIGNATURE_HEADER, SignedHeaders, SigningContext, TIMESTAMP_HEADER,
+    Tolerance, VerificationError, VerifiedBody, WebhookHmac, authorize_ingress,
 };
 pub use tool::{RequestApprovalArgs, RequestApprovalTool};

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use aura_config::{DecisionRouteConfig, GlobPattern, HitlConfig, ToolHeaderMappings, WebhookUrl};
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::header::HeaderMap;
 
 use super::decision::{ApprovalDecision, ApprovalOutcome, DecisionId};
 use super::events;
@@ -71,7 +71,11 @@ impl HitlRuntime {
                     client: WebhookClient::with_headers_and_signing(
                         build_webhook_client(),
                         url.clone(),
-                        resolve_webhook_headers(headers, headers_from_request, req_headers),
+                        crate::webhook_utils::resolve_headers(
+                            headers,
+                            headers_from_request,
+                            req_headers,
+                        ),
                         signing,
                         tool_headers_from_response.clone(),
                     ),
@@ -385,55 +389,6 @@ pub(crate) fn build_webhook_client() -> reqwest::Client {
         .connect_timeout(WEBHOOK_CONNECT_TIMEOUT)
         .build()
         .expect("reqwest client builder only fails on TLS backend init")
-}
-
-/// Resolve operator-configured webhook headers into a validated [`HeaderMap`]:
-/// static `headers` overlaid with `headers_from_request` values from the
-/// inbound client request. Invalid header names or values are skipped with
-/// a warning (matching `mcp_streamable_http.rs`).
-///
-/// Opt-in only: nothing is forwarded unless the operator configures it.
-/// Classification is deliberately absent from this surface — see
-/// [`apply_request_header_mappings`](crate::rig_builder::apply_request_header_mappings).
-fn resolve_webhook_headers(
-    static_headers: &HashMap<String, String>,
-    headers_from_request: &HashMap<String, String>,
-    req_headers: Option<&HashMap<String, String>>,
-) -> HeaderMap {
-    let empty = HashMap::new();
-    let req_headers = req_headers.unwrap_or(&empty);
-
-    let mut resolved: HashMap<String, String> = static_headers
-        .iter()
-        .map(|(k, v)| (k.to_lowercase(), v.clone()))
-        .collect();
-    let resolved_count = crate::rig_builder::apply_request_header_mappings(
-        &mut resolved,
-        headers_from_request,
-        req_headers,
-    );
-    if resolved_count > 0 {
-        tracing::info!("Webhook route: resolved {resolved_count} header(s) from request");
-    }
-
-    let mut header_map = HeaderMap::new();
-    for (key, value) in &resolved {
-        match (
-            HeaderName::from_bytes(key.as_bytes()),
-            HeaderValue::from_str(value),
-        ) {
-            (Ok(name), Ok(val)) => {
-                header_map.insert(name, val);
-            }
-            _ => {
-                tracing::warn!(
-                    "Skipping invalid webhook header '{}' (failed to convert)",
-                    key
-                );
-            }
-        }
-    }
-    header_map
 }
 
 /// HMAC signing state for the webhook route.
@@ -2294,7 +2249,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // resolve_webhook_headers unit tests
+    // webhook header resolution unit tests
     // -----------------------------------------------------------------
 
     fn make_req_headers(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
@@ -2309,7 +2264,7 @@ mod tests {
         let static_headers = make_req_headers(&[("x-tenant", "sre-prod")]);
         let headers_from_request = std::collections::HashMap::new();
         let header_map =
-            super::resolve_webhook_headers(&static_headers, &headers_from_request, None);
+            crate::webhook_utils::resolve_headers(&static_headers, &headers_from_request, None);
         assert_eq!(header_map.get("x-tenant").unwrap(), "sre-prod");
         assert_eq!(header_map.len(), 1);
     }
@@ -2320,7 +2275,7 @@ mod tests {
         let headers_from_request = make_req_headers(&[("x-tenant", "x-incoming-tenant")]);
         let req_headers = make_req_headers(&[("x-incoming-tenant", "forwarded-value")]);
 
-        let header_map = super::resolve_webhook_headers(
+        let header_map = crate::webhook_utils::resolve_headers(
             &static_headers,
             &headers_from_request,
             Some(&req_headers),
@@ -2336,7 +2291,7 @@ mod tests {
         let headers_from_request = make_req_headers(&[("authorization", "x-incoming-auth")]);
         let req_headers = make_req_headers(&[("x-incoming-auth", "dynamic-token")]);
 
-        let header_map = super::resolve_webhook_headers(
+        let header_map = crate::webhook_utils::resolve_headers(
             &static_headers,
             &headers_from_request,
             Some(&req_headers),
@@ -2349,7 +2304,7 @@ mod tests {
 
         // When the mapped request header is ABSENT, the static value is the fallback.
         let req_headers_empty = std::collections::HashMap::new();
-        let header_map_fallback = super::resolve_webhook_headers(
+        let header_map_fallback = crate::webhook_utils::resolve_headers(
             &static_headers,
             &headers_from_request,
             Some(&req_headers_empty),
@@ -2369,7 +2324,7 @@ mod tests {
         let headers_from_request = make_req_headers(&[("Authorization", "Authorization")]);
         let req_headers = make_req_headers(&[("authorization", "Token my-token")]);
 
-        let header_map = super::resolve_webhook_headers(
+        let header_map = crate::webhook_utils::resolve_headers(
             &static_headers,
             &headers_from_request,
             Some(&req_headers),
@@ -2392,7 +2347,7 @@ mod tests {
         let headers_from_request = make_req_headers(&[("authorization", "x-incoming-auth")]);
         let req_headers = make_req_headers(&[("x-incoming-auth", "dynamic-token")]);
 
-        let header_map = super::resolve_webhook_headers(
+        let header_map = crate::webhook_utils::resolve_headers(
             &static_headers,
             &headers_from_request,
             Some(&req_headers),
@@ -2412,7 +2367,7 @@ mod tests {
         let headers_from_request = std::collections::HashMap::new();
 
         let header_map =
-            super::resolve_webhook_headers(&static_headers, &headers_from_request, None);
+            crate::webhook_utils::resolve_headers(&static_headers, &headers_from_request, None);
         assert_eq!(header_map.get("x-valid").unwrap(), "ok");
         assert_eq!(
             header_map.len(),
@@ -2461,7 +2416,7 @@ mod tests {
         let headers_from_request = std::collections::HashMap::new();
 
         let header_map = tracing::subscriber::with_default(subscriber, || {
-            super::resolve_webhook_headers(&static_headers, &headers_from_request, None)
+            crate::webhook_utils::resolve_headers(&static_headers, &headers_from_request, None)
         });
         let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
 
@@ -2475,7 +2430,7 @@ mod tests {
 
         // (b) the warning is emitted and names the offending header.
         assert!(
-            log.contains("Skipping invalid webhook header"),
+            log.contains("Skipping invalid header"),
             "warning must be emitted, got log: {log}"
         );
         assert!(
@@ -2506,7 +2461,7 @@ mod tests {
         let headers_from_request = std::collections::HashMap::new();
 
         let header_map =
-            super::resolve_webhook_headers(&static_headers, &headers_from_request, None);
+            crate::webhook_utils::resolve_headers(&static_headers, &headers_from_request, None);
         assert!(
             header_map.is_empty(),
             "empty config must produce no headers (bare POST)"

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -14,6 +14,7 @@ pub mod env_flags;
 pub mod error;
 pub mod fallback_tool_parser;
 pub mod fallback_tool_stream;
+pub mod governance;
 pub mod hitl;
 pub mod inactivity;
 pub mod logging;
@@ -52,15 +53,16 @@ pub mod tools;
 pub mod turn_nudge;
 pub mod vector_dynamic;
 pub mod vector_store;
+pub mod webhook_utils;
 
 pub use builder::{Agent, AgentBuilder, FilesystemTools, build_streaming_agent};
 pub use config::{AgentRuntimeConfig, SessionId, ToolContextFactory};
 // Pure config types are owned by `aura-config` and re-exported here for
 // ergonomic consumption (`aura::LlmConfig`, etc.).
 pub use aura_config::{
-    AgentConfig, AgentSettings, EmbeddingConfig, LlmConfig, McpConfig, McpServerConfig,
-    ReasoningEffort, SkillConfig, TodoToolsConfig, ToolsConfig, VectorStoreConfig, VectorStoreType,
-    glob_match, lenient_int,
+    AgentConfig, AgentSettings, CatalogHmacConfig, CatalogWebhookConfig, EmbeddingConfig,
+    GovernanceConfig, LlmConfig, McpConfig, McpServerConfig, ReasoningEffort, SkillConfig,
+    TodoToolsConfig, ToolsConfig, VectorStoreConfig, VectorStoreType, glob_match, lenient_int,
 };
 pub use error::{BuilderError, BuilderResult};
 pub use orchestration::tools::{

--- a/crates/aura/src/mcp.rs
+++ b/crates/aura/src/mcp.rs
@@ -1200,6 +1200,18 @@ impl McpManager {
         map
     }
 
+    pub fn get_tool_definition_by_server(&self, name: &str) -> Vec<rmcp::model::Tool> {
+        if let Some(tools) = self.streamable_tools.get(name) {
+            tools.clone()
+        } else if let Some(tools) = self.sse_tools.get(name) {
+            tools.clone()
+        } else if let Some(tools) = self.stdio_tools.get(name) {
+            tools.clone()
+        } else {
+            vec![]
+        }
+    }
+
     /// Execute a tool by name (used by Ollama text-to-tool fallback).
     ///
     /// Called by `FallbackToolExecutor` when it detects tool calls in streamed text.

--- a/crates/aura/src/webhook_utils.rs
+++ b/crates/aura/src/webhook_utils.rs
@@ -1,0 +1,82 @@
+//! Shared helpers for outbound webhook egress: header resolution from
+//! `(static, headers_from_request)` mappings, and HMAC construction from an
+//! operator-facing secret string.
+//!
+//! Both the HITL approval route and the governance catalog sync configure
+//! their webhook the same way (static headers overlaid with
+//! `headers_from_request` values from the inbound request, plus an optional
+//! HMAC secret). These helpers keep the header-conversion policy and the
+//! "secret → `WebhookHmac`" construction in one place.
+
+use std::collections::HashMap;
+
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use tracing::{info, warn};
+
+use crate::hitl::{ConfigError, PrimarySecret, Tolerance, WebhookHmac};
+
+/// Resolve operator-configured webhook headers into a validated [`HeaderMap`]:
+/// `static_headers` overlaid with `headers_from_request` values pulled from the
+/// inbound client request. Invalid header names or values are skipped with a
+/// warning that names the offending key (never the value).
+///
+/// Opt-in only: nothing is forwarded unless the operator configures it.
+/// Classification is deliberately absent from this surface — see
+/// [`apply_request_header_mappings`](crate::rig_builder::apply_request_header_mappings).
+///
+/// `info_prefix` labels the caller in the "resolved N header(s)" info line
+/// (e.g. `"Webhook route"`, `"Catalog webhook"`). `warn_kind` labels the
+/// category in the "Skipping invalid ___ header" warning (e.g. `"webhook"`,
+/// `"catalog webhook"`).
+pub fn resolve_headers(
+    static_headers: &HashMap<String, String>,
+    headers_from_request: &HashMap<String, String>,
+    req_headers: Option<&HashMap<String, String>>,
+) -> HeaderMap {
+    let empty = HashMap::new();
+    let req_headers = req_headers.unwrap_or(&empty);
+
+    let mut resolved: HashMap<String, String> = static_headers
+        .iter()
+        .map(|(k, v)| (k.to_lowercase(), v.clone()))
+        .collect();
+    let resolved_count = crate::rig_builder::apply_request_header_mappings(
+        &mut resolved,
+        headers_from_request,
+        req_headers,
+    );
+    if resolved_count > 0 {
+        info!("resolved {resolved_count} header(s) from request");
+    }
+
+    let mut header_map = HeaderMap::new();
+    for (key, value) in &resolved {
+        match (
+            HeaderName::from_bytes(key.as_bytes()),
+            HeaderValue::from_str(value),
+        ) {
+            (Ok(name), Ok(val)) => {
+                header_map.insert(name, val);
+            }
+            _ => {
+                warn!("Skipping invalid header '{}' (failed to convert)", key);
+            }
+        }
+    }
+    header_map
+}
+
+/// Build a [`WebhookHmac`] from an operator-configured secret string.
+///
+/// Returns `Ok(None)` when the secret is `None` or empty (unsigned egress).
+/// Uses the default tolerance and no secondary secret; loaders that need a
+/// secondary or env-driven configuration should use
+/// [`WebhookHmac::load_from_env`] directly.
+pub fn build_hmac_from_secret(secret: Option<&str>) -> Result<Option<WebhookHmac>, ConfigError> {
+    let Some(secret) = secret.filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let primary = PrimarySecret::new(secret.as_bytes());
+    let hmac = WebhookHmac::new(primary, None, Tolerance::default())?;
+    Ok(Some(hmac))
+}


### PR DESCRIPTION
Add governance configuration schema and catalog envelope builder for
MCP tool discovery sync:

- Config is done through the [governance.catalog] section in
aura-config
- Wire format types, webhook client and conversion is handled in
aura::goverence

Fixes https://github.com/mezmo/aura/issues/599