### PR TITLE
Show a line in the REPL when a tool approval is requested

### DIFF
--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -490,6 +490,23 @@ fn flush_live_reasoning(state: &Arc<Mutex<Option<LiveReasoning>>>) -> bool {
     was_top_level
 }
 
+/// Scrollback line for an `approval_requested` event. Route-neutral: the
+/// event carries no route, and a conversational `approval_pending` prompt
+/// appends below this line rather than replacing it, so the wording must
+/// not claim a route.
+fn approval_requested_line(requested: &aura_events::ApprovalRequested) -> String {
+    use aura_events::ApprovalOriginWire;
+    let origin = match &requested.origin {
+        ApprovalOriginWire::ConfigGate {
+            matched_pattern, ..
+        } => {
+            format!("config gate · {matched_pattern}")
+        }
+        ApprovalOriginWire::AgentRequested { .. } => "agent requested".to_string(),
+    };
+    format!("⏸ Approval requested — {} ({origin})", requested.tool_name)
+}
+
 /// Live worker reasoning blocks, one per concurrently-executing task.
 /// Keyed by `task_id` so interleaved deltas from same-wave workers each
 /// update their own tree row instead of contending for a single block.
@@ -3394,20 +3411,7 @@ impl StreamHandler for ReplStreamHandler {
             let _term = lock_term();
             erase_input_frame();
 
-            use aura_events::ApprovalOriginWire;
-            let origin = match &requested.origin {
-                ApprovalOriginWire::ConfigGate { matched_pattern, .. } => {
-                    format!("config gate · {matched_pattern}")
-                }
-                ApprovalOriginWire::AgentRequested { .. } => "agent requested".to_string(),
-            };
-            // Webhook route: no approval_pending follows (conversational
-            // replaces this line with the interactive prompt within
-            // milliseconds), so a line that lingers is routed to a webhook.
-            let line = format!(
-                "⏸ Approval requested — {} ({origin}) · awaiting webhook decision",
-                requested.tool_name
-            );
+            let line = approval_requested_line(requested);
             println!("{}", line.themed(AuraStyle::Warning));
             crate::ui::prompt::increment_orch_scrollback();
             println!();
@@ -3699,8 +3703,8 @@ impl StreamHandler for ReplStreamHandler {
 #[cfg(test)]
 mod tests {
     use super::{
-        COMMAND_ALIASES, COMPACT_NUDGE_FILL, ReplTelemetryLifecycle, command_hint,
-        should_nudge_at_fill,
+        COMMAND_ALIASES, COMPACT_NUDGE_FILL, ReplTelemetryLifecycle, approval_requested_line,
+        command_hint, should_nudge_at_fill,
     };
     use crate::repl::registry;
 
@@ -3896,6 +3900,65 @@ mod tests {
             assert!(
                 registry::lookup(target).is_some(),
                 "alias {bare:?} targets unknown command {target:?}",
+            );
+        }
+    }
+
+    fn approval_requested(
+        origin: aura_events::ApprovalOriginWire,
+    ) -> aura_events::ApprovalRequested {
+        aura_events::ApprovalRequested {
+            decision_id: "d-1".to_string(),
+            tool_name: "mock_tool".to_string(),
+            origin,
+            scope: aura_events::AgentScopeWire::Single { session_id: None },
+        }
+    }
+
+    #[test]
+    fn approval_requested_line_names_tool_and_config_gate_origin() {
+        let requested = approval_requested(aura_events::ApprovalOriginWire::ConfigGate {
+            matched_pattern: "mock_*".to_string(),
+            agent_name: "hitl-fast".to_string(),
+        });
+        assert_eq!(
+            approval_requested_line(&requested),
+            "⏸ Approval requested — mock_tool (config gate · mock_*)",
+        );
+    }
+
+    #[test]
+    fn approval_requested_line_names_agent_requested_origin() {
+        let requested = approval_requested(aura_events::ApprovalOriginWire::AgentRequested {
+            reason: "destructive".to_string(),
+            agent_name: "hitl-fast".to_string(),
+        });
+        assert_eq!(
+            approval_requested_line(&requested),
+            "⏸ Approval requested — mock_tool (agent requested)",
+        );
+    }
+
+    #[test]
+    fn approval_requested_line_makes_no_route_claim() {
+        // The event is route-agnostic and the conversational prompt appends
+        // below this line rather than replacing it, so route-specific
+        // wording (the Greptile finding on PR #616) contradicts scrollback
+        // on the other route.
+        for origin in [
+            aura_events::ApprovalOriginWire::ConfigGate {
+                matched_pattern: "mock_*".to_string(),
+                agent_name: String::new(),
+            },
+            aura_events::ApprovalOriginWire::AgentRequested {
+                reason: "destructive".to_string(),
+                agent_name: String::new(),
+            },
+        ] {
+            let line = approval_requested_line(&approval_requested(origin));
+            assert!(
+                !line.to_lowercase().contains("webhook"),
+                "line makes a route claim: {line}",
             );
         }
     }

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -3375,6 +3375,61 @@ impl StreamHandler for ReplStreamHandler {
         prepare_input_line(&self.input_buf, Some(&self.cancel));
     }
 
+    fn on_approval_requested(&mut self, requested: &aura_events::ApprovalRequested) {
+        flush_live_reasoning(&self.live_reasoning);
+        flush_all_worker_reasoning(&self.live_worker_reasoning);
+
+        // Stop animation — same dance as on_approval_pending / on_approval_completed.
+        let had_ptw = if let Ok(mut guard) = self.post_tool_wave.lock() {
+            guard.take().map(|(a, _)| a.finish()).is_some()
+        } else {
+            false
+        };
+        if !had_ptw && !self.anim_cleared.load(Ordering::Relaxed) {
+            stop_and_clear_animation(&self.stop_flag);
+            self.anim_cleared.store(true, Ordering::Relaxed);
+        }
+
+        {
+            let _term = lock_term();
+            erase_input_frame();
+
+            use aura_events::ApprovalOriginWire;
+            let origin = match &requested.origin {
+                ApprovalOriginWire::ConfigGate { matched_pattern, .. } => {
+                    format!("config gate · {matched_pattern}")
+                }
+                ApprovalOriginWire::AgentRequested { .. } => "agent requested".to_string(),
+            };
+            // Webhook route: no approval_pending follows (conversational
+            // replaces this line with the interactive prompt within
+            // milliseconds), so a line that lingers is routed to a webhook.
+            let line = format!(
+                "⏸ Approval requested — {} ({origin}) · awaiting webhook decision",
+                requested.tool_name
+            );
+            println!("{}", line.themed(AuraStyle::Warning));
+            crate::ui::prompt::increment_orch_scrollback();
+            println!();
+            crate::ui::prompt::increment_orch_scrollback();
+        }
+
+        // Park with an "Awaiting approval" animation until the decision lands.
+        let (wave_anim, wave_stop) = {
+            let _term = lock_term();
+            WaveAnimation::start(
+                "Awaiting approval",
+                vec![],
+                self.input_buf.clone(),
+                Some(self.cancel.clone()),
+            )
+        };
+        if let Ok(mut guard) = self.post_tool_wave.lock() {
+            *guard = Some((wave_anim, wave_stop));
+        }
+        prepare_input_line(&self.input_buf, Some(&self.cancel));
+    }
+
     fn on_approval_pending(&mut self, pending: &aura_events::ApprovalPending) {
         flush_live_reasoning(&self.live_reasoning);
         flush_all_worker_reasoning(&self.live_worker_reasoning);


### PR DESCRIPTION
The server emits aura.approval_requested on both HITL routes, but the REPL had no handler for it, so a webhook-routed approval parked silently - only the thinking animation, no sign a human decision was pending (#615).

This renders a status line with the tool name and origin (config gate with its matched pattern, or agent requested) and parks under an "Awaiting approval" animation until the decision lands. The conversational route is unaffected: its approval_pending prompt replaces the line immediately.

One caveat for review: "awaiting webhook decision" is inferred, not read from a field, because the event does not carry the route. It works since conversational mode always renders its approval_pending prompt immediately after a requested event, leaving the line visible only on the webhook route - but a wire-level route field (aura-events plus server emission) would be the honest version, and I can do that as a follow-up if preferred.

Tested live against a webhook-routed HITL server (park, approve via the receiver, approval completed, tool result), plus cargo test -p aura-cli (470 unit + 22 integration) and clippy clean.

Fixes: #615
