### PR TITLE
fix(mcp): truncate tool-result previews on char boundaries

### DIFF
--- a/crates/aura-cli/src/ui/animation.rs
+++ b/crates/aura-cli/src/ui/animation.rs
@@ -97,7 +97,7 @@ pub(crate) fn render_queued_wave(text: &str, wave_pos: f32) -> String {
     let (width, _) = term_size();
     let max_len = (width as usize).saturating_sub(2);
     let display = if text.len() > max_len {
-        &text[..max_len]
+        &text[..text.floor_char_boundary(max_len)]
     } else {
         text
     };
@@ -721,7 +721,7 @@ pub fn print_tool_call_line(
     let (width, _) = term_size();
     let args_display = if display.len() > width as usize {
         let budget = (width as usize).saturating_sub(4);
-        format!("{}...", &display[..budget])
+        format!("{}...", &display[..display.floor_char_boundary(budget)])
     } else {
         display
     };

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -953,11 +953,7 @@ fn handle_tool_result(
         tracing::debug!(
             "Tool '{}' result_text (first 200 chars): {}",
             tool_name,
-            if result_text.len() > 200 {
-                format!("{}...", &result_text[..200])
-            } else {
-                result_text.clone()
-            }
+            truncate_result(&result_text, 200)
         );
 
         let status = detect_tool_error(&result_text);

--- a/crates/aura-web-server/tests/aura_events_test.rs
+++ b/crates/aura-web-server/tests/aura_events_test.rs
@@ -423,7 +423,7 @@ async fn test_aura_tool_complete_includes_result() {
                 .as_str()
                 .map(|s| {
                     if s.len() > 100 {
-                        format!("{}...", &s[..100])
+                        format!("{}...", &s[..s.floor_char_boundary(100)])
                     } else {
                         s.to_string()
                     }

--- a/crates/aura/src/mcp.rs
+++ b/crates/aura/src/mcp.rs
@@ -1346,11 +1346,8 @@ macro_rules! create_mcp_tool_struct {
                 {
                     Ok(response) => {
                         debug!("  Response: {}", response);
-                        let response_summary = if response.len() > 200 {
-                            format!("{}... ({} chars)", &response[..200], response.len())
-                        } else {
-                            response.clone()
-                        };
+                        let response_summary =
+                            crate::mcp_tool_execution::preview_response(&response, 200);
                         info!("Tool '{}' completed: {}", self.tool_name, response_summary);
                         Ok(response)
                     }
@@ -1451,11 +1448,7 @@ impl RigTool for StreamableHttpMcpTool {
         {
             Ok(result) => {
                 debug!("  Tool execution successful");
-                let response_summary = if result.len() > 200 {
-                    format!("{}... ({} chars)", &result[..200], result.len())
-                } else {
-                    result.clone()
-                };
+                let response_summary = crate::mcp_tool_execution::preview_response(&result, 200);
                 info!(
                     "HTTP streamable tool '{}' completed: {}",
                     self.tool_name, response_summary
@@ -1611,11 +1604,7 @@ impl RigTool for FallbackHttpMcpTool {
         {
             Ok(result) => {
                 debug!("  Fallback tool execution successful");
-                let response_summary = if result.len() > 200 {
-                    format!("{}... ({} chars)", &result[..200], result.len())
-                } else {
-                    result.clone()
-                };
+                let response_summary = crate::mcp_tool_execution::preview_response(&result, 200);
                 info!(
                     "Fallback HTTP tool '{}' completed: {}",
                     self.unique_name, response_summary

--- a/crates/aura/src/mcp_response.rs
+++ b/crates/aura/src/mcp_response.rs
@@ -180,6 +180,21 @@ pub fn extract_resource_contents(resource: &rmcp::model::ResourceContents) -> St
     }
 }
 
+/// Char-boundary-safe preview for debug logging of tool outputs.
+///
+/// `debug!` arguments are evaluated even when the DEBUG target is
+/// disabled, so preview construction must stay panic-free at any log
+/// level. A fixed byte slice can split a multi-byte character (the `─`
+/// separators common in container logs) and take down the worker.
+fn debug_preview(s: &str) -> String {
+    let (head, truncated) = crate::string_utils::truncate_for_log(s, 200);
+    if truncated {
+        format!("{head}...")
+    } else {
+        head.to_string()
+    }
+}
+
 /// Extract the result from an MCP tool call response
 ///
 /// This function handles two types of MCP tool responses:
@@ -244,11 +259,7 @@ pub fn extract_tool_result(result: CallToolResult, tool_name: &str) -> Result<Ca
         );
         debug!(
             "   Structured content preview: {}",
-            if json_str.len() > 200 {
-                format!("{}...", &json_str[..200])
-            } else {
-                json_str.clone()
-            }
+            debug_preview(&json_str)
         );
 
         return if is_error {
@@ -288,14 +299,7 @@ pub fn extract_tool_result(result: CallToolResult, tool_name: &str) -> Result<Ca
         tool_name,
         content.len()
     );
-    debug!(
-        "   Content preview: {}",
-        if content.len() > 200 {
-            format!("{}...", &content[..200])
-        } else {
-            content.clone()
-        }
-    );
+    debug!("   Content preview: {}", debug_preview(&content));
 
     if is_error {
         Ok(CallOutcome::GeneralToolError {
@@ -887,6 +891,60 @@ mod tests {
             "jsonrpc error message must be bounded; got {} bytes",
             outcome.content().len()
         );
+    }
+
+    // --- UTF-8 boundary regression tests ---
+    //
+    // `debug!` arguments are evaluated even with debug logging off, so
+    // extract_tool_result must stay panic-free for any multibyte layout
+    // whose byte 200 falls inside a character.
+
+    #[test]
+    fn test_debug_preview_stops_at_char_boundary() {
+        // '─' spans bytes 198..201: byte 200 sits mid-character here.
+        let content = format!("{}{}", "a".repeat(198), "─".repeat(50));
+        assert!(content.len() > 200);
+        let preview = debug_preview(&content);
+        assert!(std::str::from_utf8(preview.as_bytes()).is_ok());
+        assert!(preview.starts_with(&"a".repeat(198)));
+        assert!(preview.ends_with("..."));
+        assert!(preview.len() < content.len());
+    }
+
+    #[test]
+    fn test_text_content_multibyte_does_not_panic() {
+        // Sweep alignments so at least one prefix lands byte 200 mid-char
+        // regardless of serde's exact pretty-print layout.
+        for prefix in 0..10 {
+            let text = format!("{}{}", "a".repeat(180 + prefix), "─".repeat(60));
+            let result = CallToolResult {
+                content: vec![Content {
+                    raw: RawContent::Text(RawTextContent { text, meta: None }),
+                    annotations: None,
+                }],
+                structured_content: None,
+                is_error: None,
+                meta: None,
+            };
+            let outcome = extract_tool_result(result, "fetch_container_logs").unwrap();
+            assert!(!outcome.is_error());
+        }
+    }
+
+    #[test]
+    fn test_structured_content_multibyte_does_not_panic() {
+        for prefix in 0..10 {
+            let result = CallToolResult {
+                content: vec![],
+                structured_content: Some(json!({
+                    "logs": format!("{}{}", "a".repeat(180 + prefix), "─".repeat(60)),
+                })),
+                is_error: None,
+                meta: None,
+            };
+            let outcome = extract_tool_result(result, "fetch_container_logs").unwrap();
+            assert!(!outcome.is_error());
+        }
     }
 
     #[test]

--- a/crates/aura/src/mcp_tool_execution.rs
+++ b/crates/aura/src/mcp_tool_execution.rs
@@ -190,7 +190,7 @@ fn bound_transport_error(err_str: &str) -> Option<String> {
 ///
 /// # Returns
 /// Preview string suitable for logging
-fn preview_response(response: &str, max_len: usize) -> String {
+pub(crate) fn preview_response(response: &str, max_len: usize) -> String {
     if response.len() > max_len {
         let truncate_at = response.floor_char_boundary(max_len);
         format!("{}... ({} chars)", &response[..truncate_at], response.len())

--- a/crates/aura/src/orchestration/frame_validation_tests.rs
+++ b/crates/aura/src/orchestration/frame_validation_tests.rs
@@ -1679,5 +1679,9 @@ fn test_session_history_multi_artifact_listing() {
 // ========================================================================
 
 fn prompt_excerpt(s: &str) -> &str {
-    if s.len() > 200 { &s[..200] } else { s }
+    if s.len() > 200 {
+        &s[..s.floor_char_boundary(200)]
+    } else {
+        s
+    }
 }


### PR DESCRIPTION
Tool-result previews cut the output at a fixed byte index. Most of them feed debug! lines, whose arguments are evaluated even with debug logging off, so a result whose byte 200 fell inside a multibyte character (container logs are full of ─ separators) panicked the tokio worker and killed the stream. All preview sites now share the char-boundary-safe truncation helpers.

Fixes: #609