### PR TITLE
fix(cli): let /mcp add edit an agent loaded from a directory

### DIFF
--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -53,6 +53,8 @@ pub struct DirectBackend {
     extra_headers: HashMap<String, String>,
     /// Filesystem source of the loaded configs (file or directory).
     config_path: PathBuf,
+    /// Effective agent id and source file of each loaded config.
+    config_files: Vec<(String, PathBuf)>,
 }
 
 impl DirectBackend {
@@ -72,11 +74,15 @@ impl DirectBackend {
             ));
         }
 
-        let configs =
-            aura_config::load_config(config_path).context("Failed to load agent config")?;
-        if configs.is_empty() {
+        let loaded =
+            aura_config::load_config_files(config_path).context("Failed to load agent config")?;
+        if loaded.is_empty() {
             anyhow::bail!("No agent config found in {}", config_path.display());
         }
+        let (config_files, configs): (Vec<(String, PathBuf)>, Vec<aura_config::Config>) = loaded
+            .into_iter()
+            .map(|(file, config)| ((config.agent_id().to_owned(), file), config))
+            .unzip();
 
         // Load the HITL webhook HMAC once at startup; a misconfiguration
         // fails the CLI boot rather than the first approval request.
@@ -123,13 +129,34 @@ impl DirectBackend {
             app_state,
             extra_headers: headers_map,
             config_path: config_path.to_path_buf(),
+            config_files,
         })
     }
 
-    /// Path the agent configs were loaded from. May be a directory
-    /// (`load_config` accepts both) — writers must check `is_file()` first.
+    /// Path the agent configs were loaded from — a file or a directory.
+    /// Writers edit one agent's file: see [`Self::config_file_for`].
     pub fn config_path(&self) -> &Path {
         &self.config_path
+    }
+
+    /// Effective agent id and source file of every loaded config.
+    pub fn agent_config_files(&self) -> &[(String, PathBuf)] {
+        &self.config_files
+    }
+
+    /// The file a writer should edit: the only loaded agent's file, or the
+    /// file of the agent `selected` names (any spelling
+    /// [`Self::find_matching_model`] accepts). `None` when several agents
+    /// are loaded and `selected` picks none of them.
+    pub fn config_file_for(&self, selected: Option<&str>) -> Option<&Path> {
+        if let [(_, only)] = self.config_files.as_slice() {
+            return Some(only);
+        }
+        let id = self.find_matching_model(selected?)?;
+        self.config_files
+            .iter()
+            .find(|(agent, _)| *agent == id)
+            .map(|(_, file)| file.as_path())
     }
 
     /// Return `true` if any loaded config enables client-side tools.
@@ -493,12 +520,23 @@ mod tests {
             hitl_webhook_hmac: None,
             session_store: Arc::new(InMemorySessionStore::new()),
         });
+        // Synthetic: these configs were built in memory, not loaded from
+        // disk, so point at paths that cannot exist.
+        let config_files = app_state
+            .configs
+            .iter()
+            .map(|c| {
+                (
+                    c.agent_id().to_owned(),
+                    PathBuf::from(format!("/nonexistent/{}.toml", c.agent_id())),
+                )
+            })
+            .collect();
         DirectBackend {
             app_state,
             extra_headers: HashMap::new(),
-            // Synthetic: these configs were built in memory, not loaded
-            // from disk, so point at a path that cannot exist.
             config_path: PathBuf::from("/nonexistent/in-memory-test-config.toml"),
+            config_files,
         }
     }
 
@@ -630,6 +668,40 @@ preamble = "p"
     // -----------------------------------------------------------------------
     // model_ids
     // -----------------------------------------------------------------------
+
+    #[test]
+    fn config_file_for_single_config_ignores_selection() {
+        let backend = make_backend(vec![make_config("Only", None, "p")]);
+        let expected = Path::new("/nonexistent/Only.toml");
+        assert_eq!(backend.config_file_for(None), Some(expected));
+        assert_eq!(
+            backend.config_file_for(Some("something-else")),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn config_file_for_multiple_configs_needs_a_matching_selection() {
+        let backend = make_backend(vec![
+            make_config("Alpha", Some("a"), "p"),
+            make_config("Beta", None, "p"),
+        ]);
+        assert_eq!(backend.config_file_for(None), None);
+        assert_eq!(backend.config_file_for(Some("gamma")), None);
+        assert_eq!(
+            backend.config_file_for(Some("a")),
+            Some(Path::new("/nonexistent/a.toml"))
+        );
+        // Name and alias both resolve, case-insensitively, to the alias-keyed file.
+        assert_eq!(
+            backend.config_file_for(Some("ALPHA")),
+            Some(Path::new("/nonexistent/a.toml"))
+        );
+        assert_eq!(
+            backend.config_file_for(Some("beta")),
+            Some(Path::new("/nonexistent/Beta.toml"))
+        );
+    }
 
     #[test]
     fn model_ids_uses_alias_when_present() {

--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -53,8 +53,17 @@ pub struct DirectBackend {
     extra_headers: HashMap<String, String>,
     /// Filesystem source of the loaded configs (file or directory).
     config_path: PathBuf,
-    /// Effective agent id and source file of each loaded config.
-    config_files: Vec<(String, PathBuf)>,
+    agent_files: Vec<AgentFile>,
+}
+
+/// A loaded agent and the file that defines it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentFile {
+    /// Effective agent id (alias, else name).
+    pub id: String,
+    pub path: PathBuf,
+    /// `[agent].hidden`.
+    pub hidden: bool,
 }
 
 impl DirectBackend {
@@ -79,9 +88,16 @@ impl DirectBackend {
         if loaded.is_empty() {
             anyhow::bail!("No agent config found in {}", config_path.display());
         }
-        let (config_files, configs): (Vec<(String, PathBuf)>, Vec<aura_config::Config>) = loaded
+        let (agent_files, configs): (Vec<AgentFile>, Vec<aura_config::Config>) = loaded
             .into_iter()
-            .map(|(file, config)| ((config.agent_id().to_owned(), file), config))
+            .map(|(path, config)| {
+                let agent = AgentFile {
+                    id: config.agent_id().to_owned(),
+                    path,
+                    hidden: config.agent.hidden,
+                };
+                (agent, config)
+            })
             .unzip();
 
         // Load the HITL webhook HMAC once at startup; a misconfiguration
@@ -129,7 +145,7 @@ impl DirectBackend {
             app_state,
             extra_headers: headers_map,
             config_path: config_path.to_path_buf(),
-            config_files,
+            agent_files,
         })
     }
 
@@ -139,9 +155,9 @@ impl DirectBackend {
         &self.config_path
     }
 
-    /// Effective agent id and source file of every loaded config.
-    pub fn agent_config_files(&self) -> &[(String, PathBuf)] {
-        &self.config_files
+    /// Every loaded agent with the file that defines it, in load order.
+    pub fn agent_files(&self) -> &[AgentFile] {
+        &self.agent_files
     }
 
     /// The file a writer should edit: the only loaded agent's file, or the
@@ -149,14 +165,14 @@ impl DirectBackend {
     /// [`Self::find_matching_model`] accepts). `None` when several agents
     /// are loaded and `selected` picks none of them.
     pub fn config_file_for(&self, selected: Option<&str>) -> Option<&Path> {
-        if let [(_, only)] = self.config_files.as_slice() {
-            return Some(only);
+        if let [only] = self.agent_files.as_slice() {
+            return Some(&only.path);
         }
         let id = self.find_matching_model(selected?)?;
-        self.config_files
+        self.agent_files
             .iter()
-            .find(|(agent, _)| *agent == id)
-            .map(|(_, file)| file.as_path())
+            .find(|agent| agent.id == id)
+            .map(|agent| agent.path.as_path())
     }
 
     /// Return `true` if any loaded config enables client-side tools.
@@ -522,21 +538,20 @@ mod tests {
         });
         // Synthetic: these configs were built in memory, not loaded from
         // disk, so point at paths that cannot exist.
-        let config_files = app_state
+        let agent_files = app_state
             .configs
             .iter()
-            .map(|c| {
-                (
-                    c.agent_id().to_owned(),
-                    PathBuf::from(format!("/nonexistent/{}.toml", c.agent_id())),
-                )
+            .map(|c| AgentFile {
+                id: c.agent_id().to_owned(),
+                path: PathBuf::from(format!("/nonexistent/{}.toml", c.agent_id())),
+                hidden: c.agent.hidden,
             })
             .collect();
         DirectBackend {
             app_state,
             extra_headers: HashMap::new(),
             config_path: PathBuf::from("/nonexistent/in-memory-test-config.toml"),
-            config_files,
+            agent_files,
         }
     }
 
@@ -677,6 +692,24 @@ preamble = "p"
         assert_eq!(
             backend.config_file_for(Some("something-else")),
             Some(expected)
+        );
+    }
+
+    #[test]
+    fn agent_files_keep_hidden_agents_and_flag_them() {
+        let mut ghost = make_config("Ghost", None, "p");
+        ghost.agent.hidden = true;
+        let backend = make_backend(vec![make_config("Seen", None, "p"), ghost]);
+        let flags: Vec<(&str, bool)> = backend
+            .agent_files()
+            .iter()
+            .map(|agent| (agent.id.as_str(), agent.hidden))
+            .collect();
+        assert_eq!(flags, vec![("Seen", false), ("Ghost", true)]);
+        // Hidden agents stay reachable by explicit selection.
+        assert_eq!(
+            backend.config_file_for(Some("ghost")),
+            Some(Path::new("/nonexistent/Ghost.toml"))
         );
     }
 

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -15,8 +15,10 @@ use aura_config::config::McpServerConfig;
 
 use super::catalog::{CATALOG, CatalogEntry, Template};
 use crate::backend::Backend;
+use crate::backend::direct::DirectBackend;
 use crate::repl::registry::CommandContext;
 use crate::theme::{AuraStyle, Themed};
+use crate::ui::prompt::get_selected_model;
 
 /// How the wizard ended.
 enum WizardEnd {
@@ -33,25 +35,19 @@ pub(super) fn run(ctx: &mut CommandContext) {
     // The REPL loop hides the cursor around dispatch; this handler reads
     // input, so bring it back.
     let _ = crossterm::execute!(std::io::stdout(), crossterm::cursor::Show);
-    let Backend::Direct(direct) = ctx.backend else {
+    let backend = ctx.backend;
+    let Backend::Direct(direct) = backend else {
         println!(
             "/mcp add edits the local agent config, so it is only available in \
              standalone mode (run without --api-url)."
         );
         return;
     };
-    let config_path = direct.config_path().to_path_buf();
-    if !config_path.is_file() {
-        println!(
-            "The agent config was loaded from `{}`, which is not a single file. \
-             /mcp add can only edit a single-file config; add the server to one \
-             of the TOML files in that directory manually.",
-            config_path.display()
-        );
+    let Some(config_path) = target_file(ctx, direct) else {
         return;
-    }
+    };
 
-    match drive(ctx, &config_path) {
+    match drive(ctx, config_path) {
         WizardEnd::Written {
             name,
             starter_prompt,
@@ -81,6 +77,56 @@ pub(super) fn run(ctx: &mut CommandContext) {
         WizardEnd::Aborted => println!("\n/mcp add aborted — nothing was written."),
         WizardEnd::Failed(reason) => {
             println!("\n{} {reason}", "error:".themed(AuraStyle::Error));
+        }
+    }
+}
+
+/// The config file the server lands in. A lone agent, or a `/model`
+/// selection that names one, settles it without a question; otherwise the
+/// user picks the agent here. `None` ends the run — the reason is already
+/// printed.
+fn target_file<'d>(ctx: &mut CommandContext, direct: &'d DirectBackend) -> Option<&'d Path> {
+    let selected = get_selected_model();
+    if let Some(file) = direct.config_file_for(selected.as_deref()) {
+        return Some(file);
+    }
+    let files = direct.agent_config_files();
+    if files.is_empty() {
+        println!("No agent config is loaded — nothing to edit.");
+        return None;
+    }
+    if let Some(selected) = selected {
+        println!("The selected model `{selected}` does not match any loaded agent.");
+    }
+    println!(
+        "{}",
+        format!(
+            "Several agents are loaded from {} — which one gets the server?",
+            direct.config_path().display()
+        )
+        .themed(AuraStyle::Heading)
+    );
+    for (i, (agent, file)) in files.iter().enumerate() {
+        let file = file
+            .file_name()
+            .unwrap_or(file.as_os_str())
+            .to_string_lossy();
+        println!(
+            "  {} {} {} {}",
+            format!("{}.", i + 1).themed(AuraStyle::Muted),
+            agent.as_str().themed(AuraStyle::Heading),
+            "—".themed(AuraStyle::Muted),
+            file.themed(AuraStyle::Muted),
+        );
+    }
+    loop {
+        let Some(answer) = ask(ctx, &format!("Agent [1-{}]: ", files.len())) else {
+            println!("\n/mcp add aborted — nothing was written.");
+            return None;
+        };
+        match answer.parse::<usize>() {
+            Ok(n) if (1..=files.len()).contains(&n) => return Some(&files[n - 1].1),
+            _ => println!("Enter a number between 1 and {}.", files.len()),
         }
     }
 }

--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -83,17 +83,20 @@ pub(super) fn run(ctx: &mut CommandContext) {
 
 /// The config file the server lands in. A lone agent, or a `/model`
 /// selection that names one, settles it without a question; otherwise the
-/// user picks the agent here. `None` ends the run — the reason is already
-/// printed.
+/// user picks the agent here. `None` means the user aborted the pick.
 fn target_file<'d>(ctx: &mut CommandContext, direct: &'d DirectBackend) -> Option<&'d Path> {
     let selected = get_selected_model();
+    let matched = selected
+        .as_deref()
+        .and_then(|selected| direct.find_matching_model(selected));
     if let Some(file) = direct.config_file_for(selected.as_deref()) {
+        if let (Some(selected), None, [only]) = (&selected, &matched, direct.agent_files()) {
+            println!(
+                "`{selected}` matches no loaded agent; using the only one, `{}`.",
+                only.id
+            );
+        }
         return Some(file);
-    }
-    let files = direct.agent_config_files();
-    if files.is_empty() {
-        println!("No agent config is loaded — nothing to edit.");
-        return None;
     }
     if let Some(selected) = selected {
         println!("The selected model `{selected}` does not match any loaded agent.");
@@ -106,27 +109,33 @@ fn target_file<'d>(ctx: &mut CommandContext, direct: &'d DirectBackend) -> Optio
         )
         .themed(AuraStyle::Heading)
     );
-    for (i, (agent, file)) in files.iter().enumerate() {
-        let file = file
+    // Hidden agents are listed too: `hidden` governs what `/model` and the
+    // server advertise, not which file the person at the keyboard may edit.
+    let agents = direct.agent_files();
+    for (i, agent) in agents.iter().enumerate() {
+        let file = agent
+            .path
             .file_name()
-            .unwrap_or(file.as_os_str())
+            .unwrap_or(agent.path.as_os_str())
             .to_string_lossy();
+        let hidden = if agent.hidden { " (hidden)" } else { "" };
         println!(
-            "  {} {} {} {}",
+            "  {} {}{} {} {}",
             format!("{}.", i + 1).themed(AuraStyle::Muted),
-            agent.as_str().themed(AuraStyle::Heading),
+            agent.id.as_str().themed(AuraStyle::Heading),
+            hidden.themed(AuraStyle::Muted),
             "—".themed(AuraStyle::Muted),
             file.themed(AuraStyle::Muted),
         );
     }
     loop {
-        let Some(answer) = ask(ctx, &format!("Agent [1-{}]: ", files.len())) else {
+        let Some(answer) = ask(ctx, &format!("Agent [1-{}]: ", agents.len())) else {
             println!("\n/mcp add aborted — nothing was written.");
             return None;
         };
         match answer.parse::<usize>() {
-            Ok(n) if (1..=files.len()).contains(&n) => return Some(&files[n - 1].1),
-            _ => println!("Enter a number between 1 and {}.", files.len()),
+            Ok(n) if (1..=agents.len()).contains(&n) => return Some(&agents[n - 1].path),
+            _ => println!("Enter a number between 1 and {}.", agents.len()),
         }
     }
 }

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -30,7 +30,7 @@ pub use writer::upsert_mcp_server;
 
 use std::collections::HashSet;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Load a single TOML file into a Config.
 fn load_single_config<P: AsRef<Path>>(path: P) -> Result<Config, ConfigError> {
@@ -77,31 +77,42 @@ fn check_legacy_top_level_llm(toml_str: &str) -> Result<(), ConfigError> {
 /// - Each config can be serialized and deserialized correctly.
 /// - Each config is uniquely identifiable by alias or name.
 pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Vec<Config>, ConfigError> {
+    Ok(load_config_files(path)?
+        .into_iter()
+        .map(|(_, config)| config)
+        .collect())
+}
+
+/// [`load_config`], with each config paired with the file it was parsed
+/// from. A directory's files come back in path order.
+pub fn load_config_files<P: AsRef<Path>>(path: P) -> Result<Vec<(PathBuf, Config)>, ConfigError> {
     let path = path.as_ref();
 
-    let configs = if path.is_dir() {
-        let mut entries: Vec<_> = fs::read_dir(path)?
+    let files: Vec<PathBuf> = if path.is_dir() {
+        let mut files: Vec<PathBuf> = fs::read_dir(path)?
             .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "toml"))
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|ext| ext == "toml"))
             .collect();
-        entries.sort_by_key(|e| e.path());
-
-        let mut configs = Vec::new();
-        for entry in entries {
-            configs.push(load_single_config(entry.path())?);
-        }
-        if configs.is_empty() {
+        if files.is_empty() {
             return Err(ConfigError::Validation(
                 "No .toml configuration files found in directory".to_string(),
             ));
         }
-        configs
+        files.sort();
+        files
     } else {
-        vec![load_single_config(path)?]
+        vec![path.to_path_buf()]
     };
 
-    validate_unique_identifiers(&configs)?;
-    Ok(configs)
+    let mut loaded = Vec::with_capacity(files.len());
+    for file in files {
+        let config = load_single_config(&file)?;
+        loaded.push((file, config));
+    }
+
+    validate_unique_identifiers(loaded.iter().map(|(_, config)| config))?;
+    Ok(loaded)
 }
 
 /// Validate that each config is uniquely identifiable by alias or name.
@@ -109,7 +120,9 @@ pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Vec<Config>, ConfigError> 
 /// Each config's effective identifier is its alias (if set) or its name.
 /// All effective identifiers must be unique. Additionally, duplicate aliases
 /// get a distinct error message to help the user fix the right thing.
-pub fn validate_unique_identifiers(configs: &[Config]) -> Result<(), ConfigError> {
+pub fn validate_unique_identifiers<'a>(
+    configs: impl IntoIterator<Item = &'a Config>,
+) -> Result<(), ConfigError> {
     let mut seen_aliases = HashSet::new();
     let mut seen_ids = HashSet::new();
 
@@ -167,6 +180,34 @@ api_key = "test-key"
 model = "gpt-4o"
 "#
         )
+    }
+
+    #[test]
+    fn load_config_files_pairs_each_config_with_its_file() {
+        let dir = TempDir::new().unwrap();
+        let b = write_config(
+            &dir,
+            "b.toml",
+            &minimal_toml("").replace("name = \"Test\"", "name = \"B\""),
+        );
+        let a = write_config(
+            &dir,
+            "a.toml",
+            &minimal_toml("").replace("name = \"Test\"", "name = \"A\""),
+        );
+        write_config(&dir, "notes.md", "not a config");
+
+        let loaded = load_config_files(dir.path()).expect("directory should load");
+        let pairs: Vec<(&Path, &str)> = loaded
+            .iter()
+            .map(|(path, config)| (path.as_path(), config.agent.name.as_str()))
+            .collect();
+        assert_eq!(pairs, vec![(a.as_path(), "A"), (b.as_path(), "B")]);
+
+        let single = load_config_files(&a).expect("file should load");
+        assert_eq!(single.len(), 1);
+        assert_eq!(single[0].0, a);
+        assert_eq!(single[0].1.agent.name, "A");
     }
 
     #[test]

--- a/crates/aura-config/src/writer.rs
+++ b/crates/aura-config/src/writer.rs
@@ -90,19 +90,21 @@ pub fn append_worker_mcp_filter_in_str(
 
 /// Apply a text transformation to `path` and write the result atomically
 /// (temp + rename), preserving the file's permissions (configs holding
-/// credentials may be chmod 600). On error the original is untouched and
-/// the temp file removed.
+/// credentials may be chmod 600). Symlinks are followed first, so the
+/// rename replaces the file the link points at rather than the link
+/// itself. On error the original is untouched and the temp file removed.
 fn rewrite_file(
     path: &Path,
     transform: impl FnOnce(&str) -> Result<String, ConfigError>,
 ) -> Result<(), ConfigError> {
-    let existing = fs::read_to_string(path)?;
+    let path = path.canonicalize()?;
+    let existing = fs::read_to_string(&path)?;
     let updated = transform(&existing)?;
-    let permissions = fs::metadata(path)?.permissions();
+    let permissions = fs::metadata(&path)?.permissions();
     let tmp = path.with_extension(format!("toml.tmp.{}", std::process::id()));
     let written = fs::write(&tmp, updated)
         .and_then(|()| fs::set_permissions(&tmp, permissions))
-        .and_then(|()| fs::rename(&tmp, path));
+        .and_then(|()| fs::rename(&tmp, &path));
     if written.is_err() {
         let _ = fs::remove_file(&tmp);
     }
@@ -620,6 +622,32 @@ preamble = "You write"
 
         let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600, "permissions must survive the rewrite");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_upsert_through_symlink_edits_the_target_and_keeps_the_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("dotfiles").join("agent.toml");
+        std::fs::create_dir(target.parent().unwrap()).unwrap();
+        std::fs::write(&target, BASE_CONFIG).unwrap();
+        let link = dir.path().join("agent.toml");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        upsert_mcp_server(&link, "k8s", &stdio_server()).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the link must survive the rewrite"
+        );
+        assert!(
+            std::fs::read_to_string(&target)
+                .unwrap()
+                .contains("[mcp.servers.k8s]")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `/mcp add` refused any agent config loaded from a directory, which is exactly what `aura init --global` produces under `~/.aura/agents/`
- `aura-config` gains `load_config_files`, returning each config paired with the file it was parsed from; `load_config` delegates to it
- `DirectBackend` records each loaded agent's id, file, and hidden flag (`AgentFile`) at load time and exposes `config_file_for` for writers
- The wizard edits the lone agent's file directly, uses the `/model`-selected agent's file when several are loaded, and otherwise asks which agent should receive the server
- Hidden agents are listed in the picker with a `(hidden)` label: `hidden` governs what `/model` and the server advertise, not which file may be edited
- A `/model` selection that matches no agent is called out instead of silently ignored when the only loaded agent is used
- The config writer follows symlinks before its temp-and-rename write, so a symlinked agent file (dotfiles, stow) keeps its link and the target receives the edit

<img width="1154" height="409" alt="image" src="https://github.com/user-attachments/assets/19572a4a-58d7-4535-abe3-6d613f4ecf2c" />
