### PR TITLE
feat(cli): add governance sync subcommand

### DIFF
--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -153,6 +153,11 @@ impl DirectBackend {
         self.app_state.pending_approvals.clone()
     }
 
+    /// Access the loaded agent configs for governance operations.
+    pub fn configs(&self) -> &[aura_config::Config] {
+        &self.app_state.configs
+    }
+
     /// Return the effective model ID for each loaded config.
     pub(crate) fn model_ids(&self) -> Vec<String> {
         self.model_choices().into_iter().map(|m| m.id).collect()

--- a/crates/aura-cli/src/cli.rs
+++ b/crates/aura-cli/src/cli.rs
@@ -21,6 +21,13 @@ pub enum Command {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<std::ffi::OsString>,
     },
+
+    /// Governance commands for policy integration and catalog sync.
+    #[cfg(feature = "standalone-cli")]
+    Governance {
+        #[command(subcommand)]
+        command: crate::governance::GovernanceCommands,
+    },
 }
 
 /// Aura CLI — interactive chat completions REPL

--- a/crates/aura-cli/src/governance.rs
+++ b/crates/aura-cli/src/governance.rs
@@ -1,0 +1,50 @@
+//! Governance subcommand handlers for the CLI.
+//!
+//! These commands are standalone-mode only and operate on TOML agent configs
+//! directly, without requiring a running web server.
+
+use anyhow::{Context, Result};
+use aura::governance::build_catalog;
+
+#[derive(Debug, clap::Subcommand)]
+pub enum GovernanceCommands {
+    /// Discover all MCP tools and send a catalog snapshot to the governance webhook.
+    Sync,
+}
+
+pub fn run(confs: &[aura_config::Config], command: &GovernanceCommands) -> Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    match command {
+        GovernanceCommands::Sync => rt.block_on(sync_all(confs)),
+    }
+}
+
+async fn sync_all(confs: &[aura_config::Config]) -> Result<()> {
+    if confs.is_empty() {
+        anyhow::bail!("No agent configs found");
+    }
+
+    for conf in confs {
+        let res = sync_one(conf).await;
+        if let Err(e) = res {
+            let name = &conf.agent.name;
+            tracing::warn!("Failed to sync goverence data for agent {name}: {e}");
+        }
+    }
+    Ok(())
+}
+
+async fn sync_one(config: &aura_config::Config) -> Result<()> {
+    if let Some(governance_config) = &config.governance
+        && let Some(catalog_config) = &governance_config.catalog
+        && let Some(catalog) = build_catalog(config).await
+    {
+        let client = aura::governance::CatalogClient::from_config(catalog_config, None)
+            .context("Failed to create catalog client")?;
+        client
+            .send(&catalog)
+            .await
+            .context("Failed to send catalog")?;
+    }
+    Ok(())
+}

--- a/crates/aura-cli/src/init.rs
+++ b/crates/aura-cli/src/init.rs
@@ -110,7 +110,6 @@ pub struct InitArgs {
 }
 
 pub fn run_init(args: &InitArgs) -> Result<()> {
-    dotenvy::dotenv().ok();
     let is_tty = std::io::stdin().is_terminal();
     let interactive = !args.non_interactive && is_tty;
     let mut prompter = Prompter {

--- a/crates/aura-cli/src/lib.rs
+++ b/crates/aura-cli/src/lib.rs
@@ -5,6 +5,8 @@ pub mod backend;
 pub mod cli;
 pub mod config;
 pub mod event_names;
+#[cfg(feature = "standalone-cli")]
+pub mod governance;
 pub mod init;
 pub mod logging;
 pub mod oneshot;

--- a/crates/aura-cli/src/main.rs
+++ b/crates/aura-cli/src/main.rs
@@ -10,33 +10,21 @@ use aura_cli::repl::r#loop::run_repl;
 use aura_cli::ui::pre_launch;
 use aura_cli::ui::prompt::AgentHost;
 
-fn main() -> Result<()> {
-    // Catch --config/--standalone before clap parses when standalone-cli is not enabled.
-    #[cfg(not(feature = "standalone-cli"))]
-    aura_cli::cli::check_standalone_flag();
-
-    let args = Args::parse();
-
-    // Subcommands run before any backend/REPL setup (and before the tokio
-    // runtime exists — init uses blocking HTTP for model discovery).
-    match &args.command {
-        Some(aura_cli::cli::Command::Init(init_args)) => {
-            return aura_cli::init::run_init(init_args);
-        }
-        #[cfg(feature = "webserver")]
-        Some(aura_cli::cli::Command::Webserver { args }) => return aura_cli::webserver::run(args),
-        None => {}
-    }
-
-    // Load .env so a config's {{ env.* }} references resolve without manual
-    // exporting. dotenvy never overwrites — shell exports and earlier .env
-    // entries win.
+/// Resolves loading the .env files into the current environment so config
+/// template resolution has overrides.
+///
+/// Returns whether the process is running standalone or not.
+fn resolve_env_config(args: &Args) -> bool {
+    // Loads .env so a config's {{ env.* }} references resolve without manual
+    // exporting. CWD first, then the config file's directory (init writes
+    // .env next to the config). dotenvy never overwrites — shell exports and
+    // earlier .env entries win.
     dotenvy::dotenv().ok();
 
     // `resolve_standalone` reads AURA_API_URL from the process environment, so
     // it must run after the CWD `.env` is loaded.
     #[cfg(feature = "standalone-cli")]
-    let is_standalone = aura_cli::cli::resolve_standalone(&args);
+    let is_standalone = aura_cli::cli::resolve_standalone(args);
     #[cfg(not(feature = "standalone-cli"))]
     let is_standalone = false;
 
@@ -49,6 +37,36 @@ fn main() -> Result<()> {
         && let Some(dir) = aura_cli::agent_config::env_dir(&path)
     {
         dotenvy::from_path(dir.join(".env")).ok();
+    }
+
+    is_standalone
+}
+
+fn main() -> Result<()> {
+    // Catch --config/--standalone before clap parses when standalone-cli is not enabled.
+    #[cfg(not(feature = "standalone-cli"))]
+    aura_cli::cli::check_standalone_flag();
+
+    let args = Args::parse();
+
+    // Do this first since subcommands may depend on env var values
+    let is_standalone = resolve_env_config(&args);
+
+    // Subcommands run before any backend/REPL setup (and before the tokio
+    // runtime exists — init and governance uses blocking HTTP for model discovery).
+    match &args.command {
+        Some(aura_cli::cli::Command::Init(init_args)) => {
+            return aura_cli::init::run_init(init_args);
+        }
+        #[cfg(feature = "webserver")]
+        Some(aura_cli::cli::Command::Webserver { args }) => return aura_cli::webserver::run(args),
+        #[cfg(feature = "standalone-cli")]
+        Some(aura_cli::cli::Command::Governance { command }) => {
+            let conf_path = aura_cli::agent_config::resolve(args.agent_config.as_deref())?;
+            let confs = aura_config::load_config(conf_path)?;
+            return aura_cli::governance::run(&confs, command);
+        }
+        None => {}
     }
 
     let mut config = AppConfig::load(&args)?;


### PR DESCRIPTION
Add `aura governance sync` CLI subcommand for catalog sync:

- Add Governance { action: GovernanceAction } to Command enum
- Add GovernanceAction::Sync with --config option
- Add governance.rs module with run_sync() handler
- Add configs() accessor to DirectBackend
- Wire subcommand dispatch in main.rs with .env loading

Standalone-mode only. Loads configs, initializes MCP connections,
builds catalog envelope, and POSTs to governance webhook.

Ref: LOG-XXXXX

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>