### PR TITLE
fix: surface failed tasks' artifacts and preserve worker confidence

### DIFF
--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -4554,9 +4554,18 @@ Assign tasks to the worker whose tools best match the required operations."#,
         for t in &plan.tasks {
             match &t.state {
                 TaskState::Complete { result } => {
+                    // This text reaches the user unmediated — the coordinator
+                    // never ran, so the synthesis rules that preserve a
+                    // worker's confidence do not apply. Tag it here instead,
+                    // or an uncertain finding is shipped as an unqualified one.
+                    let confidence = t
+                        .structured_output
+                        .as_ref()
+                        .map(|so| format!(" (confidence: {})", so.confidence))
+                        .unwrap_or_default();
                     out.push_str(&format!(
-                        "## Task {}: {}\n\n{}\n\n",
-                        t.id, t.description, result
+                        "## Task {}: {}{}\n\n{}\n\n",
+                        t.id, t.description, confidence, result
                     ));
                 }
                 TaskState::Failed { error, .. } => {
@@ -4886,6 +4895,28 @@ mod tests {
             output_tokens,
             total_tokens: input_tokens + output_tokens,
         }
+    }
+
+    #[test]
+    fn test_raw_task_results_tag_worker_confidence() {
+        use super::super::tools::submit_result::Confidence;
+        use super::super::types::{StructuredTaskOutput, Task};
+
+        // Regression guard: this text goes to the user without passing through
+        // coordinator synthesis, so the confidence qualifier must be attached
+        // here or an uncertain finding is presented as an unqualified one.
+        let mut plan = Plan::new("Investigate");
+        let mut task = Task::new(0, "Search logs", "Query the log index");
+        task.complete("No matching records returned.".to_string());
+        task.structured_output = Some(StructuredTaskOutput {
+            summary: "Search returned no rows".to_string(),
+            confidence: Confidence::Low,
+        });
+        plan.add_task(task);
+
+        let out = Orchestrator::build_raw_task_results(&plan, "Coordinator timed out");
+
+        assert!(out.contains("## Task 0: Search logs (confidence: low)"));
     }
 
     /// Turn figures are AWS Bedrock invocation-log records for one `arithmetic`

--- a/crates/aura/src/orchestration/types.rs
+++ b/crates/aura/src/orchestration/types.rs
@@ -1631,7 +1631,9 @@ mod tests {
                 tool: "search_logs".to_string(),
                 reasoning: String::new(),
                 duration_ms: 1200,
-                outcome: ToolOutcome::Success { output_bytes: 27171 },
+                outcome: ToolOutcome::Success {
+                    output_bytes: 27171,
+                },
                 artifact_filename: Some("task-0-sre-iter-1-tool-1.txt".to_string()),
             }],
         );

--- a/crates/aura/src/orchestration/types.rs
+++ b/crates/aura/src/orchestration/types.rs
@@ -858,6 +858,14 @@ impl IterationContext {
                         }
                     };
                     redesign_lines.push(line);
+                    // A task can fail after its tools succeeded — a timeout or
+                    // depth limit reached before submit_result. Those artifacts
+                    // are on disk and readable, so list them as for completed
+                    // tasks; otherwise the findings are lost at the iteration
+                    // boundary and the next plan repeats the work blind.
+                    for line in render_artifact_lines(self.tool_traces.get(&t.id)) {
+                        redesign_lines.push(format!("    {}", line));
+                    }
                     for line in render_tool_chain_lines(self.tool_traces.get(&t.id)) {
                         redesign_lines.push(format!("    {}", line));
                     }
@@ -1602,6 +1610,37 @@ mod tests {
         assert!(prompt.contains("COMPLETED TASKS"));
         assert!(prompt.contains("saved to artifact: task-0-sre-iter-1-result.txt"));
         assert!(prompt.contains("12345 chars"));
+    }
+
+    #[test]
+    fn test_continuation_prompt_lists_artifacts_of_failed_tasks() {
+        use super::super::persistence::{ToolOutcome, ToolTraceEntry};
+
+        // Regression guard: a worker that times out or exhausts its depth
+        // budget still leaves usable tool output on disk. The coordinator must
+        // see those artifacts so it can forward them to the next iteration.
+        let mut plan = Plan::new("Investigate");
+        let mut task = Task::new(0, "Search logs", "Query the log index");
+        task.fail("timed out after 120s", FailureCategory::AgentTimeout);
+        plan.add_task(task);
+
+        let mut traces = HashMap::new();
+        traces.insert(
+            0,
+            vec![ToolTraceEntry {
+                tool: "search_logs".to_string(),
+                reasoning: String::new(),
+                duration_ms: 1200,
+                outcome: ToolOutcome::Success { output_bytes: 27171 },
+                artifact_filename: Some("task-0-sre-iter-1-tool-1.txt".to_string()),
+            }],
+        );
+
+        let ctx = IterationContext::new(1, plan, None, vec![], traces);
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
+
+        assert!(prompt.contains("FAILED TASKS"));
+        assert!(prompt.contains("[Artifact: task-0-sre-iter-1-tool-1.txt (27171 bytes)]"));
     }
 
     #[test]

--- a/crates/aura/src/prompts/continuation_prompt.md
+++ b/crates/aura/src/prompts/continuation_prompt.md
@@ -16,3 +16,7 @@ When you can answer the user from what's already available to you, respond_direc
 
 IMPORTANT — synthesis rules for `respond_directly`:
 Your response IS the final answer the user sees. Task results are NOT shown to the user. You must inline all relevant findings — exact names, values, identifiers, and data points from the task results above. Never reference tasks by number or defer to task outputs. Extract the concrete data and present it directly.
+
+Carry uncertainty across, not just findings. Each completed task above is tagged with the worker's confidence. Never state a `low` or `medium` confidence finding as established fact — report it with the qualifier the worker assigned it. Where a worker gave alternative explanations, present the alternatives rather than selecting one.
+
+An empty result establishes only that the query returned nothing. It is not evidence that the underlying data, system, or condition does not exist. Report it as "the query returned no matches", not as "X does not exist" or "X is unavailable", unless a task specifically verified that. Never build a recommended action on an inference you did not verify.


### PR DESCRIPTION
Two defects that combined to make an orchestration run report the opposite of what it had found: a worker retrieved the evidence answering the user's question, failed before submitting, and the final answer asserted a later empty result as established fact.

## Failed tasks' artifacts were invisible to the coordinator

A worker that times out or exhausts its depth budget can still have completed its tool calls successfully. That output is written to artifacts, and `load_tool_traces_for_plan` loads trace records for every task regardless of state — but `build_continuation_prompt` rendered artifact lines only in the Complete branch. The coordinator saw `Task N → failed [timeout]` with no indication that the results existed on disk, so the next plan repeated the work from scratch.

Adds the `render_artifact_lines` call to the Failed branch, mirroring the Complete branch. The existing `RESULT_FORWARDING` guidance already tells the coordinator to pass artifact filenames on to the next iteration, so no prompt change is needed for this half.

## Low-confidence results were reported as fact

Worker confidence reaches the coordinator's context (`submit_result` → persistence → `(confidence: low)` in COMPLETED TASKS), but the `respond_directly` synthesis rules only required findings be inlined concretely — nothing required uncertainty to survive. A worker's hedged, low-confidence disjunction was delivered to the user as an unqualified fact and turned into a recommended action.

Adds two rules to `continuation_prompt.md`: carry the worker's confidence qualifier across, and treat an empty result as "the query returned no matches" rather than as evidence that the underlying thing does not exist.

Prompt rules only bind the path that runs the coordinator. `build_raw_task_results` ships task results straight to the user when the post-execute coordinator call errors or the replan/time budget is spent, bypassing synthesis entirely — so it now tags each completed task with its confidence at render time.

The changes need to land together — forwarding more findings into a synthesis step that strips uncertainty would raise the confidence of whatever gets through.

## Verification

`cargo test -p aura --lib` — 1088 passed, 0 failed. `cargo fmt --check` clean, no new clippy warnings.

Both regression tests were confirmed to catch their bug: each fails with its fix reverted and passes with it restored.
