### PR TITLE
feat(instance-id): stable per-agent instance uuid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 1.4.0",
+ "machine-uid",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -2732,6 +2733,17 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "machine-uid"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe0d6336d341b10ae80e099b8f3c59f34bf8aef66ef25e83aa98bf2955c0ae7"
+dependencies = [
+ "libc",
+ "windows-registry",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "matchers"
@@ -5238,6 +5250,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ hex = "0.4"
 # Vector stores - pinned to exact version compatible with our rig-core 0.28.x fork
 rig-qdrant = "=0.1.34"
 qdrant-client = "1.14.0"
-uuid = { version = "1.0", features = ["v4", "v7", "serde"] }
+uuid = { version = "1.0", features = ["v4", "v5", "v7", "serde"] }
 
 # Enum utilities
 strum = { version = "0.26", features = ["derive"] }

--- a/crates/aura-cli/src/governance.rs
+++ b/crates/aura-cli/src/governance.rs
@@ -10,12 +10,27 @@ use aura::governance::build_catalog;
 pub enum GovernanceCommands {
     /// Discover all MCP tools and send a catalog snapshot to the governance webhook.
     Sync,
+    /// Display the computed instance ID for each loaded agent config.
+    Info,
 }
 
 pub fn run(confs: &[aura_config::Config], command: &GovernanceCommands) -> Result<()> {
-    let rt = tokio::runtime::Runtime::new()?;
     match command {
-        GovernanceCommands::Sync => rt.block_on(sync_all(confs)),
+        GovernanceCommands::Sync => {
+            let rt = tokio::runtime::Runtime::new()?;
+            rt.block_on(sync_all(confs))
+        }
+        GovernanceCommands::Info => {
+            info_all(confs);
+            Ok(())
+        }
+    }
+}
+
+fn info_all(confs: &[aura_config::Config]) {
+    for conf in confs {
+        let id = aura::instance_id::instance_id(&conf.agent);
+        println!("agent \"{}\"  instance_id: {id}", conf.agent.name);
     }
 }
 

--- a/crates/aura-cli/src/repl/governance.rs
+++ b/crates/aura-cli/src/repl/governance.rs
@@ -14,14 +14,17 @@ pub(crate) fn handle_governance(ctx: &mut CommandContext, args: &str) -> Command
 
     match subcommand {
         Some("sync") if subargs.is_empty() => handle_sync(ctx),
+        Some("info") if subargs.is_empty() => handle_info(ctx),
         _ => {
             println!(
                 "{}: /governance <subcommand>\n\n \
                 Subcommands:\n\n \
-                   sync    {}\n\n",
+                   sync    {}\n \
+                   info    {}\n\n",
                 "Usage".themed(AuraStyle::Primary),
                 "Discover MCP tools and send catalog to governance webhook"
-                    .themed(AuraStyle::Muted)
+                    .themed(AuraStyle::Muted),
+                "Display the instance ID for each loaded agent config".themed(AuraStyle::Muted),
             );
             CommandOutcome::Handled
         }
@@ -47,6 +50,28 @@ fn handle_sync(ctx: &mut CommandContext) -> CommandOutcome {
         }
         #[cfg(feature = "standalone-cli")]
         Backend::Direct(direct) => ctx.rt.block_on(run_sync_standalone(direct)),
+    }
+}
+
+/// Handle `/governance info`.
+fn handle_info(ctx: &mut CommandContext) -> CommandOutcome {
+    match ctx.backend {
+        Backend::Http(_) => {
+            println!(
+                "{}: governance commands are only supported in standalone mode\n\n \
+                The /governance info command reads agent configs directly and cannot run\n \
+                when connected to an AURA web server over HTTP.\n\n \
+                {}\n\n",
+                "Error".themed(AuraStyle::Error),
+                "To use governance commands, run the CLI in standalone mode:\n  \
+                 • omit --api-url to use the default config.toml\n  \
+                 • pass --config <path> to specify a config file or directory"
+                    .themed(AuraStyle::Muted)
+            );
+            CommandOutcome::Handled
+        }
+        #[cfg(feature = "standalone-cli")]
+        Backend::Direct(direct) => run_info_standalone(direct),
     }
 }
 
@@ -122,5 +147,35 @@ async fn run_sync_standalone(direct: &crate::backend::direct::DirectBackend) -> 
         "Finished governence sync".themed(AuraStyle::Primary)
     );
 
+    CommandOutcome::Handled
+}
+
+/// Display instance IDs in standalone mode.
+#[cfg(feature = "standalone-cli")]
+fn run_info_standalone(direct: &crate::backend::direct::DirectBackend) -> CommandOutcome {
+    use aura::instance_id::instance_id as compute_instance_id;
+
+    println!(
+        "{} {}",
+        "●".themed(AuraStyle::Emphasis),
+        "Agent instance identities".themed(AuraStyle::Primary),
+    );
+
+    let configs = direct.configs();
+    for (idx, config) in configs.iter().enumerate() {
+        let pipe = if idx + 1 < configs.len() {
+            "├─"
+        } else {
+            "└─"
+        };
+        let id = compute_instance_id(&config.agent);
+        println!(
+            "  {} {} {}",
+            pipe.themed(AuraStyle::Connector),
+            format!("\"{}\"", config.agent.name).themed(AuraStyle::Primary),
+            format!("instance_id: {id}").themed(AuraStyle::Identifier),
+        );
+    }
+    println!();
     CommandOutcome::Handled
 }

--- a/crates/aura-cli/src/test_fixtures.rs
+++ b/crates/aura-cli/src/test_fixtures.rs
@@ -37,6 +37,7 @@ pub(crate) fn worker(name: &str) -> WorkerOverview {
 pub(crate) fn agent(id: &str, workers: Vec<WorkerOverview>) -> AgentInfo {
     AgentInfo {
         id: id.to_string(),
+        instance_id: None,
         description: None,
         model: "gpt-4o".to_string(),
         workers,

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -869,6 +869,14 @@ pub struct AgentConfig {
     #[serde(default)]
     #[serde(deserialize_with = "lenient_int::deserialize_option_usize")]
     pub nudge_turns_remaining: Option<usize>,
+    /// Stable seed for instance ID derivation.
+    ///
+    /// When set, this value is hashed with the agent name and the env seed
+    /// instead of the default `sha256(name, alias)`. Supports
+    /// `{{ env.* }}` templating so the value can come from an environment
+    /// variable without being committed to the config file.
+    #[serde(default)]
+    pub instance_seed: Option<String>,
 }
 
 fn default_turn_depth() -> Option<usize> {
@@ -902,6 +910,7 @@ impl Default for AgentConfig {
             skills: SkillsConfig::default(),
             nudge_last_turn: false,
             nudge_turns_remaining: None,
+            instance_seed: None,
         }
     }
 }

--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -262,6 +262,11 @@ pub enum McpServerOverview {
 pub struct AgentInfo {
     /// Agent identifier — matches the `id` field in `/v1/models` (alias or name).
     pub id: String,
+    /// Stable per-instance UUID derived from agent config and host identity.
+    ///
+    /// Absent when the response comes from a server that predates this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
     /// Short human-readable summary of what the agent does.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -2381,6 +2381,7 @@ url = "http://127.0.0.1:9"
 
             let req = aura::hitl::ApprovalRequest {
                 version: aura::hitl::PROTOCOL_VERSION,
+                instance_id: "test-instance".to_string(),
                 decision_id: aura::hitl::DecisionId::generate(),
                 request_id: "req-smoke".into(),
                 scope: aura::hitl::AgentScope::Single { session_id: None },
@@ -2589,6 +2590,7 @@ url = "http://127.0.0.1:9"
         ) -> (aura::hitl::DecisionId, aura::hitl::AwaitingDecision) {
             let req = aura::hitl::ApprovalRequest {
                 version: aura::hitl::PROTOCOL_VERSION,
+                instance_id: "test-instance".to_string(),
                 decision_id: aura::hitl::DecisionId::generate(),
                 request_id: "req-hmac".into(),
                 scope: aura::hitl::AgentScope::Single { session_id: None },

--- a/crates/aura-web-server/src/server.rs
+++ b/crates/aura-web-server/src/server.rs
@@ -1,5 +1,6 @@
 //! Web-server entry point, shared by every binary that can launch the server.
 
+use aura::instance_id::instance_id as compute_instance_id;
 use aura_config::load_config;
 use axum::Json;
 use axum::extract::{Request, State};
@@ -335,7 +336,11 @@ async fn run(args: ServerArgs) -> std::io::Result<()> {
     for config in &configs {
         let id = config.agent.alias.as_deref().unwrap_or(&config.agent.name);
         let (provider, model) = config.agent.llm.model_info();
-        info!("Loaded agent '{}' ({}/{})", id, provider, model);
+        let iid = compute_instance_id(&config.agent);
+        info!(
+            "Loaded agent '{}' ({}/{}) [instance_id={}]",
+            id, provider, model, iid
+        );
         warn_timeout_relationships(id, config, &args);
     }
 

--- a/crates/aura-web-server/tests/common/mod.rs
+++ b/crates/aura-web-server/tests/common/mod.rs
@@ -23,6 +23,7 @@ pub fn make_parked(request_id: &str, ttl: Duration) -> ParkedApproval {
     ParkedApproval {
         request: ApprovalRequest {
             version: PROTOCOL_VERSION,
+            instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
             request_id: request_id.to_string(),
             scope: AgentScope::Single { session_id: None },

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -65,6 +65,7 @@ uuid = { workspace = true }
 
 regex = "1"
 async-stream = "0.3"
+machine-uid = "0.6"
 strum = { workspace = true }
 
 # Tokenization for scratchpad context budget

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -334,6 +334,7 @@ impl Agent {
                     scope.clone(),
                     request_id.clone(),
                     config_owned.agent.name.clone(),
+                    config_owned.instance_id.clone(),
                 ));
             config_owned.tool_wrapper = Some(match config_owned.tool_wrapper.take() {
                 Some(existing) => Arc::new(crate::tool_wrapper::ComposedWrapper::new(vec![
@@ -346,6 +347,7 @@ impl Agent {
                 scope,
                 request_id,
                 config_owned.agent.name.clone(),
+                config_owned.instance_id.clone(),
             ));
         }
 

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -141,6 +141,11 @@ pub struct AgentRuntimeConfig {
     /// single-agent and orchestration paths share one value.
     pub request_id: Option<String>,
 
+    /// Computed instance UUID for this agent, derived from agent config and
+    /// host identity. Threaded into HITL approval requests so webhook
+    /// receivers can identify which instance raised each approval.
+    pub instance_id: String,
+
     /// The `request_approval` tool, pre-built with the appropriate
     /// [`AgentScope`]. Orchestration workers set this in `create_worker` with
     /// `AgentScope::Worker`; single-agent mode sets it in `Agent::new` with
@@ -174,6 +179,7 @@ impl Clone for AgentRuntimeConfig {
             orchestration_submit_result: self.orchestration_submit_result.clone(),
             hitl: self.hitl.clone(),
             request_id: self.request_id.clone(),
+            instance_id: self.instance_id.clone(),
             hitl_request_approval_tool: self.hitl_request_approval_tool.clone(),
         }
     }
@@ -217,6 +223,7 @@ impl std::fmt::Debug for AgentRuntimeConfig {
             )
             .field("hitl", &self.hitl.as_ref().map(|_| "<hitl>"))
             .field("request_id", &self.request_id)
+            .field("instance_id", &self.instance_id)
             .field(
                 "hitl_request_approval_tool",
                 &self

--- a/crates/aura/src/governance/envelope.rs
+++ b/crates/aura/src/governance/envelope.rs
@@ -32,6 +32,8 @@ pub struct CatalogEnvelope {
 pub struct AgentEntry {
     /// Agent identifier (from config).
     pub id: String,
+    /// Stable per-instance UUID derived from agent config and host identity.
+    pub instance_id: String,
     /// Human-readable agent name.
     pub name: String,
     /// LLM model identifier.
@@ -149,6 +151,7 @@ fn build_agent_entry(config: &Config, mcp_servers: Vec<McpServerEntry>) -> Agent
 
     AgentEntry {
         id,
+        instance_id: crate::instance_id::instance_id(&config.agent).to_string(),
         name,
         model,
         mcp_servers,
@@ -476,6 +479,22 @@ api_key = "k"
         let entry = build_agent_entry(&config, vec![]);
         assert_eq!(entry.id, "sre-agent");
         assert_eq!(entry.name, "sre-agent");
+    }
+
+    #[test]
+    fn build_agent_entry_carries_instance_id() {
+        let config = agent_config_toml("sre-agent", "", "");
+        let entry = build_agent_entry(&config, vec![]);
+        assert!(
+            uuid::Uuid::parse_str(&entry.instance_id).is_ok(),
+            "instance_id must be a valid UUID: {}",
+            entry.instance_id
+        );
+        // Stable — same config produces the same ID.
+        assert_eq!(
+            build_agent_entry(&config, vec![]).instance_id,
+            entry.instance_id
+        );
     }
 
     #[test]

--- a/crates/aura/src/hitl/events.rs
+++ b/crates/aura/src/hitl/events.rs
@@ -41,6 +41,7 @@ impl<'a> From<&'a ApprovalRequest> for ApprovalRequestWire<'a> {
     fn from(request: &'a ApprovalRequest) -> Self {
         Self {
             version: request.version,
+            instance_id: request.instance_id.as_str(),
             decision_id: request.decision_id,
             request_id: request.request_id.as_str(),
             scope: scope_to_wire(&request.scope),

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -32,6 +32,8 @@ pub struct HitlApprovalWrapper {
     request_id: String,
     /// `[agent].name` of the config that built this agent.
     agent_name: String,
+    /// Instance ID of the AURA process that built this wrapper.
+    instance_id: String,
 }
 
 impl HitlApprovalWrapper {
@@ -42,6 +44,7 @@ impl HitlApprovalWrapper {
         scope: AgentScope,
         request_id: String,
         agent_name: String,
+        instance_id: String,
     ) -> Self {
         Self {
             patterns,
@@ -49,6 +52,7 @@ impl HitlApprovalWrapper {
             scope,
             request_id,
             agent_name,
+            instance_id,
         }
     }
 
@@ -79,6 +83,7 @@ impl ToolWrapper for HitlApprovalWrapper {
         };
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
+            instance_id: self.instance_id.clone(),
             decision_id: DecisionId::generate(),
             request_id: self.request_id.clone(),
             scope: self.scope.clone(),
@@ -147,6 +152,7 @@ mod tests {
             AgentScope::Single { session_id: None },
             "t".into(),
             "test-agent".to_string(),
+            "test-instance-id".to_string(),
         );
         assert_eq!(wrapper.matched_pattern("kubectl_apply"), Some("kubectl_*"));
         assert_eq!(wrapper.matched_pattern("request_approval"), None);
@@ -172,6 +178,7 @@ mod tests {
             AgentScope::Single { session_id: None },
             "req-test".into(),
             "test-agent".to_string(),
+            "test-instance-id".to_string(),
         );
         let args = serde_json::json!({});
 
@@ -424,6 +431,7 @@ mod tests {
                 AgentScope::Single { session_id: None },
                 request_id.to_string(),
                 "test-agent".to_string(),
+                "test-instance-id".to_string(),
             );
             (
                 WrappedTool::new(inner, Arc::new(gate) as Arc<dyn ToolWrapper>),

--- a/crates/aura/src/hitl/protocol.rs
+++ b/crates/aura/src/hitl/protocol.rs
@@ -18,6 +18,8 @@ pub const PROTOCOL_VERSION: u32 = 1;
 pub struct ApprovalRequest {
     /// Protocol version; always [`PROTOCOL_VERSION`].
     pub version: u32,
+    /// The instance ID of the AURA instance that raised this approval.
+    pub instance_id: String,
     /// The handle a decision resolves against.
     pub decision_id: DecisionId,
     /// The global request id (SSE routing + MCP cancellation), modeled as the
@@ -92,6 +94,7 @@ impl From<ApprovalDecisionWire> for ApprovalDecision {
 #[derive(Debug, Serialize)]
 pub(crate) struct ApprovalRequestWire<'a> {
     pub version: u32,
+    pub instance_id: &'a str,
     pub decision_id: DecisionId,
     pub request_id: &'a str,
     pub scope: AgentScopeWire,

--- a/crates/aura/src/hitl/registry.rs
+++ b/crates/aura/src/hitl/registry.rs
@@ -349,6 +349,7 @@ mod tests {
     fn test_request(request_id: &str) -> ApprovalRequest {
         ApprovalRequest {
             version: PROTOCOL_VERSION,
+            instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
             request_id: request_id.to_string(),
             scope: AgentScope::Single { session_id: None },

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -790,6 +790,7 @@ mod tests {
     fn single_request(request_id: &str, origin: ApprovalOrigin) -> ApprovalRequest {
         ApprovalRequest {
             version: PROTOCOL_VERSION,
+            instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
             request_id: request_id.into(),
             scope: AgentScope::Single { session_id: None },
@@ -802,6 +803,7 @@ mod tests {
     fn single_agent_request_wire_shape() {
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
+            instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
             request_id: "req-123".to_string(),
             scope: AgentScope::Single { session_id: None },
@@ -822,6 +824,7 @@ mod tests {
         assert_eq!(value["version"], PROTOCOL_VERSION);
         assert_eq!(value["request_id"], "req-123");
         assert!(value["decision_id"].is_string());
+        assert!(value["instance_id"].is_string());
         // scope/origin are flat, `kind`-tagged DTOs: no Rust variant names leak.
         assert_eq!(value["scope"]["kind"], "single");
         // a sessionless single-agent request omits session_id entirely (no null).
@@ -846,6 +849,7 @@ mod tests {
             "0191e8c0-1111-7000-8000-000000000000".parse().unwrap();
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
+            instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
             request_id: "req-9".to_string(),
             scope: AgentScope::Worker {
@@ -882,6 +886,7 @@ mod tests {
     fn config_gate_item_tool_call_intent_present_on_wire() {
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
+            instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
             request_id: "req-cg-intent".to_string(),
             scope: AgentScope::Single { session_id: None },
@@ -909,6 +914,7 @@ mod tests {
     fn agent_requested_item_tool_call_intent_omitted_when_absent() {
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
+            instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
             request_id: "req-ar-none".to_string(),
             scope: AgentScope::Single { session_id: None },
@@ -936,6 +942,7 @@ mod tests {
     fn agent_requested_item_tool_call_intent_present_on_wire() {
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
+            instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
             request_id: "req-ar-intent".to_string(),
             scope: AgentScope::Single { session_id: None },
@@ -1277,6 +1284,7 @@ mod tests {
         fn test_request(decision_id: DecisionId) -> ApprovalRequest {
             ApprovalRequest {
                 version: PROTOCOL_VERSION,
+                instance_id: "test-instance".to_string(),
                 decision_id,
                 request_id: "req-signed".into(),
                 scope: AgentScope::Single { session_id: None },
@@ -2204,6 +2212,7 @@ mod tests {
         };
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
+            instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
             request_id: request_id.clone(),
             scope: AgentScope::Single { session_id: None },
@@ -2554,6 +2563,7 @@ mod tests {
     fn make_approval_request() -> ApprovalRequest {
         ApprovalRequest {
             version: PROTOCOL_VERSION,
+            instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
             request_id: "hdr-test".into(),
             scope: AgentScope::Single { session_id: None },

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -28,6 +28,8 @@ pub struct RequestApprovalTool {
     scope: AgentScope,
     request_id: String,
     agent_name: String,
+    /// Instance ID of the AURA process that built this tool.
+    instance_id: String,
 }
 
 impl RequestApprovalTool {
@@ -37,12 +39,14 @@ impl RequestApprovalTool {
         scope: AgentScope,
         request_id: String,
         agent_name: String,
+        instance_id: String,
     ) -> Self {
         Self {
             route,
             scope,
             request_id,
             agent_name,
+            instance_id,
         }
     }
 }
@@ -144,6 +148,7 @@ impl Tool for RequestApprovalTool {
         let tool_call_intent = normalize_tool_call_intent(args.tool_call_intent.as_deref());
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
+            instance_id: self.instance_id.clone(),
             decision_id: DecisionId::generate(),
             request_id: self.request_id.clone(),
             scope: self.scope.clone(),
@@ -310,6 +315,7 @@ mod tests {
             AgentScope::Single { session_id: None },
             request_id.clone(),
             "test-agent".to_string(),
+            "test-instance-id".to_string(),
         );
 
         // Subscribe before the call so the Requested event is captured.
@@ -477,6 +483,7 @@ mod tests {
                 AgentScope::Single { session_id: None },
                 request_id.clone(),
                 "test-agent".to_string(),
+                "test-instance-id".to_string(),
             );
             let args = RequestApprovalArgs {
                 action_description: "delete namespace".to_string(),

--- a/crates/aura/src/instance_id.rs
+++ b/crates/aura/src/instance_id.rs
@@ -1,0 +1,477 @@
+//! Stable per-agent instance identity.
+//!
+//! Produces a deterministic [`Uuid`] that identifies a specific agent running
+//! on a specific host, without exposing raw machine credentials on the wire.
+//!
+//! ## Formula
+//!
+//! ```text
+//! instance_id = UUIDv5(AURA_NAMESPACE, ns(name) || ns(agent_seed) || ns(env_seed))
+//! ```
+//!
+//! Each component is netstring-encoded (`{byte_len}:{utf8}` for present
+//! values, `-` for absent `Option` fields) so adjacent field boundaries cannot
+//! collide — e.g. `name="ab", alias="c"` and `name="a", alias="bc"` produce
+//! distinct byte strings.
+//!
+//! - **`name`**: always the agent's configured name; ensures two agents on the
+//!   same host that share an `instance_seed` still produce distinct IDs.
+//! - **`agent_seed`**: `[agent].instance_seed` when set; otherwise
+//!   `sha256(ns(name) || ns_opt(alias))`.
+//! - **`env_seed`**: first match in priority order:
+//!   1. `AURA_INSTANCE_ID` env var (explicit operator override)
+//!   2. `{POD_NAMESPACE}/{POD_NAME}` (Kubernetes downward API)
+//!   3. OS machine ID via [`machine_uid`] — Linux `/etc/machine-id`,
+//!      macOS IOPlatformUUID, Windows `MachineGuid` registry value
+//!   4. Random [`Uuid::new_v4`], cached for the process lifetime; a
+//!      `tracing::warn` fires once when this fallback is reached
+//!
+//! The raw machine ID never leaves the process; it feeds the SHA-1 inside
+//! UUIDv5 only.
+
+use std::fmt::{Display, Write};
+use std::sync::OnceLock;
+use uuid::{Uuid, uuid};
+
+use aura_config::AgentConfig;
+
+/// Fixed namespace for all AURA instance UUIDs.
+///
+/// Changing this value silently invalidates every previously-issued instance
+/// ID. Do not modify it after the first release.
+const AURA_NAMESPACE: Uuid = uuid!("d3f5c1a7-4b2e-5f9c-a8e1-6c0d4b7f3a2e");
+
+#[derive(PartialEq, Eq)]
+pub struct ConfigSeed(String);
+impl From<&AgentConfig> for ConfigSeed {
+    fn from(agent: &AgentConfig) -> Self {
+        let mut buf = String::new();
+        match &agent.instance_seed {
+            Some(seed) => netstring_encode(&mut buf, seed),
+            None => {
+                netstring_encode(&mut buf, &agent.name);
+                netstring_encode(&mut buf, agent.alias.as_deref().unwrap_or(""));
+            }
+        }
+        Self(buf)
+    }
+}
+
+impl Display for ConfigSeed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Default)]
+struct EnvResolver {
+    #[cfg(test)]
+    pub(crate) _aura_instance_id: Option<String>,
+    #[cfg(test)]
+    pub(crate) _pod_namespace: Option<String>,
+    #[cfg(test)]
+    pub(crate) _pod_name: Option<String>,
+    #[cfg(test)]
+    pub(crate) _machine_id: Option<String>,
+}
+
+#[cfg(test)]
+impl EnvResolver {
+    #[inline]
+    fn aura_instance_id(&self) -> Option<String> {
+        self._aura_instance_id.clone()
+    }
+
+    #[inline]
+    fn pod_namespace(&self) -> Option<String> {
+        self._pod_namespace.clone()
+    }
+
+    #[inline]
+    fn pod_name(&self) -> Option<String> {
+        self._pod_name.clone()
+    }
+
+    #[inline]
+    fn machine_id(&self) -> Option<String> {
+        self._machine_id.clone()
+    }
+}
+
+#[cfg(not(test))]
+impl EnvResolver {
+    #[inline]
+    fn aura_instance_id(&self) -> Option<String> {
+        std::env::var("AURA_INSTANCE_ID").ok()
+    }
+
+    #[inline]
+    fn pod_namespace(&self) -> Option<String> {
+        std::env::var("POD_NAMESPACE").ok()
+    }
+
+    #[inline]
+    fn pod_name(&self) -> Option<String> {
+        std::env::var("POD_NAME").ok()
+    }
+
+    #[inline]
+    fn machine_id(&self) -> Option<String> {
+        machine_uid::get().ok()
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub struct EnvironmentSeed(String);
+impl From<&EnvResolver> for EnvironmentSeed {
+    fn from(resolver: &EnvResolver) -> Self {
+        // 1. Explicit operator override.
+        if let Some(v) = resolver.aura_instance_id() {
+            let v = v.trim().to_string();
+            if !v.is_empty() {
+                return Self(v);
+            }
+        }
+
+        // 2. Kubernetes downward API — both vars must be present and non-empty
+        // after trimming. A whitespace-only value falls through to the next tier.
+        if let Some(pod_ns) = resolver.pod_namespace()
+            && let Some(pod_name) = resolver.pod_name()
+        {
+            let pod_ns = pod_ns.trim();
+            let pod_name = pod_name.trim();
+            if !pod_ns.is_empty() && !pod_name.is_empty() {
+                return Self(format!("{pod_ns}/{pod_name}"));
+            }
+        }
+
+        // 3. OS machine ID (no root required; never sent on the wire).
+        if let Some(machine_id) = resolver.machine_id() {
+            let machine_id = machine_id.trim().to_string();
+            if !machine_id.is_empty() {
+                return Self(machine_id);
+            }
+        }
+
+        // 4. Random fallback — stable for the process lifetime; warn once.
+        static RANDOM_FALLBACK: OnceLock<Uuid> = OnceLock::new();
+        let uuid = RANDOM_FALLBACK
+            .get_or_init(|| {
+                tracing::warn!(
+                    "No stable machine identity found \
+                     (AURA_INSTANCE_ID, POD_NAME/POD_NAMESPACE, and the OS machine ID \
+                     are all absent). Instance IDs will be random and change on restart. \
+                     Set AURA_INSTANCE_ID for a stable identity."
+                );
+                Uuid::new_v4()
+            })
+            .to_string();
+        Self(uuid)
+    }
+}
+
+impl Display for EnvironmentSeed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct InstanceId(Uuid);
+impl InstanceId {
+    pub fn new(conf: &ConfigSeed, env: &EnvironmentSeed) -> Self {
+        Self(Uuid::new_v5(
+            &AURA_NAMESPACE,
+            format!("{env}{conf}").as_bytes(),
+        ))
+    }
+}
+
+impl Display for InstanceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Compute the instance ID for `agent` using real environment and machine-ID
+/// lookups.
+///
+/// Convenience wrapper for production call sites. Tests should construct
+/// [`EnvResolver`] directly to inject specific values for each priority tier.
+pub fn instance_id(agent: &AgentConfig) -> InstanceId {
+    let conf = ConfigSeed::from(agent);
+    let env = EnvironmentSeed::from(&EnvResolver::default());
+    InstanceId::new(&conf, &env)
+}
+
+fn netstring_encode(dest: &mut String, value: &str) {
+    let _ = write!(dest, "{}:{}", value.len(), value);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aura_config::load_config_from_str;
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    fn agent_with(name: &str, extra_fields: &str) -> AgentConfig {
+        let toml = format!(
+            r#"
+[agent]
+name = "{name}"
+system_prompt = "test"
+{extra_fields}
+
+[agent.llm]
+provider = "openai"
+api_key = "test"
+model = "gpt-4o"
+"#
+        );
+        load_config_from_str(&toml).expect("valid config").agent
+    }
+
+    /// Build an [`EnvResolver`] with explicit test values for each priority tier.
+    /// Pass `None` to leave a tier unset, causing fall-through to the next.
+    fn make_resolver(
+        aura_instance_id: Option<&str>,
+        pod_namespace: Option<&str>,
+        pod_name: Option<&str>,
+        machine_id: Option<&str>,
+    ) -> EnvResolver {
+        EnvResolver {
+            _aura_instance_id: aura_instance_id.map(String::from),
+            _pod_namespace: pod_namespace.map(String::from),
+            _pod_name: pod_name.map(String::from),
+            _machine_id: machine_id.map(String::from),
+        }
+    }
+
+    fn make_id(agent: &AgentConfig, resolver: &EnvResolver) -> InstanceId {
+        InstanceId::new(&ConfigSeed::from(agent), &EnvironmentSeed::from(resolver))
+    }
+
+    /// Encode one value as a netstring for collision-boundary tests.
+    fn ns(value: &str) -> String {
+        let mut buf = String::new();
+        netstring_encode(&mut buf, value);
+        buf
+    }
+
+    // ── Determinism ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn same_inputs_produce_same_id() {
+        let agent = agent_with("test-agent", "");
+        let resolver = make_resolver(None, None, None, Some("machine-abc"));
+        assert_eq!(make_id(&agent, &resolver), make_id(&agent, &resolver));
+    }
+
+    // ── Env seed priority order ───────────────────────────────────────────────
+
+    #[test]
+    fn aura_instance_id_wins_over_k8s_and_machine() {
+        let agent = agent_with("test-agent", "");
+        let all_set = make_resolver(
+            Some("explicit"),
+            Some("prod"),
+            Some("aura-0"),
+            Some("machine"),
+        );
+        let only_explicit = make_resolver(Some("explicit"), None, None, None);
+        assert_eq!(make_id(&agent, &all_set), make_id(&agent, &only_explicit));
+    }
+
+    #[test]
+    fn k8s_wins_over_machine_id() {
+        let agent = agent_with("test-agent", "");
+        let k8s_with_machine = make_resolver(None, Some("prod"), Some("aura-0"), Some("machine"));
+        let k8s_no_machine = make_resolver(None, Some("prod"), Some("aura-0"), None);
+        assert_eq!(
+            make_id(&agent, &k8s_with_machine),
+            make_id(&agent, &k8s_no_machine)
+        );
+    }
+
+    #[test]
+    fn k8s_requires_both_pod_vars() {
+        // Only POD_NAMESPACE — must fall through to the machine ID, not K8s.
+        let agent = agent_with("test-agent", "");
+        let only_ns = make_resolver(None, Some("prod"), None, Some("machine"));
+        let both = make_resolver(None, Some("prod"), Some("aura-0"), None);
+        assert_ne!(
+            make_id(&agent, &only_ns),
+            make_id(&agent, &both),
+            "partial K8s env must not match full K8s env"
+        );
+    }
+
+    #[test]
+    fn different_machine_ids_produce_different_ids() {
+        let agent = agent_with("test-agent", "");
+        let r1 = make_resolver(None, None, None, Some("machine-abc"));
+        let r2 = make_resolver(None, None, None, Some("machine-xyz"));
+        assert_ne!(
+            make_id(&agent, &r1),
+            make_id(&agent, &r2),
+            "different machine IDs must produce different instance IDs"
+        );
+    }
+
+    // ── Whitespace trimming and empty-value fall-through ──────────────────────────
+
+    #[test]
+    fn aura_instance_id_whitespace_only_falls_through() {
+        let agent = agent_with("test-agent", "");
+        let whitespace = make_resolver(Some("   "), None, None, Some("machine"));
+        let absent = make_resolver(None, None, None, Some("machine"));
+        assert_eq!(
+            make_id(&agent, &whitespace),
+            make_id(&agent, &absent),
+            "whitespace-only AURA_INSTANCE_ID must fall through to machine ID"
+        );
+    }
+
+    #[test]
+    fn aura_instance_id_is_trimmed() {
+        let agent = agent_with("test-agent", "");
+        let padded = make_resolver(Some("  my-id  "), None, None, None);
+        let clean = make_resolver(Some("my-id"), None, None, None);
+        assert_eq!(
+            make_id(&agent, &padded),
+            make_id(&agent, &clean),
+            "leading/trailing whitespace in AURA_INSTANCE_ID must be trimmed"
+        );
+    }
+
+    #[test]
+    fn k8s_pod_namespace_whitespace_only_falls_through() {
+        let agent = agent_with("test-agent", "");
+        let whitespace_ns = make_resolver(None, Some("   "), Some("aura-0"), Some("machine"));
+        let absent_k8s = make_resolver(None, None, None, Some("machine"));
+        assert_eq!(
+            make_id(&agent, &whitespace_ns),
+            make_id(&agent, &absent_k8s),
+            "whitespace-only POD_NAMESPACE must cause K8s tier to fall through"
+        );
+    }
+
+    #[test]
+    fn k8s_pod_name_whitespace_only_falls_through() {
+        let agent = agent_with("test-agent", "");
+        let whitespace_name = make_resolver(None, Some("prod"), Some("   "), Some("machine"));
+        let absent_k8s = make_resolver(None, None, None, Some("machine"));
+        assert_eq!(
+            make_id(&agent, &whitespace_name),
+            make_id(&agent, &absent_k8s),
+            "whitespace-only POD_NAME must cause K8s tier to fall through"
+        );
+    }
+
+    #[test]
+    fn k8s_vars_are_trimmed() {
+        let agent = agent_with("test-agent", "");
+        let padded = make_resolver(None, Some("  prod  "), Some("  aura-0  "), None);
+        let clean = make_resolver(None, Some("prod"), Some("aura-0"), None);
+        assert_eq!(
+            make_id(&agent, &padded),
+            make_id(&agent, &clean),
+            "leading/trailing whitespace in POD_NAMESPACE/POD_NAME must be trimmed"
+        );
+    }
+
+    #[test]
+    fn machine_id_whitespace_only_falls_through() {
+        // Both reach the random fallback; the process-lifetime OnceLock means
+        // they return the same UUID within a single test run.
+        let agent = agent_with("test-agent", "");
+        let whitespace = make_resolver(None, None, None, Some("   "));
+        let absent = make_resolver(None, None, None, None);
+        assert_eq!(
+            make_id(&agent, &whitespace),
+            make_id(&agent, &absent),
+            "whitespace-only machine ID must fall through to the random fallback"
+        );
+    }
+
+    #[test]
+    fn machine_id_is_trimmed() {
+        let agent = agent_with("test-agent", "");
+        let padded = make_resolver(None, None, None, Some("  abc123  "));
+        let clean = make_resolver(None, None, None, Some("abc123"));
+        assert_eq!(
+            make_id(&agent, &padded),
+            make_id(&agent, &clean),
+            "leading/trailing whitespace in machine ID must be trimmed"
+        );
+    }
+
+    // ── Agent seed ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn explicit_instance_seed_produces_different_id_than_derived() {
+        let resolver = make_resolver(None, None, None, Some("machine"));
+        let with_seed = agent_with("test-agent", r#"instance_seed = "my-seed""#);
+        let without_seed = agent_with("test-agent", "");
+        assert_ne!(
+            make_id(&with_seed, &resolver),
+            make_id(&without_seed, &resolver),
+        );
+    }
+
+    #[test]
+    fn same_explicit_seed_same_id() {
+        let resolver = make_resolver(None, None, None, Some("machine"));
+        let a1 = agent_with("test-agent", r#"instance_seed = "seed-x""#);
+        let a2 = agent_with("test-agent", r#"instance_seed = "seed-x""#);
+        assert_eq!(make_id(&a1, &resolver), make_id(&a2, &resolver));
+    }
+
+    #[test]
+    fn different_explicit_seeds_different_ids() {
+        let resolver = make_resolver(None, None, None, Some("machine"));
+        let a1 = agent_with("test-agent", r#"instance_seed = "seed-a""#);
+        let a2 = agent_with("test-agent", r#"instance_seed = "seed-b""#);
+        assert_ne!(make_id(&a1, &resolver), make_id(&a2, &resolver));
+    }
+
+    // ── Name differentiates in the derived-seed path ──────────────────────────
+
+    #[test]
+    fn different_names_without_seed_produce_different_ids() {
+        let resolver = make_resolver(None, None, None, Some("machine"));
+        let a = agent_with("agent-alpha", "");
+        let b = agent_with("agent-beta", "");
+        assert_ne!(make_id(&a, &resolver), make_id(&b, &resolver));
+    }
+
+    #[test]
+    fn shared_explicit_seed_same_env_produces_same_id() {
+        // When instance_seed is set, the ConfigSeed encodes only the seed —
+        // not the agent name — so two agents with the same seed and env are
+        // intentionally equivalent.
+        let resolver = make_resolver(None, None, None, Some("machine"));
+        let a = agent_with("agent-alpha", r#"instance_seed = "shared""#);
+        let b = agent_with("agent-beta", r#"instance_seed = "shared""#);
+        assert_eq!(
+            make_id(&a, &resolver),
+            make_id(&b, &resolver),
+            "agents sharing an explicit instance_seed and env should produce the same ID"
+        );
+    }
+
+    // ── Netstring collision prevention ────────────────────────────────────────
+
+    #[test]
+    fn netstring_avoids_cross_field_boundary_collision() {
+        // Without length-prefix encoding "ab" + "c" == "a" + "bc" == "abc".
+        // With netstrings they are distinct: "2:ab1:c" vs "1:a2:bc".
+        assert_ne!(ns("ab") + &ns("c"), ns("a") + &ns("bc"));
+    }
+
+    #[test]
+    fn netstring_empty_string_differs_from_single_char() {
+        assert_ne!(ns(""), ns("x"));
+    }
+}

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -17,6 +17,7 @@ pub mod fallback_tool_stream;
 pub mod governance;
 pub mod hitl;
 pub mod inactivity;
+pub mod instance_id;
 pub mod logging;
 pub mod mcp;
 #[cfg(feature = "otel")]

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -825,6 +825,7 @@ impl Orchestrator {
                 scope.clone(),
                 request_id.clone(),
                 worker_config.agent.name.clone(),
+                worker_config.instance_id.clone(),
             ));
             wrappers.insert(0, gate);
             worker_config.hitl_request_approval_tool = Some(crate::hitl::RequestApprovalTool::new(
@@ -832,6 +833,7 @@ impl Orchestrator {
                 scope,
                 request_id,
                 worker_config.agent.name.clone(),
+                worker_config.instance_id.clone(),
             ));
         }
 

--- a/crates/aura/src/orchestration/overview.rs
+++ b/crates/aura/src/orchestration/overview.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 pub fn agent_info(config: &Config) -> AgentInfo {
     AgentInfo {
         id: config.agent_id().to_owned(),
+        instance_id: Some(crate::instance_id::instance_id(&config.agent).to_string()),
         description: config.agent.description.clone(),
         model: config.agent.llm.model_info().1.to_owned(),
         workers: worker_overview(config),
@@ -382,6 +383,30 @@ api_key = "k"
     }
 
     #[test]
+    fn agent_info_carries_instance_id() {
+        let config = load_config_from_str(
+            r#"
+[agent]
+name = "my-agent"
+system_prompt = "p"
+[agent.llm]
+provider = "openai"
+model = "gpt-4o"
+api_key = "k"
+"#,
+        )
+        .expect("config should parse");
+
+        let id = agent_info(&config)
+            .instance_id
+            .expect("instance_id must be set");
+        // Must be a valid hyphenated UUID.
+        assert!(uuid::Uuid::parse_str(&id).is_ok(), "not a UUID: {id}");
+        // Must be stable — same config always produces the same ID.
+        assert_eq!(agent_info(&config).instance_id.unwrap(), id);
+    }
+
+    #[test]
     fn agent_info_projects_credential_free_mcp_config_view_without_connecting() {
         let base = r#"
 [agent]
@@ -535,6 +560,7 @@ api_key = "k"
         };
         let mut info = AgentInfo {
             id: "a".to_string(),
+            instance_id: None,
             description: None,
             model: "gpt-4o".to_string(),
             workers: Vec::new(),

--- a/crates/aura/src/orchestration/persistence_wrapper.rs
+++ b/crates/aura/src/orchestration/persistence_wrapper.rs
@@ -1458,6 +1458,7 @@ mod tests {
             scope,
             request_id.clone(),
             "test-agent".to_string(),
+            "test-instance-id".to_string(),
         ));
         let persistence: Arc<dyn ToolWrapper> = Arc::new(test_wrapper(Arc::new(Mutex::new(
             ExecutionPersistence::disabled(),

--- a/crates/aura/src/rig_builder.rs
+++ b/crates/aura/src/rig_builder.rs
@@ -91,6 +91,7 @@ impl RigBuilder {
                     req_headers,
                 )
             }),
+            instance_id: crate::instance_id::instance_id(&self.config.agent).to_string(),
             ..Default::default()
         }
     }

--- a/crates/aura/src/session_store/memory.rs
+++ b/crates/aura/src/session_store/memory.rs
@@ -201,6 +201,7 @@ mod tests {
         ParkedApproval {
             request: ApprovalRequest {
                 version: PROTOCOL_VERSION,
+                instance_id: "test-instance".to_string(),
                 decision_id: DecisionId::generate(),
                 request_id: request_id.to_string(),
                 scope: AgentScope::Single { session_id: None },

--- a/crates/aura/src/session_store/record.rs
+++ b/crates/aura/src/session_store/record.rs
@@ -26,6 +26,8 @@ use crate::orchestration::{RunId, TaskIdentity};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ParkedApprovalRecord {
     pub version: u32,
+    #[serde(default)]
+    pub instance_id: String,
     pub decision_id: DecisionId,
     pub request_id: String,
     pub scope: ScopeRecord,
@@ -116,6 +118,7 @@ impl From<&ParkedApproval> for ParkedApprovalRecord {
         let request = &parked.request;
         Self {
             version: request.version,
+            instance_id: request.instance_id.clone(),
             decision_id: request.decision_id,
             request_id: request.request_id.clone(),
             scope: ScopeRecord::from(&request.scope),
@@ -134,6 +137,7 @@ impl TryFrom<ParkedApprovalRecord> for ParkedApproval {
         Ok(Self {
             request: ApprovalRequest {
                 version: record.version,
+                instance_id: record.instance_id,
                 decision_id: record.decision_id,
                 request_id: record.request_id,
                 scope: record.scope.try_into()?,
@@ -245,6 +249,7 @@ mod tests {
         ParkedApproval {
             request: ApprovalRequest {
                 version: PROTOCOL_VERSION,
+                instance_id: "test-instance".to_string(),
                 decision_id: DecisionId::generate(),
                 request_id: "req-1".to_string(),
                 scope,

--- a/deployment/helm/aura/templates/deployment.yaml
+++ b/deployment/helm/aura/templates/deployment.yaml
@@ -84,7 +84,19 @@ spec:
               value: {{ .Values.streaming.emitReasoning | quote }}
             - name: STREAMING_TIMEOUT_SECS
               value: {{ .Values.streaming.timeoutSecs | quote }}
-            # Server identifier from pod name
+            # Pod identity for instance ID derivation (downward API).
+            # POD_NAME and POD_NAMESPACE feed the K8s tier of the env_seed
+            # priority chain in aura::instance_id.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # Legacy pod-name alias kept for backwards compatibility with
+            # any tooling that already reads SERVER_GUID.
             - name: SERVER_GUID
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Adds a stable, deterministic UUID per agent instance and threads it through the governance catalog, HITL webhook payloads, `GET /aura/info`, and the CLI/REPL `governance info` command. The ID survives restarts when host identity is stable (K8s downward API, OS machine-id, or `AURA_INSTANCE_ID`).

---

**feat(instance-id): add stable per-agent instance identity**

Introduces `aura::instance_id`, a new module that computes a deterministic UUIDv5 for each running agent instance. The UUID is derived from two independently-stable components:

```
ConfigSeed      — [agent].instance_seed when set; otherwise
                  netstring-encoded name + alias.
EnvironmentSeed — first match in priority order:
                  1. AURA_INSTANCE_ID env var (explicit override)
                  2. POD_NAMESPACE/POD_NAME (Kubernetes downward API)
                  3. OS machine ID via machine-uid 0.6 (Linux /etc/machine-id,
                     macOS IOPlatformUUID, Windows MachineGuid registry key)
                  4. Random UUIDv4 cached for the process lifetime, with a
                     tracing::warn emitted once when this fallback fires
```

Field boundaries in the hash input use netstring length-prefix encoding (`{len}:{value}`) so adjacent fields cannot collide.

- `aura-config`: add optional `instance_seed` field to `AgentConfig`; supports `{{ env.* }}` templating and defaults to `None`
- `aura` crate: new `instance_id` module with `ConfigSeed`, `EnvironmentSeed`, `InstanceId` types; `EnvResolver` uses `cfg(test)` fields for injection without touching process env; adds `machine-uid = 0.6` dependency; enables uuid `v5` feature
- `aura-web-server`: log `instance_id` alongside provider/model at startup for each loaded agent
- helm: inject `POD_NAME` and `POD_NAMESPACE` via the downward API; retain `SERVER_GUID` as a backwards-compatible alias

Fixes: #495

---

**feat(instance-id): expose instance id in governance info, repl, and api**

Add `instance_id` to the three consumer-facing surfaces:

- `GET /aura/info`: `AgentInfo` gains an optional `instance_id` string field (`Option` so older-server responses remain decodable). Populated by `agent_info()` / `agent_info_with_tools()` via `crate::instance_id`.
- `aura governance info` (CLI subcommand): new `Info` variant on `GovernanceCommands`; `info_all()` iterates loaded configs and prints agent name + `instance_id` to stdout.
- `/governance info` (REPL): new `info` subcommand in `handle_governance`; `run_info_standalone()` renders a themed tree of agent names and their instance IDs; HTTP mode returns the same standalone-only error as `sync`. Usage text updated to list both `sync` and `info`.

Fixes: #495

---

**feat(instance-id): add instance id to governance catalog and hitl wire**

Thread `instance_id` through the governance catalog and HITL approval request pipeline so every outbound webhook and catalog event carries the originating pod identity.

Governance:
- `AgentEntry` gains `instance_id`, populated by `build_agent_entry()` from `crate::instance_id`

HITL domain and wire:
- `ApprovalRequest` (domain) and `ApprovalRequestWire` (wire) gain `instance_id`; the `From` conversion in `events.rs` passes it through
- `HitlApprovalWrapper` and `RequestApprovalTool` each store `instance_id` and stamp it onto every `ApprovalRequest` they construct
- Session store: `ParkedApprovalRecord` carries `instance_id` with `serde(default)` so records written by older instances remain readable

Threading:
- `AgentRuntimeConfig` gains `instance_id`, computed once in `to_agent_config()` from the full `AgentConfig`
- `builder.rs` and `orchestrator.rs` pass it to both HITL constructors

Fixes: #495