### PR TITLE
feat(session-store): file-backed approval store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "rig-core",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-test",

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -24,7 +24,9 @@ pub use orchestration::{
     ArtifactsConfig, OrchestrationConfig, TimeoutsConfig, ToolVisibility, WorkerConfig,
 };
 pub use scratchpad::{ScratchpadConfig, ScratchpadToolEntry};
-pub use session_store::{RedisSessionStoreConfig, SessionStoreBackend, SessionStoreConfig};
+pub use session_store::{
+    FileSessionStoreConfig, RedisSessionStoreConfig, SessionStoreBackend, SessionStoreConfig,
+};
 pub use skills::SkillName;
 pub use writer::upsert_mcp_server;
 

--- a/crates/aura-config/src/session_store.rs
+++ b/crates/aura-config/src/session_store.rs
@@ -2,19 +2,18 @@
 //! server uses and how to reach it (when not in-memory).
 //!
 //! Configured **only via environment variables** — never in agent TOML files.
-//! TOML configs are per-agent (a server loads N of them), while the session
-//! store is deployment infrastructure with exactly one instance per server;
-//! a TOML surface would ambiguously imply one store per agent config.
+//! TOML configs are per-agent; session store is per-server.
 //!
 //! See `docs/design/session-storage.md` §8.
 //!
-//! | Env var                                   | Meaning                                     |
-//! | ----------------------------------------- | ------------------------------------------- |
-//! | `AURA_SESSION_STORE`                      | backend: `memory` (default) or `redis`      |
-//! | `AURA_SESSION_STORE_URL`                  | `redis://` / `rediss://` (Valkey ok)        |
-//! | `AURA_SESSION_STORE_PREFIX`               | key/topic namespace (default `aura`)        |
-//! | `AURA_SESSION_STORE_CONNECT_TIMEOUT_SECS` | connection timeout (default 5)              |
-//! | `AURA_SESSION_STORE_TASK_TTL_SECS`        | A2A task TTL, 0 = no expiry (default 86400) |
+//! | Env var                                   | Meaning                                         |
+//! | ----------------------------------------- | ----------------------------------------------- |
+//! | `AURA_SESSION_STORE`                      | backend: `memory` (default), `redis`, or `file` |
+//! | `AURA_SESSION_STORE_URL`                  | `redis://` / `rediss://` (Valkey ok; `redis`)   |
+//! | `AURA_SESSION_STORE_PATH`                 | store root directory (`file`; required)         |
+//! | `AURA_SESSION_STORE_PREFIX`               | key/topic namespace (default `aura`)            |
+//! | `AURA_SESSION_STORE_CONNECT_TIMEOUT_SECS` | connection timeout (default 5)                  |
+//! | `AURA_SESSION_STORE_TASK_TTL_SECS`        | A2A task TTL, 0 = no expiry (default 86400)     |
 
 use crate::error::ConfigError;
 use std::fmt;
@@ -25,11 +24,13 @@ use std::time::Duration;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum SessionStoreBackend {
-    /// Process-local state (single-instance behavior).
+    /// Process-local state.
     #[default]
     Memory,
     /// Redis/Valkey-backed shared state.
     Redis,
+    /// File-backed approvals under a root directory.
+    File,
 }
 
 impl fmt::Display for SessionStoreBackend {
@@ -37,6 +38,7 @@ impl fmt::Display for SessionStoreBackend {
         let s = match self {
             SessionStoreBackend::Memory => "memory",
             SessionStoreBackend::Redis => "redis",
+            SessionStoreBackend::File => "file",
         };
         write!(f, "{s}")
     }
@@ -49,8 +51,9 @@ impl std::str::FromStr for SessionStoreBackend {
         match s.to_ascii_lowercase().as_str() {
             "memory" => Ok(SessionStoreBackend::Memory),
             "redis" | "valkey" => Ok(SessionStoreBackend::Redis),
+            "file" => Ok(SessionStoreBackend::File),
             other => Err(ConfigError::Validation(format!(
-                "unknown session store backend '{other}' (expected 'memory' or 'redis')"
+                "unknown session store backend '{other}' (expected 'memory', 'redis', or 'file')"
             ))),
         }
     }
@@ -59,11 +62,13 @@ impl std::str::FromStr for SessionStoreBackend {
 /// The effective session-store configuration for one server deployment.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum SessionStoreConfig {
-    /// Process-local state (single-instance behavior).
+    /// Process-local state.
     #[default]
     Memory,
     /// Redis/Valkey-backed shared state.
     Redis(RedisSessionStoreConfig),
+    /// Restart-durable approvals under a root directory.
+    File(FileSessionStoreConfig),
 }
 
 /// Connection settings for the Redis/Valkey backend.
@@ -71,12 +76,19 @@ pub enum SessionStoreConfig {
 pub struct RedisSessionStoreConfig {
     /// Backend connection URL (`redis://` or `rediss://`; Valkey compatible).
     pub url: String,
-    /// Key/topic namespace, so multiple deployments can share a cluster.
+    /// Key/topic namespace.
     pub key_prefix: String,
     /// Backend connection timeout.
     pub connect_timeout: Duration,
     /// A2A task record TTL in seconds.
     pub task_ttl_secs: Option<NonZeroU64>,
+}
+
+/// Settings for the file-backed approval store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileSessionStoreConfig {
+    /// Root directory holding the per-decision ticket and decision files.
+    pub path: String,
 }
 
 const DEFAULT_KEY_PREFIX: &str = "aura";
@@ -86,8 +98,9 @@ const DEFAULT_TASK_TTL_SECS: u64 = 86_400;
 impl SessionStoreConfig {
     /// Build the deployment's session-store configuration from the
     /// `AURA_SESSION_STORE*` environment variables, defaulting to in-memory
-    /// when unset. The Redis connection vars are only read (and the URL only
-    /// required) when the backend is `redis`.
+    /// when unset. Backend-specific vars are only read (and only required)
+    /// when their backend is selected: the URL for `redis`, the path for
+    /// `file`.
     pub fn from_env() -> Result<Self, ConfigError> {
         let backend = env_var("AURA_SESSION_STORE")
             .map(|raw| raw.parse())
@@ -96,6 +109,7 @@ impl SessionStoreConfig {
         match backend {
             SessionStoreBackend::Memory => Ok(Self::Memory),
             SessionStoreBackend::Redis => Ok(Self::Redis(RedisSessionStoreConfig::from_env()?)),
+            SessionStoreBackend::File => Ok(Self::File(FileSessionStoreConfig::from_env()?)),
         }
     }
 
@@ -105,6 +119,7 @@ impl SessionStoreConfig {
         match self {
             Self::Memory => SessionStoreBackend::Memory,
             Self::Redis(_) => SessionStoreBackend::Redis,
+            Self::File(_) => SessionStoreBackend::File,
         }
     }
 }
@@ -132,6 +147,19 @@ impl RedisSessionStoreConfig {
     }
 }
 
+impl FileSessionStoreConfig {
+    /// Read the file store's root directory from the environment. The path
+    /// is required.
+    fn from_env() -> Result<Self, ConfigError> {
+        let path = env_var("AURA_SESSION_STORE_PATH").ok_or_else(|| {
+            ConfigError::Validation(
+                "AURA_SESSION_STORE=file requires AURA_SESSION_STORE_PATH".to_string(),
+            )
+        })?;
+        Ok(Self { path })
+    }
+}
+
 /// Read an env var, treating unset and empty as absent.
 fn env_var(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|v| !v.trim().is_empty())
@@ -156,11 +184,19 @@ mod tests {
         for var in [
             "AURA_SESSION_STORE",
             "AURA_SESSION_STORE_URL",
+            "AURA_SESSION_STORE_PATH",
             "AURA_SESSION_STORE_PREFIX",
             "AURA_SESSION_STORE_CONNECT_TIMEOUT_SECS",
             "AURA_SESSION_STORE_TASK_TTL_SECS",
         ] {
             unsafe { std::env::remove_var(var) };
+        }
+    }
+
+    fn expect_file(config: SessionStoreConfig) -> FileSessionStoreConfig {
+        match config {
+            SessionStoreConfig::File(file) => file,
+            other => panic!("expected the file backend, got {other:?}"),
         }
     }
 
@@ -222,6 +258,43 @@ mod tests {
             "valkey".parse::<SessionStoreBackend>().unwrap(),
             SessionStoreBackend::Redis
         );
+    }
+
+    #[test]
+    fn file_backend_reads_path() {
+        let _guard = test_env_lock::lock();
+        clear_env();
+        unsafe {
+            std::env::set_var("AURA_SESSION_STORE", "file");
+            std::env::set_var("AURA_SESSION_STORE_PATH", "/var/lib/aura/approvals");
+        }
+        let config = SessionStoreConfig::from_env();
+        clear_env();
+        let file = expect_file(config.unwrap());
+        assert_eq!(file.path, "/var/lib/aura/approvals");
+    }
+
+    #[test]
+    fn file_requires_path() {
+        let _guard = test_env_lock::lock();
+        clear_env();
+        unsafe { std::env::set_var("AURA_SESSION_STORE", "file") };
+        let err = SessionStoreConfig::from_env().unwrap_err();
+        clear_env();
+        assert!(err.to_string().contains("AURA_SESSION_STORE_PATH"));
+    }
+
+    #[test]
+    fn empty_path_is_treated_as_missing() {
+        let _guard = test_env_lock::lock();
+        clear_env();
+        unsafe {
+            std::env::set_var("AURA_SESSION_STORE", "file");
+            std::env::set_var("AURA_SESSION_STORE_PATH", "  ");
+        }
+        let err = SessionStoreConfig::from_env().unwrap_err();
+        clear_env();
+        assert!(err.to_string().contains("AURA_SESSION_STORE_PATH"));
     }
 
     #[test]

--- a/crates/aura-web-server/Cargo.toml
+++ b/crates/aura-web-server/Cargo.toml
@@ -97,3 +97,4 @@ aura-test-utils = { path = "../aura-test-utils" }
 aura-events = { path = "../aura-events" }
 tower = "0.5"
 http-body-util = "0.1"
+tempfile = "3"

--- a/crates/aura-web-server/src/session_store.rs
+++ b/crates/aura-web-server/src/session_store.rs
@@ -13,9 +13,10 @@ use std::sync::Arc;
 use a2a_server::{InMemoryTaskStore, TaskStore};
 use async_trait::async_trait;
 use aura::session_store::{
-    ApprovalStore, EventBus, InMemoryApprovalStore, InMemoryEventBus, SessionStoreError,
+    ApprovalStore, EventBus, FileApprovalStore, InMemoryApprovalStore, InMemoryEventBus,
+    SessionStoreError,
 };
-use aura_config::{SessionStoreBackend, SessionStoreConfig};
+use aura_config::{FileSessionStoreConfig, SessionStoreBackend, SessionStoreConfig};
 
 #[cfg(feature = "session-store-redis")]
 pub use redis::RedisSessionStore;
@@ -33,20 +34,25 @@ pub trait SessionStore: Send + Sync {
     /// Durable A2A tasks (the upstream `a2a_server::TaskStore` trait).
     fn tasks(&self) -> Arc<dyn TaskStore>;
 
-    /// Allows for cross-instance pub/sub (in-memory SessionStore would be single-instance only).
+    /// Cross-instance pub/sub.
     fn bus(&self) -> Arc<dyn EventBus>;
 
-    /// Cheap liveness check.
+    /// Backend health check. Implementations may touch the backend (a
+    /// round trip, a probe write) but must stay cheap enough to run on
+    /// every health probe.
     async fn ping(&self) -> Result<(), SessionStoreError>;
 }
 
-/// Construct the configured backend. Fails fast on an unreachable networked
-/// backend or a `redis` config in a build without `session-store-redis`.
+/// Construct configured backend, failing fast.
 pub async fn build_session_store(
     config: &SessionStoreConfig,
 ) -> Result<Arc<dyn SessionStore>, SessionStoreError> {
     match config {
         SessionStoreConfig::Memory => Ok(Arc::new(InMemorySessionStore::new())),
+        SessionStoreConfig::File(file_config) => {
+            // File-backed approvals; tasks and bus stay in memory.
+            Ok(Arc::new(FileSessionStore::new(file_config)?))
+        }
         #[cfg(feature = "session-store-redis")]
         SessionStoreConfig::Redis(redis_config) => {
             Ok(Arc::new(RedisSessionStore::connect(redis_config).await?))
@@ -59,8 +65,7 @@ pub async fn build_session_store(
     }
 }
 
-/// The default backend: every capability is process-local, so state is scoped
-/// to one process.
+/// The default backend.
 pub struct InMemorySessionStore {
     approvals: Arc<InMemoryApprovalStore>,
     tasks: Arc<InMemoryTaskStore>,
@@ -104,5 +109,46 @@ impl SessionStore for InMemorySessionStore {
 
     async fn ping(&self) -> Result<(), SessionStoreError> {
         Ok(())
+    }
+}
+
+/// The file-backed backend.
+pub struct FileSessionStore {
+    approvals: Arc<FileApprovalStore>,
+    tasks: Arc<InMemoryTaskStore>,
+    bus: Arc<InMemoryEventBus>,
+}
+
+impl FileSessionStore {
+    /// Open the approval store at the configured path, failing fast when it
+    /// cannot.
+    pub fn new(config: &FileSessionStoreConfig) -> Result<Self, SessionStoreError> {
+        Ok(Self {
+            approvals: Arc::new(FileApprovalStore::open(&config.path)?),
+            tasks: Arc::new(InMemoryTaskStore::new()),
+            bus: Arc::new(InMemoryEventBus::new()),
+        })
+    }
+}
+#[async_trait]
+impl SessionStore for FileSessionStore {
+    fn backend(&self) -> SessionStoreBackend {
+        SessionStoreBackend::File
+    }
+
+    fn approvals(&self) -> Arc<dyn ApprovalStore> {
+        self.approvals.clone()
+    }
+
+    fn tasks(&self) -> Arc<dyn TaskStore> {
+        self.tasks.clone()
+    }
+
+    fn bus(&self) -> Arc<dyn EventBus> {
+        self.bus.clone()
+    }
+
+    async fn ping(&self) -> Result<(), SessionStoreError> {
+        self.approvals.probe_writable().await
     }
 }

--- a/crates/aura-web-server/tests/common/mod.rs
+++ b/crates/aura-web-server/tests/common/mod.rs
@@ -1,0 +1,156 @@
+//! Backend-agnostic conformance battery for the HITL approval store
+//! ([`ApprovalStore`]): the behaviors every configured backend must share,
+//! factored out of the Redis integration tests so the Docker-free backends
+//! (file, memory) pin the same contract without a live Redis.
+//!
+//! "Instance A" and "instance B" model two server processes sharing one
+//! store. For networked backends they are separate connections to the same
+//! server; for single-process backends they are two handles to the same
+//! store, which is that backend's deployment shape.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use aura::hitl::{
+    AgentScope, ApprovalDecision, ApprovalItem, ApprovalOrigin, ApprovalRequest, DecisionId,
+    PROTOCOL_VERSION, ParkedApproval, ResolveError,
+};
+use aura::session_store::{ApprovalStore, ParkedApprovalRecord};
+
+/// A representative parked approval, expiring in `ttl`.
+pub fn make_parked(request_id: &str, ttl: Duration) -> ParkedApproval {
+    let now = chrono::Utc::now();
+    ParkedApproval {
+        request: ApprovalRequest {
+            version: PROTOCOL_VERSION,
+            decision_id: DecisionId::generate(),
+            request_id: request_id.to_string(),
+            scope: AgentScope::Single { session_id: None },
+            origin: ApprovalOrigin::ConfigGate {
+                matched_pattern: "kubectl_*".to_string(),
+                agent_name: "test-agent".to_string(),
+            },
+            items: vec![ApprovalItem {
+                tool_name: "kubectl_delete".to_string(),
+                arguments: serde_json::json!({"pod": "web-1"}),
+                tool_call_intent: Some("restarting to pick up the config change".to_string()),
+            }],
+        },
+        registered_at: now,
+        expires_at: now + chrono::Duration::from_std(ttl).unwrap(),
+    }
+}
+
+/// A ticket registered through one instance is readable, unchanged, through
+/// the other.
+pub async fn register_get_roundtrip(
+    instance_a: &Arc<dyn ApprovalStore>,
+    instance_b: &Arc<dyn ApprovalStore>,
+) {
+    let parked = make_parked("req-1", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    let expected = ParkedApprovalRecord::from(&parked);
+    instance_a.register(parked).await.unwrap();
+
+    let restored = instance_b
+        .get(&id)
+        .await
+        .unwrap()
+        .expect("instance B sees approval");
+    assert_eq!(ParkedApprovalRecord::from(&restored), expected);
+}
+
+/// The first resolve wins; a second resolve of the same id is `NotFound`.
+pub async fn resolve_is_at_most_once(
+    instance_a: &Arc<dyn ApprovalStore>,
+    instance_b: &Arc<dyn ApprovalStore>,
+) {
+    let parked = make_parked("req-2", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    instance_a.register(parked).await.unwrap();
+
+    instance_b
+        .resolve(&id, ApprovalDecision::Approved)
+        .await
+        .expect("first resolve wins");
+    assert_eq!(
+        instance_a.resolve(&id, ApprovalDecision::Approved).await,
+        Err(ResolveError::NotFound)
+    );
+}
+
+/// Concurrent resolves of one id admit exactly one winner.
+pub async fn concurrent_resolves_have_exactly_one_winner(
+    instance_a: &Arc<dyn ApprovalStore>,
+    instance_b: &Arc<dyn ApprovalStore>,
+) {
+    let parked = make_parked("req-3", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    instance_a.register(parked).await.unwrap();
+
+    let (a, b) = tokio::join!(
+        instance_a.resolve(&id, ApprovalDecision::Approved),
+        instance_b.resolve(&id, ApprovalDecision::Approved),
+    );
+    let winners = usize::from(a.is_ok()) + usize::from(b.is_ok());
+    assert_eq!(winners, 1, "exactly one resolver must win: {a:?} / {b:?}");
+}
+
+/// A resolution leaves a durable decision record readable from any instance
+/// (issue #474), surviving the rejected second resolve.
+pub async fn resolve_records_readable_decision(
+    instance_a: &Arc<dyn ApprovalStore>,
+    instance_b: &Arc<dyn ApprovalStore>,
+) {
+    let parked = make_parked("req-durable", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    instance_a.register(parked).await.unwrap();
+
+    let denied = ApprovalDecision::Denied {
+        reason: Some("not now".to_string()),
+    };
+    instance_b.resolve(&id, denied.clone()).await.unwrap();
+
+    assert_eq!(
+        instance_a.decision(&id).await.unwrap(),
+        Some(denied.clone())
+    );
+    assert_eq!(
+        instance_a.resolve(&id, ApprovalDecision::Approved).await,
+        Err(ResolveError::NotFound)
+    );
+    assert_eq!(instance_a.decision(&id).await.unwrap(), Some(denied));
+    assert_eq!(
+        instance_a.decision(&DecisionId::generate()).await.unwrap(),
+        None
+    );
+}
+
+/// A removed ticket no longer resolves.
+pub async fn remove_makes_resolve_not_found(instance: &Arc<dyn ApprovalStore>) {
+    let parked = make_parked("req-4", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    instance.register(parked).await.unwrap();
+
+    instance.remove(&id).await.unwrap();
+
+    assert_eq!(
+        instance.resolve(&id, ApprovalDecision::Approved).await,
+        Err(ResolveError::NotFound)
+    );
+}
+
+/// Cancelling by owner (request) id removes only that owner's tickets.
+pub async fn cancel_request_removes_only_matching(instance: &Arc<dyn ApprovalStore>) {
+    let cancel = make_parked("req-cancel", Duration::from_secs(60));
+    let keep = make_parked("req-keep", Duration::from_secs(60));
+    let cancel_id = cancel.request.decision_id;
+    let keep_id = keep.request.decision_id;
+    instance.register(cancel).await.unwrap();
+    instance.register(keep).await.unwrap();
+
+    instance.cancel_request("req-cancel").await.unwrap();
+
+    assert!(instance.get(&cancel_id).await.unwrap().is_none());
+    assert!(instance.get(&keep_id).await.unwrap().is_some());
+}

--- a/crates/aura-web-server/tests/file_session_store_test.rs
+++ b/crates/aura-web-server/tests/file_session_store_test.rs
@@ -1,0 +1,421 @@
+//! Conformance and contract tests for the file-backed approval store
+//! (`AURA_SESSION_STORE=file`): the shared backend-agnostic battery plus the
+//! §2.5 contract points specific to durable, retention-until-remove storage —
+//! expiry refusal, retention past the decision, the ticket's move into the
+//! decision file, owner-scoped cancel of undecided tickets, and survival of a
+//! process restart. The same battery runs against the memory backend to pin
+//! the uniform contract. No Docker: every test gets its own tempdir.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use aura::hitl::{ApprovalDecision, ResolveError};
+use aura::session_store::{
+    ApprovalStore, FileApprovalStore, InMemoryApprovalStore, ParkedApprovalRecord,
+    SessionStoreError,
+};
+
+use common::make_parked;
+
+/// Two handles to one file store at `dir`'s root: the single-writing-process
+/// deployment shape.
+fn file_pair(dir: &tempfile::TempDir) -> (Arc<dyn ApprovalStore>, Arc<dyn ApprovalStore>) {
+    let store: Arc<dyn ApprovalStore> = Arc::new(FileApprovalStore::open(dir.path()).unwrap());
+    (Arc::clone(&store), store)
+}
+
+/// Two handles to one in-memory store: the same shape for the default
+/// backend.
+fn memory_pair() -> (Arc<dyn ApprovalStore>, Arc<dyn ApprovalStore>) {
+    let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+    (Arc::clone(&store), store)
+}
+
+// ---------------------------------------------------------------------------
+// Shared battery vs the file backend
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn file_battery_register_get_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let (instance_a, instance_b) = file_pair(&dir);
+    common::register_get_roundtrip(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn file_battery_resolve_is_at_most_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let (instance_a, instance_b) = file_pair(&dir);
+    common::resolve_is_at_most_once(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn file_battery_concurrent_resolves_have_exactly_one_winner() {
+    let dir = tempfile::tempdir().unwrap();
+    let (instance_a, instance_b) = file_pair(&dir);
+    common::concurrent_resolves_have_exactly_one_winner(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn file_battery_resolve_records_readable_decision() {
+    let dir = tempfile::tempdir().unwrap();
+    let (instance_a, instance_b) = file_pair(&dir);
+    common::resolve_records_readable_decision(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn file_battery_remove_makes_resolve_not_found() {
+    let dir = tempfile::tempdir().unwrap();
+    let (instance_a, _) = file_pair(&dir);
+    common::remove_makes_resolve_not_found(&instance_a).await;
+}
+
+#[tokio::test]
+async fn file_battery_cancel_request_removes_only_matching() {
+    let dir = tempfile::tempdir().unwrap();
+    let (instance_a, _) = file_pair(&dir);
+    common::cancel_request_removes_only_matching(&instance_a).await;
+}
+
+// ---------------------------------------------------------------------------
+// Shared battery vs the memory backend (uniform contract, no Docker)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn memory_battery_register_get_roundtrip() {
+    let (instance_a, instance_b) = memory_pair();
+    common::register_get_roundtrip(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn memory_battery_resolve_is_at_most_once() {
+    let (instance_a, instance_b) = memory_pair();
+    common::resolve_is_at_most_once(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn memory_battery_concurrent_resolves_have_exactly_one_winner() {
+    let (instance_a, instance_b) = memory_pair();
+    common::concurrent_resolves_have_exactly_one_winner(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn memory_battery_resolve_records_readable_decision() {
+    let (instance_a, instance_b) = memory_pair();
+    common::resolve_records_readable_decision(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn memory_battery_remove_makes_resolve_not_found() {
+    let (instance_a, _) = memory_pair();
+    common::remove_makes_resolve_not_found(&instance_a).await;
+}
+
+#[tokio::test]
+async fn memory_battery_cancel_request_removes_only_matching() {
+    let (instance_a, _) = memory_pair();
+    common::cancel_request_removes_only_matching(&instance_a).await;
+}
+
+// ---------------------------------------------------------------------------
+// §2.5 contract: layout, expiry, retention, the move, owner-scoped cancel
+// ---------------------------------------------------------------------------
+
+/// The constructor creates the layout's two directories.
+#[test]
+fn open_creates_the_ticket_and_decision_directories() {
+    let dir = tempfile::tempdir().unwrap();
+    FileApprovalStore::open(dir.path()).unwrap();
+    assert!(dir.path().join("tickets").is_dir());
+    assert!(dir.path().join("decisions").is_dir());
+}
+
+/// §2.5: `resolve` refuses past the ticket's `expires_at`, uniformly with an
+/// unknown id; nothing is decided, and the expired ticket stays readable
+/// through `get` until `remove`.
+#[tokio::test]
+async fn expired_resolve_is_not_found_and_ticket_is_retained() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let mut parked = make_parked("req-expired", Duration::from_secs(60));
+    parked.expires_at = chrono::Utc::now() - chrono::Duration::seconds(1);
+    let id = parked.request.decision_id;
+    store.register(parked).await.unwrap();
+
+    assert_eq!(
+        store.resolve(&id, ApprovalDecision::Approved).await,
+        Err(ResolveError::NotFound)
+    );
+    assert_eq!(store.decision(&id).await.unwrap(), None);
+    let restored = store
+        .get(&id)
+        .await
+        .unwrap()
+        .expect("expired ticket retained until remove");
+    assert_eq!(restored.request.decision_id, id);
+}
+
+/// §2.5: retention is until remove — `get` returns the ticket before and
+/// after the decision, `decision` returns the record, and only `remove`
+/// clears both.
+#[tokio::test]
+async fn ticket_and_decision_are_retained_until_remove() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let parked = make_parked("req-retain", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    let expected = ParkedApprovalRecord::from(&parked);
+    store.register(parked).await.unwrap();
+
+    assert_eq!(
+        ParkedApprovalRecord::from(&store.get(&id).await.unwrap().unwrap()),
+        expected
+    );
+
+    store
+        .resolve(&id, ApprovalDecision::Approved)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        ParkedApprovalRecord::from(
+            &store
+                .get(&id)
+                .await
+                .unwrap()
+                .expect("ticket survives its decision")
+        ),
+        expected
+    );
+    assert_eq!(
+        store.decision(&id).await.unwrap(),
+        Some(ApprovalDecision::Approved)
+    );
+
+    store.remove(&id).await.unwrap();
+    assert!(store.get(&id).await.unwrap().is_none());
+    assert_eq!(store.decision(&id).await.unwrap(), None);
+    assert_eq!(
+        store.resolve(&id, ApprovalDecision::Approved).await,
+        Err(ResolveError::NotFound)
+    );
+}
+
+/// §2.5: `resolve` moves the ticket into the decision file rather than
+/// deleting it — on disk the ticket file is gone and the decision file
+/// carries both the ticket record and the decision.
+#[tokio::test]
+async fn resolve_moves_the_ticket_into_the_decision_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let parked = make_parked("req-move", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    store.register(parked).await.unwrap();
+
+    store
+        .resolve(&id, ApprovalDecision::Approved)
+        .await
+        .unwrap();
+
+    assert!(
+        !dir.path()
+            .join("tickets")
+            .join(format!("{id}.json"))
+            .exists()
+    );
+    let decision_path = dir.path().join("decisions").join(format!("{id}.json"));
+    let on_disk: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(decision_path).unwrap()).unwrap();
+    assert_eq!(on_disk["ticket"]["decision_id"], id.to_string());
+    assert_eq!(on_disk["ticket"]["request_id"], "req-move");
+    assert_eq!(on_disk["decision"]["approved"], true);
+    assert_eq!(on_disk["decision"]["reason"], serde_json::Value::Null);
+}
+
+/// §2.5: `cancel_request` removes undecided tickets by owner id; a decided
+/// ticket of the same owner and an undecided ticket of another owner survive.
+#[tokio::test]
+async fn cancel_request_removes_only_undecided_matching_tickets() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let undecided = make_parked("req-owner", Duration::from_secs(60));
+    let undecided_id = undecided.request.decision_id;
+    store.register(undecided).await.unwrap();
+    let decided = make_parked("req-owner", Duration::from_secs(60));
+    let decided_id = decided.request.decision_id;
+    store.register(decided).await.unwrap();
+    store
+        .resolve(&decided_id, ApprovalDecision::Approved)
+        .await
+        .unwrap();
+    let other = make_parked("req-other", Duration::from_secs(60));
+    let other_id = other.request.decision_id;
+    store.register(other).await.unwrap();
+
+    store.cancel_request("req-owner").await.unwrap();
+
+    assert!(store.get(&undecided_id).await.unwrap().is_none());
+    assert!(
+        store.get(&decided_id).await.unwrap().is_some(),
+        "decided ticket is retained until remove"
+    );
+    assert_eq!(
+        store.decision(&decided_id).await.unwrap(),
+        Some(ApprovalDecision::Approved)
+    );
+    assert!(store.get(&other_id).await.unwrap().is_some());
+}
+
+/// A read-only `tickets/` directory must not fail `resolve`: the decision
+/// write and its sync are the commit, and the ticket removal past them is
+/// best-effort — the stale ticket remains, `get` still returns the record,
+/// and the claim still holds against a repeat resolve.
+#[cfg(unix)]
+#[tokio::test]
+async fn resolve_succeeds_when_the_ticket_file_cannot_be_removed() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let parked = make_parked("req-readonly", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    store.register(parked).await.unwrap();
+
+    let tickets = dir.path().join("tickets");
+    std::fs::set_permissions(&tickets, std::fs::Permissions::from_mode(0o500)).unwrap();
+    let _restore = Restore(&tickets);
+
+    // Root bypasses directory permission bits; the fault this test pins
+    // cannot be established there, so skip rather than pass vacuously.
+    let probe = tickets.join(".write-probe");
+    if std::fs::write(&probe, b"x").is_ok() {
+        let _ = std::fs::remove_file(&probe);
+        eprintln!("skipping: process bypasses directory permissions (running as root?)");
+        return;
+    }
+
+    store
+        .resolve(&id, ApprovalDecision::Approved)
+        .await
+        .expect("resolve commits without the ticket removal");
+    assert_eq!(
+        store.decision(&id).await.unwrap(),
+        Some(ApprovalDecision::Approved)
+    );
+    let restored = store
+        .get(&id)
+        .await
+        .unwrap()
+        .expect("ticket record survives the failed removal");
+    assert_eq!(restored.request.decision_id, id);
+    assert_eq!(
+        store.resolve(&id, ApprovalDecision::Approved).await,
+        Err(ResolveError::NotFound)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Restart durability
+// ---------------------------------------------------------------------------
+
+/// The durability boundary is a process restart: a store reopened at the
+/// same path resolves and reads back what the previous instance parked.
+#[tokio::test]
+async fn state_survives_reopening_the_store() {
+    let dir = tempfile::tempdir().unwrap();
+    let id = {
+        let store = FileApprovalStore::open(dir.path()).unwrap();
+        let parked = make_parked("req-restart", Duration::from_secs(60));
+        let id = parked.request.decision_id;
+        store.register(parked).await.unwrap();
+        id
+    };
+
+    let reopened = FileApprovalStore::open(dir.path()).unwrap();
+    reopened
+        .resolve(&id, ApprovalDecision::Approved)
+        .await
+        .expect("resolve after reopen");
+    assert_eq!(
+        reopened.decision(&id).await.unwrap(),
+        Some(ApprovalDecision::Approved)
+    );
+}
+
+/// Restore write permission on drop, so a failed assertion cannot leave
+/// the tempdir undeletable.
+#[cfg(unix)]
+struct Restore<'a>(&'a std::path::Path);
+#[cfg(unix)]
+impl Drop for Restore<'_> {
+    fn drop(&mut self) {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(self.0, std::fs::Permissions::from_mode(0o755));
+    }
+}
+
+/// A read-only store directory must fail `open`, not the first approval:
+/// readiness keys on construction and ping, so an unwritable path rejects
+/// the server at startup.
+#[cfg(unix)]
+#[tokio::test]
+async fn open_fails_when_a_store_directory_is_not_writable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    drop(FileApprovalStore::open(dir.path()).unwrap());
+    let tickets = dir.path().join("tickets");
+    std::fs::set_permissions(&tickets, std::fs::Permissions::from_mode(0o500)).unwrap();
+    let _restore = Restore(&tickets);
+
+    let probe = tickets.join(".write-probe");
+    if std::fs::write(&probe, b"x").is_ok() {
+        let _ = std::fs::remove_file(&probe);
+        eprintln!("skipping: process bypasses directory permissions (running as root?)");
+        return;
+    }
+
+    let err = match FileApprovalStore::open(dir.path()) {
+        Ok(_) => panic!("open must refuse an unwritable store directory"),
+        Err(err) => err,
+    };
+    assert!(
+        matches!(err, SessionStoreError::Connect { .. }),
+        "expected Connect, got {err:?}"
+    );
+}
+
+/// Ping is the file backend's readiness signal: it must report an
+/// unwritable directory, and recover when writability returns.
+#[cfg(unix)]
+#[tokio::test]
+async fn ping_reports_an_unwritable_store_directory() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    store.probe_writable().await.expect("healthy store pings");
+
+    let tickets = dir.path().join("tickets");
+    std::fs::set_permissions(&tickets, std::fs::Permissions::from_mode(0o500)).unwrap();
+    let _restore = Restore(&tickets);
+
+    let probe = tickets.join(".write-probe");
+    if std::fs::write(&probe, b"x").is_ok() {
+        let _ = std::fs::remove_file(&probe);
+        eprintln!("skipping: process bypasses directory permissions (running as root?)");
+        return;
+    }
+
+    store
+        .probe_writable()
+        .await
+        .expect_err("ping must report the unwritable directory");
+    drop(store);
+
+    std::fs::set_permissions(&tickets, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let restored = FileApprovalStore::open(dir.path()).unwrap();
+    restored.probe_writable().await.expect("ping recovers");
+}

--- a/crates/aura-web-server/tests/file_session_store_test.rs
+++ b/crates/aura-web-server/tests/file_session_store_test.rs
@@ -387,8 +387,9 @@ async fn open_fails_when_a_store_directory_is_not_writable() {
     );
 }
 
-/// Ping is the file backend's readiness signal: it must report an
-/// unwritable directory, and recover when writability returns.
+/// Ping is the file backend's readiness signal: it must report either
+/// store directory becoming unwritable, and recover when writability
+/// returns.
 #[cfg(unix)]
 #[tokio::test]
 async fn ping_reports_an_unwritable_store_directory() {
@@ -398,24 +399,23 @@ async fn ping_reports_an_unwritable_store_directory() {
     let store = FileApprovalStore::open(dir.path()).unwrap();
     store.probe_writable().await.expect("healthy store pings");
 
-    let tickets = dir.path().join("tickets");
-    std::fs::set_permissions(&tickets, std::fs::Permissions::from_mode(0o500)).unwrap();
-    let _restore = Restore(&tickets);
+    for name in ["tickets", "decisions"] {
+        let locked = dir.path().join(name);
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o500)).unwrap();
+        let restore = Restore(&locked);
 
-    let probe = tickets.join(".write-probe");
-    if std::fs::write(&probe, b"x").is_ok() {
-        let _ = std::fs::remove_file(&probe);
-        eprintln!("skipping: process bypasses directory permissions (running as root?)");
-        return;
+        let probe = locked.join(".write-probe");
+        if std::fs::write(&probe, b"x").is_ok() {
+            let _ = std::fs::remove_file(&probe);
+            eprintln!("skipping: process bypasses directory permissions (running as root?)");
+            return;
+        }
+
+        store
+            .probe_writable()
+            .await
+            .expect_err("ping must report the unwritable directory");
+        drop(restore);
+        store.probe_writable().await.expect("ping recovers");
     }
-
-    store
-        .probe_writable()
-        .await
-        .expect_err("ping must report the unwritable directory");
-    drop(store);
-
-    std::fs::set_permissions(&tickets, std::fs::Permissions::from_mode(0o755)).unwrap();
-    let restored = FileApprovalStore::open(dir.path()).unwrap();
-    restored.probe_writable().await.expect("ping recovers");
 }

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -14,19 +14,19 @@
 //! Each test namespaces its keys under a unique prefix with a short TTL, so
 //! tests neither collide nor leave state behind.
 
+mod common;
+
 use std::time::Duration;
 
 use a2a::{ListTasksRequest, Message, Part, Role, Task, TaskState, TaskStatus};
-use aura::hitl::{
-    AgentScope, ApprovalDecision, ApprovalItem, ApprovalOrigin, ApprovalOutcome, ApprovalRequest,
-    DecisionId, PROTOCOL_VERSION, ParkedApproval, PendingApprovals, ResolveError,
-};
+use aura::hitl::{ApprovalDecision, ApprovalOutcome, PendingApprovals, ResolveError};
 use aura::request_cancellation::RequestCancelToken;
-use aura::session_store::ParkedApprovalRecord;
 use aura_config::{RedisSessionStoreConfig, SessionStoreBackend};
 use aura_web_server::session_store::{RedisSessionStore, SessionStore};
 use bytes::Bytes;
 use futures_util::StreamExt;
+
+use common::make_parked;
 
 fn redis_url() -> String {
     std::env::var("AURA_TEST_REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string())
@@ -333,46 +333,15 @@ async fn expired_task_is_gone_and_pruned_from_list() {
 // HITL approval store
 // ---------------------------------------------------------------------------
 
-fn make_parked(request_id: &str, ttl: Duration) -> ParkedApproval {
-    let now = chrono::Utc::now();
-    ParkedApproval {
-        request: ApprovalRequest {
-            version: PROTOCOL_VERSION,
-            decision_id: DecisionId::generate(),
-            request_id: request_id.to_string(),
-            scope: AgentScope::Single { session_id: None },
-            origin: ApprovalOrigin::ConfigGate {
-                matched_pattern: "kubectl_*".to_string(),
-                agent_name: "test-agent".to_string(),
-            },
-            items: vec![ApprovalItem {
-                tool_name: "kubectl_delete".to_string(),
-                arguments: serde_json::json!({"pod": "web-1"}),
-                tool_call_intent: Some("restarting to pick up the config change".to_string()),
-            }],
-        },
-        registered_at: now,
-        expires_at: now + chrono::Duration::from_std(ttl).unwrap(),
-    }
-}
+// The backend-agnostic battery lives in `tests/common`; each test below
+// wires it to two live Redis connections.
 
 #[tokio::test]
 async fn approval_register_get_roundtrip_preserves_record() {
     let config = test_config(60);
     let instance_a = connect(&config).await.approvals();
     let instance_b = connect(&config).await.approvals();
-
-    let parked = make_parked("req-1", Duration::from_secs(60));
-    let id = parked.request.decision_id;
-    let expected = ParkedApprovalRecord::from(&parked);
-    instance_a.register(parked).await.unwrap();
-
-    let restored = instance_b
-        .get(&id)
-        .await
-        .unwrap()
-        .expect("instance B sees approval");
-    assert_eq!(ParkedApprovalRecord::from(&restored), expected);
+    common::register_get_roundtrip(&instance_a, &instance_b).await;
 }
 
 #[tokio::test]
@@ -380,20 +349,25 @@ async fn approval_resolve_is_at_most_once_across_instances() {
     let config = test_config(60);
     let instance_a = connect(&config).await.approvals();
     let instance_b = connect(&config).await.approvals();
+    common::resolve_is_at_most_once(&instance_a, &instance_b).await;
+}
 
-    let parked = make_parked("req-2", Duration::from_secs(60));
+/// Redis-specific: the consumed ticket is gone from the store. The file
+/// backend instead moves the ticket into the decision file and retains it
+/// until `remove` (§2.5).
+#[tokio::test]
+async fn approval_resolve_removes_the_parked_record() {
+    let approvals = connect(&test_config(60)).await.approvals();
+    let parked = make_parked("req-consumed", Duration::from_secs(60));
     let id = parked.request.decision_id;
-    instance_a.register(parked).await.unwrap();
+    approvals.register(parked).await.unwrap();
 
-    instance_b
+    approvals
         .resolve(&id, ApprovalDecision::Approved)
         .await
-        .expect("first resolve wins");
-    assert_eq!(
-        instance_a.resolve(&id, ApprovalDecision::Approved).await,
-        Err(ResolveError::NotFound)
-    );
-    assert!(instance_a.get(&id).await.unwrap().is_none());
+        .unwrap();
+
+    assert!(approvals.get(&id).await.unwrap().is_none());
 }
 
 #[tokio::test]
@@ -401,20 +375,7 @@ async fn approval_concurrent_resolves_have_exactly_one_winner() {
     let config = test_config(60);
     let instance_a = connect(&config).await.approvals();
     let instance_b = connect(&config).await.approvals();
-
-    let parked = make_parked("req-3", Duration::from_secs(60));
-    let id = parked.request.decision_id;
-    instance_a.register(parked).await.unwrap();
-
-    let (a, b) = tokio::join!(
-        instance_a.resolve(&id, ApprovalDecision::Approved),
-        instance_b.resolve(&id, ApprovalDecision::Approved),
-    );
-    assert_eq!(
-        [a.is_ok(), b.is_ok()].iter().filter(|ok| **ok).count(),
-        1,
-        "exactly one resolver must win: {a:?} / {b:?}"
-    );
+    common::concurrent_resolves_have_exactly_one_winner(&instance_a, &instance_b).await;
 }
 
 /// A resolution leaves a durable decision record readable from any instance (issue #474).
@@ -423,29 +384,7 @@ async fn approval_resolve_records_decision_readable_cross_instance() {
     let config = test_config(60);
     let instance_a = connect(&config).await.approvals();
     let instance_b = connect(&config).await.approvals();
-
-    let parked = make_parked("req-durable", Duration::from_secs(60));
-    let id = parked.request.decision_id;
-    instance_a.register(parked).await.unwrap();
-
-    let denied = ApprovalDecision::Denied {
-        reason: Some("not now".to_string()),
-    };
-    instance_b.resolve(&id, denied.clone()).await.unwrap();
-
-    assert_eq!(
-        instance_a.decision(&id).await.unwrap(),
-        Some(denied.clone())
-    );
-    assert_eq!(
-        instance_a.resolve(&id, ApprovalDecision::Approved).await,
-        Err(ResolveError::NotFound)
-    );
-    assert_eq!(instance_a.decision(&id).await.unwrap(), Some(denied));
-    assert_eq!(
-        instance_a.decision(&DecisionId::generate()).await.unwrap(),
-        None
-    );
+    common::resolve_records_readable_decision(&instance_a, &instance_b).await;
 }
 
 /// The decision record's TTL keeps a margin past the parked record's.
@@ -471,32 +410,13 @@ async fn decision_record_outlives_parked_record_ttl() {
 #[tokio::test]
 async fn approval_remove_makes_resolve_not_found() {
     let approvals = connect(&test_config(60)).await.approvals();
-    let parked = make_parked("req-4", Duration::from_secs(60));
-    let id = parked.request.decision_id;
-    approvals.register(parked).await.unwrap();
-
-    approvals.remove(&id).await.unwrap();
-
-    assert_eq!(
-        approvals.resolve(&id, ApprovalDecision::Approved).await,
-        Err(ResolveError::NotFound)
-    );
+    common::remove_makes_resolve_not_found(&approvals).await;
 }
 
 #[tokio::test]
 async fn approval_cancel_request_removes_only_matching() {
     let approvals = connect(&test_config(60)).await.approvals();
-    let cancel = make_parked("req-cancel", Duration::from_secs(60));
-    let keep = make_parked("req-keep", Duration::from_secs(60));
-    let cancel_id = cancel.request.decision_id;
-    let keep_id = keep.request.decision_id;
-    approvals.register(cancel).await.unwrap();
-    approvals.register(keep).await.unwrap();
-
-    approvals.cancel_request("req-cancel").await.unwrap();
-
-    assert!(approvals.get(&cancel_id).await.unwrap().is_none());
-    assert!(approvals.get(&keep_id).await.unwrap().is_some());
+    common::cancel_request_removes_only_matching(&approvals).await;
 }
 
 #[tokio::test]

--- a/crates/aura/src/session_store/file.rs
+++ b/crates/aura/src/session_store/file.rs
@@ -77,10 +77,9 @@ struct Inner {
 }
 
 impl FileApprovalStore {
-    /// Open (or initialize) the store rooted at `root`, creating its
-    /// directories and probing the ticket directory for writes. Fails
-    /// fast: a store that cannot hold files must fail at startup, not on
-    /// the first approval.
+    /// Open (or initialize) the store rooted at `root`, creating both
+    /// directories and probing them for writes. Fails fast: a store that
+    /// cannot hold files must fail at startup, not on the first approval.
     pub fn open(root: impl AsRef<Path>) -> Result<Self, SessionStoreError> {
         let root = root.as_ref();
         fs::create_dir_all(root.join(TICKETS_DIR)).map_err(connect_err)?;
@@ -123,17 +122,18 @@ impl Inner {
         self.lock.lock().expect("file approval store lock poisoned")
     }
 
-    /// Create and unlink an empty probe file in the ticket directory, where
-    /// the first write of any approval lands. This catches permission and
-    /// mount faults, not a full disk.
+    /// Create and unlink an empty probe file in each store directory. This
+    /// catches permission and mount faults, not a full disk.
     fn probe_writable_sync(&self) -> io::Result<()> {
-        let dir = self.tickets_dir();
-        let probe = dir.join(format!(".{}.probe", uuid::Uuid::new_v4()));
-        fs::write(&probe, b"")
-            .and_then(|()| fs::remove_file(&probe))
-            .map_err(|err| {
-                io::Error::new(err.kind(), format!("{} not writable: {err}", dir.display()))
-            })
+        for dir in [self.tickets_dir(), self.decisions_dir()] {
+            let probe = dir.join(format!(".{}.probe", uuid::Uuid::new_v4()));
+            fs::write(&probe, b"")
+                .and_then(|()| fs::remove_file(&probe))
+                .map_err(|err| {
+                    io::Error::new(err.kind(), format!("{} not writable: {err}", dir.display()))
+                })?;
+        }
+        Ok(())
     }
 
     fn register_sync(&self, parked: ParkedApproval) -> Result<(), SessionStoreError> {

--- a/crates/aura/src/session_store/file.rs
+++ b/crates/aura/src/session_store/file.rs
@@ -1,0 +1,407 @@
+//! File-backed HITL approval store: one JSON file per decision id.
+//! Tickets survive process restart on a single host.
+//!
+//! Layout:
+//!
+//! | Path                                 | Content                                                    |
+//! | ----------------------------------- | ---------------------------------------------------------- |
+//! | `{root}/tickets/{decision_id}.json`   | `ParkedApprovalRecord` (the undecided ticket)              |
+//! | `{root}/decisions/{decision_id}.json` | the resolved envelope: the ticket record plus the decision |
+//!
+//! Store contract (park/reify §2.5):
+//!
+//! - `resolve` refuses past the ticket's `expires_at`, uniformly with an
+//!   unknown id; expiry is enforced only by `resolve`.
+//! - `resolve` *moves* the ticket into the decision file rather than deleting
+//!   it: `get` returns the ticket before and after the decision, `decision`
+//!   returns the recorded decision, and both are retained until `remove`.
+//! - At-most-once `resolve` is the `File::create_new` claim on the decision
+//!   file: `AlreadyExists` reads as `NotFound`.
+//! - `cancel_request` removes undecided tickets by owner (request) id;
+//!   decided entries are retained until their consumer removes them.
+//!
+//! Decision ids are validated as UUIDs before path building, so none address
+//! outside the root.
+//! Temp-file plus rename prevents partial files after crashes. A `std::sync::Mutex`
+//! serializes operations for the single writing process; no operation awaits
+//! while holding it.
+//!
+//! Store operations run on the blocking pool. Join failures map to store
+//! errors—a panicked op is a store fault, not a crash. Blocking work is not
+//! cancelled when the requester is dropped: a dropped poll still completes
+//! resolve's claim-write-move.
+//!
+//! Crash window: claim-then-write leaves an empty file if process dies
+//! mid-resolve. The aftermath fails closed; `decision` reports decode
+//! fault, `get` returns ticket. Recovery is deleting the empty file.
+//! `decision()` consumers treat `Err(Decode)` on a known id as this
+//! recoverable state, not as an unknown id.
+
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio::task::{JoinError, spawn_blocking};
+
+use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
+
+use super::{ApprovalStore, DecisionRecord, ParkedApprovalRecord, SessionStoreError};
+
+/// Undecided tickets, one `{decision_id}.json` file per ticket.
+const TICKETS_DIR: &str = "tickets";
+/// Recorded decisions, one `{decision_id}.json` file per decision.
+const DECISIONS_DIR: &str = "decisions";
+
+/// The on-disk shape of a resolved approval: the ticket record carried over
+/// from `tickets/` plus the recorded decision. Field names are a persisted
+/// contract shared by every instance reading the store — rename only with a
+/// migration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ResolvedEntry {
+    ticket: ParkedApprovalRecord,
+    decision: DecisionRecord,
+}
+
+/// A file-backed [`ApprovalStore`] over one root directory.
+pub struct FileApprovalStore {
+    inner: Arc<Inner>,
+}
+
+/// The shared store state: root directory and operation lock.
+struct Inner {
+    root: PathBuf,
+    lock: Mutex<()>,
+}
+
+impl FileApprovalStore {
+    /// Open (or initialize) the store rooted at `root`, creating its
+    /// directories and probing the ticket directory for writes. Fails
+    /// fast: a store that cannot hold files must fail at startup, not on
+    /// the first approval.
+    pub fn open(root: impl AsRef<Path>) -> Result<Self, SessionStoreError> {
+        let root = root.as_ref();
+        fs::create_dir_all(root.join(TICKETS_DIR)).map_err(connect_err)?;
+        fs::create_dir_all(root.join(DECISIONS_DIR)).map_err(connect_err)?;
+        let inner = Arc::new(Inner {
+            root: root.to_path_buf(),
+            lock: Mutex::new(()),
+        });
+        inner.probe_writable_sync().map_err(connect_err)?;
+        Ok(Self { inner })
+    }
+
+    /// Re-run the writability probe off the executor thread.
+    pub async fn probe_writable(&self) -> Result<(), SessionStoreError> {
+        let inner = Arc::clone(&self.inner);
+        spawn_blocking(move || inner.probe_writable_sync().map_err(request_err))
+            .await
+            .map_err(join_err)?
+    }
+}
+
+impl Inner {
+    fn tickets_dir(&self) -> PathBuf {
+        self.root.join(TICKETS_DIR)
+    }
+
+    fn decisions_dir(&self) -> PathBuf {
+        self.root.join(DECISIONS_DIR)
+    }
+
+    fn ticket_path(&self, id: &str) -> PathBuf {
+        self.tickets_dir().join(format!("{id}.json"))
+    }
+
+    fn decision_path(&self, id: &str) -> PathBuf {
+        self.decisions_dir().join(format!("{id}.json"))
+    }
+
+    fn lock(&self) -> MutexGuard<'_, ()> {
+        self.lock.lock().expect("file approval store lock poisoned")
+    }
+
+    /// Create and unlink an empty probe file in the ticket directory, where
+    /// the first write of any approval lands. This catches permission and
+    /// mount faults, not a full disk.
+    fn probe_writable_sync(&self) -> io::Result<()> {
+        let dir = self.tickets_dir();
+        let probe = dir.join(format!(".{}.probe", uuid::Uuid::new_v4()));
+        fs::write(&probe, b"")
+            .and_then(|()| fs::remove_file(&probe))
+            .map_err(|err| {
+                io::Error::new(err.kind(), format!("{} not writable: {err}", dir.display()))
+            })
+    }
+
+    fn register_sync(&self, parked: ParkedApproval) -> Result<(), SessionStoreError> {
+        let _guard = self.lock();
+        let id = canonical_id(&parked.request.decision_id)?;
+        let payload = serde_json::to_vec(&ParkedApprovalRecord::from(&parked))
+            .expect("approval record serializes to JSON");
+        publish(&self.ticket_path(&id), &payload)
+    }
+
+    fn get_sync(&self, id: &DecisionId) -> Result<Option<ParkedApproval>, SessionStoreError> {
+        let _guard = self.lock();
+        let id = canonical_id(id)?;
+        match fs::read(self.ticket_path(&id)) {
+            Ok(bytes) => return decode_ticket(&bytes).map(Some),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => return Err(request_err(err)),
+        }
+        match fs::read(self.decision_path(&id)) {
+            Ok(bytes) => {
+                let entry: ResolvedEntry = serde_json::from_slice(&bytes).map_err(decode_err)?;
+                restore_ticket(entry.ticket).map(Some)
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(request_err(err)),
+        }
+    }
+
+    fn resolve_sync(
+        &self,
+        id: &DecisionId,
+        decision: ApprovalDecision,
+    ) -> Result<(), ResolveError> {
+        let _guard = self.lock();
+        let id = canonical_id(id).map_err(ResolveError::Store)?;
+
+        // Read ticket before claiming avoids claiming unknown ids.
+        let record = match fs::read(self.ticket_path(&id)) {
+            Ok(bytes) => serde_json::from_slice::<ParkedApprovalRecord>(&bytes)
+                .map_err(|e| ResolveError::Store(decode_err(e)))?,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                // No ticket: unknown, resolved, or removed all return `NotFound`.
+                return Err(ResolveError::NotFound);
+            }
+            Err(err) => return Err(ResolveError::Store(request_err(err))),
+        };
+        if chrono::Utc::now() > record.expires_at {
+            return Err(ResolveError::NotFound);
+        }
+        let payload = serde_json::to_vec(&ResolvedEntry {
+            ticket: record,
+            decision: DecisionRecord::from(&decision),
+        })
+        .expect("resolved entry serializes to JSON");
+
+        let decision_path = self.decision_path(&id);
+        let mut file = match fs::File::create_new(&decision_path) {
+            Ok(file) => file,
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                return Err(ResolveError::NotFound);
+            }
+            Err(err) => return Err(ResolveError::Store(request_err(err))),
+        };
+        // Sync narrows the empty-file crash window but does not guarantee
+        // host-crash durability.
+        if let Err(err) = file.write_all(&payload).and_then(|()| file.sync_all()) {
+            // Undo claim so retry can take it.
+            let _ = fs::remove_file(&decision_path);
+            return Err(ResolveError::Store(request_err(err)));
+        }
+        // After sync commit, ticket removal is best-effort. Failure leaves
+        // a stale ticket; resolve succeeded.
+        match fs::remove_file(self.ticket_path(&id)) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => tracing::warn!(
+                decision_id = %id,
+                error = %err,
+                "stale ticket file remains after resolve; it is benign"
+            ),
+        }
+        Ok(())
+    }
+
+    fn decision_sync(
+        &self,
+        id: &DecisionId,
+    ) -> Result<Option<ApprovalDecision>, SessionStoreError> {
+        let _guard = self.lock();
+        let id = canonical_id(id)?;
+        match fs::read(self.decision_path(&id)) {
+            Ok(bytes) => {
+                let entry: ResolvedEntry = serde_json::from_slice(&bytes).map_err(decode_err)?;
+                Ok(Some(ApprovalDecision::from(entry.decision)))
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(request_err(err)),
+        }
+    }
+
+    fn remove_sync(&self, id: &DecisionId) -> Result<(), SessionStoreError> {
+        let _guard = self.lock();
+        let id = canonical_id(id)?;
+        // Remove both halves; missing halves are fine (idempotent).
+        for path in [self.ticket_path(&id), self.decision_path(&id)] {
+            if let Err(err) = fs::remove_file(&path)
+                && err.kind() != io::ErrorKind::NotFound
+            {
+                return Err(request_err(err));
+            }
+        }
+        Ok(())
+    }
+
+    fn cancel_request_sync(&self, request_id: &str) -> Result<(), SessionStoreError> {
+        let _guard = self.lock();
+        let entries = match fs::read_dir(self.tickets_dir()) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(request_err(err)),
+        };
+        for entry in entries {
+            let entry = entry.map_err(request_err)?;
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                // A mid-publish temp file, never a ticket.
+                continue;
+            }
+            let bytes = match fs::read(&path) {
+                Ok(bytes) => bytes,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(request_err(err)),
+            };
+            match serde_json::from_slice::<ParkedApprovalRecord>(&bytes) {
+                Ok(record) if record.request_id == request_id => {
+                    fs::remove_file(&path).map_err(request_err)?;
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    tracing::warn!(
+                        path = %path.display(), error = %err,
+                        "undecodable ticket file skipped by cancel_request"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ApprovalStore for FileApprovalStore {
+    async fn register(&self, parked: ParkedApproval) -> Result<(), SessionStoreError> {
+        let inner = Arc::clone(&self.inner);
+        spawn_blocking(move || inner.register_sync(parked))
+            .await
+            .map_err(join_err)?
+    }
+
+    async fn get(&self, id: &DecisionId) -> Result<Option<ParkedApproval>, SessionStoreError> {
+        let inner = Arc::clone(&self.inner);
+        let id = *id;
+        spawn_blocking(move || inner.get_sync(&id))
+            .await
+            .map_err(join_err)?
+    }
+
+    async fn resolve(
+        &self,
+        id: &DecisionId,
+        decision: ApprovalDecision,
+    ) -> Result<(), ResolveError> {
+        let inner = Arc::clone(&self.inner);
+        let id = *id;
+        spawn_blocking(move || inner.resolve_sync(&id, decision))
+            .await
+            .map_err(|err| ResolveError::Store(join_err(err)))?
+    }
+
+    async fn decision(
+        &self,
+        id: &DecisionId,
+    ) -> Result<Option<ApprovalDecision>, SessionStoreError> {
+        let inner = Arc::clone(&self.inner);
+        let id = *id;
+        spawn_blocking(move || inner.decision_sync(&id))
+            .await
+            .map_err(join_err)?
+    }
+
+    async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError> {
+        let inner = Arc::clone(&self.inner);
+        let id = *id;
+        spawn_blocking(move || inner.remove_sync(&id))
+            .await
+            .map_err(join_err)?
+    }
+
+    async fn cancel_request(&self, request_id: &str) -> Result<(), SessionStoreError> {
+        let inner = Arc::clone(&self.inner);
+        let request_id = request_id.to_owned();
+        spawn_blocking(move || inner.cancel_request_sync(&request_id))
+            .await
+            .map_err(join_err)?
+    }
+}
+
+/// Validate decision id as canonical UUID for path safety.
+fn canonical_id(id: &DecisionId) -> Result<String, SessionStoreError> {
+    let raw = id.to_string();
+    if uuid::Uuid::parse_str(&raw).is_ok_and(|parsed| parsed.to_string() == raw) {
+        Ok(raw)
+    } else {
+        Err(SessionStoreError::Request {
+            reason: format!("decision id '{raw}' is not in canonical UUID form"),
+        })
+    }
+}
+
+/// Write via temp-file plus rename: atomic within directory.
+fn publish(path: &Path, payload: &[u8]) -> Result<(), SessionStoreError> {
+    let dir = path.parent().expect("a store file always has a parent");
+    let name = path.file_name().expect("a store file is always named");
+    let tmp = dir.join(format!(
+        ".{}.{}.tmp",
+        name.to_string_lossy(),
+        uuid::Uuid::new_v4()
+    ));
+    let written = fs::write(&tmp, payload).and_then(|()| fs::rename(&tmp, path));
+    if let Err(err) = written {
+        let _ = fs::remove_file(&tmp);
+        return Err(request_err(err));
+    }
+    Ok(())
+}
+
+/// Decode stored ticket file.
+fn decode_ticket(bytes: &[u8]) -> Result<ParkedApproval, SessionStoreError> {
+    let record: ParkedApprovalRecord = serde_json::from_slice(bytes).map_err(decode_err)?;
+    restore_ticket(record)
+}
+
+/// Restore ticket record.
+fn restore_ticket(record: ParkedApprovalRecord) -> Result<ParkedApproval, SessionStoreError> {
+    ParkedApproval::try_from(record).map_err(decode_err)
+}
+
+fn connect_err(reason: impl std::fmt::Display) -> SessionStoreError {
+    SessionStoreError::Connect {
+        reason: reason.to_string(),
+    }
+}
+
+fn request_err(reason: impl std::fmt::Display) -> SessionStoreError {
+    SessionStoreError::Request {
+        reason: reason.to_string(),
+    }
+}
+
+fn decode_err(reason: impl std::fmt::Display) -> SessionStoreError {
+    SessionStoreError::Decode {
+        reason: reason.to_string(),
+    }
+}
+
+/// Join failure maps to store error.
+fn join_err(err: JoinError) -> SessionStoreError {
+    SessionStoreError::Request {
+        reason: format!("file store task failed: {err}"),
+    }
+}

--- a/crates/aura/src/session_store/memory.rs
+++ b/crates/aura/src/session_store/memory.rs
@@ -42,7 +42,7 @@ impl InMemoryApprovalStore {
         self.entries.lock().expect("approval store lock poisoned")
     }
 
-    /// Lock the decided map, dropping entries past their retention window.
+    /// Lock decided map, dropping expired entries.
     fn lock_decided(&self) -> std::sync::MutexGuard<'_, BTreeMap<DecisionId, DecidedEntry>> {
         let mut decided = self.decided.lock().expect("approval store lock poisoned");
         let now = chrono::Utc::now();
@@ -67,8 +67,18 @@ impl ApprovalStore for InMemoryApprovalStore {
         id: &DecisionId,
         decision: ApprovalDecision,
     ) -> Result<(), ResolveError> {
-        // Removal under the lock is the at-most-once guarantee.
-        let parked = self.lock().remove(id).ok_or(ResolveError::NotFound)?;
+        // Lock removal provides at-most-once.
+        let parked = {
+            let mut entries = self.lock();
+            if entries
+                .get(id)
+                .is_some_and(|parked| chrono::Utc::now() > parked.expires_at)
+            {
+                return Err(ResolveError::NotFound);
+            }
+            entries.remove(id)
+        };
+        let parked = parked.ok_or(ResolveError::NotFound)?;
         self.lock_decided().insert(
             *id,
             DecidedEntry {
@@ -251,21 +261,51 @@ mod tests {
         assert_eq!(store.decision(&DecisionId::generate()).await.unwrap(), None);
     }
 
+    /// Retention pruning drops entries past window.
     #[tokio::test]
     async fn recorded_decision_is_pruned_after_retention_window() {
         let store = InMemoryApprovalStore::new();
-        let mut entry = parked("req-prune");
-        // Retention margin is already past.
-        entry.expires_at =
-            chrono::Utc::now() - chrono::Duration::seconds(2 * DECISION_RETENTION_MARGIN_SECS);
-        let id = entry.request.decision_id;
-        store.register(entry).await.unwrap();
-        store
-            .resolve(&id, ApprovalDecision::Approved)
-            .await
-            .unwrap();
+        let id = parked("req-prune").request.decision_id;
+        store.lock_decided().insert(
+            id,
+            DecidedEntry {
+                decision: ApprovalDecision::Approved,
+                keep_until: chrono::Utc::now() - chrono::Duration::seconds(1),
+            },
+        );
 
         assert_eq!(store.decision(&id).await.unwrap(), None);
+    }
+
+    /// `resolve` refuses expired tickets.
+    #[tokio::test]
+    async fn expired_ticket_refuses_resolve() {
+        let store = InMemoryApprovalStore::new();
+        let mut entry = parked("req-expired");
+        entry.expires_at = chrono::Utc::now() - chrono::Duration::seconds(1);
+        let id = entry.request.decision_id;
+        store.register(entry).await.unwrap();
+
+        assert_eq!(
+            store.resolve(&id, ApprovalDecision::Approved).await,
+            Err(ResolveError::NotFound)
+        );
+        assert_eq!(store.decision(&id).await.unwrap(), None);
+        assert!(store.get(&id).await.unwrap().is_some());
+    }
+
+    /// `get` returns expired tickets.
+    #[tokio::test]
+    async fn expired_ticket_is_returned_by_get_until_remove() {
+        let store = InMemoryApprovalStore::new();
+        let mut entry = parked("req-expired-get");
+        entry.expires_at = chrono::Utc::now() - chrono::Duration::seconds(1);
+        let id = entry.request.decision_id;
+        store.register(entry).await.unwrap();
+
+        assert!(store.get(&id).await.unwrap().is_some());
+        store.remove(&id).await.unwrap();
+        assert!(store.get(&id).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/crates/aura/src/session_store/mod.rs
+++ b/crates/aura/src/session_store/mod.rs
@@ -1,13 +1,15 @@
 //! Pluggable cross-instance session-state capabilities: a durable store for parked
 //! HITL approvals and a pub/sub event bus.
 //!
-//! The in-memory implementations are the default; a networked backend (e.g.
-//! Redis/Valkey) implements the same traits to make a load-balanced multi-instance
-//! deployment behave like one process.
+//! The in-memory implementations are the default; a file-backed approval
+//! store survives a process restart on a single host, and a networked backend
+//! (e.g. Redis/Valkey) implements the same traits to make a load-balanced
+//! multi-instance deployment behave like one process.
 //!
 //! See `docs/design/session-storage.md` and
 //! `docs/adr/2026-07-08-session-storage.md`.
 
+mod file;
 mod memory;
 mod record;
 
@@ -20,6 +22,7 @@ use futures::Stream;
 
 use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
 
+pub use file::FileApprovalStore;
 pub use memory::{InMemoryApprovalStore, InMemoryEventBus};
 pub use record::{DecisionRecord, InvalidRecord, OriginRecord, ParkedApprovalRecord, ScopeRecord};
 
@@ -52,14 +55,16 @@ pub enum SessionStoreError {
 #[async_trait]
 pub trait ApprovalStore: Send + Sync {
     /// Persist a parked approval, keyed by its `DecisionId`. Backends with
-    /// native expiry should TTL the entry from `expires_at` so abandoned
-    /// approvals self-clean.
+    /// native expiry set the entry's TTL from `expires_at`; the file store
+    /// keeps it until `remove`.
     async fn register(&self, parked: ParkedApproval) -> Result<(), SessionStoreError>;
 
     /// Look up a parked approval.
     async fn get(&self, id: &DecisionId) -> Result<Option<ParkedApproval>, SessionStoreError>;
 
-    /// Record a terminal decision and remove the parked entry atomically.
+    /// Record a terminal decision at most once per id; later attempts read
+    /// as `NotFound`. The file backend moves the ticket into its decision
+    /// record, other backends drop it.
     async fn resolve(
         &self,
         id: &DecisionId,


### PR DESCRIPTION
## What

A file-backed `ApprovalStore` backend: one JSON file per decision id (`{root}/tickets/{id}.json`, `{root}/decisions/{id}.json`), reusing `ParkedApprovalRecord`/`DecisionRecord` as the on-disk shape. Selected by `AURA_SESSION_STORE=file` with a required `AURA_SESSION_STORE_PATH`; the A2A task store and event bus stay in memory (single-pod, single-writer model).

Supersedes #635, which targeted `main`; rebased onto `nightly` and carrying the maintainer review round (v2).

## Contract (what park mode keys on)

- `resolve` refuses past the ticket's `expires_at`, uniformly with an unknown id - enforced on BOTH the file and memory backends, so the contract holds on whichever is configured.
- `get` returns the ticket before and after the decision, and `decision` returns the recorded decision, both until `remove` (retention until removed, not a TTL margin).
- `resolve` moves the ticket into the decision file rather than deleting it; at-most-once via `File::create_new` on the decision file (`AlreadyExists` reads as `NotFound`).
- `cancel_request` removes undecided tickets by owner id; decision ids are validated as canonical UUIDs at every path-building site, so nothing escapes the store root.
- Ticket publication is temp-file + same-directory rename; the create_new-to-sync crash window is fail-closed and documented (module doc) with a one-file operator recovery.

## v2 fix round (Greptile review on #635)

- **Blocking pool:** every store operation now runs in `spawn_blocking` behind its async trait method (`Arc<Inner>` + inherent sync methods; the std mutex lives inside the task). Join failures map to store request errors callers already treat fail-closed; `tokio::fs` and an async mutex were considered and ruled out (one blocking hop per syscall; the compound read-claim-write would need a lock across awaits).
- **Commit point:** resolve's `write_all`+`sync_all` is the commit; a failed ticket removal past it logs a warning and returns success (the stale ticket is benign - `get` reads the identical record from either file, the claim still refuses a repeat resolve, `remove`/`cancel_request` clean up). Covered by a new read-only-tickets-directory test with a root-skip guard.
- **Comment pass:** behavior narration moved off data onto the implementing sites per the repo's comment conventions, and remaining verbose comments tightened to what earned its keep. On-disk shapes and the trait are unchanged.
