### PR TITLE
feat(events): approvals emit the agent event schema

### DIFF
--- a/crates/aura-events/src/agent.rs
+++ b/crates/aura-events/src/agent.rs
@@ -1,0 +1,233 @@
+//! The agent-produced event vocabulary.
+//!
+//! [`AgentEvent`] is what a running agent emits. Observers — an SSE producer, an
+//! A2A status bridge, an OTel exporter — consume this stream and project it into
+//! whatever shape they serve. Contrast [`crate::AuraStreamEvent`], which is the
+//! HTTP *wire* form of one such projection.
+//!
+//! Two properties distinguish this schema from the wire schema:
+//!
+//! - **Internally tagged.** [`crate::AuraStreamEvent`] is `#[serde(untagged)]`,
+//!   so its variant order is load-bearing during deserialization. This enum
+//!   carries a `type` discriminator instead, making variant order irrelevant.
+//! - **No correlation context.** The wire events flatten a
+//!   [`CorrelationContext`](crate::CorrelationContext) (session id, trace id)
+//!   into every payload. That is ambient request state, not something an agent
+//!   knows, so it is applied by the observer rather than carried here.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AgentContext, ApprovalCompleted, ApprovalPending, ApprovalRequested, McpServerStatus,
+    ProgressToken, WorkerPhase,
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AgentEvent {
+    pub agent: AgentContext,
+    pub payload: AgentEventPayload,
+}
+
+impl AgentEvent {
+    pub fn new(agent: AgentContext, payload: AgentEventPayload) -> Self {
+        Self { agent, payload }
+    }
+
+    /// Attributes the payload to `agent_id: "main"`.
+    pub fn single_agent(payload: AgentEventPayload) -> Self {
+        Self::new(AgentContext::single_agent(), payload)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ToolOutcome {
+    Success { result: String },
+    Failure { error: String },
+}
+
+/// What an agent has to say about its own execution.
+///
+/// `#[non_exhaustive]` because the vocabulary grows as producers move onto this
+/// schema — orchestration events in particular are not yet modelled here.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AgentEventPayload {
+    SessionInfo {
+        model: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model_context_limit: Option<u64>,
+    },
+
+    McpStatus {
+        servers: Vec<McpServerStatus>,
+    },
+
+    TextDelta {
+        content: String,
+    },
+
+    Reasoning {
+        content: String,
+    },
+
+    /// The model's decision to call a tool, ahead of any execution.
+    ToolRequested {
+        tool_id: String,
+        tool_name: String,
+        arguments: serde_json::Value,
+    },
+
+    ToolStart {
+        tool_id: String,
+        tool_name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        progress_token: Option<ProgressToken>,
+    },
+
+    ToolComplete {
+        tool_id: String,
+        tool_name: String,
+        duration_ms: u64,
+        #[serde(flatten)]
+        outcome: ToolOutcome,
+    },
+
+    ToolProgress {
+        progress_token: ProgressToken,
+        progress: f64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        total: Option<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+
+    WorkerPhase {
+        phase: WorkerPhase,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        task_id: Option<String>,
+    },
+
+    /// Provider-billed tokens for one turn.
+    ToolUsage {
+        tool_ids: Vec<String>,
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        total_tokens: u64,
+    },
+
+    /// Provider-billed tokens, cumulative across turns.
+    Usage {
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        total_tokens: u64,
+    },
+
+    /// Context-window occupancy, not billing.
+    ContextUsage {
+        context_tokens: u64,
+        response_tokens: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context_window: Option<u64>,
+    },
+
+    ScratchpadUsage {
+        tokens_intercepted: usize,
+        tokens_extracted: usize,
+    },
+
+    ApprovalRequested(ApprovalRequested),
+
+    ApprovalPending(ApprovalPending),
+
+    ApprovalCompleted(ApprovalCompleted),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn roundtrip(payload: AgentEventPayload) -> AgentEventPayload {
+        let json = serde_json::to_string(&payload).expect("payload should serialize");
+        serde_json::from_str(&json).expect("payload should deserialize")
+    }
+
+    #[test]
+    fn the_tag_names_the_variant() {
+        let json = serde_json::to_value(AgentEventPayload::TextDelta {
+            content: "hi".to_string(),
+        })
+        .expect("should serialize");
+
+        assert_eq!(json["type"], "text_delta");
+        assert_eq!(json["content"], "hi");
+    }
+
+    /// The wire enum needs `ToolComplete` declared before `ToolStart` and
+    /// `ToolUsage` before `Usage` to deserialize correctly. The tag makes the
+    /// same shapes unambiguous here regardless of declaration order.
+    #[test]
+    fn variants_the_wire_enum_must_order_are_unambiguous_here() {
+        let start = roundtrip(AgentEventPayload::ToolStart {
+            tool_id: "call_1".to_string(),
+            tool_name: "list_files".to_string(),
+            progress_token: None,
+        });
+        assert!(matches!(start, AgentEventPayload::ToolStart { .. }));
+
+        let usage = roundtrip(AgentEventPayload::Usage {
+            prompt_tokens: 1,
+            completion_tokens: 2,
+            total_tokens: 3,
+        });
+        assert!(matches!(usage, AgentEventPayload::Usage { .. }));
+    }
+
+    #[test]
+    fn tool_outcome_flattens_onto_tool_complete() {
+        let json = serde_json::to_value(AgentEventPayload::ToolComplete {
+            tool_id: "call_1".to_string(),
+            tool_name: "list_files".to_string(),
+            duration_ms: 12,
+            outcome: ToolOutcome::Failure {
+                error: "boom".to_string(),
+            },
+        })
+        .expect("should serialize");
+
+        assert_eq!(json["type"], "tool_complete");
+        assert_eq!(json["outcome"], "failure");
+        assert_eq!(json["error"], "boom");
+    }
+
+    #[test]
+    fn an_event_carries_its_emitting_agent() {
+        let event = AgentEvent::new(
+            AgentContext::worker("log_worker", None, "orchestrator"),
+            AgentEventPayload::TextDelta {
+                content: "scanning".to_string(),
+            },
+        );
+        let json = serde_json::to_value(&event).expect("should serialize");
+
+        assert_eq!(json["agent"]["agent_id"], "log_worker");
+        assert_eq!(json["agent"]["parent_agent_id"], "orchestrator");
+        assert_eq!(json["payload"]["type"], "text_delta");
+    }
+
+    #[test]
+    fn arguments_survive_a_roundtrip() {
+        let payload = roundtrip(AgentEventPayload::ToolRequested {
+            tool_id: "call_1".to_string(),
+            tool_name: "list_files".to_string(),
+            arguments: json!({ "path": "/mock", "depth": 2 }),
+        });
+
+        let AgentEventPayload::ToolRequested { arguments, .. } = payload else {
+            panic!("expected ToolRequested");
+        };
+        assert_eq!(arguments, json!({ "path": "/mock", "depth": 2 }));
+    }
+}

--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -14,6 +14,7 @@
 //! Both enums derive `Serialize + Deserialize` so they can be used for
 //! producing SSE (server) and parsing SSE (client) with the same types.
 
+pub mod agent;
 pub mod event_names;
 pub mod orchestration;
 

--- a/crates/aura-web-server/tests/agent_event_differential.rs
+++ b/crates/aura-web-server/tests/agent_event_differential.rs
@@ -1,0 +1,390 @@
+//! Proves the agent event schema reaches consumers unchanged.
+//!
+//! Each case drives `process_sse_stream_full` twice over the same logical
+//! sequence — once publishing to the request-scoped brokers directly, once
+//! publishing [`AgentEvent`]s through [`aura::agent_events`] — and asserts the
+//! SSE frames are byte-identical. Only the producer side differs; both runs
+//! subscribe the way `handlers::stream_chat_completion` does, so the broker
+//! registry and its request-id routing are under test rather than stubbed.
+//!
+//! A variant that loses a field in translation fails here.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use aura::agent_events::{Routed, publish_to_brokers};
+use aura::tool_event_broker::publish_tool_requested;
+use aura::{
+    ApprovalLifecycleEvent, NumberOrString, ProgressNotification, ProgressToken, ResponseContent,
+    StreamError, StreamItem, StreamingAgent, UsageState,
+};
+use aura::{
+    approval_event_subscribe, approval_event_unsubscribe, publish_tool_start, publish_tool_usage,
+    request_progress_subscribe, request_progress_unsubscribe, tool_event_subscribe,
+    tool_event_unsubscribe, tool_usage_subscribe, tool_usage_unsubscribe,
+};
+use aura_events::agent::{AgentEvent, AgentEventPayload};
+use aura_test_utils::mock_agent::{MockAgent, Step, items};
+use aura_test_utils::sse::{SseEvent, parse_sse_stream};
+use aura_web_server::streaming::{
+    StreamConfig, StreamTermination, StreamingCallbacks, ToolResultMode, TurnContext,
+    process_sse_stream_full,
+};
+use bytes::Bytes;
+use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
+
+const TOOL_ID: &str = "call_abc123";
+const TOOL_NAME: &str = "list_files";
+const TOOL_ARGS: &str = r#"{"path":"/mock"}"#;
+const SESSION_ID: &str = "cs-differential";
+
+fn token() -> ProgressToken {
+    ProgressToken(NumberOrString::Number(7))
+}
+
+fn args() -> serde_json::Value {
+    serde_json::json!({ "path": "/mock" })
+}
+
+/// Subscribes exactly as the production handler does, so events reach the
+/// stream through the global brokers keyed by `request_id`.
+async fn callbacks_for(request_id: &str) -> StreamingCallbacks {
+    StreamingCallbacks {
+        request_id: request_id.to_string(),
+        agent: Arc::new(MockAgent::pending()),
+        tool_event_rx: tool_event_subscribe(request_id).await,
+        progress_rx: request_progress_subscribe(request_id).await,
+        tool_usage_rx: tool_usage_subscribe(request_id).await,
+        approval_event_rx: approval_event_subscribe(request_id).await,
+        usage_state: UsageState::new(),
+        response_content: ResponseContent::new(),
+        model_name: "test/fake".to_string(),
+        stream_shutdown_token: CancellationToken::new(),
+    }
+}
+
+async fn unsubscribe_all(request_id: &str) {
+    tool_event_unsubscribe(request_id).await;
+    request_progress_unsubscribe(request_id).await;
+    tool_usage_unsubscribe(request_id).await;
+    approval_event_unsubscribe(request_id).await;
+}
+
+async fn run(request_id: &str, steps: Vec<Step>) -> Vec<SseEvent> {
+    let callbacks = callbacks_for(request_id).await;
+    let config = StreamConfig::new(true, false, ToolResultMode::Aura, 0);
+    let ctx = TurnContext::new(
+        "chatcmpl-test".to_string(),
+        "test/fake".to_string(),
+        1_700_000_000,
+        None,
+        SESSION_ID,
+    );
+
+    let stream = MockAgent::scripted(steps)
+        .stream("q", vec![], CancellationToken::new(), request_id)
+        .await
+        .expect("mock stream should start");
+
+    let (chunk_tx, mut chunk_rx) = mpsc::channel::<Result<Bytes, String>>(64);
+    let collector = tokio::spawn(async move {
+        let mut body = String::new();
+        while let Some(chunk) = chunk_rx.recv().await {
+            body.push_str(std::str::from_utf8(&chunk.expect("SSE chunk")).expect("UTF-8"));
+        }
+        body
+    });
+    let (cancel_tx, _cancel_rx) = watch::channel(false);
+
+    let termination = process_sse_stream_full(
+        &config,
+        &ctx,
+        stream,
+        chunk_tx,
+        cancel_tx,
+        Duration::from_secs(900),
+        // Far enough out that heartbeats never interleave with the script.
+        Duration::from_secs(86_400),
+        None,
+        None,
+        callbacks,
+    )
+    .await;
+    assert_eq!(termination, StreamTermination::Complete);
+
+    let body = collector.await.expect("collector should not panic");
+    unsubscribe_all(request_id).await;
+
+    let (events, done) = parse_sse_stream(&body);
+    assert!(done, "stream should terminate with [DONE]");
+    events
+}
+
+fn frames(events: &[SseEvent]) -> Vec<(Option<String>, String)> {
+    events
+        .iter()
+        .map(|e| (e.event_type.clone(), e.data.clone()))
+        .collect()
+}
+
+/// `broker` and `schema` must describe the same logical sequence. Both run with
+/// distinct request ids so their broker registrations cannot alias.
+async fn assert_paths_agree(
+    case: &str,
+    broker: impl FnOnce(&str) -> Vec<Step>,
+    schema: impl FnOnce(&str) -> Vec<Step>,
+) {
+    let broker_id = format!("req_broker_{case}");
+    let schema_id = format!("req_schema_{case}");
+
+    let via_broker = run(&broker_id, broker(&broker_id)).await;
+    let via_schema = run(&schema_id, schema(&schema_id)).await;
+
+    assert_eq!(
+        frames(&via_broker),
+        frames(&via_schema),
+        "{case}: schema path diverged from broker path"
+    );
+    assert!(
+        !via_broker.is_empty(),
+        "{case}: no frames captured, so agreement proves nothing"
+    );
+}
+
+/// Publishing through the adapter must reach a subscriber; a silent
+/// `NoSubscriber` would make both paths agree on emptiness.
+fn emit(
+    event: AgentEvent,
+) -> impl Fn(String) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send>> {
+    move |request_id: String| {
+        let event = event.clone();
+        Box::pin(async move {
+            let routed = publish_to_brokers(&request_id, &event).await;
+            assert_eq!(
+                routed,
+                Routed::Delivered,
+                "adapter should reach a subscriber"
+            );
+        })
+    }
+}
+
+fn tool_result_ok() -> Result<StreamItem, StreamError> {
+    items::tool_result(TOOL_ID, "README.md\nsrc/")
+}
+
+#[tokio::test(start_paused = true)]
+async fn tool_requested_matches() {
+    assert_paths_agree(
+        "tool_requested",
+        |_| {
+            vec![
+                Step::effect(|request_id: String| async move {
+                    publish_tool_requested(
+                        &request_id,
+                        TOOL_ID.to_string(),
+                        TOOL_NAME.to_string(),
+                        args(),
+                    )
+                    .await;
+                }),
+                Step::item(items::text("done")),
+            ]
+        },
+        |_| {
+            vec![
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolRequested {
+                        tool_id: TOOL_ID.to_string(),
+                        tool_name: TOOL_NAME.to_string(),
+                        arguments: args(),
+                    },
+                ))),
+                Step::item(items::text("done")),
+            ]
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_full_tool_turn_matches() {
+    assert_paths_agree(
+        "full_turn",
+        |_| {
+            vec![
+                Step::effect(|request_id: String| async move {
+                    publish_tool_requested(
+                        &request_id,
+                        TOOL_ID.to_string(),
+                        TOOL_NAME.to_string(),
+                        args(),
+                    )
+                    .await;
+                }),
+                Step::item(items::tool_call(TOOL_ID, TOOL_NAME, TOOL_ARGS)),
+                Step::effect(|request_id: String| async move {
+                    publish_tool_start(
+                        &request_id,
+                        TOOL_ID.to_string(),
+                        TOOL_NAME.to_string(),
+                        Some(token()),
+                    )
+                    .await;
+                }),
+                Step::effect(|request_id: String| async move {
+                    aura::request_progress::publish(
+                        &request_id,
+                        ProgressNotification {
+                            progress_token: token(),
+                            progress: 50.0,
+                            total: Some(100.0),
+                            message: Some("halfway".to_string()),
+                        },
+                    )
+                    .await;
+                }),
+                Step::item(tool_result_ok()),
+                Step::item(items::text("Here are the files.")),
+            ]
+        },
+        |_| {
+            vec![
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolRequested {
+                        tool_id: TOOL_ID.to_string(),
+                        tool_name: TOOL_NAME.to_string(),
+                        arguments: args(),
+                    },
+                ))),
+                Step::item(items::tool_call(TOOL_ID, TOOL_NAME, TOOL_ARGS)),
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolStart {
+                        tool_id: TOOL_ID.to_string(),
+                        tool_name: TOOL_NAME.to_string(),
+                        progress_token: Some(token()),
+                    },
+                ))),
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolProgress {
+                        progress_token: token(),
+                        progress: 50.0,
+                        total: Some(100.0),
+                        message: Some("halfway".to_string()),
+                    },
+                ))),
+                Step::item(tool_result_ok()),
+                Step::item(items::text("Here are the files.")),
+            ]
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn progress_without_a_message_matches() {
+    let build_broker = |_: &str| {
+        vec![
+            Step::effect(|request_id: String| async move {
+                aura::request_progress::publish(
+                    &request_id,
+                    ProgressNotification {
+                        progress_token: token(),
+                        progress: 3.0,
+                        total: None,
+                        message: None,
+                    },
+                )
+                .await;
+            }),
+            Step::item(items::text("done")),
+        ]
+    };
+    let build_schema = |_: &str| {
+        vec![
+            Step::effect(emit(AgentEvent::single_agent(
+                AgentEventPayload::ToolProgress {
+                    progress_token: token(),
+                    progress: 3.0,
+                    total: None,
+                    message: None,
+                },
+            ))),
+            Step::item(items::text("done")),
+        ]
+    };
+
+    assert_paths_agree("progress_no_message", build_broker, build_schema).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn tool_usage_matches() {
+    assert_paths_agree(
+        "tool_usage",
+        |_| {
+            vec![
+                Step::effect(|request_id: String| async move {
+                    publish_tool_usage(&request_id, vec![TOOL_ID.to_string()], 10, 5, 15).await;
+                }),
+                Step::item(items::text("done")),
+            ]
+        },
+        |_| {
+            vec![
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolUsage {
+                        tool_ids: vec![TOOL_ID.to_string()],
+                        prompt_tokens: 10,
+                        completion_tokens: 5,
+                        total_tokens: 15,
+                    },
+                ))),
+                Step::item(items::text("done")),
+            ]
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn approval_lifecycle_matches() {
+    let requested = aura_events::ApprovalRequested {
+        decision_id: "dec_1".to_string(),
+        tool_name: TOOL_NAME.to_string(),
+        origin: aura_events::ApprovalOriginWire::ConfigGate {
+            matched_pattern: "list_*".to_string(),
+            agent_name: "main".to_string(),
+        },
+        scope: aura_events::AgentScopeWire::Single {
+            session_id: Some(SESSION_ID.to_string()),
+        },
+    };
+
+    let for_broker = requested.clone();
+    let for_schema = requested.clone();
+
+    assert_paths_agree(
+        "approval",
+        move |_| {
+            vec![
+                Step::effect(move |request_id: String| {
+                    let event = ApprovalLifecycleEvent::Requested(for_broker.clone());
+                    async move {
+                        aura::approval_event_broker::publish(&request_id, event).await;
+                    }
+                }),
+                Step::item(items::text("done")),
+            ]
+        },
+        move |_| {
+            vec![
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ApprovalRequested(for_schema),
+                ))),
+                Step::item(items::text("done")),
+            ]
+        },
+    )
+    .await;
+}

--- a/crates/aura-web-server/tests/agent_event_differential.rs
+++ b/crates/aura-web-server/tests/agent_event_differential.rs
@@ -12,7 +12,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use aura::agent_events::{Routed, publish_to_brokers};
+use aura::agent_events::Routed;
 use aura::tool_event_broker::publish_tool_requested;
 use aura::{
     ApprovalLifecycleEvent, NumberOrString, ProgressNotification, ProgressToken, ResponseContent,
@@ -152,20 +152,16 @@ async fn assert_paths_agree(
     );
 }
 
-/// Publishing through the adapter must reach a subscriber; a silent
-/// `NoSubscriber` would make both paths agree on emptiness.
+/// The `Delivered` assert matters because a silent drop would make both paths
+/// agree on emptiness.
 fn emit(
     event: AgentEvent,
 ) -> impl Fn(String) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send>> {
     move |request_id: String| {
         let event = event.clone();
         Box::pin(async move {
-            let routed = publish_to_brokers(&request_id, &event).await;
-            assert_eq!(
-                routed,
-                Routed::Delivered,
-                "adapter should reach a subscriber"
-            );
+            let routed = aura::agent_events::emit(&request_id, event).await;
+            assert_eq!(routed, Routed::Delivered, "event should reach a consumer");
         })
     }
 }

--- a/crates/aura/src/agent_events.rs
+++ b/crates/aura/src/agent_events.rs
@@ -1,0 +1,300 @@
+//! Projection of [`AgentEvent`]s back onto the request-scoped brokers.
+//!
+//! Producers move onto the [`aura_events::agent`] schema one at a time. This
+//! adapter lets them do that without any consumer changing: it republishes an
+//! agent's events into the same brokers the SSE handler, A2A executor, and CLI
+//! already subscribe to, so both paths converge on identical output.
+//!
+//! Scope: the side channels only — tool lifecycle, MCP progress, tool usage,
+//! and HITL approvals. Content-bearing events ([`AgentEventPayload::TextDelta`]
+//! and friends) reach consumers through the `StreamItem` stream rather than a
+//! broker, and gain their projection alongside the producer that emits them.
+
+use aura_events::agent::{AgentEvent, AgentEventPayload};
+
+use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
+use crate::env_flags::bool_env;
+use crate::request_progress::{self, ProgressNotification};
+use crate::tool_event_broker::{publish_tool_requested, publish_tool_start, publish_tool_usage};
+
+pub const ENV_AGENT_EVENTS: &str = "AURA_AGENT_EVENTS";
+
+/// Defaults off until the schema reaches parity with the broker path.
+pub fn agent_events_enabled() -> bool {
+    bool_env(ENV_AGENT_EVENTS, false)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Routed {
+    Delivered,
+    NoSubscriber,
+    /// The payload has no broker.
+    NotSideChannel,
+}
+
+/// Publishing is fire-and-forget: a request whose subscriber has gone away
+/// yields `NoSubscriber` rather than an error. Content-bearing payloads have no
+/// broker to publish to and fall through to `NotSideChannel`; they reach
+/// consumers over the `StreamItem` stream instead.
+pub async fn publish_to_brokers(request_id: &str, event: &AgentEvent) -> Routed {
+    let delivered = match &event.payload {
+        AgentEventPayload::ToolRequested {
+            tool_id,
+            tool_name,
+            arguments,
+        } => {
+            publish_tool_requested(
+                request_id,
+                tool_id.clone(),
+                tool_name.clone(),
+                arguments.clone(),
+            )
+            .await
+        }
+
+        AgentEventPayload::ToolStart {
+            tool_id,
+            tool_name,
+            progress_token,
+        } => {
+            publish_tool_start(
+                request_id,
+                tool_id.clone(),
+                tool_name.clone(),
+                progress_token.clone(),
+            )
+            .await
+        }
+
+        AgentEventPayload::ToolProgress {
+            progress_token,
+            progress,
+            total,
+            message,
+        } => {
+            request_progress::publish(
+                request_id,
+                ProgressNotification {
+                    progress_token: progress_token.clone(),
+                    progress: *progress,
+                    total: *total,
+                    message: message.clone(),
+                },
+            )
+            .await
+        }
+
+        AgentEventPayload::ToolUsage {
+            tool_ids,
+            prompt_tokens,
+            completion_tokens,
+            total_tokens,
+        } => {
+            publish_tool_usage(
+                request_id,
+                tool_ids.clone(),
+                *prompt_tokens,
+                *completion_tokens,
+                *total_tokens,
+            )
+            .await
+        }
+
+        AgentEventPayload::ApprovalRequested(approval) => {
+            approval_event_broker::publish(
+                request_id,
+                ApprovalLifecycleEvent::Requested(approval.clone()),
+            )
+            .await
+        }
+
+        AgentEventPayload::ApprovalPending(approval) => {
+            approval_event_broker::publish(
+                request_id,
+                ApprovalLifecycleEvent::Pending(approval.clone()),
+            )
+            .await
+        }
+
+        AgentEventPayload::ApprovalCompleted(approval) => {
+            approval_event_broker::publish(
+                request_id,
+                ApprovalLifecycleEvent::Completed(approval.clone()),
+            )
+            .await
+        }
+
+        _ => return Routed::NotSideChannel,
+    };
+
+    if delivered {
+        Routed::Delivered
+    } else {
+        Routed::NoSubscriber
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aura_events::agent::ToolOutcome;
+    use aura_events::{NumberOrString, ProgressToken};
+    use serde_json::json;
+
+    use crate::request_progress::subscribe as progress_subscribe;
+    use crate::tool_event_broker::{
+        ToolLifecycleEvent, subscribe as tool_event_subscribe, tool_usage_subscribe,
+    };
+
+    fn token(n: i64) -> ProgressToken {
+        ProgressToken(NumberOrString::Number(n))
+    }
+
+    #[tokio::test]
+    async fn tool_requested_reaches_the_tool_event_broker() {
+        let request_id = "req_adapter_requested";
+        let mut rx = tool_event_subscribe(request_id).await;
+
+        let routed = publish_to_brokers(
+            request_id,
+            &AgentEvent::single_agent(AgentEventPayload::ToolRequested {
+                tool_id: "call_1".to_string(),
+                tool_name: "list_files".to_string(),
+                arguments: json!({ "path": "/mock" }),
+            }),
+        )
+        .await;
+
+        assert_eq!(routed, Routed::Delivered);
+        let event = rx.recv().await.expect("event should arrive");
+        let ToolLifecycleEvent::Requested {
+            tool_id,
+            tool_name,
+            arguments,
+        } = event
+        else {
+            panic!("expected Requested");
+        };
+        assert_eq!(tool_id, "call_1");
+        assert_eq!(tool_name, "list_files");
+        assert_eq!(arguments, json!({ "path": "/mock" }));
+    }
+
+    #[tokio::test]
+    async fn tool_start_carries_its_progress_token() {
+        let request_id = "req_adapter_start";
+        let mut rx = tool_event_subscribe(request_id).await;
+
+        publish_to_brokers(
+            request_id,
+            &AgentEvent::single_agent(AgentEventPayload::ToolStart {
+                tool_id: "call_1".to_string(),
+                tool_name: "list_files".to_string(),
+                progress_token: Some(token(7)),
+            }),
+        )
+        .await;
+
+        let ToolLifecycleEvent::Start { progress_token, .. } =
+            rx.recv().await.expect("event should arrive")
+        else {
+            panic!("expected Start");
+        };
+        assert_eq!(progress_token, Some(token(7)));
+    }
+
+    #[tokio::test]
+    async fn progress_keeps_the_raw_values_the_handler_derives_percent_from() {
+        let request_id = "req_adapter_progress";
+        let mut rx = progress_subscribe(request_id).await;
+
+        publish_to_brokers(
+            request_id,
+            &AgentEvent::single_agent(AgentEventPayload::ToolProgress {
+                progress_token: token(7),
+                progress: 50.0,
+                total: Some(100.0),
+                message: Some("halfway".to_string()),
+            }),
+        )
+        .await;
+
+        let notification = rx.recv().await.expect("notification should arrive");
+        assert_eq!(notification.progress, 50.0);
+        assert_eq!(notification.total, Some(100.0));
+        assert_eq!(notification.message.as_deref(), Some("halfway"));
+        assert_eq!(notification.percent(), Some(50));
+    }
+
+    #[tokio::test]
+    async fn tool_usage_reaches_the_usage_broker() {
+        let request_id = "req_adapter_usage";
+        let mut rx = tool_usage_subscribe(request_id).await;
+
+        publish_to_brokers(
+            request_id,
+            &AgentEvent::single_agent(AgentEventPayload::ToolUsage {
+                tool_ids: vec!["call_1".to_string()],
+                prompt_tokens: 10,
+                completion_tokens: 5,
+                total_tokens: 15,
+            }),
+        )
+        .await;
+
+        let usage = rx.recv().await.expect("usage should arrive");
+        assert_eq!(usage.tool_ids, vec!["call_1".to_string()]);
+        assert_eq!(usage.total_tokens, 15);
+    }
+
+    #[tokio::test]
+    async fn content_events_are_not_routed_to_a_broker() {
+        let routed = publish_to_brokers(
+            "req_adapter_text",
+            &AgentEvent::single_agent(AgentEventPayload::TextDelta {
+                content: "hello".to_string(),
+            }),
+        )
+        .await;
+
+        assert_eq!(routed, Routed::NotSideChannel);
+    }
+
+    #[tokio::test]
+    async fn tool_complete_is_carried_by_the_stream_not_a_broker() {
+        let routed = publish_to_brokers(
+            "req_adapter_complete",
+            &AgentEvent::single_agent(AgentEventPayload::ToolComplete {
+                tool_id: "call_1".to_string(),
+                tool_name: "list_files".to_string(),
+                duration_ms: 3,
+                outcome: ToolOutcome::Success {
+                    result: "ok".to_string(),
+                },
+            }),
+        )
+        .await;
+
+        assert_eq!(routed, Routed::NotSideChannel);
+    }
+
+    #[tokio::test]
+    async fn a_side_channel_event_with_nobody_listening_reports_no_subscriber() {
+        let routed = publish_to_brokers(
+            "req_adapter_unsubscribed",
+            &AgentEvent::single_agent(AgentEventPayload::ToolRequested {
+                tool_id: "call_1".to_string(),
+                tool_name: "list_files".to_string(),
+                arguments: json!({}),
+            }),
+        )
+        .await;
+
+        assert_eq!(routed, Routed::NoSubscriber);
+    }
+
+    #[tokio::test]
+    async fn the_flag_is_off_unless_set() {
+        assert!(!agent_events_enabled());
+    }
+}

--- a/crates/aura/src/agent_events.rs
+++ b/crates/aura/src/agent_events.rs
@@ -1,9 +1,9 @@
-//! Projection of [`AgentEvent`]s back onto the request-scoped brokers.
+//! Projection of [`AgentEvent`]s onto the request-scoped brokers.
 //!
 //! Producers move onto the [`aura_events::agent`] schema one at a time. This
 //! adapter lets them do that without any consumer changing: it republishes an
 //! agent's events into the same brokers the SSE handler, A2A executor, and CLI
-//! already subscribe to, so both paths converge on identical output.
+//! already subscribe to.
 //!
 //! Scope: the side channels only — tool lifecycle, MCP progress, tool usage,
 //! and HITL approvals. Content-bearing events ([`AgentEventPayload::TextDelta`]
@@ -13,15 +13,13 @@
 use aura_events::agent::{AgentEvent, AgentEventPayload};
 
 use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
-use crate::env_flags::bool_env;
 use crate::request_progress::{self, ProgressNotification};
 use crate::tool_event_broker::{publish_tool_requested, publish_tool_start, publish_tool_usage};
 
-pub const ENV_AGENT_EVENTS: &str = "AURA_AGENT_EVENTS";
-
-/// Defaults off until the schema reaches parity with the broker path.
-pub fn agent_events_enabled() -> bool {
-    bool_env(ENV_AGENT_EVENTS, false)
+/// The seam producers call, so a real event stream can attach here later
+/// without touching the emission sites.
+pub async fn emit(request_id: &str, event: AgentEvent) -> Routed {
+    publish_to_brokers(request_id, &event).await
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -291,10 +289,5 @@ mod tests {
         .await;
 
         assert_eq!(routed, Routed::NoSubscriber);
-    }
-
-    #[tokio::test]
-    async fn the_flag_is_off_unless_set() {
-        assert!(!agent_events_enabled());
     }
 }

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -17,7 +17,8 @@ use super::events;
 use super::protocol::{ApprovalDecisionWire, ApprovalRequest, ApprovalRequestWire};
 use super::registry::PendingApprovals;
 use super::signing::{SigningContext, WebhookHmac, authorize_ingress};
-use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
+use crate::agent_events::emit;
+use aura_events::agent::{AgentEvent, AgentEventPayload};
 
 /// Maximum time to wait for a TCP connection to the approval webhook before
 /// failing closed. Without this, an unreachable host can hang the connect
@@ -230,9 +231,9 @@ async fn webhook_round_trip<T>(
     let decision_id = request.decision_id;
     let scope = request.scope.clone();
 
-    approval_event_broker::publish(
+    emit(
         &request_id,
-        ApprovalLifecycleEvent::Requested(request.into()),
+        AgentEvent::single_agent(AgentEventPayload::ApprovalRequested(request.into())),
     )
     .await;
 
@@ -257,7 +258,11 @@ async fn webhook_round_trip<T>(
             events::completed_error(decision_id, err.to_string(), &scope, started.elapsed())
         }
     };
-    approval_event_broker::publish(&request_id, ApprovalLifecycleEvent::Completed(completed)).await;
+    emit(
+        &request_id,
+        AgentEvent::single_agent(AgentEventPayload::ApprovalCompleted(completed)),
+    )
+    .await;
     result
 }
 
@@ -319,7 +324,7 @@ impl DecisionRoute {
 
         match self {
             Self::Conversational { registry, timeout } => {
-                let requested_event = ApprovalLifecycleEvent::Requested((&request).into());
+                let requested_event = AgentEventPayload::ApprovalRequested((&request).into());
                 let expires_at = chrono::Utc::now()
                     + chrono::Duration::from_std(*timeout)
                         .expect("approval timeout fits in chrono");
@@ -330,10 +335,10 @@ impl DecisionRoute {
                 // either must find the parked record already resolvable.
                 let handle = registry.register(request, *timeout).await;
 
-                approval_event_broker::publish(&request_id, requested_event).await;
-                approval_event_broker::publish(
+                emit(&request_id, AgentEvent::single_agent(requested_event)).await;
+                emit(
                     &request_id,
-                    ApprovalLifecycleEvent::Pending(pending_event),
+                    AgentEvent::single_agent(AgentEventPayload::ApprovalPending(pending_event)),
                 )
                 .await;
 
@@ -357,9 +362,9 @@ impl DecisionRoute {
 
                 let completed_event =
                     events::completed(decision_id, &outcome, &scope, started.elapsed());
-                approval_event_broker::publish(
+                emit(
                     &request_id,
-                    ApprovalLifecycleEvent::Completed(completed_event),
+                    AgentEvent::single_agent(AgentEventPayload::ApprovalCompleted(completed_event)),
                 )
                 .await;
 

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -5,6 +5,7 @@
 //! in web services or other applications that need to build agents
 //! programmatically.
 
+pub mod agent_events;
 pub mod approval_event_broker;
 pub mod approver_headers;
 pub mod bedrock_embedding;

--- a/crates/aura/src/mcp/client.rs
+++ b/crates/aura/src/mcp/client.rs
@@ -28,7 +28,8 @@ use tracing::{debug, error, info, warn};
 use crate::approver_headers::ApproverHeaders;
 use crate::mcp::progress::ProgressEnabledHandler;
 use crate::mcp::response::extract_tool_result;
-use crate::tool_event_broker::{peek_tool_call_id, publish_tool_start};
+use crate::tool_event_broker::peek_tool_call_id;
+use aura_events::agent::{AgentEvent, AgentEventPayload};
 
 /// Custom HTTP client that captures the underlying HTTP status when a request
 /// fails.
@@ -773,11 +774,13 @@ impl McpClient {
         let progress_token = Some(handle.progress_token.clone());
         let request_id_string = http_request_id.to_string();
         if let Some(tool_call_id) = peek_tool_call_id(&request_id_string).await {
-            publish_tool_start(
+            crate::agent_events::emit(
                 http_request_id,
-                tool_call_id.clone(),
-                tool_name.to_string(),
-                progress_token.clone(),
+                AgentEvent::single_agent(AgentEventPayload::ToolStart {
+                    tool_id: tool_call_id.clone(),
+                    tool_name: tool_name.to_string(),
+                    progress_token: progress_token.clone(),
+                }),
             )
             .await;
             debug!(

--- a/crates/aura/src/mcp/progress.rs
+++ b/crates/aura/src/mcp/progress.rs
@@ -29,7 +29,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
-use crate::request_progress::{self, ProgressNotification};
+use aura_events::agent::{AgentEvent, AgentEventPayload};
 
 /// A custom ClientHandler that routes progress notifications to request-scoped channels.
 ///
@@ -119,18 +119,18 @@ impl ClientHandler for ProgressEnabledHandler {
             // Get current request ID (if any)
             let request_id = self.current_request_id.read().await.clone();
 
-            // Build notification for request-scoped broker
-            let notification = ProgressNotification {
-                progress_token: params.progress_token.clone(),
-                progress: params.progress,
-                total: params.total,
-                message: params.message.clone(),
-            };
-
             if let Some(ref req_id) = request_id {
-                // Route to request-specific channel
-                let sent = request_progress::publish(req_id, notification).await;
-                if sent {
+                let routed = crate::agent_events::emit(
+                    req_id,
+                    AgentEvent::single_agent(AgentEventPayload::ToolProgress {
+                        progress_token: params.progress_token.clone(),
+                        progress: params.progress,
+                        total: params.total,
+                        message: params.message.clone(),
+                    }),
+                )
+                .await;
+                if routed == crate::agent_events::Routed::Delivered {
                     debug!(
                         "Progress notification routed to request '{}': progress={}, message={:?}",
                         req_id, params.progress, params.message

--- a/crates/aura/src/streaming_request_hook.rs
+++ b/crates/aura/src/streaming_request_hook.rs
@@ -44,15 +44,14 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use aura_events::agent::{AgentEvent, AgentEventPayload};
 use rig::agent::{CancelSignal, StreamingPromptHook};
 use rig::completion::{CompletionModel, GetTokenUsage, Message};
 use tokio::sync::watch;
 
 use crate::orchestration::BlockedCell;
 use crate::scratchpad::{self, ContextBudget};
-use crate::tool_event_broker::{
-    pop_tool_call_id, publish_tool_requested, publish_tool_usage, push_tool_call_id,
-};
+use crate::tool_event_broker::{pop_tool_call_id, push_tool_call_id};
 
 /// Maximum pending tool IDs before warning. Prevents unbounded growth if
 /// usage events never fire (e.g., provider doesn't return token counts).
@@ -593,8 +592,15 @@ where
                 // Rig 0.28+ passes correct tool_call_id; register for event correlation
                 if let Some(id) = &tool_call_id {
                     push_tool_call_id(&request_id, id.clone()).await;
-                    publish_tool_requested(&request_id, id.clone(), tool_name.clone(), arguments)
-                        .await;
+                    crate::agent_events::emit(
+                        &request_id,
+                        AgentEvent::single_agent(AgentEventPayload::ToolRequested {
+                            tool_id: id.clone(),
+                            tool_name: tool_name.clone(),
+                            arguments,
+                        }),
+                    )
+                    .await;
                 } else {
                     tracing::warn!(
                         "Tool '{}' called without tool_call_id for request '{}' - event correlation unavailable",
@@ -730,12 +736,14 @@ where
                         tool_ids.len(),
                         tool_ids
                     );
-                    publish_tool_usage(
+                    crate::agent_events::emit(
                         &request_id,
-                        tool_ids,
-                        usage.input_tokens,
-                        usage.output_tokens,
-                        usage.total_tokens,
+                        AgentEvent::single_agent(AgentEventPayload::ToolUsage {
+                            tool_ids,
+                            prompt_tokens: usage.input_tokens,
+                            completion_tokens: usage.output_tokens,
+                            total_tokens: usage.total_tokens,
+                        }),
                     )
                     .await;
                 }


### PR DESCRIPTION
Every approval publish site builds an AgentEvent and goes through agent_events::emit. That covers the decision route's five, park mode's pair in the gate, and the two sweeps that complete a parked ticket on cancellation. hitl::events hands each producer a finished event, so an approval's payload and its envelope come from one scope.

Naming a worker's approval needs the same parent id the orchestrator stamps on that worker's other events, so that id is a constant in aura-events rather than a literal in each module.

A task with no assigned worker has no name in that scope, so its approval is attributed to the coordinator running it, while the orchestrator names the same agent by its own id. The broker payload carries no agent field, so neither value reaches a client.

Ref: #624