### PR TITLE
Add the blocked task state and park arm for orchestration workers

### DIFF
--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -1096,6 +1096,7 @@ mod tests {
     fn test_hitl_timeout_conflict_disabled_per_call_timeout() {
         let hitl = HitlConfig {
             require_approval: vec![],
+            park: ParkConfig::default(),
             route: DecisionRouteConfig::Webhook {
                 url: WebhookUrl::new("http://localhost:9999").unwrap(),
                 timeout_secs: 300,
@@ -1128,6 +1129,7 @@ mod tests {
     fn test_hitl_timeout_conflict_route_timeout_less_than_per_call() {
         let hitl = HitlConfig {
             require_approval: vec![],
+            park: ParkConfig::default(),
             route: DecisionRouteConfig::Webhook {
                 url: WebhookUrl::new("http://localhost:9999").unwrap(),
                 timeout_secs: 30,
@@ -1143,6 +1145,7 @@ mod tests {
     fn test_hitl_timeout_conflict_route_timeout_equals_per_call() {
         let hitl = HitlConfig {
             require_approval: vec![],
+            park: ParkConfig::default(),
             route: DecisionRouteConfig::Webhook {
                 url: WebhookUrl::new("http://localhost:9999").unwrap(),
                 timeout_secs: 60,
@@ -1160,6 +1163,7 @@ mod tests {
     fn test_hitl_timeout_conflict_route_timeout_greater_than_per_call() {
         let hitl = HitlConfig {
             require_approval: vec![],
+            park: ParkConfig::default(),
             route: DecisionRouteConfig::Webhook {
                 url: WebhookUrl::new("http://localhost:9999").unwrap(),
                 timeout_secs: 120,
@@ -1178,10 +1182,57 @@ mod tests {
     fn test_hitl_timeout_conflict_conversational_variant() {
         let hitl = HitlConfig {
             require_approval: vec![],
+            park: ParkConfig::default(),
             route: DecisionRouteConfig::Conversational { timeout_secs: 120 },
         };
         let msg = hitl_timeout_conflict_warning(&hitl, 60).unwrap();
         assert!(msg.contains("120s"));
+    }
+
+    // -------------------------------------------------------------------
+    // [hitl.park]
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn hitl_park_defaults_to_disabled_when_table_absent() {
+        let toml = r#"
+require_approval = ["kubectl_*"]
+
+[route]
+mode = "conversational"
+timeout_secs = 60
+"#;
+        let hitl: HitlConfig = toml::from_str(toml).unwrap();
+        assert!(!hitl.park.enabled);
+    }
+
+    #[test]
+    fn hitl_park_parses_enabled_true() {
+        let toml = r#"
+require_approval = ["kubectl_*"]
+
+[route]
+mode = "conversational"
+
+[park]
+enabled = true
+"#;
+        let hitl: HitlConfig = toml::from_str(toml).unwrap();
+        assert!(hitl.park.enabled);
+    }
+
+    #[test]
+    fn hitl_park_table_present_but_enabled_omitted_is_disabled() {
+        let toml = r#"
+require_approval = []
+
+[route]
+mode = "conversational"
+
+[park]
+"#;
+        let hitl: HitlConfig = toml::from_str(toml).unwrap();
+        assert!(!hitl.park.enabled);
     }
 
     #[test]
@@ -1387,6 +1438,17 @@ pub struct HitlConfig {
     pub require_approval: Vec<GlobPattern>,
     /// The decision route; required when `[hitl]` is present.
     pub route: DecisionRouteConfig,
+    /// `[hitl.park]` settings.
+    #[serde(default)]
+    pub park: ParkConfig,
+}
+
+/// `[hitl.park]` config table.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ParkConfig {
+    /// Park mode on or off (default off).
+    #[serde(default)]
+    pub enabled: bool,
 }
 
 /// `[hitl.route]` table. The `Webhook` variant cannot parse without a valid

--- a/crates/aura-events/src/orchestration.rs
+++ b/crates/aura-events/src/orchestration.rs
@@ -72,6 +72,7 @@ pub mod event_names {
     pub const CLARIFICATION_NEEDED: &str = "aura.orchestrator.clarification_needed";
     pub const TASK_STARTED: &str = "aura.orchestrator.task_started";
     pub const TASK_COMPLETED: &str = "aura.orchestrator.task_completed";
+    pub const TASK_BLOCKED: &str = "aura.orchestrator.task_blocked";
     pub const ITERATION_COMPLETE: &str = "aura.orchestrator.iteration_complete";
     pub const REPLAN_STARTED: &str = "aura.orchestrator.replan_started";
     pub const SYNTHESIZING: &str = "aura.orchestrator.synthesizing";
@@ -134,6 +135,17 @@ pub enum OrchestrationStreamEvent {
         worker_id: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         result: Option<String>,
+        #[serde(flatten)]
+        context: EventContext,
+    },
+    /// A worker task parked a gated call (park mode); one event per call.
+    TaskBlocked {
+        task_id: usize,
+        tool_call_id: String,
+        decision_id: String,
+        tool_name: String,
+        orchestrator_id: String,
+        worker_id: String,
         #[serde(flatten)]
         context: EventContext,
     },
@@ -236,6 +248,7 @@ impl OrchestrationStreamEvent {
             Self::ClarificationNeeded { .. } => event_names::CLARIFICATION_NEEDED,
             Self::TaskStarted { .. } => event_names::TASK_STARTED,
             Self::TaskCompleted { .. } => event_names::TASK_COMPLETED,
+            Self::TaskBlocked { .. } => event_names::TASK_BLOCKED,
             Self::IterationComplete { .. } => event_names::ITERATION_COMPLETE,
             Self::ReplanStarted { .. } => event_names::REPLAN_STARTED,
             Self::Synthesizing { .. } => event_names::SYNTHESIZING,
@@ -328,6 +341,28 @@ impl OrchestrationStreamEvent {
             orchestrator_id: orchestrator_id.into(),
             worker_id: worker_id.into(),
             result,
+            context,
+        }
+    }
+
+    /// Create a TaskBlocked event (one per parked call).
+    #[allow(clippy::too_many_arguments)]
+    pub fn task_blocked(
+        task_id: usize,
+        tool_call_id: impl Into<String>,
+        decision_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        orchestrator_id: impl Into<String>,
+        worker_id: impl Into<String>,
+        context: EventContext,
+    ) -> Self {
+        Self::TaskBlocked {
+            task_id,
+            tool_call_id: tool_call_id.into(),
+            decision_id: decision_id.into(),
+            tool_name: tool_name.into(),
+            orchestrator_id: orchestrator_id.into(),
+            worker_id: worker_id.into(),
             context,
         }
     }

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1378,6 +1378,7 @@ mod tests {
         aura_config::Config {
             hitl: Some(aura_config::HitlConfig {
                 require_approval: vec![],
+                park: aura_config::ParkConfig::default(),
                 route,
             }),
             ..make_test_config()

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -1276,6 +1276,31 @@ fn handle_orchestrator_event(
                 event_context,
             )
         }
+        OrchestratorEvent::TaskBlocked {
+            task_id,
+            orchestrator_id,
+            worker_id,
+            tool_call_id,
+            decision_id,
+            tool_name,
+        } => {
+            tracing::debug!(
+                "Orchestrator: task {} blocked awaiting approval - {} ({}, decision {})",
+                task_id,
+                tool_name,
+                tool_call_id,
+                decision_id
+            );
+            OrchestrationStreamEvent::task_blocked(
+                *task_id,
+                tool_call_id,
+                decision_id,
+                tool_name,
+                orchestrator_id,
+                worker_id,
+                event_context,
+            )
+        }
         OrchestratorEvent::IterationComplete {
             iteration,
             will_replan,

--- a/crates/aura/src/hitl/events.rs
+++ b/crates/aura/src/hitl/events.rs
@@ -126,6 +126,21 @@ pub fn completed_error(
     }
 }
 
+/// `approval_completed(cancelled)` for a parked approval nothing will consume.
+#[must_use]
+pub fn completed_cancelled(
+    decision_id: DecisionId,
+    scope: &AgentScope,
+    duration: Duration,
+) -> ApprovalCompleted {
+    completed(
+        decision_id,
+        &ApprovalOutcome::Cancelled(CancelReason::Shutdown),
+        scope,
+        duration,
+    )
+}
+
 fn origin_to_wire(origin: &ApprovalOrigin) -> ApprovalOriginWire {
     match origin {
         ApprovalOrigin::ConfigGate {

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -14,8 +14,22 @@ use serde_json::Value;
 
 use super::decision::{AgentScope, ApprovalOrigin, DecisionId};
 use super::protocol::{ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
+use super::registry::{ParkedApproval, PendingApprovals};
 use super::route::{ApprovalError, DecisionRoute, GateDecision};
+use crate::orchestration::{BlockedCell, PendingCall};
 use crate::tool_wrapper::{PreCallOutcome, ToolCallContext, ToolWrapper};
+
+/// The placeholder tool result a parked call returns.
+const PARK_SENTINEL: &str =
+    "This tool call is parked pending human approval. It has not run. Do not retry.";
+
+/// Park-arm state.
+struct ParkContext {
+    /// Registry over the approval store.
+    registry: PendingApprovals,
+    /// The worker's blocked cell.
+    cell: Arc<BlockedCell>,
+}
 
 /// Gates matching tool calls behind an approval decision.
 pub struct HitlApprovalWrapper {
@@ -32,6 +46,8 @@ pub struct HitlApprovalWrapper {
     request_id: String,
     /// `[agent].name` of the config that built this agent.
     agent_name: String,
+    /// Park arm state.
+    park: Option<ParkContext>,
 }
 
 impl HitlApprovalWrapper {
@@ -49,7 +65,15 @@ impl HitlApprovalWrapper {
             scope,
             request_id,
             agent_name,
+            park: None,
         }
+    }
+
+    /// Arm the park arm: glob-matched calls park as durable approvals.
+    #[must_use]
+    pub fn with_park(mut self, registry: PendingApprovals, cell: Arc<BlockedCell>) -> Self {
+        self.park = Some(ParkContext { registry, cell });
+        self
     }
 
     /// First configured glob that matches `tool_name`, never gating the
@@ -65,6 +89,119 @@ impl HitlApprovalWrapper {
             .find(|p| p.matches(tool_name))
             .map(|p| p.as_str())
     }
+
+    /// The park arm: register durably, publish, append to the blocked cell,
+    /// and short-circuit with the inert sentinel. Ordering is load-bearing —
+    /// a register error must fail the call closed before anything is
+    /// published or recorded, so no checkpoint can reference a decision id
+    /// the store does not hold.
+    async fn park_pre_call(
+        &self,
+        park: &ParkContext,
+        matched: &str,
+        args: &Value,
+        ctx: &ToolCallContext,
+    ) -> Result<PreCallOutcome, ToolError> {
+        // Park is worker-only: the scope carries the run and task identity.
+        let AgentScope::Worker { run_id, .. } = &self.scope else {
+            return Err(ToolError::ToolCallError(
+                "tool call blocked: park mode requires an orchestration worker scope"
+                    .to_string()
+                    .into(),
+            ));
+        };
+        // The route timeout bounds the decision window until a park TTL exists.
+        let DecisionRoute::Conversational { timeout, .. } = &*self.route else {
+            return Err(ToolError::ToolCallError(
+                "tool call blocked: park mode requires the conversational route"
+                    .to_string()
+                    .into(),
+            ));
+        };
+
+        let now = chrono::Utc::now();
+        let expires_at =
+            now + chrono::Duration::from_std(*timeout).expect("approval timeout fits in chrono");
+        let decision_id = DecisionId::generate();
+        let request = ApprovalRequest {
+            version: PROTOCOL_VERSION,
+            decision_id,
+            // Owner-id convention: every backend sweeps `cancel_request` by
+            // this field, and request teardown passes the live request id, so
+            // the run-scoped value keeps a parked ticket out of that sweep.
+            // The run's own sweep passes the same value.
+            request_id: format!("run:{run_id}"),
+            scope: self.scope.clone(),
+            origin: ApprovalOrigin::ConfigGate {
+                matched_pattern: matched.to_string(),
+                agent_name: self.agent_name.clone(),
+            },
+            items: vec![ApprovalItem {
+                tool_name: ctx.tool_name.clone(),
+                arguments: args.clone(),
+                tool_call_intent: ctx.tool_call_intent.clone(),
+            }],
+        };
+
+        // The store's own register, not the registry's park-anyway one: a
+        // fault fails the call closed.
+        let parked = ParkedApproval {
+            request,
+            registered_at: now,
+            expires_at,
+        };
+        if let Err(err) = park.registry.register_durable(parked.clone()).await {
+            tracing::warn!(
+                decision_id = %decision_id,
+                error = %err,
+                "park-mode approval register failed; failing the gated call closed",
+            );
+            return Err(ToolError::ToolCallError(
+                format!("tool call blocked: approval store register failed: {err}").into(),
+            ));
+        }
+
+        // The lifecycle pair goes to the live request's broker, not the owner id.
+        crate::approval_event_broker::publish(
+            &self.request_id,
+            crate::approval_event_broker::ApprovalLifecycleEvent::Requested(
+                (&parked.request).into(),
+            ),
+        )
+        .await;
+        crate::approval_event_broker::publish(
+            &self.request_id,
+            crate::approval_event_broker::ApprovalLifecycleEvent::Pending(super::events::pending(
+                &parked.request,
+                &parked.expires_at,
+            )),
+        )
+        .await;
+
+        let call_id = park.cell.take_current_call_id().unwrap_or_else(|| {
+            tracing::warn!(
+                decision_id = %decision_id,
+                tool_name = %ctx.tool_name,
+                "parked call has no tool-call id; recording an empty call_id",
+            );
+            String::new()
+        });
+        park.cell.push(PendingCall {
+            decision_id,
+            tool_name: ctx.tool_name.clone(),
+            arguments: args.clone(),
+            call_id,
+        });
+        tracing::info!(
+            decision_id = %decision_id,
+            tool_name = %ctx.tool_name,
+            "parked gated call awaiting human decision",
+        );
+
+        Ok(PreCallOutcome::ShortCircuit {
+            output: PARK_SENTINEL.to_string(),
+        })
+    }
 }
 
 #[async_trait]
@@ -77,6 +214,9 @@ impl ToolWrapper for HitlApprovalWrapper {
         let Some(matched) = self.matched_pattern(&ctx.tool_name) else {
             return Ok(PreCallOutcome::Proceed { overrides: None });
         };
+        if let Some(park) = &self.park {
+            return self.park_pre_call(park, matched, args, ctx).await;
+        }
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
             decision_id: DecisionId::generate(),
@@ -227,7 +367,227 @@ mod tests {
                 output: "Tool call blocked by human approval denial: too risky. Do not execute this action."
                     .to_string()
             }
-        );
+        )
+    }
+
+    // ====================================================================
+    // Park arm
+    // ====================================================================
+
+    mod park {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use super::*;
+
+        fn worker_scope() -> AgentScope {
+            AgentScope::Worker {
+                run_id: "0191e8c0-1111-7000-8000-000000000042".parse().unwrap(),
+                task: crate::orchestration::TaskIdentity::new(1, Some("operations".to_string())),
+                session_id: None,
+            }
+        }
+
+        fn conv_route(timeout: Duration) -> (PendingApprovals, Arc<DecisionRoute>) {
+            let registry = PendingApprovals::new();
+            let route = Arc::new(DecisionRoute::Conversational {
+                registry: registry.clone(),
+                timeout,
+            });
+            (registry, route)
+        }
+
+        /// Route over an explicit registry, for tests that need the store.
+        fn conv_route_over(registry: PendingApprovals, timeout: Duration) -> Arc<DecisionRoute> {
+            Arc::new(DecisionRoute::Conversational { registry, timeout })
+        }
+
+        fn parked_gate(
+            registry: &PendingApprovals,
+            route: &Arc<DecisionRoute>,
+            request_id: &str,
+            cell: &Arc<crate::orchestration::BlockedCell>,
+        ) -> HitlApprovalWrapper {
+            HitlApprovalWrapper::new(
+                Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
+                route.clone(),
+                worker_scope(),
+                request_id.to_string(),
+                "test-agent".to_string(),
+            )
+            .with_park(registry.clone(), cell.clone())
+        }
+
+        #[tokio::test]
+        async fn register_error_fails_closed_with_no_cell_entry_and_no_event() {
+            let request_id = format!("req_park_fail_{}", uuid::Uuid::new_v4().simple());
+            let mut events = crate::approval_event_broker::subscribe(&request_id).await;
+            let store: Arc<dyn crate::session_store::ApprovalStore> =
+                Arc::new(crate::session_store::FaultInjectingStore::failing_register());
+            let registry = PendingApprovals::with_backend(
+                store,
+                Arc::new(crate::session_store::InMemoryEventBus::new()),
+            );
+            let route = conv_route_over(registry.clone(), Duration::from_secs(60));
+            let cell = Arc::new(crate::orchestration::BlockedCell::default());
+            let gate = parked_gate(&registry, &route, &request_id, &cell);
+
+            let args = serde_json::json!({ "namespace": "prod" });
+            let ctx = ToolCallContext::new("kubectl_apply");
+            let result = gate.pre_call(&args, &ctx).await;
+
+            let err = result.expect_err("a register fault must fail the call closed");
+            assert!(
+                err.to_string().contains("approval store register failed"),
+                "error must name the register fault, got: {err}"
+            );
+            assert!(
+                err.to_string().contains("disk on fire"),
+                "error must carry the store's reason, got: {err}"
+            );
+            assert!(
+                cell.is_empty(),
+                "no cell entry may exist after a register fault"
+            );
+            assert!(
+                tokio::time::timeout(Duration::from_millis(50), events.recv())
+                    .await
+                    .is_err(),
+                "no approval event may be published after a register fault"
+            );
+
+            crate::approval_event_broker::unsubscribe(&request_id).await;
+        }
+
+        #[tokio::test]
+        async fn happy_path_registers_publishes_appends_and_short_circuits() {
+            let request_id = format!("req_park_ok_{}", uuid::Uuid::new_v4().simple());
+            let mut events = crate::approval_event_broker::subscribe(&request_id).await;
+            let store: Arc<dyn crate::session_store::ApprovalStore> =
+                Arc::new(crate::session_store::InMemoryApprovalStore::new());
+            let registry = PendingApprovals::with_backend(
+                store.clone(),
+                Arc::new(crate::session_store::InMemoryEventBus::new()),
+            );
+            let route = conv_route_over(registry.clone(), Duration::from_secs(120));
+            let cell = Arc::new(crate::orchestration::BlockedCell::default());
+            cell.set_current_call_id(Some("call_7".to_string()));
+            let gate = parked_gate(&registry, &route, &request_id, &cell);
+
+            let args = serde_json::json!({ "namespace": "prod" });
+            let ctx = ToolCallContext::new("kubectl_apply");
+            let outcome = gate.pre_call(&args, &ctx).await.unwrap();
+
+            assert_eq!(
+                outcome,
+                PreCallOutcome::ShortCircuit {
+                    output: super::PARK_SENTINEL.to_string()
+                },
+                "a parked call short-circuits with the inert sentinel"
+            );
+
+            // Mirror the hook's snapshot so the cell reports Blocked.
+            cell.snapshot_if_pending(
+                &[rig::completion::Message::user("do the thing")],
+                &rig::completion::Message::user("tool results"),
+            );
+            match cell.outcome() {
+                crate::orchestration::CellOutcome::Blocked { pending } => {
+                    assert_eq!(pending.len(), 1);
+                    assert_eq!(pending[0].tool_name, "kubectl_apply");
+                    assert_eq!(pending[0].call_id, "call_7");
+                    assert_eq!(pending[0].arguments, args);
+
+                    // Store: the ticket is parked under the run-scoped owner.
+                    let parked = store
+                        .get(&pending[0].decision_id)
+                        .await
+                        .unwrap()
+                        .expect("ticket parked in the store");
+                    assert_eq!(
+                        parked.request.request_id,
+                        "run:0191e8c0-1111-7000-8000-000000000042"
+                    );
+                    assert_eq!(parked.request.items[0].tool_name, "kubectl_apply");
+                    assert_eq!(parked.request.items[0].arguments, args);
+                }
+                other => panic!("expected Blocked, got {other:?}"),
+            }
+
+            // SSE: requested then pending, on the live request id.
+            match tokio::time::timeout(Duration::from_secs(1), events.recv()).await {
+                Ok(Some(crate::approval_event_broker::ApprovalLifecycleEvent::Requested(
+                    requested,
+                ))) => {
+                    assert_eq!(requested.tool_name, "kubectl_apply");
+                }
+                other => panic!("expected Requested event, got {other:?}"),
+            }
+            match tokio::time::timeout(Duration::from_secs(1), events.recv()).await {
+                Ok(Some(crate::approval_event_broker::ApprovalLifecycleEvent::Pending(
+                    pending,
+                ))) => {
+                    assert_eq!(pending.tool_name, "kubectl_apply");
+                    assert_eq!(pending.arguments, args);
+                    let scope = serde_json::to_value(&pending.scope).unwrap();
+                    assert_eq!(scope["kind"], "worker");
+                    assert_eq!(scope["run_id"], "0191e8c0-1111-7000-8000-000000000042");
+                }
+                other => panic!("expected Pending event, got {other:?}"),
+            }
+
+            crate::approval_event_broker::unsubscribe(&request_id).await;
+        }
+
+        #[tokio::test]
+        async fn two_gated_calls_append_two_cell_entries() {
+            let (registry, route) = conv_route(Duration::from_secs(60));
+            let cell = Arc::new(crate::orchestration::BlockedCell::default());
+            let gate = parked_gate(&registry, &route, "req-two-calls", &cell);
+
+            let first = gate
+                .pre_call(
+                    &serde_json::json!({ "namespace": "prod" }),
+                    &ToolCallContext::new("kubectl_apply"),
+                )
+                .await
+                .unwrap();
+            let second = gate
+                .pre_call(
+                    &serde_json::json!({ "namespace": "stage" }),
+                    &ToolCallContext::new("kubectl_delete"),
+                )
+                .await
+                .unwrap();
+            assert!(matches!(first, PreCallOutcome::ShortCircuit { .. }));
+            assert!(matches!(second, PreCallOutcome::ShortCircuit { .. }));
+
+            // Inspect without consuming: mirror the cell contents.
+            cell.snapshot_if_pending(&[], &rig::completion::Message::user("results"));
+            match cell.outcome() {
+                crate::orchestration::CellOutcome::Blocked { pending } => {
+                    assert_eq!(pending.len(), 2, "both gated calls are recorded");
+                    assert_eq!(pending[0].tool_name, "kubectl_apply");
+                    assert_eq!(pending[1].tool_name, "kubectl_delete");
+                    assert_ne!(pending[0].decision_id, pending[1].decision_id);
+                }
+                other => panic!("expected Blocked, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn ungated_tool_proceeds_without_parking() {
+            let (registry, route) = conv_route(Duration::from_secs(60));
+            let cell = Arc::new(crate::orchestration::BlockedCell::default());
+            let gate = parked_gate(&registry, &route, "req-ungated", &cell);
+
+            let outcome = gate
+                .pre_call(&serde_json::json!({}), &ToolCallContext::new("ls"))
+                .await
+                .unwrap();
+            assert_eq!(outcome, PreCallOutcome::Proceed { overrides: None });
+            assert!(cell.is_empty());
+        }
     }
 
     #[test]

--- a/crates/aura/src/hitl/mod.rs
+++ b/crates/aura/src/hitl/mod.rs
@@ -41,6 +41,7 @@ pub use decision::{
     AgentScope, ApprovalDecision, ApprovalOrigin, ApprovalOutcome, AwaitingDecision, CancelReason,
     DecisionId, Timestamp,
 };
+pub(crate) use events::completed_cancelled;
 pub use gate::HitlApprovalWrapper;
 pub use protocol::{ApprovalDecisionWire, ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
 pub use registry::{ParkedApproval, PendingApprovals, ResolveError};

--- a/crates/aura/src/hitl/registry.rs
+++ b/crates/aura/src/hitl/registry.rs
@@ -170,6 +170,18 @@ impl PendingApprovals {
         AwaitingDecision::new(id, rx, Instant::now() + timeout)
     }
 
+    /// Park-mode registration: persist the approval through the store
+    /// directly, failing on a store fault instead of parking anyway.
+    ///
+    /// Unlike [`Self::register`], no wake handle is created — nothing in this
+    /// process awaits the decision (the run is parked, and a later resume
+    /// consumes the recorded decision). A store error is returned to the
+    /// caller so the park arm can fail the gated call closed: a checkpoint
+    /// must never reference a decision id the store does not hold.
+    pub async fn register_durable(&self, parked: ParkedApproval) -> Result<(), SessionStoreError> {
+        self.0.store.register(parked).await
+    }
+
     /// Resolve a parked approval: durably record the decision in the store
     /// (at most once per `DecisionId`) and publish it on the bus, waking the
     /// parked await wherever it lives.

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -35,6 +35,8 @@ const WEBHOOK_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 pub struct HitlRuntime {
     pub patterns: Arc<[GlobPattern]>,
     pub route: Arc<DecisionRoute>,
+    /// `[hitl.park].enabled`.
+    pub park_enabled: bool,
 }
 
 impl HitlRuntime {
@@ -90,6 +92,7 @@ impl HitlRuntime {
         Self {
             patterns: Arc::from(config.require_approval.clone()),
             route: Arc::new(route),
+            park_enabled: config.park.enabled,
         }
     }
 }
@@ -1601,6 +1604,7 @@ mod tests {
             // Conversational route has no URL to validate.
             let conversational = aura_config::HitlConfig {
                 require_approval: vec![],
+                park: aura_config::ParkConfig::default(),
                 route: aura_config::DecisionRouteConfig::Conversational { timeout_secs: 60 },
             };
             validate_webhook_signing_config(&conversational, Some(&hmac)).unwrap();
@@ -1612,6 +1616,7 @@ mod tests {
         ) -> aura_config::HitlConfig {
             aura_config::HitlConfig {
                 require_approval: vec![],
+                park: aura_config::ParkConfig::default(),
                 route: aura_config::DecisionRouteConfig::Webhook {
                     url: aura_config::WebhookUrl::new(url).unwrap(),
                     timeout_secs: 300,

--- a/crates/aura/src/orchestration/events.rs
+++ b/crates/aura/src/orchestration/events.rs
@@ -100,6 +100,21 @@ pub enum OrchestratorEvent {
         /// The task result (output string or error message; truncated to Option in SSE)
         result: String,
     },
+    /// A worker task parked a gated call (park mode); one event per call.
+    TaskBlocked {
+        /// Task identifier
+        task_id: usize,
+        /// The ID of the orchestrator
+        orchestrator_id: String,
+        /// The ID of the Worker who is handling the task
+        worker_id: String,
+        /// The gated tool call's id
+        tool_call_id: String,
+        /// The parked approval's decision id
+        decision_id: String,
+        /// The gated tool's name
+        tool_name: String,
+    },
     /// An iteration of the plan-execute loop has completed.
     ///
     /// Emitted after execution completes. Indicates whether the orchestrator

--- a/crates/aura/src/orchestration/mod.rs
+++ b/crates/aura/src/orchestration/mod.rs
@@ -81,6 +81,6 @@ pub use tools::{SubmitResultDecision, SubmitResultOutput, SubmitResultTool};
 
 pub use prompt_constants::{context, fields, sections};
 pub use types::{
-    Plan, PlanningResponse, RunId, StepInput, StructuredTaskOutput, Task, TaskIdentity, TaskJson,
-    TaskState, TaskStatus,
+    BlockedCell, CellOutcome, ParkSnapshot, PendingCall, Plan, PlanningResponse, RunId, StepInput,
+    StructuredTaskOutput, Task, TaskIdentity, TaskJson, TaskState, TaskStatus,
 };

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -36,6 +36,7 @@
 //! - `PlanCreated` - when the coordinator produces a plan
 //! - `TaskStarted` - when a worker begins a task
 //! - `TaskCompleted` - when a worker finishes a task
+//! - `TaskBlocked` - when a worker parks gated calls (park mode)
 //! - `IterationComplete` - when the post-execute coordinator decision completes
 //! - `Synthesizing` - when task results are being consolidated for the coordinator
 
@@ -62,8 +63,8 @@ use super::config::OrchestrationConfig;
 use super::events::OrchestratorEvent;
 use super::persistence::ExecutionPersistence;
 use super::types::{
-    FailedTaskRecord, FailureCategory, FailureSummary, IterationContext, IterationOutcome,
-    IterationTimings, Plan, PlanningResponse, TaskState, TaskStatus,
+    BlockedCell, CellOutcome, FailedTaskRecord, FailureCategory, FailureSummary, IterationContext,
+    IterationOutcome, IterationTimings, PendingCall, Plan, PlanningResponse, TaskState, TaskStatus,
 };
 
 // ============================================================================
@@ -97,6 +98,20 @@ struct TaskExecutionParams<'a> {
 struct TaskExecutionResult {
     result: String,
     structured_output: Option<super::types::StructuredTaskOutput>,
+}
+
+/// The outcome of one worker task.
+enum TaskOutcome {
+    Completed(TaskExecutionResult),
+    /// The worker parked gated calls and its snapshot was captured.
+    Blocked(Vec<PendingCall>),
+}
+
+/// Park-mode state for one worker stream: its blocked cell and the stream key
+/// the hook looks the cell up by.
+struct WorkerPark {
+    cell: Arc<BlockedCell>,
+    key: String,
 }
 
 /// Named return type for `create_*` coordinator/worker methods.
@@ -575,11 +590,14 @@ impl Orchestrator {
     ///
     /// If a specialized worker is assigned via `worker_name`, it uses that worker's
     /// custom preamble and MCP filter. Otherwise uses generic worker with all tools.
+    ///
+    /// `park_cell` arms the gate's park arm for this worker.
     async fn create_worker(
         &self,
         task_id: usize,
         attempt: usize,
         worker_name: Option<&str>,
+        park_cell: Option<&Arc<BlockedCell>>,
     ) -> Result<AgentWithPreamble, Box<dyn std::error::Error + Send + Sync>> {
         use super::duplicate_call_guard::DuplicateCallGuard;
         use super::observer_wrapper::ObserverWrapper;
@@ -819,14 +837,21 @@ impl Orchestrator {
                 session_id: session_id_owned.map(crate::config::SessionId::new),
             };
             let request_id = worker_config.request_id.clone().unwrap_or_default();
-            let gate = Arc::new(crate::hitl::HitlApprovalWrapper::new(
+            let mut gate = crate::hitl::HitlApprovalWrapper::new(
                 hitl.patterns.clone(),
                 hitl.route.clone(),
                 scope.clone(),
                 request_id.clone(),
                 worker_config.agent.name.clone(),
-            ));
-            wrappers.insert(0, gate);
+            );
+            // The park arm needs the store-bearing route; webhook deployments
+            // keep the live decision path.
+            if let (Some(cell), crate::hitl::DecisionRoute::Conversational { registry, .. }) =
+                (park_cell, &*hitl.route)
+            {
+                gate = gate.with_park(registry.clone(), cell.clone());
+            }
+            wrappers.insert(0, Arc::new(gate));
             worker_config.hitl_request_approval_tool = Some(crate::hitl::RequestApprovalTool::new(
                 hitl.route.clone(),
                 scope,
@@ -979,6 +1004,82 @@ impl Orchestrator {
             escalation_flag,
             submit_result_decision,
         })
+    }
+
+    /// Park-mode wiring for one worker attempt: `Some` only when this run
+    /// parks gated calls (see [`Self::park_enabled`]).
+    fn worker_park(&self, task_id: usize, attempt: usize) -> Option<WorkerPark> {
+        if !self.park_enabled() {
+            return None;
+        }
+        Some(WorkerPark {
+            cell: Arc::new(BlockedCell::default()),
+            // A per-stream synthetic id, not the live request id, so the hook's
+            // tool-event publishes dead-letter instead of reaching the SSE stream.
+            key: format!("{}:task:{task_id}:attempt:{attempt}", self.orchestrator_id),
+        })
+    }
+
+    /// `[hitl.park].enabled` on the conversational route.
+    fn park_enabled(&self) -> bool {
+        self.agent_config.hitl.as_ref().is_some_and(|hitl| {
+            hitl.park_enabled
+                && matches!(
+                    &*hitl.route,
+                    crate::hitl::DecisionRoute::Conversational { .. }
+                )
+        })
+    }
+
+    /// Orphan cleanup for a parked worker whose stream ended before the hook
+    /// captured its conversation: every pending decision id is removed from
+    /// the store with an `approval_completed(cancelled)` event, so the human
+    /// is not left with a decidable approval nothing will consume.
+    async fn cancel_parked_approvals(
+        &self,
+        task_id: usize,
+        worker_name: Option<&str>,
+        pending: &[PendingCall],
+    ) {
+        let Some(hitl) = self.agent_config.hitl.clone() else {
+            return;
+        };
+        let crate::hitl::DecisionRoute::Conversational { registry, .. } = &*hitl.route else {
+            return;
+        };
+        let (run_id, session_id) = {
+            let p = self.persistence.lock().await;
+            (p.run_id().to_string(), p.session_id().map(String::from))
+        };
+        // Same scope shape `create_worker` stamps on the worker's approvals.
+        let scope =
+            run_id
+                .parse::<super::RunId>()
+                .ok()
+                .map(|run_id| crate::hitl::AgentScope::Worker {
+                    run_id,
+                    task: super::TaskIdentity::new(task_id, worker_name.map(String::from)),
+                    session_id: session_id.map(crate::config::SessionId::new),
+                });
+        let request_id = self.agent_config.request_id.clone().unwrap_or_default();
+        for call in pending {
+            registry.remove(&call.decision_id).await;
+            if let Some(ref scope) = scope {
+                crate::approval_event_broker::publish(
+                    &request_id,
+                    crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
+                        crate::hitl::completed_cancelled(call.decision_id, scope, Duration::ZERO),
+                    ),
+                )
+                .await;
+            }
+            tracing::warn!(
+                decision_id = %call.decision_id,
+                tool = %call.tool_name,
+                task_id,
+                "orphaned park approval cancelled (stream ended before snapshot)",
+            );
+        }
     }
 
     /// Drive one agent loop's stream, forwarding events and tallying usage.
@@ -1206,12 +1307,17 @@ impl Orchestrator {
     /// - Forwards `ReasoningDelta`/`Reasoning` items through `event_tx`
     /// - No early-exit — runs the complete ReAct loop
     /// - Timeout wrapping via `per_call_timeout_secs`
+    ///
+    /// `park_key` routes a park-mode worker through the hook-carrying stream
+    /// so the park-aware hook runs; the hook's own deadline is disabled because
+    /// the per-call wrap below is the single wall-clock authority.
     async fn stream_and_forward(
         &self,
         agent: &Agent,
         params: StreamCallParams<'_>,
         stream_context: Option<StreamContext<'_>>,
         decision_ready: impl Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>>,
+        park_key: Option<&str>,
     ) -> Result<ForwardedRun, Box<dyn std::error::Error + Send + Sync>> {
         let StreamCallParams {
             prompt,
@@ -1221,7 +1327,15 @@ impl Orchestrator {
         } = params;
         let timeout_secs = self.config.per_call_timeout_secs();
         let stream_future = async {
-            let stream = agent.stream_chat(prompt, history).await;
+            let stream = match park_key {
+                Some(key) => {
+                    agent
+                        .stream_chat_with_timeout(prompt, history, Duration::MAX, key)
+                        .await
+                        .0
+                }
+                None => agent.stream_chat(prompt, history).await,
+            };
             Self::drive_forward_loop(
                 stream,
                 &self.usage_state,
@@ -3024,10 +3138,19 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 .collect();
 
             if ready_tasks.is_empty() {
-                // No ready tasks but not finished - this shouldn't happen with valid plans
-                tracing::warn!(
-                    "No ready tasks but plan not finished — blocked tasks remaining after failure (dependency chain broken)"
-                );
+                // Quiescence: park outranks the replan path while a decision
+                // is outstanding.
+                if has_awaiting_task(plan) {
+                    for line in park_verdict_lines(plan) {
+                        tracing::warn!("{line}");
+                    }
+                } else {
+                    // No ready tasks but not finished - this shouldn't happen
+                    // with valid plans
+                    tracing::warn!(
+                        "No ready tasks but plan not finished — blocked tasks remaining after failure (dependency chain broken)"
+                    );
+                }
                 break;
             }
 
@@ -3085,7 +3208,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             {
                 task_compute_ms += duration_ms;
                 match result {
-                    Ok(exec_result) => {
+                    Ok(TaskOutcome::Completed(exec_result)) => {
                         let final_result = self
                             .maybe_create_artifact(
                                 task_id,
@@ -3126,6 +3249,34 @@ Assign tasks to the worker whose tools best match the required operations."#,
                                 duration_ms
                             );
                         }
+                    }
+                    Ok(TaskOutcome::Blocked(pending)) => {
+                        // The task awaits human decisions: no artifact, no
+                        // completion event; one blocked event per parked call.
+                        let worker_id = worker_name.clone().unwrap_or(self.orchestrator_id.clone());
+                        for call in &pending {
+                            let _ = event_tx
+                                .send(Ok(StreamItem::OrchestratorEvent(
+                                    OrchestratorEvent::TaskBlocked {
+                                        task_id,
+                                        orchestrator_id: self.orchestrator_id.clone(),
+                                        worker_id: worker_id.clone(),
+                                        tool_call_id: call.call_id.clone(),
+                                        decision_id: call.decision_id.to_string(),
+                                        tool_name: call.tool_name.clone(),
+                                    },
+                                )))
+                                .await;
+                        }
+                        if let Some(t) = plan.get_task_mut(task_id) {
+                            t.state = TaskState::AwaitingApproval { pending };
+                        }
+                        tracing::warn!(
+                            "Task {} ('{}') blocked awaiting approval after {}ms",
+                            task_id,
+                            task_desc,
+                            duration_ms
+                        );
                     }
                     Err(e) => {
                         let err_str = e.to_string();
@@ -3294,7 +3445,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         task_id: usize,
         params: &TaskExecutionParams<'_>,
         event_tx: Option<&tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>>,
-    ) -> Result<TaskExecutionResult, StreamError> {
+    ) -> Result<TaskOutcome, StreamError> {
         let TaskExecutionParams {
             task_description,
             task_context,
@@ -3356,12 +3507,23 @@ Assign tasks to the worker whose tools best match the required operations."#,
             actual_attempts = attempt;
             let is_final_attempt = attempt == MAX_WORKER_ATTEMPTS;
 
+            // A fresh cell per attempt: a failed attempt's entries must not
+            // leak into its retry.
+            let park = self.worker_park(task_id, attempt);
+
             let AgentWithPreamble {
                 agent: worker,
                 preamble: worker_preamble,
                 escalation_flag,
                 submit_result_decision,
-            } = self.create_worker(task_id, attempt, *worker_name).await?;
+            } = self
+                .create_worker(
+                    task_id,
+                    attempt,
+                    *worker_name,
+                    park.as_ref().map(|p| &p.cell),
+                )
+                .await?;
 
             // Retries rebuild the same preamble, and `set_attribute` appends
             // rather than replaces, so record it once per worker span.
@@ -3387,8 +3549,12 @@ Assign tasks to the worker whose tools best match the required operations."#,
             };
 
             // initial_used only counts templates + tool schemas, so bill the
-            // per-task prompt here.
-            if let Some(ref budget) = worker.scratchpad_budget {
+            // per-task prompt here. Park-mode workers skip the manual seed:
+            // their hook-carrying stream (`stream_chat_with_timeout`) seeds
+            // the budget itself, from the prompt *and* the retry history.
+            if park.is_none()
+                && let Some(ref budget) = worker.scratchpad_budget
+            {
                 let task_prompt_tokens = budget.count_tokens(&prompt);
                 budget.record_usage(task_prompt_tokens);
                 tracing::debug!(
@@ -3400,7 +3566,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
 
             // Execute the task
             let srd = submit_result_decision.clone();
-            let stream_result = self
+            let park_registration = park.as_ref().map(|p| {
+                crate::streaming_request_hook::ParkCellRegistration::new(&p.key, p.cell.clone())
+            });
+            let mut stream_result = self
                 .stream_and_forward(
                     &worker,
                     StreamCallParams {
@@ -3417,8 +3586,45 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         let srd = srd.clone();
                         Box::pin(async move { srd.lock().await.is_some() })
                     },
+                    park.as_ref().map(|p| p.key.as_str()),
                 )
                 .await;
+            drop(park_registration);
+
+            // The cell is read before the normal result handling: it is the
+            // source of truth after any stream end, the park cancel's Err included.
+            if let Some(ref park) = park {
+                match park.cell.outcome() {
+                    CellOutcome::Blocked { pending } => {
+                        tracing::info!(
+                            "Task {} blocked awaiting approval ({} pending call(s))",
+                            task_id,
+                            pending.len()
+                        );
+                        return Ok(TaskOutcome::Blocked(pending));
+                    }
+                    CellOutcome::Orphaned { pending } => {
+                        // The stream ended before the hook could snapshot: the
+                        // gated action never ran and cannot resume from a
+                        // conversation nobody captured, so cancel the decisions
+                        // and fail the task.
+                        self.cancel_parked_approvals(task_id, *worker_name, &pending)
+                            .await;
+                        let underlying = match stream_result.as_ref() {
+                            Err(e) => format!(" Underlying error: {e}"),
+                            Ok(_) => String::new(),
+                        };
+                        stream_result = Err(format!(
+                            "Worker stream ended before the parked approval snapshot \
+                             was captured for task {task_id}; {} pending approval(s) \
+                             cancelled.{underlying}",
+                            pending.len()
+                        )
+                        .into());
+                    }
+                    CellOutcome::Normal => {}
+                }
+            }
 
             // Emit per-agent ScratchpadUsage event if this worker used scratchpad.
             if let (Some(budget), Some(tx)) = (worker.scratchpad_budget.as_ref(), event_tx) {
@@ -3491,13 +3697,13 @@ Assign tasks to the worker whose tools best match the required operations."#,
                                 &prompt,
                             )
                             .await;
-                            return Ok(TaskExecutionResult {
+                            return Ok(TaskOutcome::Completed(TaskExecutionResult {
                                 result: output.result,
                                 structured_output: Some(super::types::StructuredTaskOutput {
                                     summary: output.summary,
                                     confidence: output.confidence,
                                 }),
-                            });
+                            }));
                         }
                         None if is_final_attempt => {
                             tracing::warn!(
@@ -3516,10 +3722,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
                                 &prompt,
                             )
                             .await;
-                            return Ok(TaskExecutionResult {
+                            return Ok(TaskOutcome::Completed(TaskExecutionResult {
                                 result: raw_response,
                                 structured_output: None,
-                            });
+                            }));
                         }
                         None => {
                             tracing::info!(
@@ -3569,10 +3775,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 &base_worker_prompt,
             )
             .await;
-            Ok(TaskExecutionResult {
+            Ok(TaskOutcome::Completed(TaskExecutionResult {
                 result: last_raw_response,
                 structured_output: None,
-            })
+            }))
         }
     }
 
@@ -3665,6 +3871,9 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         }
                     }
                     TaskState::Running => "▶ running".to_string(),
+                    TaskState::AwaitingApproval { pending } => {
+                        format!("⏸ awaiting approval ({} call(s))", pending.len())
+                    }
                 };
                 format!("Task {}: {} [{}]", t.id, t.description, status_detail)
             })
@@ -4142,6 +4351,30 @@ Assign tasks to the worker whose tools best match the required operations."#,
         }
 
         // ----------------------------------------------------------------
+        // PARK PATH (park mode): an awaiting task at quiescence ends the
+        // iteration here, with no post-execute coordinator call: the
+        // coordinator must not replan a task the human is deciding on.
+        // ----------------------------------------------------------------
+        if has_awaiting_task(&plan) {
+            let lines = park_verdict_lines(&plan);
+            let run_id = self.persistence.lock().await.run_id().to_string();
+            let mut message = format!("Run {} parked: task(s) awaiting human approval.\n", run_id);
+            for line in &lines {
+                message.push_str(&format!("- {line}\n"));
+            }
+            message.push_str(
+                "The run has stopped and no further tasks will execute until the \
+                 outstanding decisions are recorded.",
+            );
+            tracing::info!(
+                "Iteration {} parked at quiescence; skipping post-execute coordinator call",
+                iteration
+            );
+            self.write_run_manifest(&plan, iteration, None).await;
+            return Ok(IterationOutcome::FinalResult(message));
+        }
+
+        // ----------------------------------------------------------------
         // SUMMARIZE FAILURES (if any): builds the optional failure_summary
         // for the continuation prompt; no control-flow branching yet.
         // ----------------------------------------------------------------
@@ -4539,7 +4772,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         t.id, t.description, error
                     ));
                 }
-                TaskState::Pending | TaskState::Running => {
+                TaskState::Pending | TaskState::Running | TaskState::AwaitingApproval { .. } => {
                     out.push_str(&format!(
                         "## Task {}: {}\n\n(not executed)\n\n",
                         t.id, t.description
@@ -4794,6 +5027,47 @@ fn truncate_query(query: &str, max_len: usize) -> String {
     } else {
         truncated.to_string()
     }
+}
+
+// ============================================================================
+// Park quiescence (park mode)
+// ============================================================================
+
+/// Whether any task carries non-empty parked calls.
+fn has_awaiting_task(plan: &Plan) -> bool {
+    plan.tasks
+        .iter()
+        .any(|t| matches!(&t.state, TaskState::AwaitingApproval { pending } if !pending.is_empty()))
+}
+
+/// The warm-log verdict lines for the awaiting tasks: one line per task,
+/// naming its decision ids and gated tools.
+fn park_verdict_lines(plan: &Plan) -> Vec<String> {
+    plan.tasks
+        .iter()
+        .filter_map(|t| match &t.state {
+            TaskState::AwaitingApproval { pending } if !pending.is_empty() => {
+                let decisions = pending
+                    .iter()
+                    .map(|c| c.decision_id.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let tools = pending
+                    .iter()
+                    .map(|c| c.tool_name.clone())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Some(format!(
+                    "Park verdict: task {} (\"{}\") awaiting approval — decision(s) [{}] on tool(s) [{}]",
+                    t.id,
+                    truncate_query(&t.description, 80),
+                    decisions,
+                    tools,
+                ))
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 /// Check if an error indicates a MaxDepthError from rig's ReAct loop.
@@ -6453,5 +6727,296 @@ mod tests {
             }
             _ => panic!("Expected ToolOutput"),
         }
+    }
+
+    // ====================================================================
+    // Park quiescence (park mode)
+    // ====================================================================
+
+    use crate::hitl::DecisionId as TestDecisionId;
+    use crate::orchestration::PendingCall as TestPendingCall;
+    use crate::orchestration::Task;
+
+    fn parked_call(tool: &str) -> TestPendingCall {
+        TestPendingCall {
+            decision_id: TestDecisionId::generate(),
+            tool_name: tool.to_string(),
+            arguments: serde_json::json!({ "namespace": "prod" }),
+            call_id: "call_1".to_string(),
+        }
+    }
+
+    fn mark_awaiting(plan: &mut Plan, task_id: usize, pending: Vec<TestPendingCall>) {
+        plan.get_task_mut(task_id).unwrap().state = TaskState::AwaitingApproval { pending };
+    }
+
+    /// Single blocker mid-DAG: the gated task awaits, its dependent is not
+    /// ready, and the quiescence verdict is park.
+    #[test]
+    fn quiescence_single_blocker_mid_dag_parks() {
+        let mut plan = Plan::new("Deploy");
+        plan.add_task(Task::new(0, "Collect facts", "r"));
+        plan.add_task(Task::new(1, "Gated apply", "r").with_dependency(0));
+        plan.add_task(Task::new(2, "Verify", "r").with_dependency(1));
+        plan.get_task_mut(0).unwrap().complete("facts");
+        mark_awaiting(&mut plan, 1, vec![parked_call("kubectl_apply")]);
+
+        assert!(!plan.is_finished());
+        assert!(plan.ready_tasks().is_empty(), "the dependent is not ready");
+        assert!(has_awaiting_task(&plan));
+
+        let lines = park_verdict_lines(&plan);
+        assert_eq!(lines.len(), 1, "one verdict line per awaiting task");
+        assert!(
+            lines[0].contains("task 1"),
+            "line names the task: {}",
+            lines[0]
+        );
+        assert!(
+            lines[0].contains("kubectl_apply"),
+            "line names the tool: {}",
+            lines[0]
+        );
+    }
+
+    /// Two parallel blockers: both verdict lines appear, each naming its own
+    /// decision id.
+    #[test]
+    fn quiescence_two_parallel_blockers_park() {
+        let mut plan = Plan::new("Migrate");
+        plan.add_task(Task::new(0, "Gated apply A", "r"));
+        plan.add_task(Task::new(1, "Gated delete B", "r"));
+        mark_awaiting(&mut plan, 0, vec![parked_call("kubectl_apply")]);
+        mark_awaiting(&mut plan, 1, vec![parked_call("kubectl_delete")]);
+
+        assert!(has_awaiting_task(&plan));
+        let lines = park_verdict_lines(&plan);
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("task 0") && lines[0].contains("kubectl_apply"));
+        assert!(lines[1].contains("task 1") && lines[1].contains("kubectl_delete"));
+    }
+
+    /// A blocker does not stop dispatching while independent work remains:
+    /// a ready task keeps the run away from the quiescence point.
+    #[test]
+    fn quiescence_not_reached_while_ready_work_remains() {
+        let mut plan = Plan::new("Mix");
+        plan.add_task(Task::new(0, "Gated apply", "r"));
+        plan.add_task(Task::new(1, "Independent research", "r"));
+        mark_awaiting(&mut plan, 0, vec![parked_call("kubectl_apply")]);
+
+        let ready = plan.ready_tasks();
+        assert_eq!(ready.len(), 1, "the independent task is still dispatched");
+        assert_eq!(ready[0].id, 1);
+    }
+
+    /// Poisoned sibling: a failed task would route the existing replan path,
+    /// but an outstanding decision takes precedence — park, not replan.
+    #[test]
+    fn quiescence_park_takes_precedence_over_replan() {
+        let mut plan = Plan::new("Risky");
+        plan.add_task(Task::new(0, "Exploding sibling", "r"));
+        plan.add_task(Task::new(1, "Gated apply", "r"));
+        plan.add_task(Task::new(2, "Downstream of sibling", "r").with_dependency(0));
+        plan.get_task_mut(0)
+            .unwrap()
+            .fail("boom", FailureCategory::AgentError);
+        mark_awaiting(&mut plan, 1, vec![parked_call("kubectl_apply")]);
+
+        assert!(plan.ready_tasks().is_empty(), "dependency chain broken");
+        assert!(
+            has_awaiting_task(&plan),
+            "an outstanding decision outranks the failure-replan path"
+        );
+    }
+
+    /// No awaiting task, broken chain: the existing replan verdict.
+    #[test]
+    fn quiescence_without_awaiting_task_is_the_replan_path() {
+        let mut plan = Plan::new("Plain");
+        plan.add_task(Task::new(0, "Exploding", "r"));
+        plan.add_task(Task::new(1, "Downstream", "r").with_dependency(0));
+        plan.get_task_mut(0)
+            .unwrap()
+            .fail("boom", FailureCategory::AgentError);
+
+        assert!(!has_awaiting_task(&plan));
+        assert!(park_verdict_lines(&plan).is_empty());
+    }
+
+    /// The real `execute()` loop parks at quiescence: no worker is dispatched
+    /// for the awaiting task or its dependent, the run does not spin, and the
+    /// awaiting state survives untouched.
+    #[tokio::test]
+    async fn execute_parks_at_quiescence_without_dispatching() {
+        let orchestrator = Orchestrator::new(crate::config::AgentRuntimeConfig::default())
+            .await
+            .unwrap();
+        let mut plan = Plan::new("Park smoke");
+        plan.add_task(Task::new(0, "Done task", "r"));
+        plan.add_task(Task::new(1, "Gated task", "r"));
+        plan.add_task(Task::new(2, "Dependent", "r").with_dependency(1));
+        plan.get_task_mut(0).unwrap().complete("ok");
+        mark_awaiting(&mut plan, 1, vec![parked_call("kubectl_apply")]);
+
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(32);
+        let compute_ms = orchestrator.execute(&mut plan, &event_tx).await.unwrap();
+
+        assert_eq!(compute_ms, 0, "no worker ran");
+        assert!(matches!(
+            plan.tasks[1].state,
+            TaskState::AwaitingApproval { .. }
+        ));
+        assert!(
+            matches!(plan.tasks[2].state, TaskState::Pending),
+            "the dependent must not be dispatched while a decision is outstanding"
+        );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), event_rx.recv())
+                .await
+                .is_err(),
+            "no task events fire at the park verdict"
+        );
+    }
+
+    /// `park_enabled` requires the flag AND the conversational route — the
+    /// webhook arm of park mode is out of V1 scope.
+    #[tokio::test]
+    async fn park_enabled_requires_flag_and_conversational_route() {
+        use aura_config::GlobPattern;
+
+        fn config(park_enabled: bool, conversational: bool) -> AgentRuntimeConfig {
+            let mut config = AgentRuntimeConfig::default();
+            let route = if conversational {
+                crate::hitl::DecisionRoute::Conversational {
+                    registry: crate::hitl::PendingApprovals::new(),
+                    timeout: Duration::from_secs(60),
+                }
+            } else {
+                crate::hitl::DecisionRoute::Webhook {
+                    client: crate::hitl::WebhookClient::new(
+                        reqwest::Client::new(),
+                        aura_config::WebhookUrl::new("https://approvals.example.com/").unwrap(),
+                    ),
+                    timeout: Duration::from_secs(5),
+                }
+            };
+            config.hitl = Some(crate::hitl::HitlRuntime {
+                patterns: Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
+                route: Arc::new(route),
+                park_enabled,
+            });
+            config
+        }
+
+        let no_hitl = Orchestrator::new(AgentRuntimeConfig::default())
+            .await
+            .unwrap();
+        assert!(!no_hitl.park_enabled(), "no [hitl] table: park off");
+
+        let off = Orchestrator::new(config(false, true)).await.unwrap();
+        assert!(!off.park_enabled(), "flag off: park off");
+
+        let on = Orchestrator::new(config(true, true)).await.unwrap();
+        assert!(on.park_enabled(), "flag on + conversational: park on");
+
+        let webhook = Orchestrator::new(config(true, false)).await.unwrap();
+        assert!(!webhook.park_enabled(), "webhook route: park off");
+    }
+
+    /// The orphan cleanup: every pending decision id is removed from the
+    /// store with an `approval_completed(cancelled)` event, so no decidable
+    /// approval outlives a worker whose conversation was never captured.
+    #[tokio::test]
+    async fn cancel_parked_approvals_removes_tickets_and_publishes_cancelled() {
+        use crate::hitl::{
+            AgentScope, ApprovalOrigin, ApprovalRequest, PROTOCOL_VERSION, ParkedApproval,
+            PendingApprovals,
+        };
+        use crate::session_store::{InMemoryApprovalStore, InMemoryEventBus};
+
+        let request_id = format!("req_cancel_{}", uuid::Uuid::new_v4().simple());
+        let mut events = crate::approval_event_broker::subscribe(&request_id).await;
+
+        let store: Arc<dyn crate::session_store::ApprovalStore> =
+            Arc::new(InMemoryApprovalStore::new());
+        let registry =
+            PendingApprovals::with_backend(store.clone(), Arc::new(InMemoryEventBus::new()));
+        let config = AgentRuntimeConfig {
+            hitl: Some(crate::hitl::HitlRuntime {
+                patterns: Arc::from([aura_config::GlobPattern::new("kubectl_*").unwrap()]),
+                route: Arc::new(crate::hitl::DecisionRoute::Conversational {
+                    registry: registry.clone(),
+                    timeout: Duration::from_secs(60),
+                }),
+                park_enabled: true,
+            }),
+            request_id: Some(request_id.clone()),
+            ..AgentRuntimeConfig::default()
+        };
+        let orchestrator = Orchestrator::new(config).await.unwrap();
+
+        // Two durable registrations, as the park arm would make them.
+        let now = chrono::Utc::now();
+        let mut pending = Vec::new();
+        for tool in ["kubectl_apply", "kubectl_delete"] {
+            let decision_id = TestDecisionId::generate();
+            registry
+                .register_durable(ParkedApproval {
+                    request: ApprovalRequest {
+                        version: PROTOCOL_VERSION,
+                        decision_id,
+                        request_id: "run:test".to_string(),
+                        scope: AgentScope::Single { session_id: None },
+                        origin: ApprovalOrigin::ConfigGate {
+                            matched_pattern: "kubectl_*".to_string(),
+                            agent_name: "test-agent".to_string(),
+                        },
+                        items: vec![],
+                    },
+                    registered_at: now,
+                    expires_at: now + chrono::Duration::seconds(60),
+                })
+                .await
+                .expect("durable register succeeds");
+            assert!(
+                store.get(&decision_id).await.unwrap().is_some(),
+                "ticket parked before cleanup"
+            );
+            pending.push(TestPendingCall {
+                decision_id,
+                tool_name: tool.to_string(),
+                arguments: serde_json::json!({}),
+                call_id: "call_1".to_string(),
+            });
+        }
+
+        orchestrator
+            .cancel_parked_approvals(3, Some("operations"), &pending)
+            .await;
+
+        for call in &pending {
+            assert!(
+                store.get(&call.decision_id).await.unwrap().is_none(),
+                "orphaned decision {} removed from the store",
+                call.decision_id
+            );
+        }
+        for expected in &pending {
+            match tokio::time::timeout(Duration::from_secs(1), events.recv()).await {
+                Ok(Some(crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
+                    completed,
+                ))) => {
+                    assert_eq!(completed.decision_id, expected.decision_id.to_string());
+                    assert!(matches!(
+                        completed.outcome,
+                        aura_events::ApprovalOutcomeWire::Cancelled { .. }
+                    ));
+                }
+                other => panic!("expected Completed(cancelled) event, got {other:?}"),
+            }
+        }
+
+        crate::approval_event_broker::unsubscribe(&request_id).await;
     }
 }

--- a/crates/aura/src/orchestration/stream_events.rs
+++ b/crates/aura/src/orchestration/stream_events.rs
@@ -8,6 +8,7 @@
 //! - `aura.orchestrator.plan_created` - Plan decomposed from user query
 //! - `aura.orchestrator.task_started` - Worker began task execution
 //! - `aura.orchestrator.task_completed` - Worker finished task (success/failure)
+//! - `aura.orchestrator.task_blocked` - Worker parked gated calls (park mode)
 //! - `aura.orchestrator.iteration_complete` - Plan-execute-continue cycle done
 //! - `aura.orchestrator.synthesizing` - Consolidating task results for coordinator decision
 //! - `aura.orchestrator.tool_call_started` - Worker tool execution began
@@ -69,6 +70,7 @@ pub mod event_names {
     pub const CLARIFICATION_NEEDED: &str = "aura.orchestrator.clarification_needed";
     pub const TASK_STARTED: &str = "aura.orchestrator.task_started";
     pub const TASK_COMPLETED: &str = "aura.orchestrator.task_completed";
+    pub const TASK_BLOCKED: &str = "aura.orchestrator.task_blocked";
     pub const ITERATION_COMPLETE: &str = "aura.orchestrator.iteration_complete";
     pub const REPLAN_STARTED: &str = "aura.orchestrator.replan_started";
     pub const SYNTHESIZING: &str = "aura.orchestrator.synthesizing";
@@ -125,6 +127,19 @@ pub enum OrchestrationStreamEvent {
         task: TaskContext,
         #[serde(flatten)]
         outcome: CompletionOutcome,
+        #[serde(flatten)]
+        context: EventContext,
+    },
+    /// A worker task parked a gated call (park mode); one event per call.
+    TaskBlocked {
+        /// The gated tool call's id.
+        tool_call_id: String,
+        /// The parked approval's decision id.
+        decision_id: String,
+        /// The gated tool's name.
+        tool_name: String,
+        #[serde(flatten)]
+        task: TaskContext,
         #[serde(flatten)]
         context: EventContext,
     },
@@ -195,6 +210,7 @@ impl OrchestrationStreamEvent {
             Self::ClarificationNeeded { .. } => event_names::CLARIFICATION_NEEDED,
             Self::TaskStarted { .. } => event_names::TASK_STARTED,
             Self::TaskCompleted { .. } => event_names::TASK_COMPLETED,
+            Self::TaskBlocked { .. } => event_names::TASK_BLOCKED,
             Self::IterationComplete { .. } => event_names::ITERATION_COMPLETE,
             Self::ReplanStarted { .. } => event_names::REPLAN_STARTED,
             Self::Synthesizing { .. } => event_names::SYNTHESIZING,
@@ -299,6 +315,29 @@ impl OrchestrationStreamEvent {
                 success,
                 duration_ms,
                 result,
+            },
+            context,
+        }
+    }
+
+    /// Create a TaskBlocked event (one per parked call).
+    pub fn task_blocked(
+        task_id: usize,
+        tool_call_id: impl Into<String>,
+        decision_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        orchestrator_id: impl Into<String>,
+        worker_id: impl Into<String>,
+        context: EventContext,
+    ) -> Self {
+        Self::TaskBlocked {
+            tool_call_id: tool_call_id.into(),
+            decision_id: decision_id.into(),
+            tool_name: tool_name.into(),
+            task: TaskContext {
+                task_id,
+                orchestrator_id: orchestrator_id.into(),
+                worker_id: worker_id.into(),
             },
             context,
         }
@@ -552,6 +591,32 @@ mod tests {
         assert!(sse.starts_with(&format!("event: {}\n", event_names::TASK_COMPLETED)));
         assert!(sse.contains("\"result\":\"The mean is 30.0\""));
         assert!(sse.contains("\"success\":true"));
+    }
+
+    /// The blocked-task wire event carries the gated call's `tool_call_id`.
+    #[test]
+    fn test_format_sse_task_blocked() {
+        let event = OrchestrationStreamEvent::task_blocked(
+            2,
+            "call_42",
+            "0191e8c0-1111-7000-8000-00000000000a",
+            "kubectl_apply",
+            "orch-1",
+            "operations",
+            test_ctx(),
+        );
+        let sse = event.format_sse();
+
+        assert!(sse.starts_with("event: aura.orchestrator.task_blocked\n"));
+        assert_eq!(
+            event_names::TASK_BLOCKED,
+            aura_events::orchestration::event_names::TASK_BLOCKED
+        );
+        assert!(sse.contains("\"task_id\":2"));
+        assert!(sse.contains("\"tool_call_id\":\"call_42\""));
+        assert!(sse.contains("\"tool_name\":\"kubectl_apply\""));
+        assert!(sse.contains("\"decision_id\":\"0191e8c0-1111-7000-8000-00000000000a\""));
+        assert!(sse.contains("\"worker_id\":\"operations\""));
     }
 
     #[test]

--- a/crates/aura/src/orchestration/types.rs
+++ b/crates/aura/src/orchestration/types.rs
@@ -6,9 +6,12 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
+use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+use crate::hitl::DecisionId;
 
 /// Maximum nesting depth for step structures.
 /// Depth 0 = top-level steps list, depth 1 = inside a parallel group,
@@ -346,6 +349,9 @@ impl Serialize for Task {
                 map.serialize_entry("error", error)?;
                 map.serialize_entry("failure_category", category)?;
             }
+            TaskState::AwaitingApproval { pending } => {
+                map.serialize_entry("pending_calls", pending)?;
+            }
             _ => {}
         }
         if let Some(ref w) = self.worker {
@@ -373,6 +379,8 @@ impl<'de> Deserialize<'de> for Task {
             #[serde(default)]
             failure_category: Option<FailureCategory>,
             #[serde(default)]
+            pending_calls: Option<Vec<PendingCall>>,
+            #[serde(default)]
             worker: Option<String>,
             #[serde(default)]
             rationale: String,
@@ -389,6 +397,9 @@ impl<'de> Deserialize<'de> for Task {
             TaskStatus::Failed => TaskState::Failed {
                 error: h.error.unwrap_or_else(|| "unknown".into()),
                 category: h.failure_category.unwrap_or_default(),
+            },
+            TaskStatus::AwaitingApproval => TaskState::AwaitingApproval {
+                pending: h.pending_calls.unwrap_or_default(),
             },
         };
         Ok(Task {
@@ -477,6 +488,9 @@ pub enum TaskStatus {
     Complete,
     /// Task failed.
     Failed,
+    /// Task's worker parked gated calls; awaiting human decisions (park mode).
+    #[serde(rename = "awaiting_approval")]
+    AwaitingApproval,
 }
 
 /// Structured classification of why a task failed, surfaced in the
@@ -510,6 +524,133 @@ pub enum FailureCategory {
     AgentError,
 }
 
+/// One gated tool call parked for a human decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingCall {
+    /// The decision id the parked approval resolves against.
+    pub decision_id: DecisionId,
+    /// The gated tool's name.
+    pub tool_name: String,
+    /// The transformed arguments the gate saw.
+    pub arguments: serde_json::Value,
+    /// The model's tool-call id.
+    pub call_id: String,
+}
+
+/// The worker conversation captured for its parked calls: `history` up to the
+/// final turn, and that turn's aggregated tool-result prompt.
+#[derive(Debug, Clone)]
+pub struct ParkSnapshot {
+    pub history: Vec<rig::completion::Message>,
+    pub current_prompt: rig::completion::Message,
+}
+
+/// One worker attempt's parked calls and the conversation snapshot taken for
+/// them. Every operation is a short op under a std mutex; nothing awaits
+/// while holding the lock.
+#[derive(Debug, Default)]
+pub struct BlockedCell {
+    inner: Mutex<BlockedCellInner>,
+}
+
+#[derive(Debug, Default)]
+struct BlockedCellInner {
+    pending: Vec<PendingCall>,
+    snapshot: Option<ParkSnapshot>,
+    /// The tool-call id of the call about to execute (tools run sequentially).
+    current_call_id: Option<String>,
+}
+
+/// The blocked cell's verdict after a worker stream ends.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CellOutcome {
+    /// No parked call.
+    Normal,
+    /// Parked calls with a captured snapshot.
+    Blocked { pending: Vec<PendingCall> },
+    /// Parked calls without a snapshot: the stream ended before the hook ran.
+    Orphaned { pending: Vec<PendingCall> },
+}
+
+impl BlockedCell {
+    /// Append a parked call.
+    pub fn push(&self, call: PendingCall) {
+        self.inner
+            .lock()
+            .expect("blocked cell lock poisoned")
+            .pending
+            .push(call);
+    }
+
+    /// Stash the tool-call id the hook observed for the call about to execute.
+    pub fn set_current_call_id(&self, id: Option<String>) {
+        self.inner
+            .lock()
+            .expect("blocked cell lock poisoned")
+            .current_call_id = id;
+    }
+
+    /// Take the stashed tool-call id (consumed by the gate's park arm).
+    pub fn take_current_call_id(&self) -> Option<String> {
+        self.inner
+            .lock()
+            .expect("blocked cell lock poisoned")
+            .current_call_id
+            .take()
+    }
+
+    /// Snapshot `(history, current_prompt)` if a parked call is waiting for
+    /// one. Returns whether the snapshot was taken; an existing snapshot is
+    /// never overwritten.
+    pub fn snapshot_if_pending(
+        &self,
+        history: &[rig::completion::Message],
+        current_prompt: &rig::completion::Message,
+    ) -> bool {
+        let mut inner = self.inner.lock().expect("blocked cell lock poisoned");
+        if inner.pending.is_empty() || inner.snapshot.is_some() {
+            return false;
+        }
+        inner.snapshot = Some(ParkSnapshot {
+            history: history.to_vec(),
+            current_prompt: current_prompt.clone(),
+        });
+        true
+    }
+
+    /// The cell's verdict after a stream end, consuming the parked calls.
+    pub fn outcome(&self) -> CellOutcome {
+        let mut inner = self.inner.lock().expect("blocked cell lock poisoned");
+        if inner.pending.is_empty() {
+            return CellOutcome::Normal;
+        }
+        let pending = std::mem::take(&mut inner.pending);
+        if inner.snapshot.is_some() {
+            CellOutcome::Blocked { pending }
+        } else {
+            CellOutcome::Orphaned { pending }
+        }
+    }
+
+    /// Whether no parked call is recorded.
+    pub fn is_empty(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("blocked cell lock poisoned")
+            .pending
+            .is_empty()
+    }
+
+    /// The captured snapshot, if the hook fired.
+    pub fn snapshot(&self) -> Option<ParkSnapshot> {
+        self.inner
+            .lock()
+            .expect("blocked cell lock poisoned")
+            .snapshot
+            .clone()
+    }
+}
+
 /// Rich state of a task, making invalid states unrepresentable.
 ///
 /// Use pattern matching or `matches!()` for boolean checks.
@@ -524,6 +665,10 @@ pub enum TaskState {
         error: String,
         category: FailureCategory,
     },
+    /// The worker parked gated calls and awaits human decisions.
+    AwaitingApproval {
+        pending: Vec<PendingCall>,
+    },
 }
 
 impl From<&TaskState> for TaskStatus {
@@ -533,6 +678,7 @@ impl From<&TaskState> for TaskStatus {
             TaskState::Running => TaskStatus::Running,
             TaskState::Complete { .. } => TaskStatus::Complete,
             TaskState::Failed { .. } => TaskStatus::Failed,
+            TaskState::AwaitingApproval { .. } => TaskStatus::AwaitingApproval,
         }
     }
 }
@@ -544,6 +690,7 @@ impl std::fmt::Display for TaskStatus {
             TaskStatus::Running => write!(f, "running"),
             TaskStatus::Complete => write!(f, "complete"),
             TaskStatus::Failed => write!(f, "failed"),
+            TaskStatus::AwaitingApproval => write!(f, "awaiting_approval"),
         }
     }
 }
@@ -866,6 +1013,16 @@ impl IterationContext {
                     blocked_lines.push(format!(
                         "- Task {}: {} → blocked (dependency failed)",
                         t.id, t.description
+                    ));
+                }
+                TaskState::AwaitingApproval { pending } => {
+                    // A parked run never renders a continuation prompt; if an
+                    // awaiting task reaches here, name what it waits on.
+                    blocked_lines.push(format!(
+                        "- Task {}: {} → awaiting approval ({} pending call(s))",
+                        t.id,
+                        t.description,
+                        pending.len()
                     ));
                 }
             }
@@ -1391,6 +1548,191 @@ mod tests {
         };
         assert_eq!(error, "boom");
         assert_eq!(category, FailureCategory::AgentError);
+    }
+
+    // ========================================================================
+    // AwaitingApproval (park mode)
+    // ========================================================================
+
+    fn pending_call(tool: &str, call_id: &str) -> PendingCall {
+        PendingCall {
+            decision_id: DecisionId::generate(),
+            tool_name: tool.to_string(),
+            arguments: serde_json::json!({ "namespace": "prod" }),
+            call_id: call_id.to_string(),
+        }
+    }
+
+    #[test]
+    fn awaiting_approval_is_unfinished_and_dependents_not_ready() {
+        let mut plan = Plan::new("Test");
+        plan.add_task(Task::new(0, "Gated task", "Runs the gated tool"));
+        plan.add_task(Task::new(1, "Dependent", "Needs task 0").with_dependency(0));
+        plan.get_task_mut(0).unwrap().state = TaskState::AwaitingApproval {
+            pending: vec![pending_call("kubectl_apply", "call_1")],
+        };
+
+        assert!(!plan.is_finished(), "an awaiting task is unfinished");
+        assert!(
+            plan.ready_tasks().is_empty(),
+            "dependents of an awaiting task are not ready"
+        );
+        assert_eq!(
+            plan.pending_count(),
+            1,
+            "only the dependent counts as Pending; the awaiting task is its own state"
+        );
+    }
+
+    #[test]
+    fn task_serde_roundtrip_awaiting_approval_carries_pending_calls() {
+        let mut task = Task::new(3, "Gated task", "test rationale");
+        task.state = TaskState::AwaitingApproval {
+            pending: vec![pending_call("kubectl_delete", "call_9")],
+        };
+        let json = serde_json::to_string(&task).unwrap();
+        assert!(json.contains(r#""status":"awaiting_approval"#));
+        assert!(json.contains(r#""tool_name":"kubectl_delete"#));
+
+        let roundtripped: Task = serde_json::from_str(&json).unwrap();
+        let TaskState::AwaitingApproval { pending } = roundtripped.state else {
+            panic!("expected AwaitingApproval");
+        };
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].tool_name, "kubectl_delete");
+        assert_eq!(pending[0].call_id, "call_9");
+        assert_eq!(pending[0].arguments["namespace"], "prod");
+    }
+
+    #[test]
+    fn task_status_display_and_from_for_awaiting_approval() {
+        assert_eq!(
+            TaskStatus::AwaitingApproval.to_string(),
+            "awaiting_approval"
+        );
+        let state = TaskState::AwaitingApproval { pending: vec![] };
+        assert_eq!(
+            TaskStatus::from(&state),
+            TaskStatus::AwaitingApproval,
+            "empty pending round-trips the status without panicking"
+        );
+    }
+
+    #[test]
+    fn continuation_prompt_renders_awaiting_approval_line() {
+        let mut plan = Plan::new("Goal");
+        let mut task = Task::new(0, "Gated task", "Waits on a human");
+        task.state = TaskState::AwaitingApproval {
+            pending: vec![pending_call("kubectl_apply", "call_1")],
+        };
+        plan.add_task(task);
+
+        let ctx = IterationContext::new(1, plan, None, vec![], HashMap::new());
+        let prompt = ctx.build_continuation_prompt(3, false, 2000);
+        assert!(prompt.contains("awaiting approval (1 pending call(s))"));
+    }
+
+    // ========================================================================
+    // BlockedCell
+    // ========================================================================
+
+    #[test]
+    fn blocked_cell_empty_stream_end_is_normal() {
+        let cell = BlockedCell::default();
+        assert!(cell.is_empty());
+        assert_eq!(cell.outcome(), CellOutcome::Normal);
+    }
+
+    #[test]
+    fn blocked_cell_with_snapshot_blocks() {
+        let cell = BlockedCell::default();
+        let parked = pending_call("kubectl_apply", "call_1");
+        cell.push(parked.clone());
+        assert!(!cell.is_empty());
+
+        let history = vec![rig::completion::Message::user("do the thing")];
+        let prompt = rig::completion::Message::user("tool results");
+        assert!(cell.snapshot_if_pending(&history, &prompt));
+
+        match cell.outcome() {
+            CellOutcome::Blocked { pending } => {
+                assert_eq!(pending, vec![parked]);
+            }
+            other => panic!("expected Blocked, got {other:?}"),
+        }
+
+        // The snapshot survives the outcome read.
+        let snapshot = cell.snapshot().expect("snapshot captured");
+        assert_eq!(snapshot.history.len(), 1);
+        // Consumed: a second outcome read is normal.
+        assert_eq!(cell.outcome(), CellOutcome::Normal);
+    }
+
+    #[test]
+    fn blocked_cell_without_snapshot_is_orphaned() {
+        // Stream ended before the hook fired: cell set, no snapshot.
+        let cell = BlockedCell::default();
+        let parked = pending_call("kubectl_apply", "call_1");
+        cell.push(parked.clone());
+
+        match cell.outcome() {
+            CellOutcome::Orphaned { pending } => {
+                assert_eq!(pending, vec![parked]);
+            }
+            other => panic!("expected Orphaned, got {other:?}"),
+        }
+        assert!(
+            cell.snapshot().is_none(),
+            "no snapshot exists on the orphaned path"
+        );
+    }
+
+    #[test]
+    fn blocked_cell_snapshots_only_when_pending() {
+        let cell = BlockedCell::default();
+        let history = vec![];
+        let prompt = rig::completion::Message::user("tool results");
+        assert!(
+            !cell.snapshot_if_pending(&history, &prompt),
+            "an empty cell must not capture a snapshot"
+        );
+        assert!(cell.snapshot().is_none());
+    }
+
+    #[test]
+    fn blocked_cell_never_overwrites_the_snapshot() {
+        let cell = BlockedCell::default();
+        cell.push(pending_call("kubectl_apply", "call_1"));
+        let first_prompt = rig::completion::Message::user("first");
+        assert!(cell.snapshot_if_pending(&[], &first_prompt));
+        let second_prompt = rig::completion::Message::user("second");
+        assert!(
+            !cell.snapshot_if_pending(&[], &second_prompt),
+            "a second capture must not overwrite the first"
+        );
+    }
+
+    #[test]
+    fn blocked_cell_two_gated_calls_one_turn() {
+        let cell = BlockedCell::default();
+        cell.set_current_call_id(Some("call_a".to_string()));
+        let mut first = pending_call("kubectl_apply", "");
+        first.call_id = cell.take_current_call_id().unwrap_or_default();
+        cell.set_current_call_id(Some("call_b".to_string()));
+        let mut second = pending_call("kubectl_delete", "");
+        second.call_id = cell.take_current_call_id().unwrap_or_default();
+        cell.push(first);
+        cell.push(second);
+
+        cell.snapshot_if_pending(&[], &rig::completion::Message::user("results"));
+        match cell.outcome() {
+            CellOutcome::Blocked { pending } => {
+                assert_eq!(pending.len(), 2);
+                assert_eq!(pending[0].call_id, "call_a");
+                assert_eq!(pending[1].call_id, "call_b");
+            }
+            other => panic!("expected Blocked, got {other:?}"),
+        }
     }
 
     // ========================================================================

--- a/crates/aura/src/session_store/fault_store.rs
+++ b/crates/aura/src/session_store/fault_store.rs
@@ -1,0 +1,62 @@
+//! An approval-store double for fault injection in tests.
+
+use async_trait::async_trait;
+
+use super::{ApprovalStore, InMemoryApprovalStore, SessionStoreError};
+use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
+
+/// Delegates to an in-memory store; each `fail_*` flag makes that operation
+/// answer `SessionStoreError::Request`.
+#[derive(Default)]
+pub(crate) struct FaultInjectingStore {
+    inner: InMemoryApprovalStore,
+    fail_register: bool,
+}
+
+impl FaultInjectingStore {
+    pub(crate) fn failing_register() -> Self {
+        Self {
+            fail_register: true,
+            ..Default::default()
+        }
+    }
+}
+
+#[async_trait]
+impl ApprovalStore for FaultInjectingStore {
+    async fn register(&self, parked: ParkedApproval) -> Result<(), SessionStoreError> {
+        if self.fail_register {
+            return Err(SessionStoreError::Request {
+                reason: "disk on fire".to_string(),
+            });
+        }
+        self.inner.register(parked).await
+    }
+
+    async fn get(&self, id: &DecisionId) -> Result<Option<ParkedApproval>, SessionStoreError> {
+        self.inner.get(id).await
+    }
+
+    async fn resolve(
+        &self,
+        id: &DecisionId,
+        decision: ApprovalDecision,
+    ) -> Result<(), ResolveError> {
+        self.inner.resolve(id, decision).await
+    }
+
+    async fn decision(
+        &self,
+        id: &DecisionId,
+    ) -> Result<Option<ApprovalDecision>, SessionStoreError> {
+        self.inner.decision(id).await
+    }
+
+    async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError> {
+        self.inner.remove(id).await
+    }
+
+    async fn cancel_request(&self, request_id: &str) -> Result<(), SessionStoreError> {
+        self.inner.cancel_request(request_id).await
+    }
+}

--- a/crates/aura/src/session_store/mod.rs
+++ b/crates/aura/src/session_store/mod.rs
@@ -9,6 +9,8 @@
 //! See `docs/design/session-storage.md` and
 //! `docs/adr/2026-07-08-session-storage.md`.
 
+#[cfg(test)]
+pub(crate) mod fault_store;
 mod file;
 mod memory;
 mod record;
@@ -22,6 +24,8 @@ use futures::Stream;
 
 use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
 
+#[cfg(test)]
+pub(crate) use fault_store::FaultInjectingStore;
 pub use file::FileApprovalStore;
 pub use memory::{InMemoryApprovalStore, InMemoryEventBus};
 pub use record::{DecisionRecord, InvalidRecord, OriginRecord, ParkedApprovalRecord, ScopeRecord};

--- a/crates/aura/src/streaming_request_hook.rs
+++ b/crates/aura/src/streaming_request_hook.rs
@@ -1,10 +1,11 @@
 //! Streaming request hook for request lifecycle management.
 //!
 //! This hook manages the full lifecycle of streaming requests:
-//! 1. Timeout/cancellation - External cancellation signal (e.g., client disconnect)
-//! 2. Tool event emission - `aura.tool_requested`, `aura.tool_usage` events
-//! 3. Usage state tracking - Token counts for billing/metrics
-//! 4. Tool ID FIFO correlation - Associates tool calls with results
+//! 1. Parked approvals (park mode) - snapshot + cancel when the blocked cell is set
+//! 2. Timeout/cancellation - External cancellation signal (e.g., client disconnect)
+//! 3. Tool event emission - `aura.tool_requested`, `aura.tool_usage` events
+//! 4. Usage state tracking - Token counts for billing/metrics
+//! 5. Tool ID FIFO correlation - Associates tool calls with results
 //!
 //! # Tool Event Flow
 //!
@@ -15,6 +16,11 @@
 //!
 //! This relies on Rig's streaming mode executing tools sequentially.
 //! See `docs/rig-fork-changes.md` for analysis.
+//!
+//! # Park mode
+//!
+//! A worker stream in park mode has a [`BlockedCell`] registered under its
+//! request id; `on_completion_call` checks it before every other check.
 //!
 //! # Usage
 //!
@@ -31,22 +37,81 @@
 //! let (prompt, completion, total) = usage_state.get_final_usage();
 //! ```
 
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use rig::agent::{CancelSignal, StreamingPromptHook};
+use rig::completion::{CompletionModel, GetTokenUsage, Message};
+use tokio::sync::watch;
+
+use crate::orchestration::BlockedCell;
 use crate::scratchpad::{self, ContextBudget};
 use crate::tool_event_broker::{
     pop_tool_call_id, publish_tool_requested, publish_tool_usage, push_tool_call_id,
 };
-use rig::agent::{CancelSignal, StreamingPromptHook};
-use rig::completion::{CompletionModel, GetTokenUsage, Message};
-use std::collections::HashSet;
-use std::future::Future;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
-use tokio::sync::watch;
 
 /// Maximum pending tool IDs before warning. Prevents unbounded growth if
 /// usage events never fire (e.g., provider doesn't return token counts).
 const MAX_PENDING_TOOL_IDS: usize = 256;
+
+// ============================================================================
+// Park cells (park mode)
+// ============================================================================
+
+/// Cancel reason the hook stamps when a parked call ends the worker stream.
+pub(crate) const PARK_CANCEL_REASON: &str = "parked";
+
+/// Blocked cells of the worker streams in park mode, keyed by the per-stream
+/// id the orchestrator passes as the hook's `request_id`. The hook is built
+/// inside the streaming layer and cannot take the cell as a parameter, so it
+/// travels through this request-keyed global like the tool-event broker.
+static PARK_CELLS: OnceLock<std::sync::RwLock<HashMap<String, Arc<BlockedCell>>>> = OnceLock::new();
+
+fn park_cells() -> &'static std::sync::RwLock<HashMap<String, Arc<BlockedCell>>> {
+    PARK_CELLS.get_or_init(|| std::sync::RwLock::new(HashMap::new()))
+}
+
+/// A worker stream's park-cell registration; dropping it removes the cell
+/// and the stream's tool-event subscription.
+pub(crate) struct ParkCellRegistration(String);
+
+impl ParkCellRegistration {
+    pub(crate) fn new(key: &str, cell: Arc<BlockedCell>) -> Self {
+        park_cells()
+            .write()
+            .expect("park cell registry poisoned")
+            .insert(key.to_string(), cell);
+        Self(key.to_string())
+    }
+}
+
+impl Drop for ParkCellRegistration {
+    fn drop(&mut self) {
+        park_cells()
+            .write()
+            .expect("park cell registry poisoned")
+            .remove(&self.0);
+        // The hook keyed its tool-event FIFO under the same id; the broker is
+        // async, so that cleanup runs as its own task when a runtime exists.
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let key = std::mem::take(&mut self.0);
+            handle.spawn(async move { crate::tool_event_broker::unsubscribe(&key).await });
+        }
+    }
+}
+
+/// The blocked cell for `key`, if this stream is in park mode.
+pub(crate) fn park_cell_for(key: &str) -> Option<Arc<BlockedCell>> {
+    park_cells()
+        .read()
+        .expect("park cell registry poisoned")
+        .get(key)
+        .cloned()
+}
 
 /// Shared usage state that survives hook cloning.
 ///
@@ -421,13 +486,26 @@ where
 {
     fn on_completion_call(
         &self,
-        _prompt: &Message,
-        _history: &[Message],
+        prompt: &Message,
+        history: &[Message],
         cancel_sig: CancelSignal,
     ) -> impl Future<Output = ()> + Send {
         let has_client_tools = !self.client_tool_names.is_empty();
         let client_tool_called = self.client_tool_called.clone();
         async move {
+            // Checked before the client-tool, cancel, and timeout checks: a
+            // waiting parked call must get its snapshot whatever else is true.
+            if let Some(cell) = park_cell_for(&self.request_id)
+                && cell.snapshot_if_pending(history, prompt)
+            {
+                tracing::info!(
+                    request_id = %self.request_id,
+                    "Parked approval pending — cancelling stream (reason: {})",
+                    PARK_CANCEL_REASON
+                );
+                cancel_sig.cancel_with_reason(PARK_CANCEL_REASON);
+                return;
+            }
             // If a passthrough tool was called this turn, do not initiate
             // another LLM completion. Cancel here so the stream terminates
             // and the streaming layer can emit `finish_reason: "tool_calls"`
@@ -493,6 +571,11 @@ where
         let is_client_tool = self.client_tool_names.contains(&tool_name);
         let client_tool_called = self.client_tool_called.clone();
         async move {
+            // Stash the call id so the park arm can record it on the cell entry.
+            if let Some(cell) = park_cell_for(&request_id) {
+                cell.set_current_call_id(tool_call_id.clone());
+            }
+
             if is_client_tool {
                 tracing::info!(
                     "Client tool '{}' called for request '{}' — marking for passthrough",
@@ -682,6 +765,40 @@ mod tests {
             StreamingRequestHook::new(Duration::from_secs(60), "test_req_1");
         assert!(!hook.should_cancel());
         assert_eq!(hook.request_id, "test_req_1");
+    }
+
+    // ---------------------------------------------------------------------
+    // Park-cell registry
+    // ---------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn park_cell_registration_isolates_keys_and_removes_on_drop() {
+        let cell_a = Arc::new(BlockedCell::default());
+        let cell_b = Arc::new(BlockedCell::default());
+        let key_a = format!("park_reg_{}", uuid::Uuid::new_v4().simple());
+        let key_b = format!("park_reg_{}", uuid::Uuid::new_v4().simple());
+
+        assert!(park_cell_for(&key_a).is_none());
+        let reg_a = ParkCellRegistration::new(&key_a, cell_a.clone());
+        let reg_b = ParkCellRegistration::new(&key_b, cell_b.clone());
+
+        park_cell_for(&key_a)
+            .expect("registered cell")
+            .push(crate::orchestration::PendingCall {
+                decision_id: crate::hitl::DecisionId::generate(),
+                tool_name: "kubectl_apply".to_string(),
+                arguments: serde_json::json!({}),
+                call_id: "call_1".to_string(),
+            });
+        assert!(cell_b.is_empty(), "keys are isolated");
+
+        drop(reg_a);
+        assert!(
+            park_cell_for(&key_a).is_none(),
+            "a dropped registration is gone"
+        );
+        assert!(park_cell_for(&key_b).is_some(), "the sibling survives");
+        drop(reg_b);
     }
 
     #[test]


### PR DESCRIPTION
Part of #271 (park mode for orchestration approvals). First of three stacked PRs; merge order is this one, then #650, then #651.

A gated worker call in park mode no longer waits for a live decision. The gate registers the approval durably under a run-scoped owner and publishes the usual approval events. It then records the call on the worker's blocked cell and returns a placeholder result. The park-aware hook snapshots the worker conversation and cancels the stream, and the task lands in a new `AwaitingApproval` state that keeps its dependents from starting. At quiescence the run ends without a coordinator replan. Everything sits behind `[hitl.park].enabled`, default off, on the conversational route only.

Also here: `aura.orchestrator.task_blocked` on the wire, and a small test double for approval-store faults that the later PRs reuse.

Testing: `cargo test --workspace`, clippy with warnings denied, nightly fmt. The quiescence cases (single blocker, parallel blockers, blocker behind a running dependency, failed sibling, two gated calls in one turn, stream ending before the snapshot) are unit tests; a live run with a gated mock tool printed the expected park verdict lines.
