### PR TITLE
feat: llm prompt caching with cache-usage visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,15 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
@@ -1605,7 +1614,7 @@ dependencies = [
  "deluxe-core",
  "heck 0.4.1",
  "if_chain",
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1666,7 +1675,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -3217,15 +3226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3756,8 +3756,7 @@ dependencies = [
 [[package]]
 name = "rig-bedrock"
 version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bb353af77c971bed15752053be2d514ee1b5b7f1e6511a962f03b2324ab64d"
+source = "git+https://github.com/mezmo/rig.git?rev=8fbc59c4772566629d353459617505191e415ed2#8fbc59c4772566629d353459617505191e415ed2"
 dependencies = [
  "async-stream",
  "aws-config",
@@ -3777,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.28.0"
-source = "git+https://github.com/mezmo/rig.git?rev=5b0238a1d74e1d7c68034384b69e17f62890d517#5b0238a1d74e1d7c68034384b69e17f62890d517"
+source = "git+https://github.com/mezmo/rig.git?rev=8fbc59c4772566629d353459617505191e415ed2#8fbc59c4772566629d353459617505191e415ed2"
 dependencies = [
  "as-any",
  "async-stream",
@@ -3807,14 +3806,12 @@ dependencies = [
 
 [[package]]
 name = "rig-derive"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9149c63403a49ddfd5d373860487e6feef0021bfe5329812d1c4e72ee207c"
+version = "0.1.10"
+source = "git+https://github.com/mezmo/rig.git?rev=8fbc59c4772566629d353459617505191e415ed2#8fbc59c4772566629d353459617505191e415ed2"
 dependencies = [
- "convert_case",
+ "convert_case 0.8.0",
  "deluxe",
  "indoc",
- "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -4841,18 +4838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
-dependencies = [
- "indexmap 2.14.0",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.3",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5777,9 +5762,6 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,11 @@ strip = "symbols"
 
 [workspace.dependencies]
 rig-core = { git = "https://github.com/mezmo/rig.git", rev = "8fbc59c4772566629d353459617505191e415ed2", default-features = false, features = ["rmcp", "reqwest-rustls"] }
-# The fork's vendored copy (0.3.10 + prompt-caching support), building against
-# the same rig-core. crates.io 0.3.11+ pulls rig-core 0.31, which is
-# semver-incompatible with the 0.28 fork.
+# The fork's vendored copy (versioned "0.3.10" but carrying prompt-caching
+# support beyond the crates.io release of that number), building against the
+# same rig-core. crates.io 0.3.11+ pulls rig-core 0.31, which is
+# semver-incompatible with the 0.28 fork. This also resolves rig-derive to the
+# fork's 0.1.10 rather than the newer crates.io release.
 rig-bedrock = { git = "https://github.com/mezmo/rig.git", rev = "8fbc59c4772566629d353459617505191e415ed2" }
 
 # MCP support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ default-members = [
     "crates/aura-test-utils",
     "crates/aura-cli",
 ]
+# Keep a local rig checkout's crates out of this workspace (used when
+# temporarily path-pinning rig-core/rig-bedrock at ./rig for fork work).
+exclude = ["rig"]
 resolver = "3"
 
 [workspace.package]
@@ -35,10 +38,11 @@ codegen-units = 1
 strip = "symbols"
 
 [workspace.dependencies]
-rig-core = { git = "https://github.com/mezmo/rig.git", rev = "5b0238a1d74e1d7c68034384b69e17f62890d517", default-features = false, features = ["rmcp", "reqwest-rustls"] }
-# Pinned to exact versions compatible with our rig-core 0.28.x fork.
-# Newer versions pull in rig-core 0.31+ which is semver-incompatible with the fork.
-rig-bedrock = "=0.3.10"
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "8fbc59c4772566629d353459617505191e415ed2", default-features = false, features = ["rmcp", "reqwest-rustls"] }
+# The fork's vendored copy (0.3.10 + prompt-caching support), building against
+# the same rig-core. crates.io 0.3.11+ pulls rig-core 0.31, which is
+# semver-incompatible with the 0.28 fork.
+rig-bedrock = { git = "https://github.com/mezmo/rig.git", rev = "8fbc59c4772566629d353459617505191e415ed2" }
 
 # MCP support
 rmcp = { version = "0.12.0", features = ["transport-child-process", "client", "transport-streamable-http-client", "transport-streamable-http-client-reqwest"] }
@@ -106,5 +110,5 @@ http = "1.0"
 
 # Patch rig-core to use the fork with streaming hook + span propagation fix
 [patch.crates-io]
-rig-core = { git = "https://github.com/mezmo/rig.git", rev = "5b0238a1d74e1d7c68034384b69e17f62890d517" }
+rig-core = { git = "https://github.com/mezmo/rig.git", rev = "8fbc59c4772566629d353459617505191e415ed2" }
 

--- a/crates/aura-cli/src/api/stream.rs
+++ b/crates/aura-cli/src/api/stream.rs
@@ -73,8 +73,15 @@ pub trait StreamHandler {
     /// Called with (prompt_tokens, completion_tokens) from `aura.usage` events.
     /// These are cumulative provider-billed totals for the request, not context
     /// size — use [`on_context_usage`](Self::on_context_usage) for the context
-    /// window indicator.
-    fn on_usage(&mut self, _prompt_tokens: u64, _completion_tokens: u64) {}
+    /// window indicator. `cache_usage` is the provider-reported prompt-cache
+    /// split as `(read, creation)` tokens, if any.
+    fn on_usage(
+        &mut self,
+        _prompt_tokens: u64,
+        _completion_tokens: u64,
+        _cache_usage: Option<(u64, u64)>,
+    ) {
+    }
 
     /// Called with (context_tokens, response_tokens, context_window) from
     /// `aura.context_usage` events. `context_tokens` is the absolute size of the
@@ -263,10 +270,19 @@ where
                     if let Ok(AuraStreamEvent::Usage {
                         prompt_tokens,
                         completion_tokens,
+                        cache_read_input_tokens,
+                        cache_creation_input_tokens,
                         ..
                     }) = serde_json::from_str::<AuraStreamEvent>(&event.data)
                     {
-                        handler.on_usage(prompt_tokens, completion_tokens);
+                        let cache_usage =
+                            match (cache_read_input_tokens, cache_creation_input_tokens) {
+                                (None, None) => None,
+                                (read, creation) => {
+                                    Some((read.unwrap_or(0), creation.unwrap_or(0)))
+                                }
+                            };
+                        handler.on_usage(prompt_tokens, completion_tokens, cache_usage);
                     }
                 }
                 event_names::CONTEXT_USAGE => {
@@ -527,7 +543,12 @@ mod tests {
                 result.map(|s| s.to_string()),
             ));
         }
-        fn on_usage(&mut self, prompt_tokens: u64, completion_tokens: u64) {
+        fn on_usage(
+            &mut self,
+            prompt_tokens: u64,
+            completion_tokens: u64,
+            _cache_usage: Option<(u64, u64)>,
+        ) {
             self.usages.push((prompt_tokens, completion_tokens));
         }
         fn on_tool_usage(&mut self, prompt_tokens: u64, completion_tokens: u64) {

--- a/crates/aura-cli/src/api/types.rs
+++ b/crates/aura-cli/src/api/types.rs
@@ -246,6 +246,14 @@ pub enum DisplayEvent {
     Usage {
         prompt_tokens: u64,
         completion_tokens: u64,
+        /// Prompt tokens served from the provider's prompt cache
+        /// (a subset of `prompt_tokens`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_read_input_tokens: Option<u64>,
+        /// Prompt tokens written to the provider's prompt cache
+        /// (a subset of `prompt_tokens`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_creation_input_tokens: Option<u64>,
     },
     ContextUsage {
         context_tokens: u64,

--- a/crates/aura-cli/src/repl/commands.rs
+++ b/crates/aura-cli/src/repl/commands.rs
@@ -397,8 +397,8 @@ pub(crate) fn handle_resume(
             replay_event_log_global();
             // Seed token counters from authoritative usage JSONL after replay
             if let Some(store) = conv_store {
-                let (p, c) = store.load_usage_totals();
-                seed_status_bar_tokens(p, c);
+                let (p, c, cache_read) = store.load_usage_totals();
+                seed_status_bar_tokens(p, c, cache_read);
             }
             println!(
                 "{}",
@@ -487,7 +487,7 @@ pub(crate) fn resume_conversation(
     ConversationHistory,
     Vec<DisplayEvent>,
     bool,
-    (u64, u64),
+    (u64, u64, u64),
 )> {
     match ConversationStore::find_by_prefix(id_prefix) {
         Ok(full_uuid) => {

--- a/crates/aura-cli/src/repl/commands.rs
+++ b/crates/aura-cli/src/repl/commands.rs
@@ -473,7 +473,8 @@ pub(crate) fn handle_model(
     redraw_input_frame();
 }
 
-/// Returned tuple: (store, history, events, expanded, (prompt_tokens, completion_tokens))
+/// Returned tuple: (store, history, events, expanded,
+/// (prompt_tokens, completion_tokens, cache_read_tokens))
 #[allow(clippy::type_complexity)]
 pub(crate) fn resume_conversation(
     id_prefix: &str,

--- a/crates/aura-cli/src/repl/commands.rs
+++ b/crates/aura-cli/src/repl/commands.rs
@@ -15,9 +15,9 @@ use crate::ui::prompt::{
     get_model_cache, get_model_matches, is_expanded_output, last_sse_event, list_conversations,
     load_and_restore_sse_events, print_help, print_welcome_state, record_session_event,
     redraw_input_frame, replay_event_log_global, reset_session_status, reset_status_bar_tokens,
-    seed_model_cache, seed_status_bar_tokens, set_expanded_output, set_mid_stream_history,
-    set_selected_model, set_stream_conv_dir, set_stream_show_all, set_welcome_state,
-    toggle_stream_panel, with_event_log,
+    seed_model_cache, set_expanded_output, set_mid_stream_history, set_selected_model,
+    set_stream_conv_dir, set_stream_show_all, set_welcome_state, toggle_stream_panel,
+    with_event_log,
 };
 use crate::ui::state::{RESUME_MATCHES, get_tab_select_index, set_tab_select_index};
 use crate::ui::welcome::WelcomeState;
@@ -394,12 +394,8 @@ pub(crate) fn handle_resume(
             set_welcome_state(WelcomeState::pick());
             // Replay the event log so the user sees the conversation
             crate::ui::prompt::erase_input_frame();
+            // Replay seeds the token counters from the usage ledger.
             replay_event_log_global();
-            // Seed token counters from authoritative usage JSONL after replay
-            if let Some(store) = conv_store {
-                let (p, c, cache_read) = store.load_usage_totals();
-                seed_status_bar_tokens(p, c, cache_read);
-            }
             println!(
                 "{}",
                 "Resumed conversation. Continue below.".themed(AuraStyle::Success),

--- a/crates/aura-cli/src/repl/conversations.rs
+++ b/crates/aura-cli/src/repl/conversations.rs
@@ -158,11 +158,21 @@ impl ConversationStore {
         fs::read_to_string(&path).ok().filter(|s| !s.is_empty())
     }
 
-    pub fn append_usage(&self, prompt_tokens: u64, completion_tokens: u64, model: Option<&str>) {
+    pub fn append_usage(
+        &self,
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        cache_usage: Option<(u64, u64)>,
+        model: Option<&str>,
+    ) {
         let path = self.dir.join("usage");
         if let Ok(mut f) = fs::OpenOptions::new().create(true).append(true).open(&path) {
             let mut line =
                 serde_json::json!({ "prompt": prompt_tokens, "completion": completion_tokens });
+            if let Some((cache_read, cache_creation)) = cache_usage {
+                line["cache_read"] = serde_json::Value::from(cache_read);
+                line["cache_creation"] = serde_json::Value::from(cache_creation);
+            }
             if let Some(m) = model {
                 line["model"] = serde_json::Value::String(m.to_string());
             }
@@ -170,22 +180,26 @@ impl ConversationStore {
         }
     }
 
-    /// Sum all usage entries and return (total_prompt, total_completion).
-    pub fn load_usage_totals(&self) -> (u64, u64) {
+    /// Sum all usage entries and return (total_prompt, total_completion,
+    /// total_cache_read). Entries written before cache tracking count zero
+    /// cache-read tokens.
+    pub fn load_usage_totals(&self) -> (u64, u64, u64) {
         let path = self.dir.join("usage");
         let data = match fs::read_to_string(&path) {
             Ok(d) => d,
-            Err(_) => return (0, 0),
+            Err(_) => return (0, 0, 0),
         };
         let mut prompt_total: u64 = 0;
         let mut completion_total: u64 = 0;
+        let mut cache_read_total: u64 = 0;
         for line in data.lines() {
             if let Ok(val) = serde_json::from_str::<serde_json::Value>(line) {
                 prompt_total += val["prompt"].as_u64().unwrap_or(0);
                 completion_total += val["completion"].as_u64().unwrap_or(0);
+                cache_read_total += val["cache_read"].as_u64().unwrap_or(0);
             }
         }
-        (prompt_total, completion_total)
+        (prompt_total, completion_total, cache_read_total)
     }
 
     pub fn save_view_expanded(&self, expanded: bool) {
@@ -465,20 +479,22 @@ mod tests {
     fn usage_accumulation() {
         let tmp = TempDir::new().unwrap();
         let store = make_store(&tmp);
-        store.append_usage(100, 50, Some("gpt-4"));
-        store.append_usage(200, 75, None);
-        let (prompt, completion) = store.load_usage_totals();
+        store.append_usage(100, 50, Some((80, 10)), Some("gpt-4"));
+        store.append_usage(200, 75, None, None);
+        let (prompt, completion, cache_read) = store.load_usage_totals();
         assert_eq!(prompt, 300);
         assert_eq!(completion, 125);
+        assert_eq!(cache_read, 80, "entries without cache fields count zero");
     }
 
     #[test]
     fn usage_empty() {
         let tmp = TempDir::new().unwrap();
         let store = make_store(&tmp);
-        let (prompt, completion) = store.load_usage_totals();
+        let (prompt, completion, cache_read) = store.load_usage_totals();
         assert_eq!(prompt, 0);
         assert_eq!(completion, 0);
+        assert_eq!(cache_read, 0);
     }
 
     #[test]

--- a/crates/aura-cli/src/repl/conversations.rs
+++ b/crates/aura-cli/src/repl/conversations.rs
@@ -184,22 +184,7 @@ impl ConversationStore {
     /// total_cache_read). Entries written before cache tracking count zero
     /// cache-read tokens.
     pub fn load_usage_totals(&self) -> (u64, u64, u64) {
-        let path = self.dir.join("usage");
-        let data = match fs::read_to_string(&path) {
-            Ok(d) => d,
-            Err(_) => return (0, 0, 0),
-        };
-        let mut prompt_total: u64 = 0;
-        let mut completion_total: u64 = 0;
-        let mut cache_read_total: u64 = 0;
-        for line in data.lines() {
-            if let Ok(val) = serde_json::from_str::<serde_json::Value>(line) {
-                prompt_total += val["prompt"].as_u64().unwrap_or(0);
-                completion_total += val["completion"].as_u64().unwrap_or(0);
-                cache_read_total += val["cache_read"].as_u64().unwrap_or(0);
-            }
-        }
-        (prompt_total, completion_total, cache_read_total)
+        usage_totals_at(&self.dir)
     }
 
     pub fn save_view_expanded(&self, expanded: bool) {
@@ -345,6 +330,28 @@ impl ConversationStore {
             dir,
         }
     }
+}
+
+/// Sum the usage-ledger entries in a conversation directory as
+/// (total_prompt, total_completion, total_cache_read). The ledger, not the
+/// display-event log, is the authoritative source for conversation totals.
+pub(crate) fn usage_totals_at(dir: &Path) -> (u64, u64, u64) {
+    let path = dir.join("usage");
+    let data = match fs::read_to_string(&path) {
+        Ok(d) => d,
+        Err(_) => return (0, 0, 0),
+    };
+    let mut prompt_total: u64 = 0;
+    let mut completion_total: u64 = 0;
+    let mut cache_read_total: u64 = 0;
+    for line in data.lines() {
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(line) {
+            prompt_total += val["prompt"].as_u64().unwrap_or(0);
+            completion_total += val["completion"].as_u64().unwrap_or(0);
+            cache_read_total += val["cache_read"].as_u64().unwrap_or(0);
+        }
+    }
+    (prompt_total, completion_total, cache_read_total)
 }
 
 #[cfg(test)]

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -769,8 +769,8 @@ pub fn run_repl(
         // (replay resets + re-accumulates from view events; this ensures the
         // JSONL totals are the final source of truth).
         if let Some(ref store) = conv_store {
-            let (p, c) = store.load_usage_totals();
-            seed_status_bar_tokens(p, c);
+            let (p, c, cache_read) = store.load_usage_totals();
+            seed_status_bar_tokens(p, c, cache_read);
         }
         println!(
             "{}",
@@ -2004,12 +2004,21 @@ pub fn run_repl(
                             if let DisplayEvent::Usage {
                                 prompt_tokens,
                                 completion_tokens,
-                                ..
+                                cache_read_input_tokens,
+                                cache_creation_input_tokens,
                             } = event
                             {
+                                let cache_usage =
+                                    match (cache_read_input_tokens, cache_creation_input_tokens) {
+                                        (None, None) => None,
+                                        (read, creation) => {
+                                            Some((read.unwrap_or(0), creation.unwrap_or(0)))
+                                        }
+                                    };
                                 store.append_usage(
                                     *prompt_tokens,
                                     *completion_tokens,
+                                    cache_usage,
                                     get_selected_model().as_deref(),
                                 );
                             }

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -1953,6 +1953,8 @@ pub fn run_repl(
                             push_display_event(DisplayEvent::Usage {
                                 prompt_tokens,
                                 completion_tokens,
+                                cache_read_input_tokens: None,
+                                cache_creation_input_tokens: None,
                             });
                         }
 
@@ -2002,6 +2004,7 @@ pub fn run_repl(
                             if let DisplayEvent::Usage {
                                 prompt_tokens,
                                 completion_tokens,
+                                ..
                             } = event
                             {
                                 store.append_usage(
@@ -2488,13 +2491,23 @@ impl StreamHandler for ReplStreamHandler {
         update_status_bar();
     }
 
-    fn on_usage(&mut self, prompt_tokens: u64, completion_tokens: u64) {
+    fn on_usage(
+        &mut self,
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        cache_usage: Option<(u64, u64)>,
+    ) {
         set_status_bar_tokens(prompt_tokens, completion_tokens);
+        if let Some((cache_read, _)) = cache_usage {
+            crate::ui::status_bar::add_status_bar_cached_tokens(cache_read);
+        }
         update_status_bar();
         if let Ok(mut events) = self.turn_events.lock() {
             events.push(DisplayEvent::Usage {
                 prompt_tokens,
                 completion_tokens,
+                cache_read_input_tokens: cache_usage.map(|(read, _)| read),
+                cache_creation_input_tokens: cache_usage.map(|(_, creation)| creation),
             });
         }
     }

--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -35,13 +35,12 @@ use crate::ui::prompt::{
     print_tool_call_expanded, print_user_echo, print_welcome_state_animated, push_display_event,
     push_mid_stream_history, push_sse_event, random_bullet_color, record_session_event,
     redraw_input_frame, replay_event_log_global, reset_ctrlc_state, reset_input_geometry,
-    restore_terminal_mode, seed_model_cache, seed_status_bar_tokens, set_context_used,
-    set_context_window_usage, set_expanded_output, set_mid_stream_history, set_noncanonical_noecho,
-    set_processing, set_readline_active, set_selected_model, set_startup_status,
-    set_status_bar_tokens, set_stream_conv_dir, set_welcome_state, setup_terminal,
-    stop_and_clear_animation, styled_prompt, take_pending_command, take_queued_input,
-    task_color_for, text_lines, update_status_bar, update_status_bar_unlocked, with_event_log,
-    with_event_log_mut,
+    restore_terminal_mode, seed_model_cache, set_context_used, set_context_window_usage,
+    set_expanded_output, set_mid_stream_history, set_noncanonical_noecho, set_processing,
+    set_readline_active, set_selected_model, set_startup_status, set_status_bar_tokens,
+    set_stream_conv_dir, set_welcome_state, setup_terminal, stop_and_clear_animation,
+    styled_prompt, take_pending_command, take_queued_input, task_color_for, text_lines,
+    update_status_bar, update_status_bar_unlocked, with_event_log, with_event_log_mut,
 };
 use crate::ui::welcome::WelcomeState;
 
@@ -764,14 +763,8 @@ pub fn run_repl(
     let has_events = with_event_log(|log| !log.is_empty());
     if config.resume.is_some() && has_events {
         erase_input_frame();
+        // Replay seeds the token counters from the usage ledger.
         replay_event_log_global();
-        // Seed token counters from the authoritative usage JSONL after replay
-        // (replay resets + re-accumulates from view events; this ensures the
-        // JSONL totals are the final source of truth).
-        if let Some(ref store) = conv_store {
-            let (p, c, cache_read) = store.load_usage_totals();
-            seed_status_bar_tokens(p, c, cache_read);
-        }
         println!(
             "{}",
             "Resumed conversation. Continue below.".themed(AuraStyle::Success),

--- a/crates/aura-cli/src/ui/event_replay.rs
+++ b/crates/aura-cli/src/ui/event_replay.rs
@@ -23,7 +23,8 @@ use super::orchestrator::{
     TREE_END_BULLET, TREE_END_DURATION, TREE_MID_BULLET, TREE_MID_DURATION, format_orch_duration_ms,
 };
 use super::state::{
-    EVENT_LOG, EXPANDED_OUTPUT, STREAM_CONV_DIR, WELCOME_STATE, random_bullet_color, task_color_for,
+    EVENT_LOG, EXPANDED_OUTPUT, PROCESSING, STREAM_CONV_DIR, WELCOME_STATE, random_bullet_color,
+    task_color_for,
 };
 use super::status_bar::{
     mark_orchestrated, reset_status_bar_tokens, seed_status_bar_tokens, set_context_window_usage,
@@ -42,7 +43,15 @@ pub fn replay_event_log_global() {
         terminal::Clear(terminal::ClearType::All),
         cursor::MoveTo(0, 0)
     );
-    reset_status_bar_tokens();
+    // While a turn is streaming, the live counters are authoritative: the
+    // in-flight turn's usage is still buffered per-turn, absent from both
+    // this log and the usage ledger, so a rebuild here would erase it (and
+    // it would stay lost — counters accumulate, nothing re-adds a turn).
+    // Mid-stream replays repaint the transcript only.
+    let rebuild_counters = !PROCESSING.load(Ordering::Relaxed);
+    if rebuild_counters {
+        reset_status_bar_tokens();
+    }
 
     if let Some(ref w) = *welcome {
         w.print_static();
@@ -199,9 +208,11 @@ pub fn replay_event_log_global() {
                 cache_read_input_tokens,
                 ..
             } => {
-                set_status_bar_tokens(*prompt_tokens, *completion_tokens);
-                if let Some(cache_read) = cache_read_input_tokens {
-                    super::status_bar::add_status_bar_cached_tokens(*cache_read);
+                if rebuild_counters {
+                    set_status_bar_tokens(*prompt_tokens, *completion_tokens);
+                    if let Some(cache_read) = cache_read_input_tokens {
+                        super::status_bar::add_status_bar_cached_tokens(*cache_read);
+                    }
                 }
                 i += 1;
             }
@@ -210,14 +221,18 @@ pub fn replay_event_log_global() {
                 response_tokens,
                 context_window,
             } => {
-                set_context_window_usage(*context_tokens, *response_tokens, *context_window);
+                if rebuild_counters {
+                    set_context_window_usage(*context_tokens, *response_tokens, *context_window);
+                }
                 i += 1;
             }
             DisplayEvent::OrchestratorScratchpadSavings {
                 tokens_intercepted,
                 tokens_extracted,
             } => {
-                super::status_bar::add_scratchpad_usage(*tokens_intercepted, *tokens_extracted);
+                if rebuild_counters {
+                    super::status_bar::add_scratchpad_usage(*tokens_intercepted, *tokens_extracted);
+                }
                 i += 1;
             }
             DisplayEvent::Compacted { messages_removed } => {
@@ -719,7 +734,7 @@ pub fn replay_event_log_global() {
     // be truncated; the conversation's usage ledger is authoritative, so it
     // gets the last word on every replay (resume, /expand, style repaints).
     // An empty ledger keeps the replay-derived values.
-    if let Some(dir) = STREAM_CONV_DIR.lock().ok().and_then(|g| g.clone()) {
+    if rebuild_counters && let Some(dir) = STREAM_CONV_DIR.lock().ok().and_then(|g| g.clone()) {
         let (prompt, completion, cache_read) = crate::repl::conversations::usage_totals_at(&dir);
         if prompt > 0 {
             seed_status_bar_tokens(prompt, completion, cache_read);

--- a/crates/aura-cli/src/ui/event_replay.rs
+++ b/crates/aura-cli/src/ui/event_replay.rs
@@ -23,10 +23,11 @@ use super::orchestrator::{
     TREE_END_BULLET, TREE_END_DURATION, TREE_MID_BULLET, TREE_MID_DURATION, format_orch_duration_ms,
 };
 use super::state::{
-    EVENT_LOG, EXPANDED_OUTPUT, WELCOME_STATE, random_bullet_color, task_color_for,
+    EVENT_LOG, EXPANDED_OUTPUT, STREAM_CONV_DIR, WELCOME_STATE, random_bullet_color, task_color_for,
 };
 use super::status_bar::{
-    mark_orchestrated, reset_status_bar_tokens, set_context_window_usage, set_status_bar_tokens,
+    mark_orchestrated, reset_status_bar_tokens, seed_status_bar_tokens, set_context_window_usage,
+    set_status_bar_tokens,
 };
 
 /// Clear the terminal and replay all recorded events.
@@ -711,6 +712,17 @@ pub fn replay_event_log_global() {
                 println!();
                 i += 1;
             }
+        }
+    }
+
+    // The counters rebuilt above come from the display-event log, which may
+    // be truncated; the conversation's usage ledger is authoritative, so it
+    // gets the last word on every replay (resume, /expand, style repaints).
+    // An empty ledger keeps the replay-derived values.
+    if let Some(dir) = STREAM_CONV_DIR.lock().ok().and_then(|g| g.clone()) {
+        let (prompt, completion, cache_read) = crate::repl::conversations::usage_totals_at(&dir);
+        if prompt > 0 {
+            seed_status_bar_tokens(prompt, completion, cache_read);
         }
     }
 }

--- a/crates/aura-cli/src/ui/event_replay.rs
+++ b/crates/aura-cli/src/ui/event_replay.rs
@@ -195,8 +195,13 @@ pub fn replay_event_log_global() {
             DisplayEvent::Usage {
                 prompt_tokens,
                 completion_tokens,
+                cache_read_input_tokens,
+                ..
             } => {
                 set_status_bar_tokens(*prompt_tokens, *completion_tokens);
+                if let Some(cache_read) = cache_read_input_tokens {
+                    super::status_bar::add_status_bar_cached_tokens(*cache_read);
+                }
                 i += 1;
             }
             DisplayEvent::ContextUsage {

--- a/crates/aura-cli/src/ui/prompt.rs
+++ b/crates/aura-cli/src/ui/prompt.rs
@@ -27,8 +27,8 @@ pub use super::status_bar::{
     AgentHost, add_scratchpad_usage, add_turn_notice, begin_turn_context_tracking,
     clear_turn_notices, context_fill_ratio, fresh_context_fill_ratio, get_context_tokens,
     get_cumulative_tokens, handle_ctrlc, mark_orchestrated, record_session_event,
-    reset_ctrlc_state, reset_session_status, reset_status_bar_tokens, seed_status_bar_tokens,
-    set_agent_host, set_context_used, set_context_window_usage, set_mcp_counts, set_session_info,
+    reset_ctrlc_state, reset_session_status, reset_status_bar_tokens, set_agent_host,
+    set_context_used, set_context_window_usage, set_mcp_counts, set_session_info,
     set_status_bar_tokens, set_status_segments, update_status_bar,
 };
 

--- a/crates/aura-cli/src/ui/state.rs
+++ b/crates/aura-cli/src/ui/state.rs
@@ -62,6 +62,7 @@ pub(crate) static STATUS_HINT: Mutex<Vec<String>> = Mutex::new(Vec::new());
 pub(crate) static TURN_NOTICES: Mutex<Vec<String>> = Mutex::new(Vec::new());
 pub(crate) static CUMULATIVE_PROMPT: Mutex<u64> = Mutex::new(0);
 pub(crate) static CUMULATIVE_COMPLETION: Mutex<u64> = Mutex::new(0);
+pub(crate) static CUMULATIVE_CACHE_READ: Mutex<u64> = Mutex::new(0);
 pub(crate) static CUMULATIVE_SCRATCHPAD_INTERCEPTED: Mutex<u64> = Mutex::new(0);
 pub(crate) static CUMULATIVE_SCRATCHPAD_EXTRACTED: Mutex<u64> = Mutex::new(0);
 pub(crate) static PROCESSING: AtomicBool = AtomicBool::new(false);

--- a/crates/aura-cli/src/ui/status_bar.rs
+++ b/crates/aura-cli/src/ui/status_bar.rs
@@ -425,12 +425,15 @@ pub fn set_context_window_usage(
 }
 
 /// Seed cumulative token counters (used when resuming).
-pub fn seed_status_bar_tokens(prompt_tokens: u64, completion_tokens: u64) {
+pub fn seed_status_bar_tokens(prompt_tokens: u64, completion_tokens: u64, cache_read_tokens: u64) {
     if let Ok(mut g) = CUMULATIVE_PROMPT.lock() {
         *g = prompt_tokens;
     }
     if let Ok(mut g) = CUMULATIVE_COMPLETION.lock() {
         *g = completion_tokens;
+    }
+    if let Ok(mut g) = CUMULATIVE_CACHE_READ.lock() {
+        *g = cache_read_tokens;
     }
 }
 

--- a/crates/aura-cli/src/ui/status_bar.rs
+++ b/crates/aura-cli/src/ui/status_bar.rs
@@ -21,11 +21,11 @@ use crate::theme::{AuraStyle, Themed};
 use super::animation::render_queued_wave;
 use super::state::{
     AGENT_HOST, CONTEXT_USED, CONTEXT_USED_FRESH, CTRLC_HINT_VISIBLE, CTRLC_RESET_SKIP,
-    CUMULATIVE_COMPLETION, CUMULATIVE_PROMPT, CUMULATIVE_SCRATCHPAD_EXTRACTED,
-    CUMULATIVE_SCRATCHPAD_INTERCEPTED, CURSOR_ROW, CWD, FRAME_LINES, LAST_CTRLC, MCP_COUNTS,
-    MODEL_CONTEXT_LIMIT, ORCHESTRATED, PROCESSING, QUEUED_INPUT, QUEUED_WAVE_POS, SESSION_MODEL,
-    STATUS_HINT, STATUS_ROWS, STATUS_SEGMENTS, TURN_NOTICES, get_selected_model, lock_term,
-    status_rows, term_size,
+    CUMULATIVE_CACHE_READ, CUMULATIVE_COMPLETION, CUMULATIVE_PROMPT,
+    CUMULATIVE_SCRATCHPAD_EXTRACTED, CUMULATIVE_SCRATCHPAD_INTERCEPTED, CURSOR_ROW, CWD,
+    FRAME_LINES, LAST_CTRLC, MCP_COUNTS, MODEL_CONTEXT_LIMIT, ORCHESTRATED, PROCESSING,
+    QUEUED_INPUT, QUEUED_WAVE_POS, SESSION_MODEL, STATUS_HINT, STATUS_ROWS, STATUS_SEGMENTS,
+    TURN_NOTICES, get_selected_model, lock_term, status_rows, term_size,
 };
 use super::status_line::{self, ContextUsage, DEFAULT_SEGMENTS, Segment, Snapshot};
 use super::text::strip_control_chars;
@@ -157,6 +157,7 @@ fn capture_snapshot() -> Snapshot {
         context,
         prompt_tokens: CUMULATIVE_PROMPT.lock().map(|g| *g).unwrap_or(0),
         completion_tokens: CUMULATIVE_COMPLETION.lock().map(|g| *g).unwrap_or(0),
+        cached_prompt_tokens: CUMULATIVE_CACHE_READ.lock().map(|g| *g).unwrap_or(0),
         scratchpad_intercepted: CUMULATIVE_SCRATCHPAD_INTERCEPTED
             .lock()
             .map(|g| *g)
@@ -328,6 +329,14 @@ pub fn set_status_bar_tokens(prompt_tokens: u64, completion_tokens: u64) {
     }
 }
 
+/// Accumulate prompt tokens the provider served from its prompt cache
+/// (a subset of the prompt tokens counted by `set_status_bar_tokens`).
+pub fn add_status_bar_cached_tokens(cache_read_tokens: u64) {
+    if let Ok(mut g) = CUMULATIVE_CACHE_READ.lock() {
+        *g += cache_read_tokens;
+    }
+}
+
 /// Accumulate scratchpad savings.
 pub fn add_scratchpad_usage(tokens_intercepted: u64, tokens_extracted: u64) {
     if let Ok(mut g) = CUMULATIVE_SCRATCHPAD_INTERCEPTED.lock() {
@@ -433,6 +442,9 @@ pub fn reset_status_bar_tokens() {
         *g = 0;
     }
     if let Ok(mut g) = CUMULATIVE_COMPLETION.lock() {
+        *g = 0;
+    }
+    if let Ok(mut g) = CUMULATIVE_CACHE_READ.lock() {
         *g = 0;
     }
     if let Ok(mut g) = CUMULATIVE_SCRATCHPAD_INTERCEPTED.lock() {

--- a/crates/aura-cli/src/ui/status_line.rs
+++ b/crates/aura-cli/src/ui/status_line.rs
@@ -106,6 +106,9 @@ pub struct Snapshot {
     pub prompt_tokens: u64,
     /// Cumulative completion tokens across the conversation.
     pub completion_tokens: u64,
+    /// Cumulative prompt tokens served from the provider's prompt cache
+    /// (a subset of `prompt_tokens`).
+    pub cached_prompt_tokens: u64,
     /// Tokens of tool output diverted to the scratchpad.
     pub scratchpad_intercepted: u64,
     /// Tokens read back into context from the scratchpad.
@@ -187,14 +190,21 @@ fn piece(segment: Segment, snapshot: &Snapshot) -> Option<Piece> {
             if snapshot.prompt_tokens == 0 && snapshot.completion_tokens == 0 {
                 return None;
             }
-            (
+            let text = if snapshot.cached_prompt_tokens > 0 {
+                format!(
+                    "in {} ({} cached) / out {}",
+                    compact(snapshot.prompt_tokens),
+                    compact(snapshot.cached_prompt_tokens),
+                    compact(snapshot.completion_tokens)
+                )
+            } else {
                 format!(
                     "in {} / out {}",
                     compact(snapshot.prompt_tokens),
                     compact(snapshot.completion_tokens)
-                ),
-                AuraStyle::StatusTokens,
-            )
+                )
+            };
+            (text, AuraStyle::StatusTokens)
         }
         Segment::Scratchpad => {
             if snapshot.scratchpad_intercepted == 0 {
@@ -460,6 +470,7 @@ mod tests {
             }),
             prompt_tokens: 182_000,
             completion_tokens: 41_000,
+            cached_prompt_tokens: 0,
             scratchpad_intercepted: 0,
             scratchpad_extracted: 0,
             mcp: Some(McpCounts {
@@ -625,6 +636,18 @@ mod tests {
         };
         let line = strip_ansi(&render(&snapshot, &[Segment::Tokens], 80, ""));
         assert_eq!(line, "in 182k / out 41k");
+    }
+
+    #[test]
+    fn tokens_show_cached_share_when_reported() {
+        let snapshot = Snapshot {
+            prompt_tokens: 182_000,
+            completion_tokens: 41_000,
+            cached_prompt_tokens: 150_000,
+            ..Snapshot::default()
+        };
+        let line = strip_ansi(&render(&snapshot, &[Segment::Tokens], 80, ""));
+        assert_eq!(line, "in 182k (150k cached) / out 41k");
     }
 
     #[test]

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -96,6 +96,9 @@ pub enum LlmConfig {
         /// Context window size in tokens.
         #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
         context_window: Option<u64>,
+        /// Anthropic prompt caching (`cache_control` breakpoints). Off by default.
+        #[serde(default)]
+        prompt_caching: bool,
         /// Controls the randomness and creativity of the llm
         #[serde(default)]
         temperature: Option<f64>,
@@ -116,6 +119,11 @@ pub enum LlmConfig {
         /// Context window size in tokens.
         #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
         context_window: Option<u64>,
+        /// Bedrock prompt caching (`cachePoint` breakpoints). Off by default;
+        /// enable only for models that support prompt caching — Bedrock
+        /// rejects requests otherwise.
+        #[serde(default)]
+        prompt_caching: bool,
         #[serde(default)]
         temperature: Option<f64>,
         /// Additional provider-specific parameters merged into the API request.

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -96,7 +96,7 @@ pub enum LlmConfig {
         /// Context window size in tokens.
         #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
         context_window: Option<u64>,
-        /// Anthropic prompt caching (`cache_control` breakpoints). Off by default.
+        /// Anthropic prompt caching (`cache_control` breakpoints).
         #[serde(default)]
         prompt_caching: bool,
         /// Controls the randomness and creativity of the llm
@@ -119,9 +119,7 @@ pub enum LlmConfig {
         /// Context window size in tokens.
         #[serde(default, deserialize_with = "lenient_int::deserialize_option_u64")]
         context_window: Option<u64>,
-        /// Bedrock prompt caching (`cachePoint` breakpoints). Off by default;
-        /// enable only for models that support prompt caching — Bedrock
-        /// rejects requests otherwise.
+        /// Bedrock prompt caching (`cachePoint` breakpoints).
         #[serde(default)]
         prompt_caching: bool,
         #[serde(default)]

--- a/crates/aura-config/src/config_test.rs
+++ b/crates/aura-config/src/config_test.rs
@@ -333,6 +333,68 @@ model = "claude-3-sonnet-20240229"
     }
 
     #[test]
+    fn test_anthropic_prompt_caching_flag() {
+        let base = r#"
+[agent]
+name = "Cache Agent"
+system_prompt = "Basic prompt"
+
+[agent.llm]
+provider = "anthropic"
+api_key = "test_key"
+model = "claude-sonnet-4-5"
+"#;
+
+        let config = load_config_from_str(base).expect("Failed to parse config");
+        match &config.agent.llm {
+            crate::config::LlmConfig::Anthropic { prompt_caching, .. } => {
+                assert!(!prompt_caching, "prompt_caching should default to false");
+            }
+            _ => panic!("Expected Anthropic LLM config"),
+        }
+
+        let enabled = format!("{base}prompt_caching = true\n");
+        let config = load_config_from_str(&enabled).expect("Failed to parse config");
+        match &config.agent.llm {
+            crate::config::LlmConfig::Anthropic { prompt_caching, .. } => {
+                assert!(prompt_caching);
+            }
+            _ => panic!("Expected Anthropic LLM config"),
+        }
+    }
+
+    #[test]
+    fn test_bedrock_prompt_caching_flag() {
+        let base = r#"
+[agent]
+name = "Bedrock Cache Agent"
+system_prompt = "Basic prompt"
+
+[agent.llm]
+provider = "bedrock"
+model = "anthropic.claude-sonnet-4-20250514-v1:0"
+region = "us-east-1"
+"#;
+
+        let config = load_config_from_str(base).expect("Failed to parse config");
+        match &config.agent.llm {
+            crate::config::LlmConfig::Bedrock { prompt_caching, .. } => {
+                assert!(!prompt_caching, "prompt_caching should default to false");
+            }
+            _ => panic!("Expected Bedrock LLM config"),
+        }
+
+        let enabled = format!("{base}prompt_caching = true\n");
+        let config = load_config_from_str(&enabled).expect("Failed to parse config");
+        match &config.agent.llm {
+            crate::config::LlmConfig::Bedrock { prompt_caching, .. } => {
+                assert!(prompt_caching);
+            }
+            _ => panic!("Expected Bedrock LLM config"),
+        }
+    }
+
+    #[test]
     fn test_config_validation() {
         // Test config with missing API key (should fail validation)
         let invalid_config = r#"

--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -421,6 +421,14 @@ pub enum AuraStreamEvent {
         completion_tokens: u64,
         /// Total tokens used
         total_tokens: u64,
+        /// Prompt tokens served from the provider's prompt cache
+        /// (a subset of `prompt_tokens`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_read_input_tokens: Option<u64>,
+        /// Prompt tokens written to the provider's prompt cache
+        /// (a subset of `prompt_tokens`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_creation_input_tokens: Option<u64>,
         #[serde(flatten)]
         correlation: CorrelationContext,
     },
@@ -636,17 +644,22 @@ impl AuraStreamEvent {
         }
     }
 
-    /// Create a Usage event (emitted at stream end).
+    /// Create a Usage event (emitted at stream end). `cache_usage` is the
+    /// provider-reported prompt-cache split as `(read, creation)` tokens, if
+    /// any.
     pub fn usage(
         prompt_tokens: u64,
         completion_tokens: u64,
         total_tokens: u64,
+        cache_usage: Option<(u64, u64)>,
         correlation: CorrelationContext,
     ) -> Self {
         Self::Usage {
             prompt_tokens,
             completion_tokens,
             total_tokens,
+            cache_read_input_tokens: cache_usage.map(|(read, _)| read),
+            cache_creation_input_tokens: cache_usage.map(|(_, creation)| creation),
             correlation,
         }
     }
@@ -910,17 +923,49 @@ mod tests {
 
     #[test]
     fn usage_roundtrip() {
-        let event = AuraStreamEvent::usage(100, 50, 150, CorrelationContext::new("s1", None));
+        let event = AuraStreamEvent::usage(100, 50, 150, None, CorrelationContext::new("s1", None));
         let json = serde_json::to_string(&event).unwrap();
+        assert!(
+            !json.contains("cache_read_input_tokens"),
+            "absent cache usage must not serialize"
+        );
         let parsed: AuraStreamEvent = serde_json::from_str(&json).unwrap();
         match parsed {
             AuraStreamEvent::Usage {
                 prompt_tokens,
                 completion_tokens,
+                cache_read_input_tokens,
                 ..
             } => {
                 assert_eq!(prompt_tokens, 100);
                 assert_eq!(completion_tokens, 50);
+                assert_eq!(cache_read_input_tokens, None);
+            }
+            other => panic!("expected Usage, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn usage_roundtrip_with_cache() {
+        let event = AuraStreamEvent::usage(
+            100,
+            50,
+            150,
+            Some((80, 20)),
+            CorrelationContext::new("s1", None),
+        );
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: AuraStreamEvent = serde_json::from_str(&json).unwrap();
+        match parsed {
+            AuraStreamEvent::Usage {
+                prompt_tokens,
+                cache_read_input_tokens,
+                cache_creation_input_tokens,
+                ..
+            } => {
+                assert_eq!(prompt_tokens, 100);
+                assert_eq!(cache_read_input_tokens, Some(80));
+                assert_eq!(cache_creation_input_tokens, Some(20));
             }
             other => panic!("expected Usage, got {:?}", other),
         }

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -398,7 +398,7 @@ impl AgentExecutor for AuraAgentExecutor {
                             metadata: None,
                         }));
                     }
-                    Ok(StreamItem::TurnUsage(_)) => {
+                    Ok(StreamItem::TurnUsage(..)) => {
                         event!(Level::DEBUG, request_id, "turn usage");
                     }
                     Ok(StreamItem::ContextUsage { .. }) => {

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -442,8 +442,8 @@ where
     termination
 }
 
-/// Resolve the cumulative billed usage `(prompt, completion, total)` for the
-/// final `aura.usage` event.
+/// Resolve the cumulative billed usage `(prompt, completion, total,
+/// cache_usage)` for the final `aura.usage` event.
 ///
 /// The single-agent path carries rig's turn-aggregated usage on
 /// `StreamItem::Final` (`usage_stats`), which sums every LLM turn — including
@@ -451,22 +451,30 @@ where
 /// rig invokes `on_stream_completion_response_finish` only for turns that
 /// produced assistant text, so the hook total (`UsageState::get_final_usage`)
 /// under-reports whenever a tool turn had no text preamble (common on
-/// Bedrock-Claude). Prefer the aggregated `Final` usage when present.
+/// Bedrock-Claude). Prefer the aggregated `Final` usage when present — and
+/// take the cache split from the same source (`final_cache_usage`), so the
+/// event's cache counts stay a subset of the prompt total next to them.
 ///
-/// Orchestration leaves `Final.usage` zero and accumulates billed tokens through
-/// `UsageState::accumulate_usage`, so fall back to the hook total when no
-/// aggregated `Final` usage is available.
+/// Orchestration leaves `Final.usage` zero and accumulates billed tokens
+/// through `UsageState::accumulate_usage` (which sees every turn via
+/// `TurnUsage`), so fall back to the hook totals — billed and cache alike —
+/// when no aggregated `Final` usage is available.
 fn resolve_billed_usage(
     usage_stats: &Option<UsageInfo>,
+    final_cache_usage: Option<(u64, u64)>,
     usage_state: &UsageState,
-) -> (u64, u64, u64) {
+) -> (u64, u64, u64, Option<(u64, u64)>) {
     match usage_stats {
         Some(u) if u.prompt_tokens > 0 => (
             u.prompt_tokens,
             u.completion_tokens,
             u.prompt_tokens + u.completion_tokens,
+            final_cache_usage,
         ),
-        _ => usage_state.get_final_usage(),
+        _ => {
+            let (prompt, completion, total) = usage_state.get_final_usage();
+            (prompt, completion, total, usage_state.get_cache_usage())
+        }
     }
 }
 
@@ -500,8 +508,11 @@ async fn send_final_events(
 
     // Emit aura.usage (cumulative billed) and aura.context_usage at stream end.
     if emit_custom_events {
-        let (prompt, completion, total) =
-            resolve_billed_usage(&state.usage_stats, &callbacks.usage_state);
+        let (prompt, completion, total, cache_usage) = resolve_billed_usage(
+            &state.usage_stats,
+            state.final_cache_usage,
+            &callbacks.usage_state,
+        );
         if prompt > 0 {
             tracing::debug!(
                 "Emitting aura.usage event: prompt={}, completion={}, total={}",
@@ -513,7 +524,7 @@ async fn send_final_events(
                 prompt,
                 completion,
                 total,
-                callbacks.usage_state.get_cache_usage(),
+                cache_usage,
                 ctx.correlation.clone(),
             );
             let _ = tx.send(Ok(Bytes::from(usage_event.format_sse()))).await;
@@ -711,6 +722,12 @@ fn handle_stream_item(
                 prompt_tokens: final_info.usage.input_tokens,
                 completion_tokens: final_info.usage.output_tokens,
                 total_tokens: final_info.usage.total_tokens,
+            });
+            state.final_cache_usage = final_info.cache_usage.map(|cache| {
+                (
+                    cache.cache_read_input_tokens,
+                    cache.cache_creation_input_tokens,
+                )
             });
 
             tracing::debug!(
@@ -1665,10 +1682,11 @@ mod tests {
             total_tokens: 12_250,
         });
 
-        // The fix: aura.usage reflects the aggregated total, not the undercount.
+        // The fix: aura.usage reflects the aggregated total, not the undercount,
+        // and the cache split comes from the same aggregated population.
         assert_eq!(
-            resolve_billed_usage(&usage_stats, &usage_state),
-            (12_000, 250, 12_250),
+            resolve_billed_usage(&usage_stats, Some((9_000, 2_000)), &usage_state),
+            (12_000, 250, 12_250, Some((9_000, 2_000))),
             "aura.usage must include every turn, including tool-only turns"
         );
     }
@@ -1688,9 +1706,10 @@ mod tests {
             total_tokens: 0,
         });
 
+        usage_state.store_cache_usage(4_000, 1_000);
         assert_eq!(
-            resolve_billed_usage(&usage_stats, &usage_state),
-            (13_000, 600, 13_600),
+            resolve_billed_usage(&usage_stats, None, &usage_state),
+            (13_000, 600, 13_600, Some((4_000, 1_000))),
             "orchestration billed usage comes from accumulate_usage"
         );
     }
@@ -1701,7 +1720,35 @@ mod tests {
         // usage, so fall back to whatever the hook recorded.
         let usage_state = UsageState::new();
         usage_state.store_usage(1500, 100, 1600, false);
-        assert_eq!(resolve_billed_usage(&None, &usage_state), (1500, 100, 1600));
+        assert_eq!(
+            resolve_billed_usage(&None, None, &usage_state),
+            (1500, 100, 1600, None)
+        );
+    }
+
+    #[test]
+    fn test_resolve_billed_usage_cache_split_matches_population() {
+        // A Bedrock-style tool loop: the hook missed the tool-only turn
+        // (it fires only on text turns), so its counters — billed and cache —
+        // under-report. The aggregated Final carries the full-run cache
+        // split; using the hook's split next to the aggregated totals would
+        // break the "cache is a subset of prompt_tokens" contract.
+        let usage_state = UsageState::new();
+        usage_state.store_usage(4_000, 150, 4_150, false); // text turn only
+        usage_state.store_cache_usage(3_000, 500); // text turn's split only
+
+        let usage_stats = Some(UsageInfo {
+            prompt_tokens: 12_000,
+            completion_tokens: 250,
+            total_tokens: 12_250,
+        });
+        let (_, _, _, cache) =
+            resolve_billed_usage(&usage_stats, Some((9_000, 2_000)), &usage_state);
+        assert_eq!(
+            cache,
+            Some((9_000, 2_000)),
+            "cache split must come from the same turn population as the totals"
+        );
     }
 
     #[tokio::test]
@@ -1756,6 +1803,7 @@ mod tests {
                     output_tokens: 5,
                     total_tokens: 15,
                 },
+                cache_usage: None,
             })),
         ];
         let stream = futures_util::stream::iter(items);

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -509,8 +509,13 @@ async fn send_final_events(
                 completion,
                 total
             );
-            let usage_event =
-                AuraStreamEvent::usage(prompt, completion, total, ctx.correlation.clone());
+            let usage_event = AuraStreamEvent::usage(
+                prompt,
+                completion,
+                total,
+                callbacks.usage_state.get_cache_usage(),
+                ctx.correlation.clone(),
+            );
             let _ = tx.send(Ok(Bytes::from(usage_event.format_sse()))).await;
         }
 
@@ -717,7 +722,7 @@ fn handle_stream_item(
 
             vec![]
         }
-        StreamItem::FinalMarker | StreamItem::TurnUsage(_) => {
+        StreamItem::FinalMarker | StreamItem::TurnUsage(..) => {
             // Internal markers - filtered out
             tracing::debug!("Received final/turn-usage marker");
             vec![]

--- a/crates/aura-web-server/src/streaming/types.rs
+++ b/crates/aura-web-server/src/streaming/types.rs
@@ -229,6 +229,9 @@ pub mod context {
         pub needs_separator: bool,
         pub is_first_chunk: bool,
         pub usage_stats: Option<UsageInfo>,
+        /// Prompt-cache split from `StreamItem::Final`, matching
+        /// `usage_stats`'s turn population.
+        pub final_cache_usage: Option<(u64, u64)>,
         /// Accumulated response content - Always populated regardless of streaming or not.
         pub accumulated_content: String,
         /// Stream error captured for OTel span recording.

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -620,6 +620,8 @@ impl Agent {
 
                 tracing::info!("Creating Bedrock completion model: {}", model);
                 let mut completion_model = bedrock_client.completion_model(model);
+                // Opt-in per agent: Bedrock rejects cachePoint blocks on
+                // models without prompt-caching support.
                 if *prompt_caching {
                     tracing::info!("  Prompt caching enabled");
                     completion_model = completion_model.with_prompt_caching();

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -525,6 +525,7 @@ impl Agent {
                 api_key,
                 model,
                 base_url,
+                prompt_caching,
                 temperature,
                 additional_params,
                 ..
@@ -544,7 +545,11 @@ impl Agent {
                 let client = client_builder.build()?;
                 tracing::info!("Anthropic client initialized successfully");
 
-                let completion_model = client.completion_model(model);
+                let mut completion_model = client.completion_model(model);
+                if *prompt_caching {
+                    tracing::info!("  Prompt caching enabled");
+                    completion_model = completion_model.with_prompt_caching();
+                }
 
                 // Create agent builder with system prompt and temperature
                 let mut agent_builder = rig::agent::AgentBuilder::new(completion_model);
@@ -581,6 +586,7 @@ impl Agent {
                 model,
                 region,
                 profile,
+                prompt_caching,
                 temperature,
                 additional_params,
                 ..
@@ -613,7 +619,11 @@ impl Agent {
                 tracing::info!("AWS Bedrock client initialized successfully");
 
                 tracing::info!("Creating Bedrock completion model: {}", model);
-                let completion_model = bedrock_client.completion_model(model);
+                let mut completion_model = bedrock_client.completion_model(model);
+                if *prompt_caching {
+                    tracing::info!("  Prompt caching enabled");
+                    completion_model = completion_model.with_prompt_caching();
+                }
                 tracing::info!("Bedrock completion model created successfully");
 
                 // Create agent builder with system prompt and temperature
@@ -1254,7 +1264,7 @@ impl Agent {
                     usage = response.usage;
                     break;
                 }
-                Ok(StreamItem::FinalMarker) | Ok(StreamItem::TurnUsage(_)) => {
+                Ok(StreamItem::FinalMarker) | Ok(StreamItem::TurnUsage(..)) => {
                     // Per-turn marker — not end-of-stream. Continue collecting.
                 }
                 Ok(_) => {
@@ -1325,7 +1335,7 @@ impl Agent {
         };
         state.reset();
         Box::pin(stream.map(move |item| {
-            if matches!(item, Ok(StreamItem::TurnUsage(_))) {
+            if matches!(item, Ok(StreamItem::TurnUsage(..))) {
                 state.record_turn_completed();
             }
             item

--- a/crates/aura/src/fallback_tool_stream.rs
+++ b/crates/aura/src/fallback_tool_stream.rs
@@ -114,7 +114,7 @@ impl FallbackToolExecutor {
                         // Forward the original text
                         yield item;
                     }
-                    Ok(StreamItem::Final(_)) | Ok(StreamItem::FinalMarker) | Ok(StreamItem::TurnUsage(_)) => {
+                    Ok(StreamItem::Final(_)) | Ok(StreamItem::FinalMarker) | Ok(StreamItem::TurnUsage(..)) => {
                         // Stream is ending - check if buffered text contains a tool call
                         // BUT only if no proper tool_calls were already executed
                         let (buffered_text, has_native_tool_calls) = {

--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -119,6 +119,12 @@ pub const ATTR_LLM_MODEL_NAME: &str = "llm.model_name";
 pub const ATTR_LLM_TOKEN_PROMPT: &str = "llm.token_count.prompt";
 /// Completion / output token count.
 pub const ATTR_LLM_TOKEN_COMPLETION: &str = "llm.token_count.completion";
+/// Prompt tokens served from the provider's prompt cache
+/// (a sub-count of `llm.token_count.prompt`).
+pub const ATTR_LLM_TOKEN_PROMPT_CACHE_READ: &str = "llm.token_count.prompt_details.cache_read";
+/// Prompt tokens written to the provider's prompt cache
+/// (a sub-count of `llm.token_count.prompt`).
+pub const ATTR_LLM_TOKEN_PROMPT_CACHE_WRITE: &str = "llm.token_count.prompt_details.cache_write";
 /// LLM call parameters (temperature, max_tokens, …) as a JSON object string.
 pub const ATTR_LLM_INVOCATION_PARAMETERS: &str = "llm.invocation_parameters";
 /// End-user identifier from the request.

--- a/crates/aura/src/openinference_exporter.rs
+++ b/crates/aura/src/openinference_exporter.rs
@@ -21,7 +21,8 @@
 
 use crate::logging::{
     ATTR_GEN_AI_SYSTEM_INSTRUCTIONS, ATTR_INPUT_VALUE, ATTR_LLM_MODEL_NAME, ATTR_LLM_PROVIDER,
-    ATTR_LLM_SYSTEM, ATTR_LLM_TOKEN_COMPLETION, ATTR_LLM_TOKEN_PROMPT, ATTR_OUTPUT_VALUE,
+    ATTR_LLM_SYSTEM, ATTR_LLM_TOKEN_COMPLETION, ATTR_LLM_TOKEN_PROMPT,
+    ATTR_LLM_TOKEN_PROMPT_CACHE_READ, ATTR_LLM_TOKEN_PROMPT_CACHE_WRITE, ATTR_OUTPUT_VALUE,
     ATTR_TOOL_NAME, ATTR_TOOL_PARAMETERS,
 };
 use futures::future::BoxFuture;
@@ -181,6 +182,18 @@ fn transform_span(mut span: SpanData) -> SpanData {
             }
             "gen_ai.usage.output_tokens" => {
                 extra_attrs.push(KeyValue::new(ATTR_LLM_TOKEN_COMPLETION, kv.value.clone()));
+            }
+            "gen_ai.usage.cache_read_input_tokens" => {
+                extra_attrs.push(KeyValue::new(
+                    ATTR_LLM_TOKEN_PROMPT_CACHE_READ,
+                    kv.value.clone(),
+                ));
+            }
+            "gen_ai.usage.cache_creation_input_tokens" => {
+                extra_attrs.push(KeyValue::new(
+                    ATTR_LLM_TOKEN_PROMPT_CACHE_WRITE,
+                    kv.value.clone(),
+                ));
             }
             "gen_ai.tool.name" => {
                 extra_attrs.push(KeyValue::new(ATTR_TOOL_NAME, kv.value.clone()));
@@ -609,7 +622,8 @@ mod tests {
     fn test_translates_llm_attributes() {
         use crate::logging::{
             ATTR_LLM_MODEL_NAME, ATTR_LLM_PROVIDER, ATTR_LLM_SYSTEM, ATTR_LLM_TOKEN_COMPLETION,
-            ATTR_LLM_TOKEN_PROMPT,
+            ATTR_LLM_TOKEN_PROMPT, ATTR_LLM_TOKEN_PROMPT_CACHE_READ,
+            ATTR_LLM_TOKEN_PROMPT_CACHE_WRITE,
         };
 
         let span = make_span(
@@ -619,6 +633,8 @@ mod tests {
                 KeyValue::new("gen_ai.request.model", "gpt-4"),
                 KeyValue::new("gen_ai.usage.input_tokens", 100i64),
                 KeyValue::new("gen_ai.usage.output_tokens", 50i64),
+                KeyValue::new("gen_ai.usage.cache_read_input_tokens", 80i64),
+                KeyValue::new("gen_ai.usage.cache_creation_input_tokens", 15i64),
             ],
         );
         let result = transform_span(span);
@@ -638,6 +654,18 @@ mod tests {
         );
         assert!(find_attr(&result, "llm.token_count.prompt").is_some());
         assert!(find_attr(&result, "llm.token_count.completion").is_some());
+        assert_eq!(
+            find_attr(&result, "llm.token_count.prompt_details.cache_read")
+                .unwrap()
+                .to_string(),
+            "80"
+        );
+        assert_eq!(
+            find_attr(&result, "llm.token_count.prompt_details.cache_write")
+                .unwrap()
+                .to_string(),
+            "15"
+        );
 
         // Keys match logging.rs constants (drift guard)
         assert!(find_attr(&result, ATTR_LLM_SYSTEM).is_some());
@@ -645,10 +673,13 @@ mod tests {
         assert!(find_attr(&result, ATTR_LLM_MODEL_NAME).is_some());
         assert!(find_attr(&result, ATTR_LLM_TOKEN_PROMPT).is_some());
         assert!(find_attr(&result, ATTR_LLM_TOKEN_COMPLETION).is_some());
+        assert!(find_attr(&result, ATTR_LLM_TOKEN_PROMPT_CACHE_READ).is_some());
+        assert!(find_attr(&result, ATTR_LLM_TOKEN_PROMPT_CACHE_WRITE).is_some());
 
         // Originals stripped
         assert!(find_attr(&result, "gen_ai.system").is_none());
         assert!(find_attr(&result, "gen_ai.request.model").is_none());
+        assert!(find_attr(&result, "gen_ai.usage.cache_read_input_tokens").is_none());
     }
 
     /// Verify gen_ai.tool.* attributes are translated, keys match logging.rs constants.

--- a/crates/aura/src/orchestration/factory.rs
+++ b/crates/aura/src/orchestration/factory.rs
@@ -108,6 +108,7 @@ impl OrchestratorFactory {
                                     crate::provider_agent::FinalResponseInfo {
                                         content: final_result,
                                         usage: Default::default(),
+                                        cache_usage: None,
                                     }
                                 ))).await;
                             }

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -443,7 +443,12 @@ struct TurnTally {
 }
 
 impl TurnTally {
-    fn record(&mut self, turn: &rig::completion::Usage, usage_state: &crate::UsageState) {
+    fn record(
+        &mut self,
+        turn: &rig::completion::Usage,
+        cache: Option<rig::completion::CacheUsage>,
+        usage_state: &crate::UsageState,
+    ) {
         self.total.input_tokens += turn.input_tokens;
         self.total.output_tokens += turn.output_tokens;
         self.total.total_tokens += turn.total_tokens;
@@ -453,6 +458,12 @@ impl TurnTally {
             total_tokens: turn.total_tokens,
         };
         usage_state.accumulate_usage(turn.input_tokens, turn.output_tokens);
+        if let Some(cache) = cache {
+            usage_state.store_cache_usage(
+                cache.cache_read_input_tokens,
+                cache.cache_creation_input_tokens,
+            );
+        }
     }
 
     /// Reconcile against a loop total the provider reported separately.
@@ -1156,8 +1167,8 @@ impl Orchestrator {
                     Ok(StreamItem::FinalMarker) => {
                         // Per-turn marker — not end-of-stream. Continue collecting.
                     }
-                    Ok(StreamItem::TurnUsage(turn)) => {
-                        tally.record(&turn, usage_state);
+                    Ok(StreamItem::TurnUsage(turn, cache)) => {
+                        tally.record(&turn, cache, usage_state);
                         if let Some(budget) = scratchpad_budget {
                             budget.set_estimated_used(turn.input_tokens, turn.output_tokens);
                         }
@@ -1183,8 +1194,10 @@ impl Orchestrator {
                         );
                         if decision_ready().await {
                             tracing::debug!("{}: decision captured, reading turn usage", phase);
-                            if let Some(Ok(StreamItem::TurnUsage(turn))) = stream.next().await {
-                                tally.record(&turn, usage_state);
+                            if let Some(Ok(StreamItem::TurnUsage(turn, cache))) =
+                                stream.next().await
+                            {
+                                tally.record(&turn, cache, usage_state);
                             }
                             return Ok(LoopStep::End);
                         }
@@ -1413,8 +1426,10 @@ impl Orchestrator {
                             );
                             if decision_ready().await {
                                 tracing::debug!("{}: decision captured, reading turn usage", phase);
-                                if let Some(Ok(StreamItem::TurnUsage(turn))) = stream.next().await {
-                                    tally.record(&turn, &self.usage_state);
+                                if let Some(Ok(StreamItem::TurnUsage(turn, cache))) =
+                                    stream.next().await
+                                {
+                                    tally.record(&turn, cache, &self.usage_state);
                                 }
                                 return Ok(LoopStep::End);
                             }
@@ -1439,8 +1454,8 @@ impl Orchestrator {
                             final_total = Some(info.usage);
                             return Ok(LoopStep::End);
                         }
-                        Ok(StreamItem::TurnUsage(turn)) => {
-                            tally.record(&turn, &self.usage_state);
+                        Ok(StreamItem::TurnUsage(turn, cache)) => {
+                            tally.record(&turn, cache, &self.usage_state);
                         }
                         Ok(StreamItem::FinalMarker) => return Ok(LoopStep::End),
                         // MaxDepthError: success if decision was captured, error otherwise
@@ -2615,6 +2630,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 api_key,
                 model,
                 base_url,
+                prompt_caching,
                 ..
             } => {
                 let mut cb = rig::providers::anthropic::Client::<reqwest::Client>::builder()
@@ -2622,10 +2638,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 if let Some(url) = base_url {
                     cb = cb.base_url(url);
                 }
-                let cm = cb
+                let mut cm = cb
                     .build()
                     .map_err(|e| format!("Failed to build Anthropic coordinator: {}", e))?
                     .completion_model(model);
+                if *prompt_caching {
+                    cm = cm.with_prompt_caching();
+                }
                 Ok(ProviderAgent::Anthropic(Self::build_agent_with_tools(
                     cm,
                     preamble,
@@ -2641,6 +2660,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 model,
                 region,
                 profile,
+                prompt_caching,
                 ..
             } => {
                 use aws_config::{BehaviorVersion, Region};
@@ -2656,10 +2676,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         .load()
                         .await
                 };
-                let cm = rig_bedrock::client::Client::from(aws_sdk_bedrockruntime::Client::new(
-                    &sdk_config,
-                ))
+                let mut cm = rig_bedrock::client::Client::from(
+                    aws_sdk_bedrockruntime::Client::new(&sdk_config),
+                )
                 .completion_model(model);
+                if *prompt_caching {
+                    cm = cm.with_prompt_caching();
+                }
                 Ok(ProviderAgent::Bedrock(Self::build_agent_with_tools(
                     cm,
                     preamble,
@@ -2829,6 +2852,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 api_key,
                 model,
                 base_url,
+                prompt_caching,
                 additional_params,
                 ..
             } => {
@@ -2837,10 +2861,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 if let Some(url) = base_url {
                     cb = cb.base_url(url);
                 }
-                let cm = cb
+                let mut cm = cb
                     .build()
                     .map_err(|e| format!("Failed to build Anthropic worker: {}", e))?
                     .completion_model(model);
+                if *prompt_caching {
+                    cm = cm.with_prompt_caching();
+                }
                 let mut builder = rig::agent::AgentBuilder::new(cm);
                 builder = builder.name(&worker_config.agent.name);
                 builder = builder.provider_name(llm_provider).model_name(llm_model);
@@ -2864,6 +2891,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 model,
                 region,
                 profile,
+                prompt_caching,
                 additional_params,
                 ..
             } => {
@@ -2880,10 +2908,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         .load()
                         .await
                 };
-                let cm = rig_bedrock::client::Client::from(aws_sdk_bedrockruntime::Client::new(
-                    &sdk_config,
-                ))
+                let mut cm = rig_bedrock::client::Client::from(
+                    aws_sdk_bedrockruntime::Client::new(&sdk_config),
+                )
                 .completion_model(model);
+                if *prompt_caching {
+                    cm = cm.with_prompt_caching();
+                }
                 let mut builder = rig::agent::AgentBuilder::new(cm);
                 builder = builder.name(&worker_config.agent.name);
                 builder = builder.provider_name(llm_provider).model_name(llm_model);
@@ -4895,8 +4926,8 @@ mod tests {
         let usage_state = crate::UsageState::new();
         let mut tally = TurnTally::default();
 
-        tally.record(&usage(2012, 115), &usage_state);
-        tally.record(&usage(2152, 124), &usage_state);
+        tally.record(&usage(2012, 115), None, &usage_state);
+        tally.record(&usage(2152, 124), None, &usage_state);
 
         // Billed usage is the whole loop.
         assert_eq!(usage_state.get_final_usage(), (4164, 239, 4403));
@@ -4910,8 +4941,8 @@ mod tests {
     fn test_tally_reconciles_to_zero_when_every_turn_was_recorded() {
         let usage_state = crate::UsageState::new();
         let mut tally = TurnTally::default();
-        tally.record(&usage(2012, 115), &usage_state);
-        tally.record(&usage(2152, 124), &usage_state);
+        tally.record(&usage(2012, 115), None, &usage_state);
+        tally.record(&usage(2152, 124), None, &usage_state);
 
         // The provider's loop total for these turns — nothing bypassed record().
         let unrecorded = tally.reconcile(&usage(4164, 239));
@@ -4924,7 +4955,7 @@ mod tests {
     fn test_tally_reconcile_surfaces_turns_that_bypassed_record() {
         let usage_state = crate::UsageState::new();
         let mut tally = TurnTally::default();
-        tally.record(&usage(2012, 115), &usage_state);
+        tally.record(&usage(2012, 115), None, &usage_state);
 
         let unrecorded = tally.reconcile(&usage(4164, 239));
 
@@ -4936,7 +4967,7 @@ mod tests {
     fn test_tally_reconcile_saturates_when_total_trails_recorded() {
         let usage_state = crate::UsageState::new();
         let mut tally = TurnTally::default();
-        tally.record(&usage(4164, 239), &usage_state);
+        tally.record(&usage(4164, 239), None, &usage_state);
 
         let unrecorded = tally.reconcile(&usage(100, 10));
 
@@ -4960,7 +4991,7 @@ mod tests {
         ] {
             let mut tally = TurnTally::default();
             for turn in &turns {
-                tally.record(turn, &usage_state);
+                tally.record(turn, None, &usage_state);
             }
         }
 
@@ -4988,7 +5019,10 @@ mod tests {
     }
 
     fn turn(input_tokens: u64, output_tokens: u64) -> Result<StreamItem, StreamError> {
-        Ok(StreamItem::TurnUsage(usage(input_tokens, output_tokens)))
+        Ok(StreamItem::TurnUsage(
+            usage(input_tokens, output_tokens),
+            None,
+        ))
     }
 
     fn tool_result(id: &str) -> Result<StreamItem, StreamError> {

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -5080,6 +5080,7 @@ mod tests {
                     crate::provider_agent::FinalResponseInfo {
                         content: "done".to_string(),
                         usage: usage(4164, 239),
+                        cache_usage: None,
                     },
                 )),
             ],
@@ -5133,6 +5134,7 @@ mod tests {
                     crate::provider_agent::FinalResponseInfo {
                         content: "done".to_string(),
                         usage: usage(4164, 239),
+                        cache_usage: None,
                     },
                 )),
             ],

--- a/crates/aura/src/provider_agent.rs
+++ b/crates/aura/src/provider_agent.rs
@@ -380,11 +380,10 @@ pub enum StreamItem {
     Final(FinalResponseInfo),
     /// Internal marker for final response (filtered out before returning to caller)
     FinalMarker,
-    /// Per-turn token usage from intermediate turns (not end-of-stream).
+    /// Per-turn token usage from intermediate turns (not end-of-stream),
+    /// with the turn's provider-reported prompt-cache split.
     /// Emitted on every Rig `Final` chunk so callers can capture usage
     /// even when they short-circuit before the terminal `FinalResponse`.
-    /// The second field carries the turn's prompt-cache counts when the
-    /// provider reported any.
     TurnUsage(Usage, Option<rig::completion::CacheUsage>),
     /// Orchestrator status event (plan progress, task status, etc.)
     OrchestratorEvent(OrchestratorEvent),

--- a/crates/aura/src/provider_agent.rs
+++ b/crates/aura/src/provider_agent.rs
@@ -383,7 +383,9 @@ pub enum StreamItem {
     /// Per-turn token usage from intermediate turns (not end-of-stream).
     /// Emitted on every Rig `Final` chunk so callers can capture usage
     /// even when they short-circuit before the terminal `FinalResponse`.
-    TurnUsage(Usage),
+    /// The second field carries the turn's prompt-cache counts when the
+    /// provider reported any.
+    TurnUsage(Usage, Option<rig::completion::CacheUsage>),
     /// Orchestrator status event (plan progress, task status, etc.)
     OrchestratorEvent(OrchestratorEvent),
     /// Per-agent scratchpad usage report.
@@ -529,7 +531,7 @@ fn map_stream_item<R: rig::completion::GetTokenUsage>(
                         output_tokens: 0,
                         total_tokens: 0,
                     });
-                    return Ok(StreamItem::TurnUsage(usage));
+                    return Ok(StreamItem::TurnUsage(usage, resp.cache_token_usage()));
                 }
             };
             Ok(StreamItem::StreamAssistantItem(mapped))

--- a/crates/aura/src/provider_agent.rs
+++ b/crates/aura/src/provider_agent.rs
@@ -432,6 +432,8 @@ pub enum StreamItem {
 pub struct FinalResponseInfo {
     pub content: String,
     pub usage: Usage,
+    /// Prompt-cache split matching `usage`'s turn population.
+    pub cache_usage: Option<rig::completion::CacheUsage>,
 }
 
 /// Streamed assistant content (provider-agnostic).
@@ -550,6 +552,7 @@ fn map_stream_item<R: rig::completion::GetTokenUsage>(
             Ok(StreamItem::Final(FinalResponseInfo {
                 content: final_resp.response().to_string(),
                 usage,
+                cache_usage: final_resp.cache_usage(),
             }))
         }
         // Handle any future variants added to the non-exhaustive enum

--- a/crates/aura/src/stream_events.rs
+++ b/crates/aura/src/stream_events.rs
@@ -331,6 +331,7 @@ mod tests {
             21500,
             342,
             21842,
+            Some((18000, 2100)),
             CorrelationContext::new("sess_final", Some("trace_xyz".to_string())),
         );
         let sse = event.format_sse();
@@ -338,6 +339,8 @@ mod tests {
         assert!(sse.contains("\"prompt_tokens\":21500"));
         assert!(sse.contains("\"completion_tokens\":342"));
         assert!(sse.contains("\"total_tokens\":21842"));
+        assert!(sse.contains("\"cache_read_input_tokens\":18000"));
+        assert!(sse.contains("\"cache_creation_input_tokens\":2100"));
         assert!(sse.contains("\"session_id\":\"sess_final\""));
         assert!(sse.contains("\"trace_id\":\"trace_xyz\""));
     }
@@ -352,7 +355,7 @@ mod tests {
             AuraStreamEvent::tool_usage(vec![], 0, 0, 0, CorrelationContext::default());
         assert_eq!(tool_usage.event_name(), event_names::TOOL_USAGE);
 
-        let usage = AuraStreamEvent::usage(0, 0, 0, CorrelationContext::default());
+        let usage = AuraStreamEvent::usage(0, 0, 0, None, CorrelationContext::default());
         assert_eq!(usage.event_name(), event_names::USAGE);
     }
 

--- a/crates/aura/src/streaming_request_hook.rs
+++ b/crates/aura/src/streaming_request_hook.rs
@@ -64,6 +64,12 @@ pub struct UsageState {
     accumulated_completion_tokens: Arc<AtomicU64>,
     /// Completion tokens spent on tool-call turns.
     tool_completion_tokens: Arc<AtomicU64>,
+    /// Whether any turn reported prompt-cache usage.
+    cache_seen: Arc<AtomicBool>,
+    /// Cumulative input tokens served from the provider's prompt cache.
+    cache_read_tokens: Arc<AtomicU64>,
+    /// Cumulative input tokens written to the provider's prompt cache.
+    cache_creation_tokens: Arc<AtomicU64>,
     /// Input tokens of the most recent turn.
     last_input_tokens: Arc<AtomicU64>,
     /// Output tokens of the most recent turn.
@@ -105,6 +111,30 @@ impl UsageState {
     /// The response completion tokens can be derived as `completion - tool_completion`.
     pub fn get_tool_completion_tokens(&self) -> u64 {
         self.tool_completion_tokens.load(Ordering::Acquire)
+    }
+
+    /// Cumulative prompt-cache usage as `(cache_read, cache_creation)`, summed
+    /// across every LLM turn. `None` until a provider reports cache counts, so
+    /// providers without prompt caching (or with it disabled) stay silent. Both
+    /// counts are subsets of the billed prompt tokens in `get_final_usage`.
+    pub fn get_cache_usage(&self) -> Option<(u64, u64)> {
+        if !self.cache_seen.load(Ordering::Acquire) {
+            return None;
+        }
+        Some((
+            self.cache_read_tokens.load(Ordering::Acquire),
+            self.cache_creation_tokens.load(Ordering::Acquire),
+        ))
+    }
+
+    /// Accumulate one turn's prompt-cache counts (both the single-agent and
+    /// orchestration paths).
+    pub fn store_cache_usage(&self, cache_read: u64, cache_creation: u64) {
+        self.cache_seen.store(true, Ordering::Release);
+        self.cache_read_tokens
+            .fetch_add(cache_read, Ordering::AcqRel);
+        self.cache_creation_tokens
+            .fetch_add(cache_creation, Ordering::AcqRel);
     }
 
     /// Record one completion turn (single-agent path): accumulate billed
@@ -580,6 +610,7 @@ where
         // Extract usage if the response type supports it
         // StreamingResponse implements GetTokenUsage which has token_usage()
         let usage = response.token_usage();
+        let cache_usage = response.cache_token_usage();
 
         async move {
             if let Some(usage) = usage {
@@ -596,6 +627,12 @@ where
                     usage.total_tokens,
                     is_tool_turn,
                 );
+                if let Some(cache) = cache_usage {
+                    usage_state.store_cache_usage(
+                        cache.cache_read_input_tokens,
+                        cache.cache_creation_input_tokens,
+                    );
+                }
 
                 // Feed LLM ground-truth into the scratchpad budget so its
                 // remaining-budget hints reflect real context pressure (the
@@ -625,6 +662,9 @@ where
                     prompt_tokens = usage.input_tokens,
                     completion_tokens = usage.output_tokens,
                     total_tokens = usage.total_tokens,
+                    cache_read_input_tokens = cache_usage.map(|c| c.cache_read_input_tokens),
+                    cache_creation_input_tokens =
+                        cache_usage.map(|c| c.cache_creation_input_tokens),
                     "Token usage captured"
                 );
             }
@@ -760,6 +800,22 @@ mod tests {
             prompt > 0,
             "handler uses prompt > 0 to gate aura.usage emission"
         );
+    }
+
+    #[test]
+    fn test_cache_usage_accumulates_and_is_none_until_reported() {
+        let usage_state = UsageState::new();
+        assert_eq!(
+            usage_state.get_cache_usage(),
+            None,
+            "no cache usage reported yet — event must omit the fields"
+        );
+
+        // Turn 1: cold cache — everything written. Turn 2: full read-back.
+        usage_state.store_cache_usage(0, 18_000);
+        usage_state.store_cache_usage(18_000, 500);
+
+        assert_eq!(usage_state.get_cache_usage(), Some((18_000, 18_500)));
     }
 
     #[test]

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -215,6 +215,8 @@ model = "gpt-5.2"
 # reasoning_effort = "medium"  # none, minimal, low, medium, high, xhigh (provider/model support varies)
 # max_tokens = 8192
 # base_url = "https://api.openai.com/v1"  # custom endpoint
+# (OpenAI caches prompts >= 1024 tokens automatically -- no flag needed;
+# cache reads appear in aura.usage as cache_read_input_tokens.)
 # Context window size in tokens. Used for usage percentage reporting
 # in aura.session_info streaming events. Set this to your model's
 # actual context window.
@@ -224,6 +226,12 @@ model = "gpt-5.2"
 # provider = "anthropic"
 # api_key = "{{ env.ANTHROPIC_API_KEY }}"
 # model = "claude-sonnet-4-20250514"
+# Prompt caching (default: off). Places cache_control breakpoints so
+# repeated prefixes (system prompt, tools, conversation history) are
+# served from Anthropic's prompt cache: reads bill at ~10% of input
+# price, writes at a premium over it. Workers inherit this with
+# [agent.llm]; override per worker under [orchestration.worker.<name>.llm].
+# prompt_caching = true
 
 # Ollama alternative (no API key needed):
 # provider = "ollama"
@@ -234,6 +242,12 @@ model = "gpt-5.2"
 # provider = "bedrock"
 # model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
 # region = "{{ env.AWS_REGION }}"
+# Prompt caching (default: off). Adds cachePoint blocks after the system
+# prompt, tool definitions, and last message. Enable only for models
+# that support caching (Claude 3.5 Sonnet v2 / 3.7 / 4.x / 5, Nova) --
+# Bedrock rejects requests carrying cachePoints on other models. Reads
+# bill at a reduced rate, writes at a premium. Workers inherit as above.
+# prompt_caching = true
 
 # Google Gemini alternative:
 # provider = "gemini"


### PR DESCRIPTION
## Summary

Adds opt-in provider prompt caching and end-to-end cache-usage visibility. Depends on the fork changes merged in mezmo/rig#12 (pinned here).

- **`prompt_caching` flag** on `[agent.llm]` for **Anthropic** (`cache_control` breakpoints on the system prompt + last message, covering tools via render order) and **Bedrock** (`cachePoint` blocks after system, tools, and last message). Off by default: writes bill at a premium, and Bedrock rejects cachePoints on models without caching support. **OpenAI** caching is automatic — this PR only surfaces its `cached_tokens`. Wired at all three construction sites (single-agent, coordinator, workers); workers inherit or override per `[orchestration.worker.<name>.llm]`.
- **`aura.usage`** gains optional `cache_read_input_tokens` / `cache_creation_input_tokens` — sub-counts of `prompt_tokens`, omitted entirely when no provider reports cache usage, so existing consumers see byte-identical payloads. Orchestration accumulates per-worker turns into the same totals via the widened `StreamItem::TurnUsage`.
- **CLI** status line shows `in N (M cached) / out K`; the split lands in the replayable event log (old logs still parse).
- **OpenInference**: `gen_ai.usage.cache_*` span attributes translate to `llm.token_count.prompt_details.cache_read`/`cache_write`, which Phoenix (v13+) renders in the token breakdown and prices.
- **rig-bedrock** moves from crates.io `=0.3.10` to the fork's vendored copy at the same version, retiring the 0.3.11-semver pin hazard.

## Breaking change (aura-events API)

The **wire format is backward compatible** (new fields are optional and omitted when absent), but the `aura-events` **Rust API** breaks for external consumers:

- `AuraStreamEvent::usage()` takes a new `cache_usage: Option<(u64, u64)>` parameter.
- The `AuraStreamEvent::Usage` variant gains two fields, which breaks exhaustive struct patterns even if the constructor change were papered over — so no purely additive option exists.
- `aura-cli`'s `StreamHandler::on_usage` gains the same parameter (all in-tree impls updated).

Accepted as a 0.2.x break rather than adding a parallel `usage_with_cache` constructor (which would only cover half the break) or rewriting history for a `BREAKING CHANGE` footer. External matchers add `..`/`None`; this note is the changelog record of the break.

## Testing

- `cargo test --workspace` green (2149); clippy + fmt clean; new unit tests for config parsing, usage accumulation, event serde (including the untagged-enum ordering guard), status-line rendering, and the OpenInference translation.
- Wire-verified with capture servers: Anthropic requests carry `cache_control` only when the flag is set; Bedrock requests carry `cachePoint {"type": "default"}`.
- Live-verified against real Bedrock (`us.anthropic.claude-sonnet-5`): cold run reports the 8.8k-token prefix as cache creation, warm run reads all of it back; `aura.usage`, the status line, and Phoenix's token breakdown all agree with the provider totals.

Refs: #630
