### PR TITLE
feat(events): add agent event schema and broker adapter

### DIFF
--- a/crates/aura-events/src/agent.rs
+++ b/crates/aura-events/src/agent.rs
@@ -1,0 +1,269 @@
+//! The agent-produced event vocabulary.
+//!
+//! [`AgentEvent`] is what a running agent emits. Observers — an SSE producer, an
+//! A2A status bridge, an OTel exporter — consume this stream and project it into
+//! whatever shape they serve. Contrast [`crate::AuraStreamEvent`], which is the
+//! HTTP *wire* form of one such projection.
+//!
+//! Two properties distinguish this schema from the wire schema:
+//!
+//! - **Internally tagged.** [`crate::AuraStreamEvent`] is `#[serde(untagged)]`,
+//!   so its variant order is load-bearing during deserialization. This enum
+//!   carries a `type` discriminator instead, making variant order irrelevant.
+//! - **No correlation context.** The wire events flatten a
+//!   [`CorrelationContext`](crate::CorrelationContext) (session id, trace id)
+//!   into every payload. That is ambient request state, not something an agent
+//!   knows, so it is applied by the observer rather than carried here.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AgentContext, ApprovalCompleted, ApprovalPending, ApprovalRequested, McpServerStatus, Progress,
+    ProgressToken, TokenCount, TokenUsage, ToolCallId, ToolName, WorkerPhase,
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AgentEvent {
+    pub agent: AgentContext,
+    pub payload: AgentEventPayload,
+}
+
+impl AgentEvent {
+    pub fn new(agent: AgentContext, payload: AgentEventPayload) -> Self {
+        Self { agent, payload }
+    }
+
+    /// Attributes the payload to `agent_id: "main"`.
+    pub fn single_agent(payload: AgentEventPayload) -> Self {
+        Self::new(AgentContext::single_agent(), payload)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ToolOutcome {
+    Success { result: String },
+    Failure { error: String },
+}
+
+/// What an agent has to say about its own execution.
+///
+/// `#[non_exhaustive]` because the vocabulary grows as producers move onto this
+/// schema — orchestration events in particular are not yet modelled here.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AgentEventPayload {
+    SessionInfo {
+        model: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model_context_limit: Option<TokenCount>,
+    },
+
+    McpStatus {
+        servers: Vec<McpServerStatus>,
+    },
+
+    TextDelta {
+        content: String,
+    },
+
+    Reasoning {
+        content: String,
+    },
+
+    /// The model's decision to call a tool, ahead of any execution.
+    ToolRequested {
+        tool_call_id: ToolCallId,
+        tool_name: ToolName,
+        arguments: serde_json::Value,
+    },
+
+    ToolStart {
+        tool_call_id: ToolCallId,
+        tool_name: ToolName,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        progress_token: Option<ProgressToken>,
+    },
+
+    ToolComplete {
+        tool_call_id: ToolCallId,
+        tool_name: ToolName,
+        duration_ms: u64,
+        #[serde(flatten)]
+        outcome: ToolOutcome,
+    },
+
+    ToolProgress {
+        progress_token: ProgressToken,
+        progress: Progress,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+
+    WorkerPhase {
+        phase: WorkerPhase,
+        /// Plan-relative: unique within its iteration, not across a run.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        task_id: Option<usize>,
+    },
+
+    /// One turn's tokens, attributed to the tool calls that turn covered.
+    ToolUsage {
+        tool_call_ids: Vec<ToolCallId>,
+        #[serde(flatten)]
+        usage: TokenUsage,
+    },
+
+    /// Cumulative across every turn.
+    Usage {
+        #[serde(flatten)]
+        usage: TokenUsage,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_read_input_tokens: Option<TokenCount>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_creation_input_tokens: Option<TokenCount>,
+    },
+
+    /// Context-window occupancy, not billing.
+    ContextUsage {
+        context_tokens: TokenCount,
+        response_tokens: TokenCount,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context_window: Option<TokenCount>,
+    },
+
+    ScratchpadUsage {
+        tokens_intercepted: TokenCount,
+        tokens_extracted: TokenCount,
+    },
+
+    ApprovalRequested(ApprovalRequested),
+
+    ApprovalPending(ApprovalPending),
+
+    ApprovalCompleted(ApprovalCompleted),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn roundtrip(payload: AgentEventPayload) -> AgentEventPayload {
+        let json = serde_json::to_string(&payload).expect("payload should serialize");
+        serde_json::from_str(&json).expect("payload should deserialize")
+    }
+
+    #[test]
+    fn the_tag_names_the_variant() {
+        let json = serde_json::to_value(AgentEventPayload::TextDelta {
+            content: "hi".to_string(),
+        })
+        .expect("should serialize");
+
+        assert_eq!(json["type"], "text_delta");
+        assert_eq!(json["content"], "hi");
+    }
+
+    /// The wire enum needs `ToolComplete` declared before `ToolStart` and
+    /// `ToolUsage` before `Usage` to deserialize correctly. The tag makes the
+    /// same shapes unambiguous here regardless of declaration order.
+    #[test]
+    fn variants_the_wire_enum_must_order_are_unambiguous_here() {
+        let start = roundtrip(AgentEventPayload::ToolStart {
+            tool_call_id: ToolCallId::new("call_1"),
+            tool_name: ToolName::new("list_files"),
+            progress_token: None,
+        });
+        assert!(matches!(start, AgentEventPayload::ToolStart { .. }));
+
+        let usage = roundtrip(AgentEventPayload::Usage {
+            usage: TokenUsage {
+                prompt_tokens: TokenCount::new(1),
+                completion_tokens: TokenCount::new(2),
+                total_tokens: TokenCount::new(3),
+            },
+            cache_read_input_tokens: Some(TokenCount::new(80)),
+            cache_creation_input_tokens: Some(TokenCount::new(4)),
+        });
+        assert!(matches!(
+            usage,
+            AgentEventPayload::Usage {
+                cache_read_input_tokens: Some(_),
+                cache_creation_input_tokens: Some(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn tool_outcome_flattens_onto_tool_complete() {
+        let json = serde_json::to_value(AgentEventPayload::ToolComplete {
+            tool_call_id: ToolCallId::new("call_1"),
+            tool_name: ToolName::new("list_files"),
+            duration_ms: 12,
+            outcome: ToolOutcome::Failure {
+                error: "boom".to_string(),
+            },
+        })
+        .expect("should serialize");
+
+        assert_eq!(json["type"], "tool_complete");
+        assert_eq!(json["outcome"], "failure");
+        assert_eq!(json["error"], "boom");
+    }
+
+    #[test]
+    fn an_event_carries_its_emitting_agent() {
+        let event = AgentEvent::new(
+            AgentContext::worker("log_worker", None, "orchestrator"),
+            AgentEventPayload::TextDelta {
+                content: "scanning".to_string(),
+            },
+        );
+        let json = serde_json::to_value(&event).expect("should serialize");
+
+        assert_eq!(json["agent"]["agent_id"], "log_worker");
+        assert_eq!(json["agent"]["parent_agent_id"], "orchestrator");
+        assert_eq!(json["payload"]["type"], "text_delta");
+    }
+
+    /// `ToolUsage` is the one variant that mixes a flattened struct with a
+    /// field of its own, so it exercises `flatten` under the `type` tag.
+    #[test]
+    fn a_flattened_usage_survives_a_roundtrip_beside_its_tool_ids() {
+        let payload = roundtrip(AgentEventPayload::ToolUsage {
+            tool_call_ids: vec![ToolCallId::new("call_1")],
+            usage: TokenUsage {
+                prompt_tokens: TokenCount::new(10),
+                completion_tokens: TokenCount::new(5),
+                total_tokens: TokenCount::new(15),
+            },
+        });
+
+        let AgentEventPayload::ToolUsage {
+            tool_call_ids,
+            usage,
+        } = payload
+        else {
+            panic!("expected ToolUsage");
+        };
+        assert_eq!(tool_call_ids, vec![ToolCallId::new("call_1")]);
+        assert_eq!(usage.total_tokens.get(), 15);
+    }
+
+    #[test]
+    fn arguments_survive_a_roundtrip() {
+        let payload = roundtrip(AgentEventPayload::ToolRequested {
+            tool_call_id: ToolCallId::new("call_1"),
+            tool_name: ToolName::new("list_files"),
+            arguments: json!({ "path": "/mock", "depth": 2 }),
+        });
+
+        let AgentEventPayload::ToolRequested { arguments, .. } = payload else {
+            panic!("expected ToolRequested");
+        };
+        assert_eq!(arguments, json!({ "path": "/mock", "depth": 2 }));
+    }
+}

--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -14,6 +14,7 @@
 //! Both enums derive `Serialize + Deserialize` so they can be used for
 //! producing SSE (server) and parsing SSE (client) with the same types.
 
+pub mod agent;
 pub mod event_names;
 pub mod orchestration;
 
@@ -61,6 +62,176 @@ pub fn format_named_sse(event_name: &str, data: &impl Serialize) -> String {
     format!("event: {event_name}\ndata: {json}\n\n")
 }
 
+// --- Domain value types -----------------------------------------------------
+//
+// The building blocks shared by the agent schema ([`agent::AgentEventPayload`])
+// and the wire schema below. Opaque newtypes reached through canonical
+// conversion traits; each serializes as its inner value.
+
+/// Generates the shared surface of a string newtype: construction, borrowing,
+/// display, and comparison against the string types.
+macro_rules! string_newtype {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Self {
+                Self(value.into())
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            pub fn into_string(self) -> String {
+                self.0
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(value: String) -> Self {
+                Self(value)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(value: &str) -> Self {
+                Self(value.to_owned())
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl PartialEq<str> for $name {
+            fn eq(&self, other: &str) -> bool {
+                self.0 == other
+            }
+        }
+
+        impl PartialEq<&str> for $name {
+            fn eq(&self, other: &&str) -> bool {
+                self.0 == *other
+            }
+        }
+
+        impl PartialEq<String> for $name {
+            fn eq(&self, other: &String) -> bool {
+                &self.0 == other
+            }
+        }
+    };
+}
+
+string_newtype! {
+    /// The id a model assigns to one tool call.
+    ToolCallId
+}
+
+string_newtype! {
+    ToolName
+}
+
+/// Tokens as reported by a model provider, never counted locally.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct TokenCount(u64);
+
+impl TokenCount {
+    pub fn new(tokens: u64) -> Self {
+        Self(tokens)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for TokenCount {
+    fn from(tokens: u64) -> Self {
+        Self(tokens)
+    }
+}
+
+impl From<TokenCount> for u64 {
+    fn from(count: TokenCount) -> Self {
+        count.0
+    }
+}
+
+impl std::fmt::Display for TokenCount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// One provider-billed token measurement.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenUsage {
+    pub prompt_tokens: TokenCount,
+    pub completion_tokens: TokenCount,
+    /// Total as the provider reported it, not a sum of the other two fields.
+    pub total_tokens: TokenCount,
+}
+
+/// How far along an operation is, in whatever unit the reporter chose.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Progress {
+    pub current: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total: Option<f64>,
+}
+
+impl Progress {
+    pub fn ratio(current: f64, total: f64) -> Self {
+        Self {
+            current,
+            total: Some(total),
+        }
+    }
+
+    pub fn indeterminate(current: f64) -> Self {
+        Self {
+            current,
+            total: None,
+        }
+    }
+
+    /// A zero total counts as complete.
+    pub fn percent(&self) -> Option<u8> {
+        self.total.map(|total| {
+            if total == 0.0 {
+                100
+            } else {
+                ((self.current / total) * 100.0).min(100.0) as u8
+            }
+        })
+    }
+}
+
+impl std::fmt::Display for Progress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.total {
+            Some(total) => write!(f, "{}/{total}", self.current),
+            None => write!(f, "{}", self.current),
+        }
+    }
+}
+
 /// Context identifying which agent emitted an event.
 ///
 /// For single-agent deployments, use `AgentContext::single_agent()` which sets
@@ -69,7 +240,7 @@ pub fn format_named_sse(event_name: &str, data: &impl Serialize) -> String {
 ///
 /// Note: `AgentContext::default()` gives an empty `agent_id` - use `single_agent()`
 /// for the standard single-agent context.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct AgentContext {
     /// Unique identifier for this agent (e.g., "main", "log_worker", "rca_worker")
     pub agent_id: String,
@@ -414,6 +585,8 @@ pub enum AuraStreamEvent {
         /// Total tokens used
         total_tokens: u64,
         #[serde(flatten)]
+        agent: AgentContext,
+        #[serde(flatten)]
         correlation: CorrelationContext,
     },
     /// Emitted at stream end with final usage information.
@@ -638,6 +811,7 @@ impl AuraStreamEvent {
         prompt_tokens: u64,
         completion_tokens: u64,
         total_tokens: u64,
+        agent: AgentContext,
         correlation: CorrelationContext,
     ) -> Self {
         Self::ToolUsage {
@@ -645,6 +819,7 @@ impl AuraStreamEvent {
             prompt_tokens,
             completion_tokens,
             total_tokens,
+            agent,
             correlation,
         }
     }
@@ -713,6 +888,63 @@ impl AuraStreamEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn percent_needs_a_total() {
+        assert_eq!(Progress::ratio(50.0, 100.0).percent(), Some(50));
+        assert_eq!(Progress::indeterminate(50.0).percent(), None);
+    }
+
+    /// A server reporting `0/0` has nothing left to do, so it reads as done
+    /// rather than as a division by zero.
+    #[test]
+    fn a_zero_total_is_complete() {
+        assert_eq!(Progress::ratio(0.0, 0.0).percent(), Some(100));
+    }
+
+    #[test]
+    fn percent_is_capped_at_a_hundred() {
+        assert_eq!(Progress::ratio(150.0, 100.0).percent(), Some(100));
+    }
+
+    #[test]
+    fn a_string_newtype_serializes_as_its_bare_string() {
+        let json = serde_json::to_value(ToolCallId::new("call_abc")).unwrap();
+        assert_eq!(json, serde_json::json!("call_abc"));
+        assert_eq!(
+            serde_json::from_value::<ToolCallId>(json).unwrap(),
+            "call_abc"
+        );
+    }
+
+    /// `TokenUsage` flattens into the event variants that carry it, so the
+    /// grouping stays invisible on the wire.
+    #[test]
+    fn token_usage_flattens_to_bare_counts() {
+        #[derive(Serialize)]
+        struct Carrier {
+            #[serde(flatten)]
+            usage: TokenUsage,
+        }
+
+        let json = serde_json::to_value(Carrier {
+            usage: TokenUsage {
+                prompt_tokens: TokenCount::new(10),
+                completion_tokens: TokenCount::new(5),
+                total_tokens: TokenCount::new(15),
+            },
+        })
+        .unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15
+            })
+        );
+    }
 
     #[test]
     fn agent_info_mcp_servers_backward_compatible() {

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -26,12 +26,12 @@ use super::types::{
     FunctionCallChunk, MessageRole, StreamConfig, ToolCallChunk, ToolResultMode, ToolResultStatus,
     TurnContext, TurnState, detect_tool_error, format_sse_chunk, truncate_result,
 };
-use aura::stream_events::AuraStreamEvent;
+use aura::stream_events::{AgentContext, AuraStreamEvent, CorrelationContext};
 use aura::{
     ApprovalLifecycleEvent, EventContext, OrchestrationStreamEvent, OrchestratorEvent,
     PASSTHROUGH_MARKER, ProgressNotification, RequestCancellation, ResponseContent, StreamError,
     StreamItem, StreamedAssistantContent, StreamedUserContent, StreamingAgent, ToolCall,
-    ToolLifecycleEvent, ToolResult, ToolUsageEvent, UsageState,
+    ToolCallId, ToolLifecycleEvent, ToolResult, ToolUsageEvent, UsageState,
 };
 use bytes::Bytes;
 use futures_util::{Stream, StreamExt};
@@ -240,19 +240,18 @@ where
                     inactivity.touch();
                     let event = AuraStreamEvent::progress(
                         notification.message.clone().unwrap_or_else(|| {
-                            format!("Progress: {}/{:?}", notification.progress, notification.total)
+                            format!("Progress: {}", notification.progress)
                         }),
                         "mcp_progress",
                         notification.percent(),
                         Some(notification.progress_token.clone()),
-                        ctx.agent_context.clone(),
+                        notification.agent.clone().unwrap_or_else(|| ctx.agent_context.clone()),
                         ctx.correlation.clone(),
                     );
                     tracing::debug!(
-                        "Emitting aura.progress event: token={:?}, progress={}/{:?}",
+                        "Emitting aura.progress event: token={:?}, progress={}",
                         notification.progress_token,
-                        notification.progress,
-                        notification.total
+                        notification.progress
                     );
                     if tx.send(Ok(Bytes::from(event.format_sse()))).await.is_err() {
                         tracing::info!("Client disconnected during progress notification");
@@ -266,29 +265,29 @@ where
                 if let Some(tool_event) = tool_event {
                     inactivity.touch();
                     let sse_event = match tool_event {
-                        ToolLifecycleEvent::Requested { tool_id, tool_name, arguments } => {
+                        ToolLifecycleEvent::Requested { tool_id, tool_name, arguments, agent } => {
                             tracing::debug!(
                                 "Emitting aura.tool_requested event: tool_id={}, tool_name={}",
                                 tool_id, tool_name
                             );
                             AuraStreamEvent::tool_requested(
-                                &tool_id,
-                                &tool_name,
+                                tool_id.as_str(),
+                                tool_name.as_str(),
                                 arguments,
-                                ctx.agent_context.clone(),
+                                agent.unwrap_or_else(|| ctx.agent_context.clone()),
                                 ctx.correlation.clone(),
                             )
                         }
-                        ToolLifecycleEvent::Start { tool_id, tool_name, progress_token } => {
+                        ToolLifecycleEvent::Start { tool_id, tool_name, progress_token, agent } => {
                             tracing::debug!(
                                 "Emitting aura.tool_start event: tool_id={}, tool_name={}, progress_token={:?}",
                                 tool_id, tool_name, progress_token
                             );
                             AuraStreamEvent::tool_start(
-                                &tool_id,
-                                &tool_name,
+                                tool_id.as_str(),
+                                tool_name.as_str(),
                                 progress_token,
-                                ctx.agent_context.clone(),
+                                agent.unwrap_or_else(|| ctx.agent_context.clone()),
                                 ctx.correlation.clone(),
                             )
                         }
@@ -328,15 +327,9 @@ where
                     inactivity.touch();
                     tracing::debug!(
                         "Emitting aura.tool_usage event: tool_ids={:?}, prompt_tokens={}",
-                        usage_event.tool_ids, usage_event.prompt_tokens
+                        usage_event.tool_ids, usage_event.usage.prompt_tokens
                     );
-                    let sse_event = AuraStreamEvent::tool_usage(
-                        usage_event.tool_ids,
-                        usage_event.prompt_tokens,
-                        usage_event.completion_tokens,
-                        usage_event.total_tokens,
-                        ctx.correlation.clone(),
-                    );
+                    let sse_event = tool_usage_sse(usage_event, ctx.agent_context.clone(), ctx.correlation.clone());
                     if tx.send(Ok(Bytes::from(sse_event.format_sse()))).await.is_err() {
                         tracing::info!("Client disconnected during tool_usage event");
                         break StreamTermination::Disconnected;
@@ -478,6 +471,25 @@ fn resolve_billed_usage(
     }
 }
 
+fn tool_usage_sse(
+    event: ToolUsageEvent,
+    agent: AgentContext,
+    correlation: CorrelationContext,
+) -> AuraStreamEvent {
+    AuraStreamEvent::tool_usage(
+        event
+            .tool_ids
+            .into_iter()
+            .map(ToolCallId::into_string)
+            .collect(),
+        event.usage.prompt_tokens.get(),
+        event.usage.completion_tokens.get(),
+        event.usage.total_tokens.get(),
+        event.agent.clone().unwrap_or(agent),
+        correlation,
+    )
+}
+
 /// Send final usage events, finish chunk, and [DONE] marker to the client.
 async fn send_final_events(
     emit_custom_events: bool,
@@ -489,11 +501,9 @@ async fn send_final_events(
     // Drain any pending tool_usage events before emitting final aura.usage
     if emit_custom_events {
         while let Ok(usage_event) = callbacks.tool_usage_rx.try_recv() {
-            let sse_event = AuraStreamEvent::tool_usage(
-                usage_event.tool_ids,
-                usage_event.prompt_tokens,
-                usage_event.completion_tokens,
-                usage_event.total_tokens,
+            let sse_event = tool_usage_sse(
+                usage_event,
+                ctx.agent_context.clone(),
                 ctx.correlation.clone(),
             );
             if tx
@@ -1555,6 +1565,7 @@ fn build_final_chunk(ctx: &TurnContext, state: &TurnState) -> Vec<Bytes> {
 mod tests {
     use super::*;
     use aura::stream_events::{AgentContext, CorrelationContext};
+    use aura::{Progress, ToolName};
     use aura_events::event_names;
 
     /// Verify handle_tool_call does NOT emit aura.tool_requested events directly.
@@ -2415,9 +2426,9 @@ mod tests {
                                 progress_token: aura::ProgressToken(aura::NumberOrString::Number(
                                     n,
                                 )),
-                                progress: n as f64,
-                                total: Some(3.0),
+                                progress: Progress::ratio(n as f64, 3.0),
                                 message: Some("working".into()),
+                                agent: None,
                             })
                             .await;
                     }
@@ -2625,9 +2636,10 @@ mod tests {
                 let tx = tx.clone();
                 async move {
                     tx.send(ToolLifecycleEvent::Requested {
-                        tool_id: TOOL_ID.to_string(),
-                        tool_name: TOOL_NAME.to_string(),
+                        tool_id: ToolCallId::new(TOOL_ID),
+                        tool_name: ToolName::new(TOOL_NAME),
                         arguments: json!({ "path": "/mock" }),
+                        agent: None,
                     })
                     .await
                     .expect("tool event channel open");
@@ -2641,9 +2653,10 @@ mod tests {
                 let tx = tx.clone();
                 async move {
                     tx.send(ToolLifecycleEvent::Start {
-                        tool_id: TOOL_ID.to_string(),
-                        tool_name: TOOL_NAME.to_string(),
+                        tool_id: ToolCallId::new(TOOL_ID),
+                        tool_name: ToolName::new(TOOL_NAME),
                         progress_token: Some(ProgressToken(NumberOrString::Number(7))),
+                        agent: None,
                     })
                     .await
                     .expect("tool event channel open");
@@ -2658,9 +2671,9 @@ mod tests {
                 async move {
                     tx.send(ProgressNotification {
                         progress_token: ProgressToken(NumberOrString::Number(7)),
-                        progress: 50.0,
-                        total: Some(100.0),
+                        progress: Progress::ratio(50.0, 100.0),
                         message: Some("halfway".to_string()),
+                        agent: None,
                     })
                     .await
                     .expect("progress channel open");

--- a/crates/aura-web-server/tests/agent_event_differential.rs
+++ b/crates/aura-web-server/tests/agent_event_differential.rs
@@ -1,0 +1,396 @@
+//! Proves the agent event schema reaches consumers unchanged.
+//!
+//! Each case drives `process_sse_stream_full` twice over the same logical
+//! sequence — once publishing to the request-scoped brokers directly, once
+//! publishing [`AgentEvent`]s through [`aura::agent_events`] — and asserts the
+//! SSE frames are byte-identical. Only the producer side differs; both runs
+//! subscribe the way `handlers::stream_chat_completion` does, so the broker
+//! registry and its request-id routing are under test rather than stubbed.
+//!
+//! A variant that loses a field in translation fails here.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use aura::agent_events::{Routed, publish_to_brokers};
+use aura::tool_event_broker::publish_tool_requested;
+use aura::{
+    ApprovalLifecycleEvent, NumberOrString, Progress, ProgressNotification, ProgressToken,
+    ResponseContent, StreamError, StreamItem, StreamingAgent, TokenUsage, ToolCallId, ToolName,
+    UsageState,
+};
+use aura::{
+    approval_event_subscribe, approval_event_unsubscribe, publish_tool_start, publish_tool_usage,
+    request_progress_subscribe, request_progress_unsubscribe, tool_event_subscribe,
+    tool_event_unsubscribe, tool_usage_subscribe, tool_usage_unsubscribe,
+};
+use aura_events::TokenCount;
+use aura_events::agent::{AgentEvent, AgentEventPayload};
+use aura_test_utils::mock_agent::{MockAgent, Step, items};
+use aura_test_utils::sse::{SseEvent, parse_sse_stream};
+use aura_web_server::streaming::{
+    StreamConfig, StreamTermination, StreamingCallbacks, ToolResultMode, TurnContext,
+    process_sse_stream_full,
+};
+use bytes::Bytes;
+use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
+
+const TOOL_ID: &str = "call_abc123";
+const TOOL_NAME: &str = "list_files";
+const TOOL_ARGS: &str = r#"{"path":"/mock"}"#;
+const SESSION_ID: &str = "cs-differential";
+
+fn token() -> ProgressToken {
+    ProgressToken(NumberOrString::Number(7))
+}
+
+fn args() -> serde_json::Value {
+    serde_json::json!({ "path": "/mock" })
+}
+
+fn usage() -> TokenUsage {
+    TokenUsage {
+        prompt_tokens: TokenCount::new(10),
+        completion_tokens: TokenCount::new(5),
+        total_tokens: TokenCount::new(15),
+    }
+}
+
+/// Subscribes exactly as the production handler does, so events reach the
+/// stream through the global brokers keyed by `request_id`.
+async fn callbacks_for(request_id: &str) -> StreamingCallbacks {
+    StreamingCallbacks {
+        request_id: request_id.to_string(),
+        agent: Arc::new(MockAgent::pending()),
+        tool_event_rx: tool_event_subscribe(request_id).await,
+        progress_rx: request_progress_subscribe(request_id).await,
+        tool_usage_rx: tool_usage_subscribe(request_id).await,
+        approval_event_rx: approval_event_subscribe(request_id).await,
+        usage_state: UsageState::new(),
+        response_content: ResponseContent::new(),
+        model_name: "test/fake".to_string(),
+        stream_shutdown_token: CancellationToken::new(),
+    }
+}
+
+async fn unsubscribe_all(request_id: &str) {
+    tool_event_unsubscribe(request_id).await;
+    request_progress_unsubscribe(request_id).await;
+    tool_usage_unsubscribe(request_id).await;
+    approval_event_unsubscribe(request_id).await;
+}
+
+async fn run(request_id: &str, steps: Vec<Step>) -> Vec<SseEvent> {
+    let callbacks = callbacks_for(request_id).await;
+    let config = StreamConfig::new(true, false, ToolResultMode::Aura, 0);
+    let ctx = TurnContext::new(
+        "chatcmpl-test".to_string(),
+        "test/fake".to_string(),
+        1_700_000_000,
+        None,
+        SESSION_ID,
+    );
+
+    let stream = MockAgent::scripted(steps)
+        .stream("q", vec![], CancellationToken::new(), request_id)
+        .await
+        .expect("mock stream should start");
+
+    let (chunk_tx, mut chunk_rx) = mpsc::channel::<Result<Bytes, String>>(64);
+    let collector = tokio::spawn(async move {
+        let mut body = String::new();
+        while let Some(chunk) = chunk_rx.recv().await {
+            body.push_str(std::str::from_utf8(&chunk.expect("SSE chunk")).expect("UTF-8"));
+        }
+        body
+    });
+    let (cancel_tx, _cancel_rx) = watch::channel(false);
+
+    let termination = process_sse_stream_full(
+        &config,
+        &ctx,
+        stream,
+        chunk_tx,
+        cancel_tx,
+        Duration::from_secs(900),
+        // Far enough out that heartbeats never interleave with the script.
+        Duration::from_secs(86_400),
+        None,
+        None,
+        callbacks,
+    )
+    .await;
+    assert_eq!(termination, StreamTermination::Complete);
+
+    let body = collector.await.expect("collector should not panic");
+    unsubscribe_all(request_id).await;
+
+    let (events, done) = parse_sse_stream(&body);
+    assert!(done, "stream should terminate with [DONE]");
+    events
+}
+
+fn frames(events: &[SseEvent]) -> Vec<(Option<String>, String)> {
+    events
+        .iter()
+        .map(|e| (e.event_type.clone(), e.data.clone()))
+        .collect()
+}
+
+/// `broker` and `schema` must describe the same logical sequence. Both run with
+/// distinct request ids so their broker registrations cannot alias.
+async fn assert_paths_agree(
+    case: &str,
+    broker: impl FnOnce(&str) -> Vec<Step>,
+    schema: impl FnOnce(&str) -> Vec<Step>,
+) {
+    let broker_id = format!("req_broker_{case}");
+    let schema_id = format!("req_schema_{case}");
+
+    let via_broker = run(&broker_id, broker(&broker_id)).await;
+    let via_schema = run(&schema_id, schema(&schema_id)).await;
+
+    assert_eq!(
+        frames(&via_broker),
+        frames(&via_schema),
+        "{case}: schema path diverged from broker path"
+    );
+    assert!(
+        !via_broker.is_empty(),
+        "{case}: no frames captured, so agreement proves nothing"
+    );
+}
+
+/// Publishing through the adapter must reach a subscriber; a silent
+/// `NoSubscriber` would make both paths agree on emptiness.
+fn emit(
+    event: AgentEvent,
+) -> impl Fn(String) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send>> {
+    move |request_id: String| {
+        let event = event.clone();
+        Box::pin(async move {
+            let routed = publish_to_brokers(&request_id, event).await;
+            assert_eq!(
+                routed,
+                Routed::Delivered,
+                "adapter should reach a subscriber"
+            );
+        })
+    }
+}
+
+fn tool_result_ok() -> Result<StreamItem, StreamError> {
+    items::tool_result(TOOL_ID, "README.md\nsrc/")
+}
+
+#[tokio::test(start_paused = true)]
+async fn tool_requested_matches() {
+    assert_paths_agree(
+        "tool_requested",
+        |_| {
+            vec![
+                Step::effect(|request_id: String| async move {
+                    publish_tool_requested(
+                        &request_id,
+                        ToolCallId::new(TOOL_ID),
+                        ToolName::new(TOOL_NAME),
+                        args(),
+                    )
+                    .await;
+                }),
+                Step::item(items::text("done")),
+            ]
+        },
+        |_| {
+            vec![
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolRequested {
+                        tool_call_id: ToolCallId::new(TOOL_ID),
+                        tool_name: ToolName::new(TOOL_NAME),
+                        arguments: args(),
+                    },
+                ))),
+                Step::item(items::text("done")),
+            ]
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_full_tool_turn_matches() {
+    assert_paths_agree(
+        "full_turn",
+        |_| {
+            vec![
+                Step::effect(|request_id: String| async move {
+                    publish_tool_requested(
+                        &request_id,
+                        ToolCallId::new(TOOL_ID),
+                        ToolName::new(TOOL_NAME),
+                        args(),
+                    )
+                    .await;
+                }),
+                Step::item(items::tool_call(TOOL_ID, TOOL_NAME, TOOL_ARGS)),
+                Step::effect(|request_id: String| async move {
+                    publish_tool_start(
+                        &request_id,
+                        ToolCallId::new(TOOL_ID),
+                        ToolName::new(TOOL_NAME),
+                        Some(token()),
+                    )
+                    .await;
+                }),
+                Step::effect(|request_id: String| async move {
+                    aura::request_progress::publish(
+                        &request_id,
+                        ProgressNotification {
+                            progress_token: token(),
+                            progress: Progress::ratio(50.0, 100.0),
+                            message: Some("halfway".to_string()),
+                            agent: None,
+                        },
+                    )
+                    .await;
+                }),
+                Step::item(tool_result_ok()),
+                Step::item(items::text("Here are the files.")),
+            ]
+        },
+        |_| {
+            vec![
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolRequested {
+                        tool_call_id: ToolCallId::new(TOOL_ID),
+                        tool_name: ToolName::new(TOOL_NAME),
+                        arguments: args(),
+                    },
+                ))),
+                Step::item(items::tool_call(TOOL_ID, TOOL_NAME, TOOL_ARGS)),
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolStart {
+                        tool_call_id: ToolCallId::new(TOOL_ID),
+                        tool_name: ToolName::new(TOOL_NAME),
+                        progress_token: Some(token()),
+                    },
+                ))),
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolProgress {
+                        progress_token: token(),
+                        progress: Progress::ratio(50.0, 100.0),
+                        message: Some("halfway".to_string()),
+                    },
+                ))),
+                Step::item(tool_result_ok()),
+                Step::item(items::text("Here are the files.")),
+            ]
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn progress_without_a_message_matches() {
+    let build_broker = |_: &str| {
+        vec![
+            Step::effect(|request_id: String| async move {
+                aura::request_progress::publish(
+                    &request_id,
+                    ProgressNotification {
+                        progress_token: token(),
+                        progress: Progress::indeterminate(3.0),
+                        message: None,
+                        agent: None,
+                    },
+                )
+                .await;
+            }),
+            Step::item(items::text("done")),
+        ]
+    };
+    let build_schema = |_: &str| {
+        vec![
+            Step::effect(emit(AgentEvent::single_agent(
+                AgentEventPayload::ToolProgress {
+                    progress_token: token(),
+                    progress: Progress::indeterminate(3.0),
+                    message: None,
+                },
+            ))),
+            Step::item(items::text("done")),
+        ]
+    };
+
+    assert_paths_agree("progress_no_message", build_broker, build_schema).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn tool_usage_matches() {
+    assert_paths_agree(
+        "tool_usage",
+        |_| {
+            vec![
+                Step::effect(|request_id: String| async move {
+                    publish_tool_usage(&request_id, vec![ToolCallId::new(TOOL_ID)], usage()).await;
+                }),
+                Step::item(items::text("done")),
+            ]
+        },
+        |_| {
+            vec![
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolUsage {
+                        tool_call_ids: vec![ToolCallId::new(TOOL_ID)],
+                        usage: usage(),
+                    },
+                ))),
+                Step::item(items::text("done")),
+            ]
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn approval_lifecycle_matches() {
+    let requested = aura_events::ApprovalRequested {
+        decision_id: "dec_1".to_string(),
+        tool_name: TOOL_NAME.to_string(),
+        origin: aura_events::ApprovalOriginWire::ConfigGate {
+            matched_pattern: "list_*".to_string(),
+            agent_name: "main".to_string(),
+        },
+        scope: aura_events::AgentScopeWire::Single {
+            session_id: Some(SESSION_ID.to_string()),
+        },
+    };
+
+    let for_broker = requested.clone();
+    let for_schema = requested.clone();
+
+    assert_paths_agree(
+        "approval",
+        move |_| {
+            vec![
+                Step::effect(move |request_id: String| {
+                    let event = ApprovalLifecycleEvent::Requested(for_broker.clone());
+                    async move {
+                        aura::approval_event_broker::publish(&request_id, event).await;
+                    }
+                }),
+                Step::item(items::text("done")),
+            ]
+        },
+        move |_| {
+            vec![
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ApprovalRequested(for_schema),
+                ))),
+                Step::item(items::text("done")),
+            ]
+        },
+    )
+    .await;
+}

--- a/crates/aura-web-server/tests/mcp_progress_test.rs
+++ b/crates/aura-web-server/tests/mcp_progress_test.rs
@@ -155,7 +155,7 @@ async fn test_request_progress_broker_accessible() {
 /// Verifies progress notifications only go to the correct request (no cross-request leakage).
 #[tokio::test]
 async fn test_request_progress_isolation() {
-    use aura::{NumberOrString, ProgressNotification, ProgressToken};
+    use aura::{NumberOrString, Progress, ProgressNotification, ProgressToken};
     use std::sync::Arc;
 
     let mut rx1 = request_progress_subscribe("req_1").await;
@@ -163,9 +163,9 @@ async fn test_request_progress_isolation() {
 
     let notification = ProgressNotification {
         progress_token: ProgressToken(NumberOrString::String(Arc::from("token_1"))),
-        progress: 50.0,
-        total: Some(100.0),
+        progress: Progress::ratio(50.0, 100.0),
         message: Some("Progress for request 1".to_string()),
+        agent: None,
     };
 
     let broker = request_progress_global();
@@ -191,7 +191,7 @@ async fn test_request_progress_isolation() {
 
 #[tokio::test]
 async fn test_unsubscribe_stops_progress() {
-    use aura::{NumberOrString, ProgressNotification, ProgressToken};
+    use aura::{NumberOrString, Progress, ProgressNotification, ProgressToken};
 
     let request_id = "req_cancel_test";
     let mut rx = request_progress_subscribe(request_id).await;
@@ -199,9 +199,9 @@ async fn test_unsubscribe_stops_progress() {
     let broker = request_progress_global();
     let notification = ProgressNotification {
         progress_token: ProgressToken(NumberOrString::Number(1)),
-        progress: 10.0,
-        total: Some(100.0),
+        progress: Progress::ratio(10.0, 100.0),
         message: Some("Step 1".to_string()),
+        agent: None,
     };
     broker.publish(request_id, notification).await;
 
@@ -212,9 +212,9 @@ async fn test_unsubscribe_stops_progress() {
 
     let notification2 = ProgressNotification {
         progress_token: ProgressToken(NumberOrString::Number(1)),
-        progress: 20.0,
-        total: Some(100.0),
+        progress: Progress::ratio(20.0, 100.0),
         message: Some("Step 2 - should not be received".to_string()),
+        agent: None,
     };
     let sent = broker.publish(request_id, notification2).await;
 

--- a/crates/aura/src/agent_events.rs
+++ b/crates/aura/src/agent_events.rs
@@ -1,0 +1,387 @@
+//! Projection of [`AgentEvent`]s back onto the request-scoped brokers.
+//!
+//! Producers move onto the [`aura_events::agent`] schema one at a time. This
+//! adapter lets them do that without any consumer changing, because it
+//! republishes an agent's events into the same brokers the SSE handler already
+//! subscribes to, so both paths converge on identical output.
+//!
+//! Scope: the side channels only — tool lifecycle, MCP progress, tool usage,
+//! and HITL approvals. Content-bearing events ([`AgentEventPayload::TextDelta`]
+//! and friends) reach consumers through the `StreamItem` stream rather than a
+//! broker, and gain their projection alongside the producer that emits them.
+
+use aura_events::agent::{AgentEvent, AgentEventPayload};
+
+use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
+use crate::env_flags::bool_env;
+use crate::request_progress::{self, ProgressNotification};
+use crate::tool_event_broker::{self, ToolLifecycleEvent, ToolUsageEvent};
+
+pub const ENV_AGENT_EVENTS: &str = "AURA_AGENT_EVENTS";
+
+/// Defaults off until the schema reaches parity with the broker path.
+pub fn agent_events_enabled() -> bool {
+    bool_env(ENV_AGENT_EVENTS, false)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Routed {
+    Delivered,
+    NoSubscriber,
+    /// The payload has no broker.
+    NotSideChannel,
+}
+
+/// Publishing is fire-and-forget, so a request whose subscriber has gone away
+/// yields `NoSubscriber` rather than an error. Content-bearing payloads have no
+/// broker to publish to and fall through to `NotSideChannel`; they reach
+/// consumers over the `StreamItem` stream instead.
+///
+/// The event's [`AgentContext`] rides along on every broker event that carries
+/// one, so a worker's tool call stays attributed to the worker rather than to
+/// the stream's own agent.
+pub async fn publish_to_brokers(request_id: &str, event: AgentEvent) -> Routed {
+    let AgentEvent { agent, payload } = event;
+    let delivered = match payload {
+        AgentEventPayload::ToolRequested {
+            tool_call_id,
+            tool_name,
+            arguments,
+        } => {
+            tool_event_broker::publish(
+                request_id,
+                ToolLifecycleEvent::Requested {
+                    tool_id: tool_call_id,
+                    tool_name,
+                    arguments,
+                    agent: Some(agent),
+                },
+            )
+            .await
+        }
+
+        AgentEventPayload::ToolStart {
+            tool_call_id,
+            tool_name,
+            progress_token,
+        } => {
+            tool_event_broker::publish(
+                request_id,
+                ToolLifecycleEvent::Start {
+                    tool_id: tool_call_id,
+                    tool_name,
+                    progress_token,
+                    agent: Some(agent),
+                },
+            )
+            .await
+        }
+
+        AgentEventPayload::ToolProgress {
+            progress_token,
+            progress,
+            message,
+        } => {
+            request_progress::publish(
+                request_id,
+                ProgressNotification {
+                    progress_token,
+                    progress,
+                    message,
+                    agent: Some(agent),
+                },
+            )
+            .await
+        }
+
+        AgentEventPayload::ToolUsage {
+            tool_call_ids,
+            usage,
+        } => {
+            tool_event_broker::publish_usage(
+                request_id,
+                ToolUsageEvent {
+                    tool_ids: tool_call_ids,
+                    usage,
+                    agent: Some(agent),
+                },
+            )
+            .await
+        }
+
+        AgentEventPayload::ApprovalRequested(approval) => {
+            approval_event_broker::publish(request_id, ApprovalLifecycleEvent::Requested(approval))
+                .await
+        }
+
+        AgentEventPayload::ApprovalPending(approval) => {
+            approval_event_broker::publish(request_id, ApprovalLifecycleEvent::Pending(approval))
+                .await
+        }
+
+        AgentEventPayload::ApprovalCompleted(approval) => {
+            approval_event_broker::publish(request_id, ApprovalLifecycleEvent::Completed(approval))
+                .await
+        }
+
+        // Listed rather than folded into the wildcard: `AgentEventPayload` is
+        // `#[non_exhaustive]` across the crate boundary, so the wildcard is
+        // mandatory and exhaustiveness checking cannot flag a new side-channel
+        // variant that forgets its arm here.
+        AgentEventPayload::SessionInfo { .. }
+        | AgentEventPayload::McpStatus { .. }
+        | AgentEventPayload::TextDelta { .. }
+        | AgentEventPayload::Reasoning { .. }
+        | AgentEventPayload::ToolComplete { .. }
+        | AgentEventPayload::WorkerPhase { .. }
+        | AgentEventPayload::Usage { .. }
+        | AgentEventPayload::ContextUsage { .. }
+        | AgentEventPayload::ScratchpadUsage { .. } => return Routed::NotSideChannel,
+
+        unknown => {
+            tracing::warn!(
+                payload = ?std::mem::discriminant(&unknown),
+                "agent event payload has no broker arm; the event reached no consumer"
+            );
+            return Routed::NotSideChannel;
+        }
+    };
+
+    if delivered {
+        Routed::Delivered
+    } else {
+        Routed::NoSubscriber
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aura_events::agent::ToolOutcome;
+    use aura_events::{
+        AgentContext, NumberOrString, Progress, ProgressToken, TokenCount, TokenUsage, ToolCallId,
+        ToolName,
+    };
+    use serde_json::json;
+
+    use crate::request_progress::subscribe as progress_subscribe;
+    use crate::tool_event_broker::{
+        ToolLifecycleEvent, subscribe as tool_event_subscribe, tool_usage_subscribe,
+    };
+
+    fn token(n: i64) -> ProgressToken {
+        ProgressToken(NumberOrString::Number(n))
+    }
+
+    #[tokio::test]
+    async fn tool_requested_reaches_the_tool_event_broker() {
+        let request_id = "req_adapter_requested";
+        let mut rx = tool_event_subscribe(request_id).await;
+
+        let routed = publish_to_brokers(
+            request_id,
+            AgentEvent::single_agent(AgentEventPayload::ToolRequested {
+                tool_call_id: ToolCallId::new("call_1"),
+                tool_name: ToolName::new("list_files"),
+                arguments: json!({ "path": "/mock" }),
+            }),
+        )
+        .await;
+
+        assert_eq!(routed, Routed::Delivered);
+        let event = rx.recv().await.expect("event should arrive");
+        let ToolLifecycleEvent::Requested {
+            tool_id,
+            tool_name,
+            arguments,
+            ..
+        } = event
+        else {
+            panic!("expected Requested");
+        };
+        assert_eq!(tool_id, "call_1");
+        assert_eq!(tool_name, "list_files");
+        assert_eq!(arguments, json!({ "path": "/mock" }));
+    }
+
+    #[tokio::test]
+    async fn tool_start_carries_its_progress_token() {
+        let request_id = "req_adapter_start";
+        let mut rx = tool_event_subscribe(request_id).await;
+
+        publish_to_brokers(
+            request_id,
+            AgentEvent::single_agent(AgentEventPayload::ToolStart {
+                tool_call_id: ToolCallId::new("call_1"),
+                tool_name: ToolName::new("list_files"),
+                progress_token: Some(token(7)),
+            }),
+        )
+        .await;
+
+        let ToolLifecycleEvent::Start { progress_token, .. } =
+            rx.recv().await.expect("event should arrive")
+        else {
+            panic!("expected Start");
+        };
+        assert_eq!(progress_token, Some(token(7)));
+    }
+
+    #[tokio::test]
+    async fn progress_keeps_the_raw_values_the_handler_derives_percent_from() {
+        let request_id = "req_adapter_progress";
+        let mut rx = progress_subscribe(request_id).await;
+
+        publish_to_brokers(
+            request_id,
+            AgentEvent::single_agent(AgentEventPayload::ToolProgress {
+                progress_token: token(7),
+                progress: Progress::ratio(50.0, 100.0),
+                message: Some("halfway".to_string()),
+            }),
+        )
+        .await;
+
+        let notification = rx.recv().await.expect("notification should arrive");
+        assert_eq!(notification.progress.current, 50.0);
+        assert_eq!(notification.progress.total, Some(100.0));
+        assert_eq!(notification.message.as_deref(), Some("halfway"));
+        assert_eq!(notification.percent(), Some(50));
+    }
+
+    /// A worker context, because `single_agent` is what the SSE handler stamps
+    /// when a usage event carries none — asserting on it would pass either way.
+    #[tokio::test]
+    async fn tool_usage_carries_its_agent() {
+        let request_id = "req_adapter_usage_agent";
+        let mut rx = tool_usage_subscribe(request_id).await;
+        let worker = AgentContext::worker("log_worker", None, "coordinator");
+
+        publish_to_brokers(
+            request_id,
+            AgentEvent::new(
+                worker.clone(),
+                AgentEventPayload::ToolUsage {
+                    tool_call_ids: vec![ToolCallId::new("call_1")],
+                    usage: TokenUsage {
+                        prompt_tokens: TokenCount::new(10),
+                        completion_tokens: TokenCount::new(2),
+                        total_tokens: TokenCount::new(12),
+                    },
+                },
+            ),
+        )
+        .await;
+
+        let event = rx.recv().await.expect("event should arrive");
+        assert_eq!(event.agent, Some(worker));
+    }
+
+    #[tokio::test]
+    async fn tool_usage_reaches_the_usage_broker() {
+        let request_id = "req_adapter_usage";
+        let mut rx = tool_usage_subscribe(request_id).await;
+
+        publish_to_brokers(
+            request_id,
+            AgentEvent::single_agent(AgentEventPayload::ToolUsage {
+                tool_call_ids: vec![ToolCallId::new("call_1")],
+                usage: TokenUsage {
+                    prompt_tokens: TokenCount::new(10),
+                    completion_tokens: TokenCount::new(5),
+                    total_tokens: TokenCount::new(15),
+                },
+            }),
+        )
+        .await;
+
+        let usage = rx.recv().await.expect("usage should arrive");
+        assert_eq!(usage.tool_ids, vec![ToolCallId::new("call_1")]);
+        assert_eq!(usage.usage.total_tokens.get(), 15);
+    }
+
+    #[tokio::test]
+    async fn content_events_are_not_routed_to_a_broker() {
+        let routed = publish_to_brokers(
+            "req_adapter_text",
+            AgentEvent::single_agent(AgentEventPayload::TextDelta {
+                content: "hello".to_string(),
+            }),
+        )
+        .await;
+
+        assert_eq!(routed, Routed::NotSideChannel);
+    }
+
+    #[tokio::test]
+    async fn tool_complete_is_carried_by_the_stream_not_a_broker() {
+        let routed = publish_to_brokers(
+            "req_adapter_complete",
+            AgentEvent::single_agent(AgentEventPayload::ToolComplete {
+                tool_call_id: ToolCallId::new("call_1"),
+                tool_name: ToolName::new("list_files"),
+                duration_ms: 3,
+                outcome: ToolOutcome::Success {
+                    result: "ok".to_string(),
+                },
+            }),
+        )
+        .await;
+
+        assert_eq!(routed, Routed::NotSideChannel);
+    }
+
+    #[tokio::test]
+    async fn a_side_channel_event_with_nobody_listening_reports_no_subscriber() {
+        let routed = publish_to_brokers(
+            "req_adapter_unsubscribed",
+            AgentEvent::single_agent(AgentEventPayload::ToolRequested {
+                tool_call_id: ToolCallId::new("call_1"),
+                tool_name: ToolName::new("list_files"),
+                arguments: json!({}),
+            }),
+        )
+        .await;
+
+        assert_eq!(routed, Routed::NoSubscriber);
+    }
+
+    /// A worker's tool call stays the worker's. Every other adapter test uses
+    /// [`AgentEvent::single_agent`], where dropping the context and stamping
+    /// the stream's own agent are indistinguishable.
+    #[tokio::test]
+    async fn a_workers_context_survives_the_broker_hop() {
+        let request_id = "req_adapter_worker_context";
+        let mut rx = tool_event_subscribe(request_id).await;
+        let worker = AgentContext::worker("log_worker", None, "orchestrator");
+
+        publish_to_brokers(
+            request_id,
+            AgentEvent::new(
+                worker.clone(),
+                AgentEventPayload::ToolRequested {
+                    tool_call_id: ToolCallId::new("call_1"),
+                    tool_name: ToolName::new("list_files"),
+                    arguments: json!({}),
+                },
+            ),
+        )
+        .await;
+
+        let ToolLifecycleEvent::Requested { agent, .. } =
+            rx.recv().await.expect("event should arrive")
+        else {
+            panic!("expected Requested");
+        };
+        assert_eq!(agent, Some(worker));
+    }
+
+    /// Probes an unset name rather than [`ENV_AGENT_EVENTS`] itself, because
+    /// reading the real var asserts on the ambient environment and fails for
+    /// anyone who has the flag exported.
+    #[test]
+    fn the_flag_is_off_unless_set() {
+        assert_eq!(ENV_AGENT_EVENTS, "AURA_AGENT_EVENTS");
+        assert!(!bool_env("AURA_AGENT_EVENTS_UNSET_PROBE", false));
+    }
+}

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -5,6 +5,7 @@
 //! in web services or other applications that need to build agents
 //! programmatically.
 
+pub mod agent_events;
 pub mod approval_event_broker;
 pub mod approver_headers;
 pub mod bedrock_embedding;
@@ -100,7 +101,7 @@ pub use mcp::{InFlightRequests, McpManager, ProgressEnabledHandler};
 pub use rag_tools::{AutoIngest, VectorIngestTool};
 pub use request_cancellation::{RequestCancellation, RequestId};
 pub use request_progress::{
-    ProgressNotification, RequestProgressBroker, global as request_progress_global,
+    Progress, ProgressNotification, RequestProgressBroker, global as request_progress_global,
     subscribe as request_progress_subscribe, unsubscribe as request_progress_unsubscribe,
 };
 pub use rmcp::model::{NumberOrString, ProgressToken};
@@ -113,7 +114,7 @@ pub use streaming_request_hook::{ResponseContent, StreamingRequestHook, UsageSta
 pub use tool_call_observer::{RetryHint, ToolCallObserver, ToolEvent, ToolOutcome};
 pub use tool_error_detection::{DetectedToolError, ToolResultStatus, detect_tool_error};
 pub use tool_event_broker::{
-    ToolCallId, ToolEventBroker, ToolLifecycleEvent, ToolName, ToolUsageEvent,
+    TokenUsage, ToolCallId, ToolEventBroker, ToolLifecycleEvent, ToolName, ToolUsageEvent,
     global as tool_event_global, peek_tool_call_id, pop_tool_call_id, publish_tool_start,
     publish_tool_usage, push_tool_call_id, subscribe as tool_event_subscribe, tool_usage_subscribe,
     tool_usage_unsubscribe, unsubscribe as tool_event_unsubscribe,

--- a/crates/aura/src/mcp/client.rs
+++ b/crates/aura/src/mcp/client.rs
@@ -28,7 +28,7 @@ use tracing::{debug, error, info, warn};
 use crate::approver_headers::ApproverHeaders;
 use crate::mcp::progress::ProgressEnabledHandler;
 use crate::mcp::response::extract_tool_result;
-use crate::tool_event_broker::{peek_tool_call_id, publish_tool_start};
+use crate::tool_event_broker::{ToolName, peek_tool_call_id, publish_tool_start};
 
 /// Custom HTTP client that captures the underlying HTTP status when a request
 /// fails.
@@ -776,7 +776,7 @@ impl McpClient {
             publish_tool_start(
                 http_request_id,
                 tool_call_id.clone(),
-                tool_name.to_string(),
+                ToolName::new(tool_name),
                 progress_token.clone(),
             )
             .await;

--- a/crates/aura/src/mcp/progress.rs
+++ b/crates/aura/src/mcp/progress.rs
@@ -29,7 +29,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
-use crate::request_progress::{self, ProgressNotification};
+use crate::request_progress::{self, Progress, ProgressNotification};
 
 /// A custom ClientHandler that routes progress notifications to request-scoped channels.
 ///
@@ -122,9 +122,12 @@ impl ClientHandler for ProgressEnabledHandler {
             // Build notification for request-scoped broker
             let notification = ProgressNotification {
                 progress_token: params.progress_token.clone(),
-                progress: params.progress,
-                total: params.total,
+                progress: Progress {
+                    current: params.progress,
+                    total: params.total,
+                },
                 message: params.message.clone(),
+                agent: None,
             };
 
             if let Some(ref req_id) = request_id {

--- a/crates/aura/src/request_progress.rs
+++ b/crates/aura/src/request_progress.rs
@@ -9,6 +9,8 @@ use std::sync::OnceLock;
 use tokio::sync::{RwLock, mpsc};
 use tracing::debug;
 
+pub use aura_events::{AgentContext, Progress};
+
 /// Channel capacity for progress notifications per request
 const PROGRESS_CHANNEL_CAPACITY: usize = 1024;
 
@@ -17,24 +19,15 @@ const PROGRESS_CHANNEL_CAPACITY: usize = 1024;
 pub struct ProgressNotification {
     /// The progress token (correlates to tool call)
     pub progress_token: ProgressToken,
-    /// Current progress value (rmcp uses f64 for JSON-RPC compatibility)
-    pub progress: f64,
-    /// Total progress value (if known)
-    pub total: Option<f64>,
+    pub progress: Progress,
     /// Optional message describing current step
     pub message: Option<String>,
+    pub agent: Option<AgentContext>,
 }
 
 impl ProgressNotification {
-    /// Calculate percent completion (0-100) if total is known
     pub fn percent(&self) -> Option<u8> {
-        self.total.map(|total| {
-            if total == 0.0 {
-                100
-            } else {
-                ((self.progress / total) * 100.0).min(100.0) as u8
-            }
-        })
+        self.progress.percent()
     }
 }
 
@@ -191,16 +184,16 @@ mod tests {
 
         let notification = ProgressNotification {
             progress_token: numeric_token(1),
-            progress: 50.0,
-            total: Some(100.0),
+            progress: Progress::ratio(50.0, 100.0),
             message: Some("Halfway there".to_string()),
+            agent: None,
         };
 
         let sent = broker.publish("req_123", notification).await;
         assert!(sent);
 
         let received = rx.recv().await.unwrap();
-        assert_eq!(received.progress, 50.0);
+        assert_eq!(received.progress.current, 50.0);
         assert_eq!(received.message, Some("Halfway there".to_string()));
     }
 
@@ -210,9 +203,9 @@ mod tests {
 
         let notification = ProgressNotification {
             progress_token: numeric_token(1),
-            progress: 50.0,
-            total: Some(100.0),
+            progress: Progress::ratio(50.0, 100.0),
             message: None,
+            agent: None,
         };
 
         // No subscriber - should return false
@@ -229,9 +222,9 @@ mod tests {
         // Send to req_1 only
         let notification = ProgressNotification {
             progress_token: string_token("token_1"),
-            progress: 25.0,
-            total: Some(100.0),
+            progress: Progress::ratio(25.0, 100.0),
             message: Some("Request 1 progress".to_string()),
+            agent: None,
         };
         broker.publish("req_1", notification).await;
 
@@ -244,33 +237,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_percent_calculation() {
-        let notification = ProgressNotification {
-            progress_token: numeric_token(1),
-            progress: 50.0,
-            total: Some(100.0),
-            message: None,
-        };
-        assert_eq!(notification.percent(), Some(50));
-
-        let notification_no_total = ProgressNotification {
-            progress_token: numeric_token(2),
-            progress: 50.0,
-            total: None,
-            message: None,
-        };
-        assert_eq!(notification_no_total.percent(), None);
-
-        let notification_zero_total = ProgressNotification {
-            progress_token: numeric_token(3),
-            progress: 0.0,
-            total: Some(0.0),
-            message: None,
-        };
-        assert_eq!(notification_zero_total.percent(), Some(100));
-    }
-
-    #[tokio::test]
     async fn test_multiple_notifications_same_request() {
         let broker = RequestProgressBroker::new();
         let mut rx = broker.subscribe("req_123").await;
@@ -279,9 +245,9 @@ mod tests {
         for i in 1..=5 {
             let notification = ProgressNotification {
                 progress_token: numeric_token(1),
-                progress: i as f64 * 20.0,
-                total: Some(100.0),
+                progress: Progress::ratio(i as f64 * 20.0, 100.0),
                 message: Some(format!("Step {}", i)),
+                agent: None,
             };
             broker.publish("req_123", notification).await;
         }
@@ -289,7 +255,7 @@ mod tests {
         // Should receive all 5
         for i in 1..=5 {
             let received = rx.recv().await.unwrap();
-            assert_eq!(received.progress, i as f64 * 20.0);
+            assert_eq!(received.progress.current, i as f64 * 20.0);
             assert_eq!(received.message, Some(format!("Step {}", i)));
         }
     }
@@ -308,9 +274,9 @@ mod tests {
         // Publish should fail because receiver is gone, triggering cleanup
         let notification = ProgressNotification {
             progress_token: numeric_token(1),
-            progress: 50.0,
-            total: Some(100.0),
+            progress: Progress::ratio(50.0, 100.0),
             message: Some("Should fail".to_string()),
+            agent: None,
         };
         let sent = broker.publish("req_cleanup", notification).await;
 
@@ -332,9 +298,9 @@ mod tests {
         // Publish should succeed
         let notification = ProgressNotification {
             progress_token: numeric_token(1),
-            progress: 75.0,
-            total: Some(100.0),
+            progress: Progress::ratio(75.0, 100.0),
             message: Some("Should succeed".to_string()),
+            agent: None,
         };
         let sent = broker.publish("req_active", notification).await;
         assert!(sent);
@@ -343,7 +309,7 @@ mod tests {
         let received = rx.recv().await;
         assert!(received.is_some());
         let msg = received.unwrap();
-        assert_eq!(msg.progress, 75.0);
+        assert_eq!(msg.progress.current, 75.0);
         assert_eq!(msg.message, Some("Should succeed".to_string()));
 
         // Subscription still active
@@ -369,9 +335,9 @@ mod tests {
             for i in 0..send_count {
                 let notification = ProgressNotification {
                     progress_token: numeric_token(i as i64),
-                    progress: i as f64,
-                    total: Some(send_count as f64),
+                    progress: Progress::ratio(i as f64, send_count as f64),
                     message: Some(format!("msg {}", i)),
+                    agent: None,
                 };
                 broker.publish("req_backpressure", notification).await;
             }
@@ -395,9 +361,9 @@ mod tests {
         for i in 0..PROGRESS_CHANNEL_CAPACITY {
             let notification = ProgressNotification {
                 progress_token: numeric_token(i as i64),
-                progress: i as f64,
-                total: Some(PROGRESS_CHANNEL_CAPACITY as f64),
+                progress: Progress::ratio(i as f64, PROGRESS_CHANNEL_CAPACITY as f64),
                 message: None,
+                agent: None,
             };
             assert!(broker.publish("req_drain", notification).await);
         }
@@ -427,9 +393,9 @@ mod tests {
                     for i in 0..10 {
                         let notification = ProgressNotification {
                             progress_token: numeric_token((publisher_id * 10 + i) as i64),
-                            progress: i as f64,
-                            total: Some(10.0),
+                            progress: Progress::ratio(i as f64, 10.0),
                             message: Some(format!("pub {} msg {}", publisher_id, i)),
+                            agent: None,
                         };
                         broker.publish("req_concurrent", notification).await;
                     }

--- a/crates/aura/src/stream_events.rs
+++ b/crates/aura/src/stream_events.rs
@@ -314,6 +314,7 @@ mod tests {
             18777,
             500,
             19277,
+            AgentContext::single_agent(),
             CorrelationContext::new("sess_123", None),
         );
         let sse = event.format_sse();
@@ -351,8 +352,14 @@ mod tests {
             AuraStreamEvent::session_info("gpt-4", None, CorrelationContext::default());
         assert_eq!(session_info.event_name(), event_names::SESSION_INFO);
 
-        let tool_usage =
-            AuraStreamEvent::tool_usage(vec![], 0, 0, 0, CorrelationContext::default());
+        let tool_usage = AuraStreamEvent::tool_usage(
+            vec![],
+            0,
+            0,
+            0,
+            AgentContext::single_agent(),
+            CorrelationContext::default(),
+        );
         assert_eq!(tool_usage.event_name(), event_names::TOOL_USAGE);
 
         let usage = AuraStreamEvent::usage(0, 0, 0, None, CorrelationContext::default());

--- a/crates/aura/src/streaming_request_hook.rs
+++ b/crates/aura/src/streaming_request_hook.rs
@@ -51,7 +51,8 @@ use tokio::sync::watch;
 use crate::orchestration::BlockedCell;
 use crate::scratchpad::{self, ContextBudget};
 use crate::tool_event_broker::{
-    pop_tool_call_id, publish_tool_requested, publish_tool_usage, push_tool_call_id,
+    TokenUsage, ToolCallId, ToolName, pop_tool_call_id, publish_tool_requested, publish_tool_usage,
+    push_tool_call_id,
 };
 
 /// Maximum pending tool IDs before warning. Prevents unbounded growth if
@@ -140,7 +141,7 @@ pub struct UsageState {
     /// Output tokens of the most recent turn.
     last_output_tokens: Arc<AtomicU64>,
     /// Tool IDs completed since the last usage event (for aura.tool_usage correlation)
-    pending_tool_ids: Arc<Mutex<Vec<String>>>,
+    pending_tool_ids: Arc<Mutex<Vec<ToolCallId>>>,
 }
 
 impl UsageState {
@@ -255,7 +256,7 @@ impl UsageState {
     /// Add a tool ID to the pending list.
     ///
     /// Called from on_tool_result when a tool completes.
-    pub fn add_pending_tool_id(&self, tool_id: String) {
+    pub fn add_pending_tool_id(&self, tool_id: ToolCallId) {
         match self.pending_tool_ids.lock() {
             Ok(mut pending) => {
                 if pending.len() >= MAX_PENDING_TOOL_IDS {
@@ -283,7 +284,7 @@ impl UsageState {
     /// Take all pending tool IDs, leaving the list empty.
     ///
     /// Called when usage becomes available to associate tools with usage snapshot.
-    pub fn take_pending_tool_ids(&self) -> Vec<String> {
+    pub fn take_pending_tool_ids(&self) -> Vec<ToolCallId> {
         match self.pending_tool_ids.lock() {
             Ok(mut pending) => std::mem::take(&mut *pending),
             Err(poisoned) => {
@@ -592,8 +593,9 @@ where
 
                 // Rig 0.28+ passes correct tool_call_id; register for event correlation
                 if let Some(id) = &tool_call_id {
+                    let id = ToolCallId::new(id);
                     push_tool_call_id(&request_id, id.clone()).await;
-                    publish_tool_requested(&request_id, id.clone(), tool_name.clone(), arguments)
+                    publish_tool_requested(&request_id, id, ToolName::new(&tool_name), arguments)
                         .await;
                 } else {
                     tracing::warn!(
@@ -660,7 +662,7 @@ where
                 // This allows us to correlate tools with the usage snapshot when
                 // on_stream_completion_response_finish fires
                 if let Some(id) = tool_call_id {
-                    usage_state.add_pending_tool_id(id);
+                    usage_state.add_pending_tool_id(ToolCallId::new(id));
                 }
 
                 tracing::debug!(
@@ -733,9 +735,11 @@ where
                     publish_tool_usage(
                         &request_id,
                         tool_ids,
-                        usage.input_tokens,
-                        usage.output_tokens,
-                        usage.total_tokens,
+                        TokenUsage {
+                            prompt_tokens: usage.input_tokens.into(),
+                            completion_tokens: usage.output_tokens.into(),
+                            total_tokens: usage.total_tokens.into(),
+                        },
                     )
                     .await;
                 }
@@ -939,8 +943,8 @@ mod tests {
     fn test_usage_state_pending_tool_ids() {
         let usage_state = UsageState::new();
 
-        usage_state.add_pending_tool_id("call_abc".to_string());
-        usage_state.add_pending_tool_id("call_def".to_string());
+        usage_state.add_pending_tool_id(ToolCallId::new("call_abc"));
+        usage_state.add_pending_tool_id(ToolCallId::new("call_def"));
 
         let tool_ids = usage_state.take_pending_tool_ids();
         assert_eq!(tool_ids, vec!["call_abc", "call_def"]);
@@ -973,11 +977,11 @@ mod tests {
 
         // Fill to capacity
         for i in 0..MAX_PENDING_TOOL_IDS {
-            usage_state.add_pending_tool_id(format!("call_{}", i));
+            usage_state.add_pending_tool_id(ToolCallId::new(format!("call_{}", i)));
         }
 
         // Add one more - should drop oldest
-        usage_state.add_pending_tool_id("call_overflow".to_string());
+        usage_state.add_pending_tool_id(ToolCallId::new("call_overflow"));
 
         let tool_ids = usage_state.take_pending_tool_ids();
         assert_eq!(tool_ids.len(), MAX_PENDING_TOOL_IDS);

--- a/crates/aura/src/tool_event_broker.rs
+++ b/crates/aura/src/tool_event_broker.rs
@@ -26,14 +26,10 @@ use std::sync::OnceLock;
 use tokio::sync::{RwLock, mpsc};
 use tracing::debug;
 
+pub use aura_events::{AgentContext, TokenUsage, ToolCallId, ToolName};
+
 /// Channel capacity for tool events per request
 const EVENT_CHANNEL_CAPACITY: usize = 32;
-
-// Type aliases for tool identifiers - upgrade to newtypes later
-/// The unique ID assigned by the LLM to a specific tool call
-pub type ToolCallId = String;
-/// The name of a tool (e.g., "search", "list_files")
-pub type ToolName = String;
 
 /// Tool lifecycle events routed through the broker.
 ///
@@ -49,6 +45,7 @@ pub enum ToolLifecycleEvent {
         tool_name: ToolName,
         /// The tool arguments as JSON
         arguments: serde_json::Value,
+        agent: Option<AgentContext>,
     },
     /// Emitted from execution context when MCP actually begins.
     /// Provides the progress_token for correlating with aura.progress events.
@@ -56,12 +53,13 @@ pub enum ToolLifecycleEvent {
         tool_id: ToolCallId,
         tool_name: ToolName,
         progress_token: Option<ProgressToken>,
+        agent: Option<AgentContext>,
     },
 }
 
 impl ToolLifecycleEvent {
     /// Get the tool_id regardless of event variant
-    pub fn tool_id(&self) -> &str {
+    pub fn tool_id(&self) -> &ToolCallId {
         match self {
             ToolLifecycleEvent::Requested { tool_id, .. } => tool_id,
             ToolLifecycleEvent::Start { tool_id, .. } => tool_id,
@@ -69,7 +67,7 @@ impl ToolLifecycleEvent {
     }
 
     /// Get the tool_name regardless of event variant
-    pub fn tool_name(&self) -> &str {
+    pub fn tool_name(&self) -> &ToolName {
         match self {
             ToolLifecycleEvent::Requested { tool_name, .. } => tool_name,
             ToolLifecycleEvent::Start { tool_name, .. } => tool_name,
@@ -77,21 +75,11 @@ impl ToolLifecycleEvent {
     }
 }
 
-/// Tool usage event emitted when usage information becomes available.
-///
-/// This associates tool calls with their usage snapshot. When
-/// `on_stream_completion_response_finish` fires, all tools that completed
-/// since the last usage event are grouped together.
 #[derive(Clone, Debug)]
 pub struct ToolUsageEvent {
-    /// Tool IDs that share this usage snapshot
-    pub tool_ids: Vec<String>,
-    /// Prompt tokens (context size at this point)
-    pub prompt_tokens: u64,
-    /// Completion tokens generated
-    pub completion_tokens: u64,
-    /// Total tokens used
-    pub total_tokens: u64,
+    pub tool_ids: Vec<ToolCallId>,
+    pub usage: TokenUsage,
+    pub agent: Option<AgentContext>,
 }
 
 /// Request-scoped tool event broker that routes MCP tool events
@@ -115,7 +103,7 @@ pub struct ToolEventBroker {
     /// Hook pushes when on_tool_call fires, execution peeks when tool starts,
     /// hook pops when on_tool_result fires.
     /// Sequential execution in streaming mode guarantees correct ordering.
-    pending_tool_calls: RwLock<HashMap<String, VecDeque<String>>>,
+    pending_tool_calls: RwLock<HashMap<String, VecDeque<ToolCallId>>>,
 }
 
 impl ToolEventBroker {
@@ -172,7 +160,7 @@ impl ToolEventBroker {
     /// Called when the hook's `on_tool_call` fires. The execution context
     /// will peek this ID when the tool actually starts executing.
     /// FIFO order is guaranteed by sequential tool execution in streaming mode.
-    pub async fn push_tool_call_id(&self, request_id: &str, tool_call_id: impl Into<String>) {
+    pub async fn push_tool_call_id(&self, request_id: &str, tool_call_id: impl Into<ToolCallId>) {
         let mut pending = self.pending_tool_calls.write().await;
         let queue = pending.entry(request_id.to_string()).or_default();
         let tool_call_id = tool_call_id.into();
@@ -194,7 +182,7 @@ impl ToolEventBroker {
     /// This ensures push/pop pairing regardless of tool type.
     ///
     /// Returns `None` if no pending tool_call_id exists.
-    pub async fn peek_tool_call_id(&self, request_id: &str) -> Option<String> {
+    pub async fn peek_tool_call_id(&self, request_id: &str) -> Option<ToolCallId> {
         let pending = self.pending_tool_calls.read().await;
 
         let queue = pending.get(request_id)?;
@@ -220,7 +208,7 @@ impl ToolEventBroker {
     /// This ensures push/pop pairing for ALL tools (MCP and non-MCP).
     ///
     /// Returns `None` if no pending tool_call_id exists.
-    pub async fn pop_tool_call_id(&self, request_id: &str) -> Option<String> {
+    pub async fn pop_tool_call_id(&self, request_id: &str) -> Option<ToolCallId> {
         let mut pending = self.pending_tool_calls.write().await;
 
         let queue = pending.get_mut(request_id)?;
@@ -325,6 +313,7 @@ pub async fn publish_tool_requested(
             tool_id,
             tool_name,
             arguments,
+            agent: None,
         },
     )
     .await
@@ -343,23 +332,24 @@ pub async fn publish_tool_start(
             tool_id,
             tool_name,
             progress_token,
+            agent: None,
         },
     )
     .await
 }
 
 /// Convenience function to push a tool_call_id from hook context.
-pub async fn push_tool_call_id(request_id: &RequestId, tool_call_id: String) {
+pub async fn push_tool_call_id(request_id: &RequestId, tool_call_id: ToolCallId) {
     global().push_tool_call_id(request_id, tool_call_id).await
 }
 
 /// Convenience function to peek at the next tool_call_id (for MCP execution).
-pub async fn peek_tool_call_id(request_id: &RequestId) -> Option<String> {
+pub async fn peek_tool_call_id(request_id: &RequestId) -> Option<ToolCallId> {
     global().peek_tool_call_id(request_id).await
 }
 
 /// Convenience function to pop a tool_call_id (from on_tool_result).
-pub async fn pop_tool_call_id(request_id: &RequestId) -> Option<String> {
+pub async fn pop_tool_call_id(request_id: &RequestId) -> Option<ToolCallId> {
     global().pop_tool_call_id(request_id).await
 }
 
@@ -462,21 +452,23 @@ pub async fn tool_usage_unsubscribe(request_id: &str) {
 ///
 /// Called from `on_stream_completion_response_finish` when usage becomes available.
 /// Associates the listed tool_ids with the usage snapshot.
+/// Publish a prebuilt usage event, so a caller that knows the agent can name it.
+pub async fn publish_usage(request_id: &str, event: ToolUsageEvent) -> bool {
+    usage_broker_global().publish(request_id, event).await
+}
+
 pub async fn publish_tool_usage(
     request_id: &str,
-    tool_ids: Vec<String>,
-    prompt_tokens: u64,
-    completion_tokens: u64,
-    total_tokens: u64,
+    tool_ids: Vec<ToolCallId>,
+    usage: TokenUsage,
 ) -> bool {
     usage_broker_global()
         .publish(
             request_id,
             ToolUsageEvent {
                 tool_ids,
-                prompt_tokens,
-                completion_tokens,
-                total_tokens,
+                usage,
+                agent: None,
             },
         )
         .await
@@ -485,6 +477,7 @@ pub async fn publish_tool_usage(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aura_events::TokenCount;
     use rmcp::model::NumberOrString;
     use std::sync::Arc;
 
@@ -525,9 +518,10 @@ mod tests {
         let mut rx = broker.subscribe("req_123").await;
 
         let event = ToolLifecycleEvent::Start {
-            tool_id: "call_abc".to_string(),
-            tool_name: "list_pipelines".to_string(),
+            tool_id: ToolCallId::new("call_abc"),
+            tool_name: ToolName::new("list_pipelines"),
             progress_token: Some(numeric_token(42)),
+            agent: None,
         };
 
         let sent = broker.publish("req_123", event).await;
@@ -539,6 +533,7 @@ mod tests {
                 tool_id,
                 tool_name,
                 progress_token,
+                ..
             } => {
                 assert_eq!(tool_id, "call_abc");
                 assert_eq!(tool_name, "list_pipelines");
@@ -554,9 +549,10 @@ mod tests {
         let mut rx = broker.subscribe("req_123").await;
 
         let event = ToolLifecycleEvent::Requested {
-            tool_id: "call_abc".to_string(),
-            tool_name: "search".to_string(),
+            tool_id: ToolCallId::new("call_abc"),
+            tool_name: ToolName::new("search"),
             arguments: serde_json::json!({"query": "test"}),
+            agent: None,
         };
 
         let sent = broker.publish("req_123", event).await;
@@ -568,6 +564,7 @@ mod tests {
                 tool_id,
                 tool_name,
                 arguments,
+                ..
             } => {
                 assert_eq!(tool_id, "call_abc");
                 assert_eq!(tool_name, "search");
@@ -582,9 +579,10 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         let event = ToolLifecycleEvent::Start {
-            tool_id: "call_abc".to_string(),
-            tool_name: "list_pipelines".to_string(),
+            tool_id: ToolCallId::new("call_abc"),
+            tool_name: ToolName::new("list_pipelines"),
             progress_token: None,
+            agent: None,
         };
 
         let sent = broker.publish("req_nonexistent", event).await;
@@ -598,9 +596,10 @@ mod tests {
         let mut rx2 = broker.subscribe("req_2").await;
 
         let event = ToolLifecycleEvent::Start {
-            tool_id: "call_1".to_string(),
-            tool_name: "tool_for_req_1".to_string(),
+            tool_id: ToolCallId::new("call_1"),
+            tool_name: ToolName::new("tool_for_req_1"),
             progress_token: Some(string_token("token_1")),
+            agent: None,
         };
         broker.publish("req_1", event).await;
 
@@ -618,9 +617,10 @@ mod tests {
         let mut rx = broker.subscribe("req_123").await;
 
         let event = ToolLifecycleEvent::Start {
-            tool_id: "call_xyz".to_string(),
-            tool_name: "some_tool".to_string(),
+            tool_id: ToolCallId::new("call_xyz"),
+            tool_name: ToolName::new("some_tool"),
             progress_token: None,
+            agent: None,
         };
 
         broker.publish("req_123", event).await;
@@ -648,7 +648,7 @@ mod tests {
         broker.push_tool_call_id("req_1", "call_abc123").await;
 
         let result = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(result, Some("call_abc123".to_string()));
+        assert_eq!(result, Some(ToolCallId::new("call_abc123")));
 
         // Second pop should return None (consumed)
         let result2 = broker.pop_tool_call_id("req_1").await;
@@ -674,13 +674,13 @@ mod tests {
 
         // Pops should return in FIFO order
         let first = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(first, Some("call_first".to_string()));
+        assert_eq!(first, Some(ToolCallId::new("call_first")));
 
         let second = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(second, Some("call_second".to_string()));
+        assert_eq!(second, Some(ToolCallId::new("call_second")));
 
         let third = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(third, Some("call_third".to_string()));
+        assert_eq!(third, Some(ToolCallId::new("call_third")));
 
         // Fourth should be None
         let fourth = broker.pop_tool_call_id("req_1").await;
@@ -696,10 +696,10 @@ mod tests {
 
         // Each request gets its own tool_call_id
         let result1 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(result1, Some("call_for_req_1".to_string()));
+        assert_eq!(result1, Some(ToolCallId::new("call_for_req_1")));
 
         let result2 = broker.pop_tool_call_id("req_2").await;
-        assert_eq!(result2, Some("call_for_req_2".to_string()));
+        assert_eq!(result2, Some(ToolCallId::new("call_for_req_2")));
     }
 
     #[tokio::test]
@@ -727,15 +727,15 @@ mod tests {
 
         // Peek should return the item
         let result = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(result, Some("call_abc".to_string()));
+        assert_eq!(result, Some(ToolCallId::new("call_abc")));
 
         // Peek again should return the same item (not consumed)
         let result2 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(result2, Some("call_abc".to_string()));
+        assert_eq!(result2, Some(ToolCallId::new("call_abc")));
 
         // Pop should also return the same item
         let result3 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(result3, Some("call_abc".to_string()));
+        assert_eq!(result3, Some(ToolCallId::new("call_abc")));
 
         // Now it's consumed
         let result4 = broker.peek_tool_call_id("req_1").await;
@@ -760,19 +760,19 @@ mod tests {
 
         // Peek returns first item
         let peek1 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek1, Some("call_first".to_string()));
+        assert_eq!(peek1, Some(ToolCallId::new("call_first")));
 
         // Pop removes first item
         let pop1 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop1, Some("call_first".to_string()));
+        assert_eq!(pop1, Some(ToolCallId::new("call_first")));
 
         // Peek now returns second item
         let peek2 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek2, Some("call_second".to_string()));
+        assert_eq!(peek2, Some(ToolCallId::new("call_second")));
 
         // Pop removes second item
         let pop2 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop2, Some("call_second".to_string()));
+        assert_eq!(pop2, Some(ToolCallId::new("call_second")));
 
         // Both are now empty
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -792,11 +792,11 @@ mod tests {
 
         // Simulate MCP execution (peek)
         let for_tool_start = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(for_tool_start, Some("call_mcp_1".to_string()));
+        assert_eq!(for_tool_start, Some(ToolCallId::new("call_mcp_1")));
 
         // Simulate on_tool_result (pop)
         let cleanup = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(cleanup, Some("call_mcp_1".to_string()));
+        assert_eq!(cleanup, Some(ToolCallId::new("call_mcp_1")));
 
         // Queue is now empty
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -817,7 +817,7 @@ mod tests {
 
         // Simulate on_tool_result (pop)
         let cleanup = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(cleanup, Some("call_vector_1".to_string()));
+        assert_eq!(cleanup, Some(ToolCallId::new("call_vector_1")));
 
         // Queue is clean
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -833,19 +833,19 @@ mod tests {
         broker.push_tool_call_id("req_1", "call_vector").await;
         // Vector store executes (no peek)
         let pop1 = broker.pop_tool_call_id("req_1").await; // on_tool_result
-        assert_eq!(pop1, Some("call_vector".to_string()));
+        assert_eq!(pop1, Some(ToolCallId::new("call_vector")));
 
         // Tool 2: MCP HTTP tool
         broker.push_tool_call_id("req_1", "call_mcp").await;
         let peek2 = broker.peek_tool_call_id("req_1").await; // MCP execution
-        assert_eq!(peek2, Some("call_mcp".to_string()));
+        assert_eq!(peek2, Some(ToolCallId::new("call_mcp")));
         let pop2 = broker.pop_tool_call_id("req_1").await; // on_tool_result
-        assert_eq!(pop2, Some("call_mcp".to_string()));
+        assert_eq!(pop2, Some(ToolCallId::new("call_mcp")));
 
         // Tool 3: Another vector store
         broker.push_tool_call_id("req_1", "call_vector_2").await;
         let pop3 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop3, Some("call_vector_2".to_string()));
+        assert_eq!(pop3, Some(ToolCallId::new("call_vector_2")));
 
         // Queue integrity maintained - all clean
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -863,14 +863,14 @@ mod tests {
 
         // MCP execution peeks
         let peek = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek, Some("call_failing_tool".to_string()));
+        assert_eq!(peek, Some(ToolCallId::new("call_failing_tool")));
 
         // Tool execution fails... but on_tool_result still fires
         // (Rig converts Err(e) to e.to_string() and calls on_tool_result)
 
         // on_tool_result pops (even on failure)
         let pop = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop, Some("call_failing_tool".to_string()));
+        assert_eq!(pop, Some(ToolCallId::new("call_failing_tool")));
 
         // Queue is clean despite failure
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -885,25 +885,25 @@ mod tests {
         // Tool 1: Success
         broker.push_tool_call_id("req_1", "call_1_success").await;
         let peek1 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek1, Some("call_1_success".to_string()));
+        assert_eq!(peek1, Some(ToolCallId::new("call_1_success")));
         // Tool executes successfully
         let pop1 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop1, Some("call_1_success".to_string()));
+        assert_eq!(pop1, Some(ToolCallId::new("call_1_success")));
 
         // Tool 2: Failure (but on_tool_result still fires)
         broker.push_tool_call_id("req_1", "call_2_failure").await;
         let peek2 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek2, Some("call_2_failure".to_string()));
+        assert_eq!(peek2, Some(ToolCallId::new("call_2_failure")));
         // Tool execution fails...
         let pop2 = broker.pop_tool_call_id("req_1").await; // on_tool_result still fires
-        assert_eq!(pop2, Some("call_2_failure".to_string()));
+        assert_eq!(pop2, Some(ToolCallId::new("call_2_failure")));
 
         // Tool 3: Success - must get correct tool_call_id, not stale one
         broker.push_tool_call_id("req_1", "call_3_success").await;
         let peek3 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek3, Some("call_3_success".to_string())); // Not call_2!
+        assert_eq!(peek3, Some(ToolCallId::new("call_3_success"))); // Not call_2!
         let pop3 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop3, Some("call_3_success".to_string()));
+        assert_eq!(pop3, Some(ToolCallId::new("call_3_success")));
 
         // Queue integrity maintained
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -919,16 +919,16 @@ mod tests {
         broker.push_tool_call_id("req_1", "call_vector_fails").await;
         // Tool execution fails... no peek happened
         let pop1 = broker.pop_tool_call_id("req_1").await; // on_tool_result
-        assert_eq!(pop1, Some("call_vector_fails".to_string()));
+        assert_eq!(pop1, Some(ToolCallId::new("call_vector_fails")));
 
         // Next MCP tool should work correctly
         broker
             .push_tool_call_id("req_1", "call_mcp_after_failure")
             .await;
         let peek2 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek2, Some("call_mcp_after_failure".to_string()));
+        assert_eq!(peek2, Some(ToolCallId::new("call_mcp_after_failure")));
         let pop2 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop2, Some("call_mcp_after_failure".to_string()));
+        assert_eq!(pop2, Some(ToolCallId::new("call_mcp_after_failure")));
 
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
     }
@@ -947,15 +947,15 @@ mod tests {
 
         // Request 2 peeks and pops (success)
         let peek_r2 = broker.peek_tool_call_id("req_2").await;
-        assert_eq!(peek_r2, Some("call_2_success".to_string()));
+        assert_eq!(peek_r2, Some(ToolCallId::new("call_2_success")));
         let pop_r2 = broker.pop_tool_call_id("req_2").await;
-        assert_eq!(pop_r2, Some("call_2_success".to_string()));
+        assert_eq!(pop_r2, Some(ToolCallId::new("call_2_success")));
 
         // Request 1 still has its item (failure doesn't affect isolation)
         let peek_r1 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek_r1, Some("call_1_fail".to_string()));
+        assert_eq!(peek_r1, Some(ToolCallId::new("call_1_fail")));
         let pop_r1 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop_r1, Some("call_1_fail".to_string()));
+        assert_eq!(pop_r1, Some(ToolCallId::new("call_1_fail")));
 
         // Both queues clean
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -970,17 +970,19 @@ mod tests {
 
         for i in 0..100 {
             let tool_id = format!("call_{}", i);
-            broker.push_tool_call_id("req_stress", &tool_id).await;
+            broker
+                .push_tool_call_id("req_stress", tool_id.as_str())
+                .await;
 
             // Simulate MCP tool (peek)
             if i % 2 == 0 {
                 let peek = broker.peek_tool_call_id("req_stress").await;
-                assert_eq!(peek, Some(tool_id.clone()));
+                assert_eq!(peek, Some(ToolCallId::new(&tool_id)));
             }
 
             // on_tool_result (pop) - always fires
             let pop = broker.pop_tool_call_id("req_stress").await;
-            assert_eq!(pop, Some(tool_id));
+            assert_eq!(pop, Some(ToolCallId::new(tool_id)));
         }
 
         // Queue should be empty after 100 push/pop cycles
@@ -1030,10 +1032,13 @@ mod tests {
         let mut rx = broker.subscribe("req_usage_1").await;
 
         let event = ToolUsageEvent {
-            tool_ids: vec!["call_abc".to_string(), "call_def".to_string()],
-            prompt_tokens: 18777,
-            completion_tokens: 500,
-            total_tokens: 19277,
+            tool_ids: vec![ToolCallId::new("call_abc"), ToolCallId::new("call_def")],
+            usage: TokenUsage {
+                prompt_tokens: TokenCount::new(18777),
+                completion_tokens: TokenCount::new(500),
+                total_tokens: TokenCount::new(19277),
+            },
+            agent: None,
         };
 
         let sent = broker.publish("req_usage_1", event).await;
@@ -1041,9 +1046,9 @@ mod tests {
 
         let received = rx.recv().await.unwrap();
         assert_eq!(received.tool_ids, vec!["call_abc", "call_def"]);
-        assert_eq!(received.prompt_tokens, 18777);
-        assert_eq!(received.completion_tokens, 500);
-        assert_eq!(received.total_tokens, 19277);
+        assert_eq!(received.usage.prompt_tokens.get(), 18777);
+        assert_eq!(received.usage.completion_tokens.get(), 500);
+        assert_eq!(received.usage.total_tokens.get(), 19277);
     }
 
     #[tokio::test]
@@ -1058,9 +1063,12 @@ mod tests {
                 "req_usage_2",
                 ToolUsageEvent {
                     tool_ids: vec![],
-                    prompt_tokens: 0,
-                    completion_tokens: 0,
-                    total_tokens: 0,
+                    usage: TokenUsage {
+                        prompt_tokens: TokenCount::new(0),
+                        completion_tokens: TokenCount::new(0),
+                        total_tokens: TokenCount::new(0),
+                    },
+                    agent: None,
                 },
             )
             .await;
@@ -1078,10 +1086,13 @@ mod tests {
             .publish(
                 "req_usage_a",
                 ToolUsageEvent {
-                    tool_ids: vec!["tool_for_a".to_string()],
-                    prompt_tokens: 1000,
-                    completion_tokens: 100,
-                    total_tokens: 1100,
+                    tool_ids: vec![ToolCallId::new("tool_for_a")],
+                    usage: TokenUsage {
+                        prompt_tokens: TokenCount::new(1000),
+                        completion_tokens: TokenCount::new(100),
+                        total_tokens: TokenCount::new(1100),
+                    },
+                    agent: None,
                 },
             )
             .await;


### PR DESCRIPTION
Adds aura_events::agent, the event vocabulary a running agent emits, and aura::agent_events, which republishes it onto the request-scoped brokers so consumers are unaffected. A differential test asserts both paths produce identical SSE.

The schema is typed with domain value types rather than bare primitives: ToolCallId, ToolName, TokenCount, TokenUsage, and Progress. The tool_event_broker's ToolCallId/ToolName aliases resolve to the newtypes, so publish_tool_requested and publish_tool_start no longer take interchangeable strings positionally, publish_tool_usage takes one TokenUsage instead of three bare u64s, and ProgressNotification carries the current/total pair as a single value that owns percent(). Scratchpad token counts move from usize to u64 with every other count.

No producer emits the schema yet; agent_events_enabled reads AURA_AGENT_EVENTS and is the seam producers will gate on.

Ref: https://github.com/mezmo/aura/issues/618