### PR TITLE
feat(examples): feature-focused example configs and loadability fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,19 +21,19 @@ LLM_API_KEY=sk-...
 #     LLM_MODEL=claude-sonnet-4-20250514
 #     LLM_API_KEY=sk-ant-...
 #
-#   Ollama (local, no API key needed):
-#     LLM_PROVIDER=ollama
-#     LLM_MODEL=llama3.1
-#     LLM_API_KEY=unused
-#     LLM_BASE_URL=http://host.docker.internal:11434
-#
 #   llama-server / llama.cpp (local, OpenAI-compatible):
 #     LLM_PROVIDER=openai
 #     LLM_MODEL=local-model
 #     LLM_API_KEY=unused
 #     LLM_BASE_URL=http://host.docker.internal:8080/v1
+#
+#   Ollama and Bedrock cannot be selected here: quickstart.toml always sends
+#   api_key, which those providers reject. Use a dedicated config instead:
+#     CONFIG_PATH=examples/complete/local-ollama-stdio.toml
+#     CONFIG_PATH=examples/minimal/bedrock.toml
 
-# Optional: base URL override (required for Ollama and llama-server)
+# Optional: base URL override. Only takes effect if you also uncomment the
+# base_url line under [agent.llm] in quickstart.toml.
 # LLM_BASE_URL=
 
 # ── Provider-Specific API Keys ──────────────────────────────────────
@@ -44,6 +44,8 @@ LLM_API_KEY=sk-...
 # OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=sk-ant-...
 # GOOGLE_API_KEY=...
+# OPENROUTER_API_KEY=sk-or-...
+# AWS_REGION=us-east-1          # bedrock configs; credentials come from AWS_PROFILE / IAM
 
 # ── Optional: MCP Server Keys ───────────────────────────────────────
 # MEZMO_API_KEY=...

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -1607,6 +1607,7 @@ context_window = 200000
             repo_root.join("configs"),
             repo_root.join("examples/minimal"),
             repo_root.join("examples/complete"),
+            repo_root.join("examples/multi-agent"),
         ];
         let single_files = [
             repo_root.join("quickstart.toml"),

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -1578,8 +1578,14 @@ context_window = 200000
     fn test_all_shipped_configs_parse() {
         let _env_lock = crate::test_env_lock::lock();
 
+        // Examples that persist data place memory_dir under $HOME/.aura/;
+        // point HOME at a scratch directory so loading them (which creates
+        // and write-probes memory_dir) leaves nothing in the real home.
+        let fake_home = tempfile::TempDir::new().unwrap();
+
         // Set env vars every shipped config expects so env resolution succeeds.
         unsafe {
+            std::env::set_var("HOME", fake_home.path());
             std::env::set_var("OPENAI_API_KEY", "test-openai");
             std::env::set_var("ANTHROPIC_API_KEY", "test-anthropic");
             std::env::set_var("GOOGLE_API_KEY", "test-google");

--- a/examples/complete/client-tools.toml
+++ b/examples/complete/client-tools.toml
@@ -1,0 +1,48 @@
+# Client-side tools — let the model read files on the machine running the
+# `aura` CLI, not on the server.
+#
+# USE AT YOUR OWN RISK. This hands the model tools that execute on the
+# client. Both sides must opt in: the CLI must be started with
+# `--enable-client-tools`, and this config must set
+# `enable_client_tools = true`. `client_tool_filter` then narrows which of
+# the advertised tools the server will attach.
+#
+# Client tools advertised by the CLI:
+#   Shell, Read, ListFiles, Update, SearchFiles, FindFiles, FileInfo
+# This example allows only the read-only ones. Remove the filter (or list
+# "Shell"/"Update") to allow command execution and file edits.
+#
+# Single-agent mode only: orchestration coordinators and workers never
+# receive client tools, even when the request offers them.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY="sk-..."
+#
+# Usage:
+#   CONFIG_PATH=examples/complete/client-tools.toml cargo run --bin aura -- webserver
+#   # in the directory you want the model to see:
+#   aura --api-url http://localhost:8080 --enable-client-tools
+#
+# Docs: https://docs.mezmo.com/aura/client-side-tools
+
+[agent]
+name = "Code Reader"
+model_owner = "mezmo"
+system_prompt = """
+You help developers understand the project in their current directory.
+Use the client tools to list, find, search, and read files; never assume
+a file's contents. Give file paths and line numbers with every claim.
+You cannot modify files or run commands in this configuration.
+"""
+turn_depth = 15
+
+# Attach client tools offered on the request (default: false).
+enable_client_tools = true
+# Glob patterns (`*`, `?`) against client tool names. Omitted or empty
+# means every advertised tool is attached.
+client_tool_filter = ["Read", "ListFiles", "SearchFiles", "FindFiles", "FileInfo"]
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"

--- a/examples/complete/client-tools.toml
+++ b/examples/complete/client-tools.toml
@@ -8,8 +8,9 @@
 # the advertised tools the server will attach.
 #
 # Client tools advertised by the CLI:
-#   Shell, Read, ListFiles, Update, SearchFiles, FindFiles, FileInfo
-# This example allows only the read-only ones. Remove the filter (or list
+#   Shell, Read, ListFiles, Update, SearchFiles, FindFiles, FileInfo,
+#   CompactContext
+# This example allows only the read-only file tools. Remove the filter (or list
 # "Shell"/"Update") to allow command execution and file edits.
 #
 # Single-agent mode only: orchestration coordinators and workers never

--- a/examples/complete/hitl-conversational.toml
+++ b/examples/complete/hitl-conversational.toml
@@ -1,0 +1,68 @@
+# Human-in-the-loop (conversational route) — gate destructive Kubernetes
+# tools behind the person who is already chatting with the agent.
+#
+# When a gated tool is called, the stream emits `aura.approval_requested`
+# and parks the call. The `aura` CLI shows an approve/deny prompt and answers
+# automatically; any other client answers by POSTing the decision to
+# `/v1/approvals/{decision_id}`. Requests must use `stream: true`.
+# For an approver who is NOT at the client (pager, chat-ops, policy
+# service), see hitl-webhook.toml.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY="sk-..."
+#   Kubernetes context configured (kubectl access)
+#   Start the K8s MCP server WITHOUT --read-only so mutating tools exist:
+#     npx -y kubernetes-mcp-server@latest --port 8081
+#
+# Usage:
+#   AURA_CUSTOM_EVENTS=true CONFIG_PATH=examples/complete/hitl-conversational.toml \
+#     cargo run --bin aura -- webserver
+#   cargo run -p aura-cli -- --api-url http://localhost:8080
+#
+# Docs: https://docs.mezmo.com/aura/hitl
+
+# Presence of the [hitl] table enables gating; there is no `enabled` key.
+[hitl]
+# Glob patterns matched against MCP tool names. A tool is gated if it matches
+# ANY pattern. The built-in `request_approval` tool is never gated.
+require_approval = [
+  "*_delete",                 # pods_delete, resources_delete, ...
+  "pods_exec",
+  "resources_create_or_update",
+  "helm_install",
+  "helm_uninstall",
+]
+
+# [hitl.route] is required whenever [hitl] is present.
+[hitl.route]
+mode = "conversational"
+# How long a parked tool call waits for the user's answer (default 60).
+timeout_secs = 120
+
+[mcp]
+sanitize_schemas = true
+
+# Kubernetes — cluster inspection and management
+# https://github.com/containers/kubernetes-mcp-server
+[mcp.servers.kubernetes]
+transport = "http_streamable"
+url = "http://localhost:8081/mcp"
+description = "Kubernetes cluster operations: pods, deployments, services, logs"
+
+[agent]
+name = "Kubernetes Operator"
+model_owner = "mezmo"
+system_prompt = """
+You are a Kubernetes operations assistant. You may inspect any resource
+freely. Mutating operations (delete, exec, apply, helm) require the user's
+approval — the platform will pause the call and ask them; you do not need
+to ask yourself. State clearly what you are about to change and why before
+you call a mutating tool, so the approval prompt has context. If an
+approval is denied, stop and offer a read-only alternative.
+"""
+turn_depth = 20
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"

--- a/examples/complete/hitl-webhook.toml
+++ b/examples/complete/hitl-webhook.toml
@@ -1,0 +1,76 @@
+# Human-in-the-loop (webhook route) — gate destructive Kubernetes tools behind
+# an external approval service. Read-only tools run immediately; anything
+# matching `require_approval` is parked until the webhook answers.
+#
+# Use the webhook route when the approver is NOT the person chatting with the
+# agent (e.g. an on-call engineer paged through Slack/PagerDuty, or a policy
+# service). For an approver who is already at the client, see
+# hitl-conversational.toml.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY="sk-..."
+#   Kubernetes context configured (kubectl access)
+#   Start the K8s MCP server WITHOUT --read-only so mutating tools exist:
+#     npx -y kubernetes-mcp-server@latest --port 8081
+#   An HTTP endpoint that accepts the approval request and replies allow/deny:
+#     export HITL_WEBHOOK_URL="https://approvals.example.com/aura"
+#   Optional but recommended — sign outbound webhook requests (HMAC-SHA256,
+#   min 32 bytes) and verify the response:
+#     export AURA_HITL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+#
+# Usage:
+#   CONFIG_PATH=examples/complete/hitl-webhook.toml cargo run --bin aura -- webserver
+#
+# Docs: https://docs.mezmo.com/aura/hitl
+
+# Presence of the [hitl] table enables gating; there is no `enabled` key.
+[hitl]
+# Glob patterns matched against MCP tool names. A tool is gated if it matches
+# ANY pattern. The built-in `request_approval` tool is never gated.
+require_approval = [
+  "*_delete",                 # pods_delete, resources_delete, ...
+  "pods_exec",
+  "resources_create_or_update",
+  "helm_install",
+  "helm_uninstall",
+]
+
+# [hitl.route] is required whenever [hitl] is present.
+[hitl.route]
+mode = "webhook"
+url = "{{ env.HITL_WEBHOOK_URL | default: 'https://approvals.example.com/aura' }}"
+# How long a parked tool call waits for the webhook before failing (default 300).
+timeout_secs = 300
+# Static headers sent on every webhook request.
+headers = { "x-aura-tenant" = "sre-prod" }
+# Forward headers from the inbound chat request to the webhook, so the approval
+# service can see who asked. Keys are webhook header names, values are inbound
+# request header names (matched case-insensitively).
+headers_from_request = { "authorization" = "authorization" }
+
+[mcp]
+sanitize_schemas = true
+
+# Kubernetes — cluster inspection and management
+# https://github.com/containers/kubernetes-mcp-server
+[mcp.servers.kubernetes]
+transport = "http_streamable"
+url = "http://localhost:8081/mcp"
+description = "Kubernetes cluster operations: pods, deployments, services, logs"
+
+[agent]
+name = "Kubernetes Operator"
+model_owner = "mezmo"
+system_prompt = """
+You are a Kubernetes operations assistant. You may inspect any resource
+freely. Mutating operations (delete, exec, apply, helm) require human
+approval — the platform will pause the call and ask; you do not need to
+ask yourself. If an approval is denied, explain what you intended to do
+and stop. Always name the namespace and resource explicitly.
+"""
+turn_depth = 20
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"

--- a/examples/complete/local-ollama-stdio.toml
+++ b/examples/complete/local-ollama-stdio.toml
@@ -1,0 +1,61 @@
+# Fully local agent — Ollama for the model, a stdio MCP server for tools.
+# No API keys, no network egress.
+#
+# The stdio transport spawns the MCP server as a child process per request
+# and talks JSON-RPC over its stdin/stdout. `cmd[0]` is the executable,
+# `cmd[1..]` and `args` are its arguments, `env` is added to its environment.
+#
+# Prerequisites:
+#   1. Install Ollama: https://ollama.com
+#   2. Pull a tool-capable model: ollama pull qwen3:30b-a3b
+#   3. Node.js 18+ for the filesystem MCP server (fetched on first run by npx)
+#   4. A directory the agent may read:
+#        mkdir -p /tmp/aura-sandbox && cp README.md /tmp/aura-sandbox/
+#
+# Usage:
+#   CONFIG_PATH=examples/complete/local-ollama-stdio.toml cargo run --bin aura -- webserver
+#
+# Docs: https://docs.mezmo.com/aura/ollama-guide
+
+[mcp]
+sanitize_schemas = true
+
+# Filesystem — read/search files under an allow-listed root.
+# https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem
+[mcp.servers.filesystem]
+transport = "stdio"
+cmd = ["npx", "-y", "@modelcontextprotocol/server-filesystem"]
+# Trailing arguments; here, the only directory the server may expose.
+args = ["/tmp/aura-sandbox"]
+# Extra environment for the child process (inherits the server's env too).
+env = { NODE_NO_WARNINGS = "1" }
+description = "Read, search, and list files under /tmp/aura-sandbox"
+
+[agent]
+name = "Local File Assistant"
+model_owner = "local"
+system_prompt = """
+You answer questions about the files in /tmp/aura-sandbox. Use the
+filesystem tools to read them; never guess file contents. Quote the
+relevant lines and name the file they came from.
+"""
+turn_depth = 8
+
+[agent.llm]
+provider = "ollama"
+model = "qwen3:30b-a3b"
+# Ollama's default; set this when Ollama runs on another host or in Docker
+# (e.g. http://host.docker.internal:11434).
+base_url = "http://localhost:11434"
+temperature = 0.2
+# Some local models emit tool calls as text instead of native tool_call
+# structures. This parses those from the stream and executes them via MCP.
+# Applies to single-agent mode only (see mezmo/aura#193 for orchestration).
+fallback_tool_parsing = true
+
+# Passed straight through to Ollama's API.
+# https://github.com/ollama/ollama/blob/main/docs/modelfile.md
+[agent.llm.additional_params]
+# Ollama's default context is small; raise it so tool schemas + file
+# contents fit. Costs VRAM.
+num_ctx = 32000

--- a/examples/complete/local-ollama-stdio.toml
+++ b/examples/complete/local-ollama-stdio.toml
@@ -1,5 +1,6 @@
-# Fully local agent — Ollama for the model, a stdio MCP server for tools.
-# No API keys, no network egress.
+# Local agent — Ollama for the model, a stdio MCP server for tools. No API
+# keys. Once the model is pulled and the MCP server package is installed,
+# nothing leaves the machine at request time.
 #
 # The stdio transport spawns the MCP server as a child process per request
 # and talks JSON-RPC over its stdin/stdout. `cmd[0]` is the executable,
@@ -8,7 +9,10 @@
 # Prerequisites:
 #   1. Install Ollama: https://ollama.com
 #   2. Pull a tool-capable model: ollama pull qwen3:30b-a3b
-#   3. Node.js 18+ for the filesystem MCP server (fetched on first run by npx)
+#   3. Node.js 18+. `npx -y` downloads the filesystem MCP server from the npm
+#      registry on first run; for an air-gapped host install it ahead of time
+#      (npm install -g @modelcontextprotocol/server-filesystem) and change
+#      `cmd` below to ["mcp-server-filesystem"].
 #   4. A directory the agent may read:
 #        mkdir -p /tmp/aura-sandbox && cp README.md /tmp/aura-sandbox/
 #

--- a/examples/complete/orchestrated-worker-overrides.toml
+++ b/examples/complete/orchestrated-worker-overrides.toml
@@ -1,0 +1,205 @@
+# Orchestration — every per-worker override, and every [orchestration.*]
+# knob, in one place. Same K8s + Prometheus setup as kubernetes-sre.toml.
+#
+# Inheritance rules shown by the three workers below:
+#   k8s-discovery       inherits everything from [agent.*] (llm, scratchpad, skills)
+#   prometheus-analyst  overrides llm, scratchpad, and skills
+#   summarizer          no MCP tools; scratchpad explicitly off
+#
+# Per-worker `.scratchpad` REPLACES the agent's table — it is not merged.
+# An override table therefore has to repeat `enabled = true`, or the worker
+# silently runs without scratchpad.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY="sk-..."
+#   Kubernetes context configured (kubectl access)
+#   Start the K8s MCP server:
+#     npx -y kubernetes-mcp-server@latest --port 8081 --read-only
+#   export PROMETHEUS_URL="http://localhost:9090"
+#   Start the Prometheus MCP server:
+#     docker run -i --rm -e PROMETHEUS_URL -e PROMETHEUS_MCP_SERVER_TRANSPORT=http \
+#       -e PROMETHEUS_MCP_BIND_PORT=8082 -p 8082:8082 ghcr.io/pab1it0/prometheus-mcp-server:latest
+#
+# Usage (from the repo root, so the skills path resolves):
+#   AURA_CUSTOM_EVENTS=true CONFIG_PATH=examples/complete/orchestrated-worker-overrides.toml \
+#     cargo run --bin aura -- webserver
+#
+# Docs: https://docs.mezmo.com/aura/configuration-reference#orchestration
+
+# Shared by orchestration persistence ({memory_dir}/{run_id}/...) and worker
+# scratchpads. Required because scratchpad is enabled below.
+memory_dir = "/tmp/aura-worker-overrides"
+
+[mcp]
+sanitize_schemas = true
+
+[mcp.servers.kubernetes]
+transport = "http_streamable"
+url = "http://localhost:8081/mcp"
+description = "Kubernetes cluster operations: pods, deployments, services, logs, events"
+
+[mcp.servers.prometheus]
+transport = "http_streamable"
+url = "http://localhost:8082/mcp"
+description = "Prometheus metrics queries and alert status"
+
+# ── Agent defaults (the coordinator, and what workers inherit) ────────
+
+[agent]
+name = "SRE Coordinator"
+model_owner = "mezmo"
+# In orchestration mode this is the coordinator's prompt.
+system_prompt = """
+You coordinate Kubernetes investigations.
+
+ROUTING
+- Workload state, events, logs → k8s-discovery
+- Metrics, targets, PromQL → prometheus-analyst
+- Turning findings into a report → summarizer
+Dispatch independent tasks in parallel. Answer trivial questions directly.
+"""
+# Default tool-call budget per worker task; workers may override.
+turn_depth = 10
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+# Required on every LLM that a scratchpad-enabled worker resolves to.
+context_window = 400_000
+
+# Default scratchpad for workers that don't override it.
+[agent.scratchpad]
+enabled = true
+context_safety_margin = 0.20
+max_extraction_tokens = 10_000
+turn_depth_bonus = 6
+
+# Default skill sources for workers that don't override them.
+[[agent.skills.local]]
+source = "examples/complete/skills"
+
+# ── Orchestration ─────────────────────────────────────────────────────
+
+[orchestration]
+enabled = true
+# Plan → execute → re-plan cycles before the coordinator must answer.
+max_planning_cycles = 3
+# Malformed-plan retries before falling back to a single generic task.
+max_plan_parse_retries = 3
+# Let the coordinator skip orchestration for simple questions.
+allow_direct_answers = true
+# Let the coordinator ask the user a question instead of planning.
+allow_clarification = true
+# What the coordinator sees about tools while planning (display only):
+# "none" | "summary" (names per worker) | "full" (names + descriptions).
+tools_in_planning = "summary"
+# Truncate each worker's tool list in the planning prompt after N names.
+max_tools_per_worker = 10
+# Consecutive identical tool calls before the worker is nudged / blocked.
+duplicate_call_nudge_threshold = 3
+duplicate_call_block_threshold = 5
+# Extra instructions injected into the GENERIC worker preamble (used for
+# tasks not assigned to a named worker). Named workers use `preamble`.
+worker_system_prompt = "Report exact resource names and namespaces."
+
+[orchestration.timeouts]
+# Wall-clock budget for one coordinator phase or one worker task; 0 disables.
+per_call_timeout_secs = 180
+# Max silence between stream items before a call is treated as stalled;
+# 0 disables. Must be below per_call_timeout_secs to have any effect.
+# Tool execution time does not count as silence.
+stream_inactivity_timeout_secs = 60
+
+# Backoff for transient failures (provider 5xx, 408, connection errors)
+# on coordinator planning calls. Retry 1 waits base_delay_ms; each later
+# retry doubles the wait, capped at max_delay_ms.
+[orchestration.retry]
+base_delay_ms = 500
+max_delay_ms = 5000
+# Retries after the initial planning call.
+max_retries = 3
+
+[orchestration.artifacts]
+# Worker results longer than this (chars) are written to disk and
+# replaced inline by a summary of at most result_summary_length chars.
+result_artifact_threshold = 4000
+result_summary_length = 2000
+# Tool outputs larger than this (chars) or slower than this (ms) are
+# promoted to artifact files with an inline pointer. 0 = always / never.
+tool_output_artifact_threshold = 500
+tool_output_duration_threshold_ms = 5000
+# Prior run manifests injected into the coordinator prompt as session
+# context; 0 disables.
+session_history_turns = 3
+# Run directories kept per session before the oldest are pruned; 0 = keep all.
+max_session_runs = 20
+# Include condensed tool-call reasoning in the re-planning prompt.
+show_tool_reasoning_in_continuation = false
+
+# ── Workers ───────────────────────────────────────────────────────────
+
+# Inherits [agent.llm], [agent.scratchpad], and [agent.skills] unchanged.
+[orchestration.worker.k8s-discovery]
+description = "Kubernetes workload state: namespaces, pods, events, logs"
+preamble = """
+You are a Kubernetes discovery specialist. Use tools for every fact;
+never guess cluster state. Report names, kinds, replicas, and conditions.
+"""
+# Overrides [agent].turn_depth for this worker.
+turn_depth = 8
+# Glob patterns (`*`, `?`) against MCP tool names. Omit for all tools.
+mcp_filter = [
+  "namespaces_list",
+  "pods_list", "pods_list_in_namespace", "pods_get", "pods_log", "pods_top",
+  "events_list",
+  "resources_get", "resources_list",
+]
+# Names from [[vector_stores]] this worker may search (none defined here;
+# see rag-knowledge-base.toml). Default: no retrieval access.
+vector_stores = []
+
+# Overrides llm, scratchpad, and skills.
+[orchestration.worker.prometheus-analyst]
+description = "Prometheus metrics: PromQL queries, targets, metric metadata"
+preamble = """
+You are a Prometheus analyst. Run the query, then report metric names,
+labels, and values exactly as returned. Do not fabricate numbers.
+"""
+turn_depth = 8
+mcp_filter = ["health_check", "execute_query", "execute_range_query",
+              "list_metrics", "get_metric_metadata", "get_targets"]
+
+# A complete LLM config — provider tag and credentials included — not a
+# partial patch of [agent.llm].
+[orchestration.worker.prometheus-analyst.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-4o"
+context_window = 128_000
+temperature = 0.1
+
+# Replaces [agent.scratchpad] wholesale: `enabled` must be repeated.
+[orchestration.worker.prometheus-analyst.scratchpad]
+enabled = true
+max_extraction_tokens = 4_000
+turn_depth_bonus = 4
+
+# `local = []` disables skills for this worker. A non-empty list would
+# replace (not extend) the agent's sources.
+[orchestration.worker.prometheus-analyst.skills]
+local = []
+
+# No tools, no scratchpad; just synthesizes what the others found.
+[orchestration.worker.summarizer]
+description = "Writes the final incident summary from other workers' findings"
+preamble = """
+You are a technical writer. Using only the material in your task, produce:
+Impact / Since / Cause / Evidence / Next step. Quote evidence verbatim.
+"""
+turn_depth = 2
+# Empty list = no MCP tools at all (omitting the key would mean ALL tools).
+mcp_filter = []
+
+[orchestration.worker.summarizer.scratchpad]
+enabled = false

--- a/examples/complete/orchestrated-worker-overrides.toml
+++ b/examples/complete/orchestrated-worker-overrides.toml
@@ -27,8 +27,10 @@
 # Docs: https://docs.mezmo.com/aura/configuration-reference#orchestration
 
 # Shared by orchestration persistence ({memory_dir}/{run_id}/...) and worker
-# scratchpads. Required because scratchpad is enabled below.
-memory_dir = "/tmp/aura-worker-overrides"
+# scratchpads. Required because scratchpad is enabled below. Tool output is
+# stored here in plaintext with default permissions, so keep it under a
+# directory only your user can read rather than a shared path like /tmp.
+memory_dir = "{{ env.HOME }}/.aura/worker-overrides"
 
 [mcp]
 sanitize_schemas = true

--- a/examples/complete/rag-knowledge-base.toml
+++ b/examples/complete/rag-knowledge-base.toml
@@ -1,0 +1,102 @@
+# RAG — an orchestrated support agent that answers from vector stores.
+#
+# Two stores are configured:
+#   runbooks     Qdrant collection you populate yourself (any embedding
+#                pipeline that writes 1536-dim vectors for text-embedding-3-small)
+#   customer_kb  Amazon Bedrock Knowledge Base (managed; Bedrock owns the
+#                embeddings, so no embedding_model is configured for it)
+#
+# Every store becomes a `vector_search_<name>` tool. In orchestration mode a
+# worker sees NO stores unless it lists them in `vector_stores`, and the
+# coordinator sees only `coordinator_vector_stores`. This keeps retrieval
+# scoped: the knowledge worker searches both stores; the coordinator can
+# check runbooks while planning; the general worker has none.
+#
+# A third type, `in_memory`, is accepted by the config but is created empty
+# and cannot be populated from TOML — it exists for tests. Use Qdrant or
+# Bedrock KB for real data.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY="sk-..."          # LLM + Qdrant embeddings
+#   export AWS_REGION="us-east-1"
+#   export AWS_PROFILE="default"            # credentials for the Bedrock KB
+#   export BEDROCK_KB_ID="ABCDEFGHIJ"       # your knowledge base id
+#   Qdrant (gRPC port) with a `runbooks` collection:
+#     docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant
+#     export QDRANT_URL="http://localhost:6334"
+#
+# Usage:
+#   CONFIG_PATH=examples/complete/rag-knowledge-base.toml cargo run --bin aura -- webserver
+#
+# Docs: https://docs.mezmo.com/aura/configuration-reference#vector_stores
+
+[[vector_stores]]
+name = "runbooks"
+type = "qdrant"
+# Prepended to search results so the model knows what it is reading.
+context_prefix = "Internal SRE runbooks and postmortems"
+url = "{{ env.QDRANT_URL | default: 'http://localhost:6334' }}"
+collection_name = "runbooks"
+
+# Required for in_memory and qdrant stores; must match how the collection
+# was embedded.
+[vector_stores.embedding_model]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "text-embedding-3-small"
+
+[[vector_stores]]
+name = "customer_kb"
+type = "bedrock_kb"
+context_prefix = "Customer-facing product documentation"
+knowledge_base_id = "{{ env.BEDROCK_KB_ID | default: 'REPLACE_WITH_KB_ID' }}"
+region = "{{ env.AWS_REGION }}"
+profile = "{{ env.AWS_PROFILE | default: 'default' }}"
+# true for a Bedrock *managed* knowledge base; false (default) for a classic
+# vector-store-backed one. Wrong value → ValidationException at query time.
+managed = true
+
+[agent]
+name = "Support Researcher"
+model_owner = "mezmo"
+# In orchestration mode this is the coordinator's prompt.
+system_prompt = """
+You coordinate answers to product and operations questions. Break the
+question into lookups, send them to the knowledge worker, and compose a
+final answer that cites which store each fact came from. If the stores
+have no relevant content, say so instead of guessing.
+"""
+turn_depth = 10
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+
+[orchestration]
+enabled = true
+max_planning_cycles = 2
+allow_direct_answers = true
+# Stores the coordinator itself may search while planning.
+coordinator_vector_stores = ["runbooks"]
+
+[orchestration.worker.knowledge]
+description = "Searches runbooks and the customer knowledge base"
+preamble = """
+You are a research specialist. Search the vector stores available to you,
+quote the most relevant passages verbatim, and return them with the store
+name and any document identifiers. Do not summarize away specifics.
+"""
+# Store names must match [[vector_stores]].name. Omit or leave empty for a
+# worker with no retrieval access.
+vector_stores = ["runbooks", "customer_kb"]
+# This worker has no MCP tools; retrieval only.
+mcp_filter = []
+
+[orchestration.worker.general]
+description = "Reasons over material already retrieved; no store access"
+preamble = """
+You are an analyst. Work only from the material given to you in the task
+and produce a clear, structured conclusion.
+"""
+mcp_filter = []

--- a/examples/complete/reasoning-models.toml
+++ b/examples/complete/reasoning-models.toml
@@ -1,0 +1,86 @@
+# Reasoning / extended-thinking parameters — set per provider, side by side.
+#
+# These knobs live in different places and are rejected under the wrong
+# provider ([agent.llm] and every worker .llm reject unknown keys):
+#   openai      reasoning_effort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
+#   anthropic   [..llm.additional_params.thinking]  type + budget_tokens
+#   gemini      [..llm.additional_params]           provider thinking config
+#   ollama      [..llm.additional_params]           num_ctx, seed, top_p, ...
+# `additional_params` is merged into the provider request as-is; AURA does
+# not validate its contents.
+#
+# The coordinator runs on GPT-5 with high reasoning; one worker runs on
+# Claude with extended thinking; another runs GPT-5 with reasoning turned
+# down for cheap, fast lookups. Each worker's `.llm` is a complete config
+# with its own provider tag and credentials.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY="sk-..."
+#   export ANTHROPIC_API_KEY="sk-ant-..."
+#
+# Usage:
+#   CONFIG_PATH=examples/complete/reasoning-models.toml cargo run --bin aura -- webserver
+
+[agent]
+name = "Analysis Coordinator"
+model_owner = "mezmo"
+system_prompt = """
+You coordinate analytical questions. Send anything that needs careful
+multi-step reasoning (trade-offs, root-cause arguments, design reviews)
+to deep-analysis. Send quick factual lookups and reformatting to fast.
+Answer trivial questions yourself.
+"""
+turn_depth = 6
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+# OpenAI-only key. "none" disables reasoning on models that allow it.
+reasoning_effort = "high"
+max_tokens = 16_000
+
+[orchestration]
+enabled = true
+max_planning_cycles = 2
+allow_direct_answers = true
+
+[orchestration.worker.deep-analysis]
+description = "Careful multi-step reasoning: trade-offs, root causes, design review"
+preamble = """
+You are a senior analyst. Think the problem through before answering.
+State your assumptions, weigh alternatives, and give a recommendation
+with the evidence that supports it.
+"""
+turn_depth = 4
+mcp_filter = []
+
+[orchestration.worker.deep-analysis.llm]
+provider = "anthropic"
+api_key = "{{ env.ANTHROPIC_API_KEY }}"
+model = "claude-sonnet-4-5-20250929"
+# Anthropic requires temperature 1.0 when thinking is enabled.
+temperature = 1.0
+# max_tokens must exceed the thinking budget.
+max_tokens = 16_000
+context_window = 200_000
+
+# Sent verbatim as the `thinking` field of the Messages API request.
+[orchestration.worker.deep-analysis.llm.additional_params.thinking]
+type = "enabled"
+budget_tokens = 8_000
+
+[orchestration.worker.fast]
+description = "Quick factual lookups, reformatting, short summaries"
+preamble = """
+You answer quickly and briefly. No preamble, no caveats.
+"""
+turn_depth = 2
+mcp_filter = []
+
+[orchestration.worker.fast.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+reasoning_effort = "minimal"
+max_tokens = 2_000

--- a/examples/complete/scratchpad-single-agent.toml
+++ b/examples/complete/scratchpad-single-agent.toml
@@ -1,0 +1,82 @@
+# Scratchpad (context-window management) — a single agent that inspects a
+# Kubernetes cluster without letting large tool outputs (pod logs, event
+# lists, resource dumps) flood the context window.
+#
+# When an MCP tool returns more than its `min_tokens` threshold, the output is
+# written to disk under `memory_dir` and the model receives a short pointer
+# instead. The agent then uses the scratchpad exploration tools (head, slice,
+# grep, schema, get_in, iterate_over, item_schema, read) to pull out only what
+# it needs.
+#
+# Three settings must be present together or the config fails to load:
+#   1. top-level `memory_dir`               (where intercepted outputs are written)
+#   2. `[agent.llm].context_window`         (budget math needs the real window size)
+#   3. `[agent.scratchpad].enabled = true`
+#
+# Prerequisites:
+#   export OPENAI_API_KEY="sk-..."
+#   Kubernetes context configured (kubectl access)
+#   Start the K8s MCP server:
+#     npx -y kubernetes-mcp-server@latest --port 8081 --read-only
+#
+# Usage:
+#   CONFIG_PATH=examples/complete/scratchpad-single-agent.toml cargo run --bin aura -- webserver
+#
+# Docs: https://docs.mezmo.com/aura/scratchpad
+
+# Created if missing and checked for writability at startup.
+# Single-agent files land in {memory_dir}/scratchpad/.
+memory_dir = "/tmp/aura-scratchpad"
+
+[mcp]
+sanitize_schemas = true
+
+# Kubernetes — cluster inspection
+# https://github.com/containers/kubernetes-mcp-server
+[mcp.servers.kubernetes]
+transport = "http_streamable"
+url = "http://localhost:8081/mcp"
+description = "Kubernetes cluster operations: pods, deployments, services, logs, events"
+
+# Per-tool interception thresholds for this server, in tokens. Keys are glob
+# patterns (`*` and `?`) matched against tool names; the longest matching
+# pattern wins. Omit this table entirely to use the default of 5120 for
+# every tool.
+[mcp.servers.kubernetes.scratchpad]
+"*" = { min_tokens = 5_120 }          # default for everything on this server
+"pods_log" = { min_tokens = 1_500 }   # logs are big and rarely needed in full
+"events_list" = { min_tokens = 1_500 }
+"resources_list" = { min_tokens = 2_500 }
+
+[agent]
+name = "Kubernetes Investigator"
+model_owner = "mezmo"
+system_prompt = """
+You are a Kubernetes troubleshooting assistant.
+
+Large tool outputs are saved to a scratchpad instead of being returned
+inline; you will see a pointer like [scratchpad: file_id=...]. When that
+happens, do not re-run the tool. Use the scratchpad tools to inspect the
+saved output: `head` or `schema` first to learn its shape, then `grep`,
+`slice`, `get_in`, or `iterate_over` to extract exactly what you need.
+
+Report concrete resource names, namespaces, timestamps, and counts. Never
+invent values you did not read from the data.
+"""
+turn_depth = 12
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+# Required when scratchpad is enabled. Use the real window for your model.
+context_window = 400_000
+
+[agent.scratchpad]
+enabled = true
+# Fraction of context_window held back for reasoning and the final answer.
+context_safety_margin = 0.20
+# Cap on tokens a single exploration tool call may return.
+max_extraction_tokens = 10_000
+# Extra ReAct turns granted so exploration calls don't eat the turn budget.
+turn_depth_bonus = 6

--- a/examples/complete/scratchpad-single-agent.toml
+++ b/examples/complete/scratchpad-single-agent.toml
@@ -24,9 +24,15 @@
 #
 # Docs: https://docs.mezmo.com/aura/scratchpad
 
-# Created if missing and checked for writability at startup.
-# Single-agent files land in {memory_dir}/scratchpad/.
-memory_dir = "/tmp/aura-scratchpad"
+# Created if missing and checked for writability at startup. Single-agent
+# files land in {memory_dir}/scratchpad/.
+#
+# Intercepted tool output (pod logs, events, resource dumps) is written here
+# in plaintext, and AURA does not tighten permissions on what it creates.
+# Keep it under a directory only your user can read; avoid shared locations
+# such as /tmp, where another local user could read the files or pre-create
+# the path.
+memory_dir = "{{ env.HOME }}/.aura/scratchpad"
 
 [mcp]
 sanitize_schemas = true
@@ -40,10 +46,11 @@ description = "Kubernetes cluster operations: pods, deployments, services, logs,
 
 # Per-tool interception thresholds for this server, in tokens. Keys are glob
 # patterns (`*` and `?`) matched against tool names; the longest matching
-# pattern wins. Omit this table entirely to use the default of 5120 for
-# every tool.
+# pattern wins. A server with no entries here is never intercepted, so a
+# catch-all `"*"` entry is what turns scratchpad on for the whole server.
+# `min_tokens` defaults to 5120 when omitted (`"*" = {}`).
 [mcp.servers.kubernetes.scratchpad]
-"*" = { min_tokens = 5_120 }          # default for everything on this server
+"*" = { min_tokens = 5_120 }          # everything on this server
 "pods_log" = { min_tokens = 1_500 }   # logs are big and rarely needed in full
 "events_list" = { min_tokens = 1_500 }
 "resources_list" = { min_tokens = 2_500 }
@@ -55,8 +62,9 @@ system_prompt = """
 You are a Kubernetes troubleshooting assistant.
 
 Large tool outputs are saved to a scratchpad instead of being returned
-inline; you will see a pointer like [scratchpad: file_id=...]. When that
-happens, do not re-run the tool. Use the scratchpad tools to inspect the
+inline; you will see a pointer like
+[scratchpad: output saved to '<file>' (~N tokens, N lines, format=json)].
+When that happens, do not re-run the tool. Use the scratchpad tools to inspect the
 saved output: `head` or `schema` first to learn its shape, then `grep`,
 `slice`, `get_in`, or `iterate_over` to extract exactly what you need.
 

--- a/examples/complete/skills-agent.toml
+++ b/examples/complete/skills-agent.toml
@@ -1,0 +1,53 @@
+# Skills — an agent that loads procedural knowledge on demand from local
+# SKILL.md files (Agent Skills spec: https://agentskills.io/specification).
+#
+# Each subdirectory of a `source` path that contains a SKILL.md becomes one
+# skill. At startup the catalog (name + description) is put in the agent's
+# context; the full body is only read when the model calls `load_skill`, so
+# you can ship many skills without paying for them on every request.
+#
+# The skill shipped with this example lives in ./skills/incident-triage/.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY="sk-..."
+#   Kubernetes context configured (kubectl access)
+#   Start the K8s MCP server:
+#     npx -y kubernetes-mcp-server@latest --port 8081 --read-only
+#
+# Usage (run from the repo root — `source` paths resolve against the process
+# working directory):
+#   CONFIG_PATH=examples/complete/skills-agent.toml cargo run --bin aura -- webserver
+#
+# Docs: https://docs.mezmo.com/aura/skills
+
+[mcp]
+sanitize_schemas = true
+
+# Kubernetes — cluster inspection
+# https://github.com/containers/kubernetes-mcp-server
+[mcp.servers.kubernetes]
+transport = "http_streamable"
+url = "http://localhost:8081/mcp"
+description = "Kubernetes cluster operations: pods, deployments, services, logs, events"
+
+[agent]
+name = "SRE Assistant"
+model_owner = "mezmo"
+system_prompt = """
+You are an SRE assistant with access to a Kubernetes cluster and a library
+of skills. When a request matches a skill's description, call `load_skill`
+first and follow the procedure it gives you before using cluster tools.
+Cite which skill you followed in your answer.
+"""
+turn_depth = 15
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+
+# One entry per directory of skills. Add more [[agent.skills.local]] tables to
+# combine sources; when two sources define the same skill name, the first
+# listed wins and a warning is logged.
+[[agent.skills.local]]
+source = "examples/complete/skills"

--- a/examples/complete/skills/incident-triage/SKILL.md
+++ b/examples/complete/skills/incident-triage/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: incident-triage
+description: Use when asked to triage, investigate, or diagnose a Kubernetes incident, outage, or unhealthy workload. Gives the step-by-step order of investigation and the format for the findings.
+---
+# Incident triage
+
+Follow these steps in order. Do not skip ahead to a fix.
+
+## 1. Establish scope
+
+- Identify the namespace and workload named in the request. If none is
+  given, list namespaces and ask which one before continuing.
+- Record the time the problem was first noticed.
+
+## 2. Check workload state
+
+- List pods for the workload and note any that are not `Running`/`Ready`.
+- For each unhealthy pod, note restart count, last termination reason, and
+  the age of the current container.
+
+## 3. Read recent events
+
+- List events for the namespace, most recent first.
+- Look for: `OOMKilled`, `CrashLoopBackOff`, `FailedScheduling`,
+  `ImagePullBackOff`, probe failures, node pressure.
+
+## 4. Read logs — narrowly
+
+- Fetch logs only for the unhealthy pods, only the tail (last 200 lines).
+- Search for stack traces, connection refused/timeouts, and the first
+  error after the last successful startup line.
+
+## 5. Report
+
+Use exactly this structure:
+
+```
+Impact:      <what is broken, for whom>
+Since:       <timestamp, from events or first error>
+Cause:       <best current hypothesis, with the evidence line that supports it>
+Evidence:    <pod names, event reasons, log excerpts — quoted, not paraphrased>
+Next step:   <one action, read-only unless the user asked for a fix>
+```
+
+If the evidence does not support a single cause, say so and list the two
+most likely candidates with what would distinguish them.

--- a/examples/multi-agent/README.md
+++ b/examples/multi-agent/README.md
@@ -1,0 +1,32 @@
+# Multi-agent directory example
+
+One `aura webserver` process serving three agents. Point `CONFIG_PATH` at
+this directory and every `.toml` in it is loaded as a separate agent.
+
+```bash
+export OPENAI_API_KEY="sk-..."
+npx -y kubernetes-mcp-server@latest --port 8081 --read-only   # for sre.toml
+CONFIG_PATH=examples/multi-agent/ DEFAULT_AGENT=sre cargo run --bin aura -- webserver
+```
+
+| File | `model` id | Notes |
+| --- | --- | --- |
+| `sre.toml` | `sre` | Kubernetes MCP tools |
+| `writer.toml` | `writer` | no tools, cheaper model |
+| `internal-eval.toml` | `eval` | `hidden = true` — callable, but absent from `/v1/models` |
+
+Rules the loader enforces across the directory:
+
+- Every agent's id (`alias`, or `name` when no alias) must be unique.
+- `DEFAULT_AGENT` (or `--default-agent`) must match one of those ids, or
+  the server refuses to start. With more than one agent and no default,
+  requests that omit `model` get a 400.
+- Files are loaded in sorted filename order; each is validated on its own.
+
+Try it:
+
+```bash
+curl -s localhost:8080/v1/models | jq '.data[].id'     # sre, writer — not eval
+aura --api-url http://localhost:8080 --model writer
+aura --api-url http://localhost:8080 --model eval       # still works
+```

--- a/examples/multi-agent/internal-eval.toml
+++ b/examples/multi-agent/internal-eval.toml
@@ -1,0 +1,24 @@
+# Multi-agent server, agent 3 of 3 — see README.md in this directory.
+#
+# A hidden agent: still callable with `model = "eval"`, but omitted from
+# /v1/models so chat UIs that build a model picker from that list never
+# show it. Useful for evaluation harnesses, canaries, or an agent only a
+# known caller should reach.
+
+[agent]
+name = "Evaluation Canary"
+alias = "eval"
+description = "Internal prompt-evaluation target; not for end users"
+model_owner = "mezmo"
+hidden = true
+system_prompt = """
+You are an evaluation target. Answer as concisely as possible and never
+add caveats or follow-up questions.
+"""
+turn_depth = 1
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+temperature = 0.0

--- a/examples/multi-agent/sre.toml
+++ b/examples/multi-agent/sre.toml
@@ -1,0 +1,39 @@
+# Multi-agent server, agent 1 of 3 — see README.md in this directory.
+#
+# Point CONFIG_PATH at the directory and every .toml in it is loaded as a
+# separate agent. Clients pick one with the OpenAI `model` field; the value
+# is the agent's `alias` when set, otherwise its `name`.
+#
+# Usage (from the repo root):
+#   CONFIG_PATH=examples/multi-agent/ DEFAULT_AGENT=sre cargo run --bin aura -- webserver
+#   curl -s localhost:8080/v1/models | jq '.data[].id'
+#   aura --api-url http://localhost:8080 --model sre
+
+[mcp]
+sanitize_schemas = true
+
+[mcp.servers.kubernetes]
+transport = "http_streamable"
+url = "http://localhost:8081/mcp"
+description = "Kubernetes cluster operations: pods, deployments, services, logs"
+
+[agent]
+name = "Kubernetes SRE Agent"
+# The id clients use in `model`. Must be unique across the directory;
+# without an alias the `name` is used instead.
+alias = "sre"
+# Shown in /v1/models and /aura/info.
+description = "Investigates Kubernetes workloads and cluster health"
+# `owned_by` in /v1/models (defaults to the provider name).
+model_owner = "mezmo"
+system_prompt = """
+You are a Kubernetes SRE assistant. Inspect cluster state with the
+available tools, prefer read-only operations, and always name namespaces
+and resources explicitly.
+"""
+turn_depth = 15
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"

--- a/examples/multi-agent/writer.toml
+++ b/examples/multi-agent/writer.toml
@@ -1,0 +1,23 @@
+# Multi-agent server, agent 2 of 3 — see README.md in this directory.
+#
+# A tool-less agent on a cheaper model, served from the same process as
+# sre.toml. Select it with `model = "writer"`.
+
+[agent]
+name = "Technical Writer"
+alias = "writer"
+description = "Drafts and edits runbooks, postmortems, and status updates"
+model_owner = "mezmo"
+system_prompt = """
+You are a technical writer for an SRE team. Turn notes into clear,
+structured documents: runbooks with numbered steps, postmortems with
+timeline / impact / root cause / action items, and status updates that a
+non-engineer can read. Ask for missing facts rather than inventing them.
+"""
+turn_depth = 3
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-4o-mini"
+temperature = 0.4

--- a/examples/quickstart-k8s-sre/aura-values.yaml
+++ b/examples/quickstart-k8s-sre/aura-values.yaml
@@ -108,7 +108,6 @@ config:
     [orchestration]
     enabled = true
     max_planning_cycles = 2
-    quality_threshold = 0.7
     allow_direct_answers = true
     allow_clarification = false
     tools_in_planning = "summary"

--- a/examples/quickstart-orchestration-math/config.toml
+++ b/examples/quickstart-orchestration-math/config.toml
@@ -62,7 +62,6 @@ description = "Math MCP server providing arithmetic, statistics, and trigonometr
 [orchestration]
 enabled = true
 max_planning_cycles = 2
-quality_threshold = 0.7
 allow_direct_answers = true
 allow_clarification = true
 tools_in_planning = "summary"

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -16,7 +16,26 @@
 #   examples/complete/incident-response-mezmo.toml    - PagerDuty + Mezmo
 #   examples/complete/incident-response-datadog.toml  - PagerDuty + Datadog
 #   examples/complete/kubernetes-sre.toml             - K8s MCP + Prometheus
+#   examples/complete/kubernetes-sre-orchestrated-multi-model.toml
+#                                                     - orchestration, per-worker LLM
 #   examples/complete/devops-assistant.toml           - GitHub MCP
+#   examples/complete/hidden-agent.toml               - alias + hidden from /v1/models
+#
+# Feature-focused configs:
+#   examples/complete/hitl-webhook.toml               - approval gate, webhook route
+#   examples/complete/hitl-conversational.toml        - approval gate, in-chat route
+#   examples/complete/scratchpad-single-agent.toml    - large tool outputs → scratchpad
+#   examples/complete/skills-agent.toml               - on-demand SKILL.md loading
+#   examples/complete/rag-knowledge-base.toml         - Qdrant + Bedrock KB retrieval
+#   examples/complete/local-ollama-stdio.toml         - Ollama + stdio MCP, no API keys
+#   examples/complete/orchestrated-worker-overrides.toml
+#                                                     - every per-worker override + [orchestration.*] knob
+#   examples/complete/reasoning-models.toml           - reasoning_effort / thinking params per provider
+#   examples/complete/client-tools.toml               - CLI-side file tools, read-only filter
+#
+# Several agents from one server: examples/multi-agent/ (CONFIG_PATH=<dir>)
+#
+# Runnable quickstarts (compose / Helm): examples/quickstart-*/
 
 # ── MCP Tool Servers ────────────────────────────────────────────────
 [mcp]

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -91,7 +91,7 @@ description = "Example STDIO MCP server"
 
 # Static headers sent with every request.
 [mcp.servers.example_http.headers]
-Authorization = "Bearer {{ env.MCP_TOKEN }}"
+Authorization = "Bearer {{ env.MCP_TOKEN | default: '' }}"
 
 # ── Header forwarding ───────────────────────────────────────────────
 # Forward headers from the incoming HTTP request to an MCP server.

--- a/quickstart.toml
+++ b/quickstart.toml
@@ -86,11 +86,10 @@ provider = "{{ env.LLM_PROVIDER }}"
 api_key = "{{ env.LLM_API_KEY }}"
 model = "{{ env.LLM_MODEL }}"
 context_window = 200_000
-# base_url = "{{ env.LLM_BASE_URL }}"    # Uncomment for Ollama or llama-server
-# fallback_tool_parsing = true            # Ollama only. Known issue: currently applied in
-#                                         # single-agent mode ([orchestration].enabled =
-#                                         # false) only, not the orchestration coordinator/
-#                                         # workers — a bug tracked in mezmo/aura#193.
+# base_url = "{{ env.LLM_BASE_URL }}"    # Uncomment for llama-server or any OpenAI-compatible endpoint
+# This template always sends api_key, which the ollama and bedrock providers
+# reject. For a local model use examples/complete/local-ollama-stdio.toml;
+# for Bedrock use examples/minimal/bedrock.toml.
 
 [agent.scratchpad]
 enabled = true
@@ -103,7 +102,6 @@ turn_depth_bonus = 6
 [orchestration]
 enabled = true
 max_planning_cycles = 2
-quality_threshold = 0.75
 allow_direct_answers = true
 allow_clarification = true
 tools_in_planning = "summary"


### PR DESCRIPTION
## Why

Every example under `examples/complete/` was a variation of one shape: OpenAI plus `http_streamable` MCP. Nothing in `examples/` showed `[hitl]`, `[agent.scratchpad]`, skills, client tools, per-worker overrides, vector stores, the stdio transport, or reasoning parameters. Where those features were configured at all it was in integration fixtures or in commented-out blocks of `reference.toml`. Separately, three shipped configs carried a key the loader does not know about, and two of the copy-paste recipes in the repo could not load.

## What

The first commit adds nine configs to `examples/complete/` and a three-agent `examples/multi-agent/` directory. Each file loads as-is with the env vars its header names, and each is parse-tested by `test_all_shipped_configs_parse` (the test now walks `examples/multi-agent/` too).

| File | Shows |
| --- | --- |
| `hitl-webhook.toml`, `hitl-conversational.toml` | `[hitl]` gate on mutating Kubernetes tools, one per route mode |
| `scratchpad-single-agent.toml` | `memory_dir`, `context_window`, and `[agent.scratchpad]` together, plus per-tool `min_tokens` |
| `skills-agent.toml` + `skills/incident-triage/SKILL.md` | `[[agent.skills.local]]` with a real skill directory |
| `rag-knowledge-base.toml` | Qdrant and Bedrock KB stores, `coordinator_vector_stores`, per-worker `vector_stores` |
| `local-ollama-stdio.toml` | Ollama with `fallback_tool_parsing` and a stdio MCP server, no API keys |
| `orchestrated-worker-overrides.toml` | every per-worker override and every `[orchestration.*]` key at its default |
| `reasoning-models.toml` | `reasoning_effort` and Anthropic thinking params, per provider |
| `client-tools.toml` | `enable_client_tools` with a read-only `client_tool_filter` |
| `multi-agent/` | directory-mode loading with `alias`, `hidden`, `DEFAULT_AGENT` |

The second commit fixes the existing files:

- `examples/reference.toml` had a live `{{ env.MCP_TOKEN }}` with no default, so the `cp examples/reference.toml config.toml` step in `DEVELOPMENT.md` failed unless `MCP_TOKEN` was set. It now needs only `OPENAI_API_KEY`.
- `quality_threshold` is not an `[orchestration]` key and was silently dropped. Removed from `quickstart.toml` and both quickstart examples.
- The Ollama recipe in `.env.example` could not load: `quickstart.toml` always sends `api_key`, and the `ollama` provider rejects it. The recipe now points at `local-ollama-stdio.toml`. `OPENROUTER_API_KEY` and `AWS_REGION` are listed because the minimal configs need them.

## Notes for review

- `reasoning-models.toml` puts an Anthropic worker under an OpenAI coordinator. The config layer and orchestrator have no provider-equality check, but the existing multi-model example stays on one provider, so this one deserves a live run.
- `in_memory` vector stores are created empty and `add_documents` only logs (`crates/aura/src/vector_store.rs:185`, `:332`), so the RAG example uses Qdrant and Bedrock KB and says so in a comment.
- Per-worker `.scratchpad` replaces the agent table rather than merging with it (`orchestrator.rs:661-663`). The overrides example repeats `enabled = true` and explains why. The hosted scratchpad page and the `scratchpad.rs` struct comment still say "merged"; that needs a separate fix.
- Not in this PR: the Helm chart still renders a top-level `[llm]` table and documents `quality_threshold`, and `docs.mezmo.com/aura/example-configs` needs the new rows.

## Checks

`cargo +nightly fmt --check`, `cargo clippy -p aura-config --tests`, `cargo test -p aura-config` (205 passed), commitlint.
