### PR TITLE
test(web-server): fix lib test compile after cache_usage addition

### DIFF
--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -2861,6 +2861,7 @@ mod tests {
                     output_tokens: output,
                     total_tokens: input + output,
                 },
+                cache_usage: None,
             }))
         }
 


### PR DESCRIPTION
The aura-web-server lib test target has not compiled on nightly since `FinalResponseInfo` gained the `cache_usage` field: the streaming handler tests' `final_item` helper still built the struct without it. Adds `cache_usage: None`, which matches what those tests simulated before the field existed.

`cargo test -p aura-web-server --lib`: 167 passed.

Refs: #630