### PR TITLE
Add the park commit machinery and run guard

### DIFF
--- a/crates/aura-events/src/orchestration.rs
+++ b/crates/aura-events/src/orchestration.rs
@@ -73,6 +73,7 @@ pub mod event_names {
     pub const TASK_STARTED: &str = "aura.orchestrator.task_started";
     pub const TASK_COMPLETED: &str = "aura.orchestrator.task_completed";
     pub const TASK_BLOCKED: &str = "aura.orchestrator.task_blocked";
+    pub const RUN_PARKED: &str = "aura.orchestrator.run_parked";
     pub const ITERATION_COMPLETE: &str = "aura.orchestrator.iteration_complete";
     pub const REPLAN_STARTED: &str = "aura.orchestrator.replan_started";
     pub const SYNTHESIZING: &str = "aura.orchestrator.synthesizing";
@@ -146,6 +147,15 @@ pub enum OrchestrationStreamEvent {
         tool_name: String,
         orchestrator_id: String,
         worker_id: String,
+        #[serde(flatten)]
+        context: EventContext,
+    },
+    /// The run parked with a published checkpoint (park mode); terminal.
+    RunParked {
+        run_id: String,
+        decision_ids: Vec<String>,
+        expires_at: String,
+        iteration: usize,
         #[serde(flatten)]
         context: EventContext,
     },
@@ -249,6 +259,7 @@ impl OrchestrationStreamEvent {
             Self::TaskStarted { .. } => event_names::TASK_STARTED,
             Self::TaskCompleted { .. } => event_names::TASK_COMPLETED,
             Self::TaskBlocked { .. } => event_names::TASK_BLOCKED,
+            Self::RunParked { .. } => event_names::RUN_PARKED,
             Self::IterationComplete { .. } => event_names::ITERATION_COMPLETE,
             Self::ReplanStarted { .. } => event_names::REPLAN_STARTED,
             Self::Synthesizing { .. } => event_names::SYNTHESIZING,
@@ -363,6 +374,23 @@ impl OrchestrationStreamEvent {
             tool_name: tool_name.into(),
             orchestrator_id: orchestrator_id.into(),
             worker_id: worker_id.into(),
+            context,
+        }
+    }
+
+    /// Create a RunParked event (terminal, one per parked run).
+    pub fn run_parked(
+        run_id: impl Into<String>,
+        decision_ids: Vec<String>,
+        expires_at: impl Into<String>,
+        iteration: usize,
+        context: EventContext,
+    ) -> Self {
+        Self::RunParked {
+            run_id: run_id.into(),
+            decision_ids,
+            expires_at: expires_at.into(),
+            iteration,
             context,
         }
     }

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -1419,6 +1419,27 @@ fn handle_orchestrator_event(
                 event_context,
             )
         }
+        OrchestratorEvent::RunParked {
+            run_id,
+            decision_ids,
+            expires_at,
+            iteration,
+        } => {
+            tracing::debug!(
+                "Orchestrator: run {} parked at iteration {} ({} decision(s), expires {})",
+                run_id,
+                iteration,
+                decision_ids.len(),
+                expires_at
+            );
+            OrchestrationStreamEvent::run_parked(
+                run_id,
+                decision_ids.clone(),
+                expires_at,
+                *iteration,
+                event_context,
+            )
+        }
     };
 
     vec![Bytes::from(sse_event.format_sse())]

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -16,7 +16,7 @@ use super::decision::{AgentScope, ApprovalOrigin, DecisionId};
 use super::protocol::{ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
 use super::registry::{ParkedApproval, PendingApprovals};
 use super::route::{ApprovalError, DecisionRoute, GateDecision};
-use crate::orchestration::{BlockedCell, PendingCall};
+use crate::orchestration::{BlockedCell, ParkGuard, PendingCall};
 use crate::tool_wrapper::{PreCallOutcome, ToolCallContext, ToolWrapper};
 
 /// The placeholder tool result a parked call returns.
@@ -29,6 +29,8 @@ struct ParkContext {
     registry: PendingApprovals,
     /// The worker's blocked cell.
     cell: Arc<BlockedCell>,
+    /// The run's park guard.
+    guard: Arc<ParkGuard>,
 }
 
 /// Gates matching tool calls behind an approval decision.
@@ -75,8 +77,17 @@ impl HitlApprovalWrapper {
 
     /// Arm the park arm: glob-matched calls park as durable approvals.
     #[must_use]
-    pub fn with_park(mut self, registry: PendingApprovals, cell: Arc<BlockedCell>) -> Self {
-        self.park = Some(ParkContext { registry, cell });
+    pub(crate) fn with_park(
+        mut self,
+        registry: PendingApprovals,
+        cell: Arc<BlockedCell>,
+        guard: Arc<ParkGuard>,
+    ) -> Self {
+        self.park = Some(ParkContext {
+            registry,
+            cell,
+            guard,
+        });
         self
     }
 
@@ -166,6 +177,24 @@ impl HitlApprovalWrapper {
             ));
         }
 
+        let call_id = park.cell.take_current_call_id().unwrap_or_else(|| {
+            tracing::warn!(
+                decision_id = %decision_id,
+                tool_name = %ctx.tool_name,
+                "parked call has no tool-call id; recording an empty call_id",
+            );
+            String::new()
+        });
+        let call = PendingCall {
+            decision_id,
+            tool_name: ctx.tool_name.clone(),
+            arguments: args.clone(),
+            call_id,
+        };
+        // The guard learns the id now, so a run dropped before the task
+        // returns still sweeps this ticket.
+        park.guard.record(&self.scope, std::slice::from_ref(&call));
+
         // The lifecycle pair goes to the live request's broker, not the owner id.
         crate::approval_event_broker::publish(
             &self.request_id,
@@ -183,20 +212,7 @@ impl HitlApprovalWrapper {
         )
         .await;
 
-        let call_id = park.cell.take_current_call_id().unwrap_or_else(|| {
-            tracing::warn!(
-                decision_id = %decision_id,
-                tool_name = %ctx.tool_name,
-                "parked call has no tool-call id; recording an empty call_id",
-            );
-            String::new()
-        });
-        park.cell.push(PendingCall {
-            decision_id,
-            tool_name: ctx.tool_name.clone(),
-            arguments: args.clone(),
-            call_id,
-        });
+        park.cell.push(call);
         tracing::info!(
             decision_id = %decision_id,
             tool_name = %ctx.tool_name,
@@ -424,7 +440,15 @@ mod tests {
                 "test-agent".to_string(),
                 "test-instance".to_string(),
             )
-            .with_park(registry.clone(), cell.clone())
+            .with_park(
+                registry.clone(),
+                cell.clone(),
+                ParkGuard::new(
+                    registry.clone(),
+                    "0191e8c0-1111-7000-8000-000000000042".to_string(),
+                    request_id.to_string(),
+                ),
+            )
         }
 
         #[tokio::test]
@@ -596,6 +620,56 @@ mod tests {
                 .unwrap();
             assert_eq!(outcome, PreCallOutcome::Proceed { overrides: None });
             assert!(cell.is_empty());
+        }
+
+        #[tokio::test]
+        async fn guard_learns_the_decision_at_registration() {
+            let store: Arc<dyn crate::session_store::ApprovalStore> =
+                Arc::new(crate::session_store::InMemoryApprovalStore::new());
+            let registry = PendingApprovals::with_backend(
+                store.clone(),
+                Arc::new(crate::session_store::InMemoryEventBus::new()),
+            );
+            let route = conv_route_over(registry.clone(), Duration::from_secs(60));
+            let cell = Arc::new(crate::orchestration::BlockedCell::default());
+            let guard = ParkGuard::new(
+                registry.clone(),
+                "0191e8c0-1111-7000-8000-000000000042".to_string(),
+                "req-guard".to_string(),
+            );
+            let gate = HitlApprovalWrapper::new(
+                Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
+                route,
+                worker_scope(),
+                "req-guard".to_string(),
+                "test-agent".to_string(),
+                "test-instance".to_string(),
+            )
+            .with_park(registry, cell.clone(), Arc::clone(&guard));
+
+            gate.pre_call(
+                &serde_json::json!({}),
+                &ToolCallContext::new("kubectl_apply"),
+            )
+            .await
+            .unwrap();
+            let decision_id = match cell.outcome() {
+                crate::orchestration::CellOutcome::Orphaned { pending } => pending[0].decision_id,
+                other => panic!("expected a parked call, got {other:?}"),
+            };
+            assert!(store.get(&decision_id).await.unwrap().is_some());
+
+            // The run ends unpublished: the guard sweeps the ticket the park
+            // arm registered, without any record from the orchestrator.
+            drop(gate);
+            drop(guard);
+            for _ in 0..200 {
+                if store.get(&decision_id).await.unwrap().is_none() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            assert!(store.get(&decision_id).await.unwrap().is_none());
         }
     }
 

--- a/crates/aura/src/hitl/registry.rs
+++ b/crates/aura/src/hitl/registry.rs
@@ -205,6 +205,14 @@ impl PendingApprovals {
         Ok(())
     }
 
+    /// The parked approval record for an id, propagating a store fault.
+    pub async fn try_parked(
+        &self,
+        id: &DecisionId,
+    ) -> Result<Option<ParkedApproval>, SessionStoreError> {
+        self.0.store.get(id).await
+    }
+
     /// The durably recorded decision for an already-resolved approval, if
     /// any. A store fault reads as "no recorded decision" (logged), so
     /// callers keep their fail-closed shape.

--- a/crates/aura/src/orchestration/events.rs
+++ b/crates/aura/src/orchestration/events.rs
@@ -115,6 +115,17 @@ pub enum OrchestratorEvent {
         /// The gated tool's name
         tool_name: String,
     },
+    /// The run parked with a published checkpoint (park mode); terminal.
+    RunParked {
+        /// The parked run's id.
+        run_id: String,
+        /// The decision ids still awaiting a human decision.
+        decision_ids: Vec<String>,
+        /// RFC 3339 timestamp after which the decisions expire.
+        expires_at: String,
+        /// Which iteration the run parked in (1-indexed).
+        iteration: usize,
+    },
     /// An iteration of the plan-execute loop has completed.
     ///
     /// Emitted after execution completes. Indicates whether the orchestrator

--- a/crates/aura/src/orchestration/mod.rs
+++ b/crates/aura/src/orchestration/mod.rs
@@ -80,6 +80,7 @@ pub use tools::ReadArtifactTool;
 pub use tools::wait_for::{StopReason, WaitForError, WaitForOutput, WaitForTool};
 pub use tools::{SubmitResultDecision, SubmitResultOutput, SubmitResultTool};
 
+pub(crate) use park::ParkGuard;
 pub use prompt_constants::{context, fields, sections};
 pub use types::{
     BlockedCell, CellOutcome, ParkSnapshot, PendingCall, Plan, PlanningResponse, RunId, StepInput,

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -37,6 +37,7 @@
 //! - `TaskStarted` - when a worker begins a task
 //! - `TaskCompleted` - when a worker finishes a task
 //! - `TaskBlocked` - when a worker parks gated calls (park mode)
+//! - `RunParked` - when a run parks with a published checkpoint (park mode)
 //! - `IterationComplete` - when the post-execute coordinator decision completes
 //! - `Synthesizing` - when task results are being consolidated for the coordinator
 
@@ -61,10 +62,12 @@ use super::tools::{InspectToolParamsTool, ListToolsTool, ReadArtifactTool};
 
 use super::config::OrchestrationConfig;
 use super::events::OrchestratorEvent;
+use super::park::{ParkGuard, ParkedTaskRecord, ParkedTaskRecords};
 use super::persistence::ExecutionPersistence;
 use super::types::{
     BlockedCell, CellOutcome, FailedTaskRecord, FailureCategory, FailureSummary, IterationContext,
-    IterationOutcome, IterationTimings, PendingCall, Plan, PlanningResponse, TaskState, TaskStatus,
+    IterationOutcome, IterationTimings, ParkSnapshot, PendingCall, Plan, PlanningResponse,
+    TaskState, TaskStatus,
 };
 
 // ============================================================================
@@ -101,10 +104,15 @@ struct TaskExecutionResult {
 }
 
 /// The outcome of one worker task.
+#[allow(clippy::large_enum_variant)]
 enum TaskOutcome {
     Completed(TaskExecutionResult),
     /// The worker parked gated calls and its snapshot was captured.
-    Blocked(Vec<PendingCall>),
+    Blocked {
+        pending: Vec<PendingCall>,
+        attempt: usize,
+        snapshot: ParkSnapshot,
+    },
 }
 
 /// Park-mode state for one worker stream: its blocked cell and the stream key
@@ -411,6 +419,9 @@ pub struct Orchestrator {
 
     /// Outer wall-clock budget for the whole run; `None` is unbounded.
     pub(super) outer_budget: Option<Duration>,
+
+    /// Run-scoped park guard (park mode).
+    park_guard: Option<Arc<ParkGuard>>,
 }
 
 /// Stream context for reasoning attribution in `stream_and_forward`.
@@ -555,6 +566,22 @@ impl Orchestrator {
         let orchestrator_id = uuid::Uuid::new_v4().to_string();
 
         let run_id_str = persistence.lock().await.run_id().to_string();
+        // One guard per park-mode run; it stays inert until the park arm
+        // records a decision id.
+        let park_guard = agent_config
+            .hitl
+            .as_ref()
+            .filter(|hitl| hitl.park_enabled)
+            .and_then(|hitl| match &*hitl.route {
+                crate::hitl::DecisionRoute::Conversational { registry, .. } => {
+                    Some(ParkGuard::new(
+                        registry.clone(),
+                        run_id_str.clone(),
+                        agent_config.request_id.clone().unwrap_or_default(),
+                    ))
+                }
+                crate::hitl::DecisionRoute::Webhook { .. } => None,
+            });
         let default_turn_depth = agent_config
             .agent
             .turn_depth
@@ -577,6 +604,7 @@ impl Orchestrator {
             persistence,
             usage_state: crate::UsageState::new(),
             outer_budget: None,
+            park_guard,
         })
     }
 
@@ -847,10 +875,13 @@ impl Orchestrator {
             );
             // The park arm needs the store-bearing route; webhook deployments
             // keep the live decision path.
-            if let (Some(cell), crate::hitl::DecisionRoute::Conversational { registry, .. }) =
-                (park_cell, &*hitl.route)
+            if let (
+                Some(cell),
+                Some(guard),
+                crate::hitl::DecisionRoute::Conversational { registry, .. },
+            ) = (park_cell, self.park_guard.as_ref(), &*hitl.route)
             {
-                gate = gate.with_park(registry.clone(), cell.clone());
+                gate = gate.with_park(registry.clone(), cell.clone(), Arc::clone(guard));
             }
             wrappers.insert(0, Arc::new(gate));
             worker_config.hitl_request_approval_tool = Some(crate::hitl::RequestApprovalTool::new(
@@ -1033,6 +1064,28 @@ impl Orchestrator {
         })
     }
 
+    /// The worker approval scope stamped on a task's approvals — the same
+    /// shape `create_worker` builds for the gate and the park guard's
+    /// cancellation events.
+    async fn worker_scope(
+        &self,
+        task_id: usize,
+        worker_name: Option<&str>,
+    ) -> Option<crate::hitl::AgentScope> {
+        let (run_id, session_id) = {
+            let p = self.persistence.lock().await;
+            (p.run_id().to_string(), p.session_id().map(String::from))
+        };
+        run_id
+            .parse::<super::RunId>()
+            .ok()
+            .map(|run_id| crate::hitl::AgentScope::Worker {
+                run_id,
+                task: super::TaskIdentity::new(task_id, worker_name.map(String::from)),
+                session_id: session_id.map(crate::config::SessionId::new),
+            })
+    }
+
     /// Orphan cleanup for a parked worker whose stream ended before the hook
     /// captured its conversation: every pending decision id is removed from
     /// the store with an `approval_completed(cancelled)` event, so the human
@@ -1049,20 +1102,7 @@ impl Orchestrator {
         let crate::hitl::DecisionRoute::Conversational { registry, .. } = &*hitl.route else {
             return;
         };
-        let (run_id, session_id) = {
-            let p = self.persistence.lock().await;
-            (p.run_id().to_string(), p.session_id().map(String::from))
-        };
-        // Same scope shape `create_worker` stamps on the worker's approvals.
-        let scope =
-            run_id
-                .parse::<super::RunId>()
-                .ok()
-                .map(|run_id| crate::hitl::AgentScope::Worker {
-                    run_id,
-                    task: super::TaskIdentity::new(task_id, worker_name.map(String::from)),
-                    session_id: session_id.map(crate::config::SessionId::new),
-                });
+        let scope = self.worker_scope(task_id, worker_name).await;
         let request_id = self.agent_config.request_id.clone().unwrap_or_default();
         for call in pending {
             registry.remove(&call.decision_id).await;
@@ -3117,16 +3157,17 @@ Assign tasks to the worker whose tools best match the required operations."#,
     /// Each worker receives the plan goal (not the raw query) to understand context.
     ///
     /// Returns the aggregate task-compute time (sum of per-task wall durations
-    /// across all waves), used for the iteration's phase-timing breakdown.
+    /// across all waves) and the park records of the tasks that blocked.
     async fn execute(
         &self,
         plan: &mut Plan,
         event_tx: &tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>,
-    ) -> Result<u64, StreamError> {
+    ) -> Result<(u64, ParkedTaskRecords), StreamError> {
         use futures::StreamExt;
         use futures::stream::FuturesUnordered;
 
         let mut task_compute_ms: u64 = 0;
+        let mut park_records: ParkedTaskRecords = ParkedTaskRecords::new();
         while !plan.is_finished() {
             // Collect ready tasks with their context and worker assignment
             // Tuple: (task_id, description, context, worker_name)
@@ -3252,7 +3293,11 @@ Assign tasks to the worker whose tools best match the required operations."#,
                             );
                         }
                     }
-                    Ok(TaskOutcome::Blocked(pending)) => {
+                    Ok(TaskOutcome::Blocked {
+                        pending,
+                        attempt,
+                        snapshot,
+                    }) => {
                         // The task awaits human decisions: no artifact, no
                         // completion event; one blocked event per parked call.
                         let worker_id = worker_name.clone().unwrap_or(self.orchestrator_id.clone());
@@ -3273,6 +3318,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         if let Some(t) = plan.get_task_mut(task_id) {
                             t.state = TaskState::AwaitingApproval { pending };
                         }
+                        park_records.insert(task_id, ParkedTaskRecord { attempt, snapshot });
                         tracing::warn!(
                             "Task {} ('{}') blocked awaiting approval after {}ms",
                             task_id,
@@ -3316,7 +3362,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             }
         }
 
-        Ok(task_compute_ms)
+        Ok((task_compute_ms, park_records))
     }
 
     /// Collect failed tasks from this iteration into failure records.
@@ -3603,7 +3649,17 @@ Assign tasks to the worker whose tools best match the required operations."#,
                             task_id,
                             pending.len()
                         );
-                        return Ok(TaskOutcome::Blocked(pending));
+                        // `outcome` reports Blocked only when the snapshot
+                        // was captured, so the read-back cannot miss.
+                        let snapshot = park
+                            .cell
+                            .snapshot()
+                            .expect("cell outcome Blocked implies a captured snapshot");
+                        return Ok(TaskOutcome::Blocked {
+                            pending,
+                            attempt,
+                            snapshot,
+                        });
                     }
                     CellOutcome::Orphaned { pending } => {
                         // The stream ended before the hook could snapshot: the
@@ -4318,8 +4374,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
         // ----------------------------------------------------------------
         // EXECUTE: Run workers on tasks (parallel when possible)
         // ----------------------------------------------------------------
-        let task_compute_ms = match self.execute(&mut plan, event_tx).await {
-            Ok(ms) => ms,
+        let (task_compute_ms, park_records) = match self.execute(&mut plan, event_tx).await {
+            Ok(result) => result,
             Err(e) => {
                 self.write_run_manifest(&plan, iteration, None).await;
                 return Err(e);
@@ -4353,27 +4409,57 @@ Assign tasks to the worker whose tools best match the required operations."#,
         }
 
         // ----------------------------------------------------------------
-        // PARK PATH (park mode): an awaiting task at quiescence ends the
-        // iteration here, with no post-execute coordinator call: the
-        // coordinator must not replan a task the human is deciding on.
+        // PARK PATH (park mode): an awaiting task at quiescence ends the run
+        // here, with no post-execute coordinator call: the coordinator must
+        // not replan a task the human is deciding on. The commit refreshes
+        // the awaiting set, publishes the checkpoint, and emits run_parked;
+        // a failed commit publishes nothing and cancels the run's approvals.
         // ----------------------------------------------------------------
         if has_awaiting_task(&plan) {
-            let lines = park_verdict_lines(&plan);
-            let run_id = self.persistence.lock().await.run_id().to_string();
-            let mut message = format!("Run {} parked: task(s) awaiting human approval.\n", run_id);
-            for line in &lines {
-                message.push_str(&format!("- {line}\n"));
-            }
-            message.push_str(
-                "The run has stopped and no further tasks will execute until the \
-                 outstanding decisions are recorded.",
-            );
             tracing::info!(
                 "Iteration {} parked at quiescence; skipping post-execute coordinator call",
                 iteration
             );
-            self.write_run_manifest(&plan, iteration, None).await;
-            return Ok(IterationOutcome::FinalResult(message));
+            let conversation = coordinator_state.conversation.clone();
+            let routing_decision = coordinator_state.routing_decision.lock().await.clone();
+            let result = self
+                .park_run(
+                    query,
+                    chat_history,
+                    &conversation,
+                    routing_decision.as_ref(),
+                    iteration,
+                    planning_ms,
+                    failure_history.as_slice(),
+                    &plan,
+                    &park_records,
+                    event_tx,
+                )
+                .await;
+            let tool_traces = self.load_tool_traces_for_plan(&plan).await;
+            let timings = Self::iteration_timings(
+                &tool_traces,
+                planning_ms,
+                execution_start,
+                task_compute_ms,
+            );
+            match &result {
+                Ok(_) => {
+                    self.write_run_manifest_full(
+                        &plan,
+                        iteration,
+                        Some(super::persistence::RunStatus::Parked),
+                        Some("Parked awaiting human approval".to_string()),
+                        Some(timings),
+                    )
+                    .await
+                }
+                Err(_) => {
+                    self.write_run_manifest(&plan, iteration, Some(timings))
+                        .await
+                }
+            }
+            return result.map(IterationOutcome::FinalResult);
         }
 
         // ----------------------------------------------------------------
@@ -4463,27 +4549,15 @@ Assign tasks to the worker whose tools best match the required operations."#,
         // build_raw_task_results ships the worker output the user already
         // paid for instead of an empty response.
         // ----------------------------------------------------------------
+
         let tool_traces = self.load_tool_traces_for_plan(&plan).await;
 
         // Phase timings for this iteration. `execution_ms` is the wall-clock
         // from plan-ready to here (the continuation-prompt entrypoint);
         // `tool_ms` is the aggregate tool-execution time within it, so
         // `execution_ms - tool_ms` approximates LLM-thinking time.
-        let tool_ms: u64 = tool_traces
-            .values()
-            .flat_map(|entries| entries.iter())
-            .map(|e| e.duration_ms)
-            .sum();
-        let timings = IterationTimings {
-            planning_ms,
-            execution_ms: execution_start.elapsed().as_millis() as u64,
-            task_compute_ms,
-            tool_ms,
-        };
-        let current_span = tracing::Span::current();
-        current_span.record("orchestration.execution_ms", timings.execution_ms);
-        current_span.record("orchestration.task_compute_ms", timings.task_compute_ms);
-        current_span.record("orchestration.tool_ms", timings.tool_ms);
+        let timings =
+            Self::iteration_timings(&tool_traces, planning_ms, execution_start, task_compute_ms);
 
         let post_execute_ctx = IterationContext::new(
             iteration,
@@ -4550,9 +4624,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     orchestration_start.elapsed().as_secs_f64(),
                     decision_latency,
                 );
-                self.write_run_manifest_with_summary(
+                self.write_run_manifest_full(
                     &plan,
                     iteration,
+                    None,
                     response_summary,
                     Some(timings),
                 )
@@ -4787,6 +4862,31 @@ Assign tasks to the worker whose tools best match the required operations."#,
 
     /// Collect the condensed tool traces for all tasks in a plan, for
     /// continuation prompt rendering.
+    /// The iteration's phase timings, recorded on the current span.
+    fn iteration_timings(
+        tool_traces: &std::collections::HashMap<usize, Vec<super::persistence::ToolTraceEntry>>,
+        planning_ms: u64,
+        execution_start: Instant,
+        task_compute_ms: u64,
+    ) -> IterationTimings {
+        let tool_ms: u64 = tool_traces
+            .values()
+            .flat_map(|entries| entries.iter())
+            .map(|e| e.duration_ms)
+            .sum();
+        let timings = IterationTimings {
+            planning_ms,
+            execution_ms: execution_start.elapsed().as_millis() as u64,
+            task_compute_ms,
+            tool_ms,
+        };
+        let current_span = tracing::Span::current();
+        current_span.record("orchestration.execution_ms", timings.execution_ms);
+        current_span.record("orchestration.task_compute_ms", timings.task_compute_ms);
+        current_span.record("orchestration.tool_ms", timings.tool_ms);
+        timings
+    }
+
     async fn load_tool_traces_for_plan(
         &self,
         plan: &Plan,
@@ -4805,25 +4905,157 @@ Assign tasks to the worker whose tools best match the required operations."#,
         traces
     }
 
-    /// Called at the end of `run_orchestration_loop()` on all exit paths.
-    /// Errors are logged but not propagated — manifest is observability, not control flow.
-    ///
-    /// `timings` carries the final iteration's phase timings when available
-    /// (`None` for paths that failed before the timed consolidation step).
+    /// Commit the park checkpoint and end the run: refresh the awaiting set
+    /// against the store, publish the document, then emit the terminal
+    /// `run_parked` event only after the publish succeeded. A failed commit
+    /// publishes nothing, emits no event, and cancels the run's approvals.
+    #[allow(clippy::too_many_arguments)]
+    async fn park_run(
+        &self,
+        query: &str,
+        chat_history: &[rig::completion::Message],
+        coordinator_conversation: &[rig::completion::Message],
+        routing_decision: Option<&PlanningResponse>,
+        iteration: usize,
+        planning_ms: u64,
+        failure_history: &[FailedTaskRecord],
+        plan: &Plan,
+        park_records: &ParkedTaskRecords,
+        event_tx: &tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>,
+    ) -> Result<String, StreamError> {
+        let Some(hitl) = self.agent_config.hitl.clone() else {
+            return Err("run parked without the HITL runtime configured".into());
+        };
+        let crate::hitl::DecisionRoute::Conversational { registry, timeout } = &*hitl.route else {
+            return Err("run parked without the conversational route".into());
+        };
+        let (run_id, session_id) = {
+            let p = self.persistence.lock().await;
+            (p.run_id().to_string(), p.session_id().map(String::from))
+        };
+
+        let Some(memory_dir) = self.agent_config.effective_memory_dir().map(str::to_string) else {
+            // No memory_dir means no checkpoint can exist, so the run's
+            // approvals must not stay decidable.
+            tracing::error!(
+                run_id = %run_id,
+                "park commit impossible: no memory_dir configured; cancelling approvals",
+            );
+            self.cancel_run_parked_approvals(plan, &run_id).await;
+            return Err(format!(
+                "Run {run_id} parked but no memory_dir is configured, so no \
+                 checkpoint can be written. The run's pending approvals were cancelled.",
+            )
+            .into());
+        };
+
+        let inputs = super::park::ParkCommitInputs {
+            state: super::park::RunStateForPark {
+                run_id: &run_id,
+                session_id: session_id.as_deref(),
+                query,
+                chat_history,
+                coordinator_conversation,
+                routing_decision,
+                iteration,
+                planning_ms,
+                failure_history,
+            },
+            plan,
+            records: park_records,
+            registry,
+            memory_dir: &memory_dir,
+            config: &self.agent_config,
+            decision_window: *timeout,
+        };
+
+        match super::park::commit_from_run_state(&inputs).await {
+            Ok(commit) => {
+                if let Some(ref guard) = self.park_guard {
+                    guard.mark_published();
+                }
+                Self::emit_event(
+                    event_tx,
+                    OrchestratorEvent::RunParked {
+                        run_id: run_id.clone(),
+                        decision_ids: commit
+                            .refreshed
+                            .decision_ids
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect(),
+                        expires_at: commit.expires_at,
+                        iteration,
+                    },
+                )
+                .await;
+                let mut message =
+                    format!("Run {run_id} parked: task(s) awaiting human approval.\n");
+                for line in park_verdict_lines(plan) {
+                    message.push_str(&format!("- {line}\n"));
+                }
+                message.push_str(
+                    "The run has stopped and no further tasks will execute until the \
+                     outstanding decisions are recorded.",
+                );
+                Ok(message)
+            }
+            Err(e) => {
+                tracing::error!(
+                    run_id = %run_id,
+                    error = %e,
+                    "park commit failed; cancelling the run's approvals",
+                );
+                self.cancel_run_parked_approvals(plan, &run_id).await;
+                Err(format!(
+                    "Park commit failed for run {run_id}: {e}. The run's pending \
+                     approvals were cancelled.",
+                )
+                .into())
+            }
+        }
+    }
+
+    /// Collect the plan's awaiting decision ids and sweep them, so no
+    /// decidable approval outlives a run that has no checkpoint.
+    async fn cancel_run_parked_approvals(&self, plan: &Plan, run_id: &str) {
+        let Some(hitl) = self.agent_config.hitl.clone() else {
+            return;
+        };
+        let crate::hitl::DecisionRoute::Conversational { registry, .. } = &*hitl.route else {
+            return;
+        };
+        let mut cancelled = Vec::new();
+        for task in &plan.tasks {
+            let TaskState::AwaitingApproval { pending } = &task.state else {
+                continue;
+            };
+            let Some(scope) = self.worker_scope(task.id, task.worker.as_deref()).await else {
+                continue;
+            };
+            cancelled.extend(pending.iter().map(|call| (call.decision_id, scope.clone())));
+        }
+        let request_id = self.agent_config.request_id.clone().unwrap_or_default();
+        super::park::cancel_run_approvals(registry, run_id, &request_id, cancelled.into_iter())
+            .await;
+    }
+
     async fn write_run_manifest(
         &self,
         plan: &Plan,
         iterations: usize,
         timings: Option<IterationTimings>,
     ) {
-        self.write_run_manifest_with_summary(plan, iterations, None, timings)
+        self.write_run_manifest_full(plan, iterations, None, None, timings)
             .await;
     }
 
-    async fn write_run_manifest_with_summary(
+    /// `status_override` replaces the status derived from the task counts.
+    async fn write_run_manifest_full(
         &self,
         plan: &Plan,
         iterations: usize,
+        status_override: Option<super::persistence::RunStatus>,
         response_summary: Option<String>,
         timings: Option<IterationTimings>,
     ) {
@@ -4835,13 +5067,15 @@ Assign tasks to the worker whose tools best match the required operations."#,
         let persistence = self.persistence.lock().await;
 
         let all_complete = plan.completed_count() == plan.tasks.len();
-        let status = if all_complete {
-            RunStatus::Success
-        } else if plan.completed_count() > 0 {
-            RunStatus::PartialSuccess
-        } else {
-            RunStatus::Failed
-        };
+        let status = status_override.unwrap_or_else(|| {
+            if all_complete {
+                RunStatus::Success
+            } else if plan.completed_count() > 0 {
+                RunStatus::PartialSuccess
+            } else {
+                RunStatus::Failed
+            }
+        });
 
         let artifacts_meta = match persistence.list_artifacts_with_metadata().await {
             Ok(meta) => meta,
@@ -6862,9 +7096,13 @@ mod tests {
         mark_awaiting(&mut plan, 1, vec![parked_call("kubectl_apply")]);
 
         let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(32);
-        let compute_ms = orchestrator.execute(&mut plan, &event_tx).await.unwrap();
+        let (compute_ms, park_records) = orchestrator.execute(&mut plan, &event_tx).await.unwrap();
 
         assert_eq!(compute_ms, 0, "no worker ran");
+        assert!(
+            park_records.is_empty(),
+            "no park record exists for a pre-marked awaiting plan"
+        );
         assert!(matches!(
             plan.tasks[1].state,
             TaskState::AwaitingApproval { .. }
@@ -7019,6 +7257,553 @@ mod tests {
                 other => panic!("expected Completed(cancelled) event, got {other:?}"),
             }
         }
+
+        crate::approval_event_broker::unsubscribe(&request_id).await;
+    }
+
+    // ====================================================================
+    // Park commit (park mode)
+    // ====================================================================
+
+    use crate::hitl::{ApprovalItem, ParkedApproval};
+    use crate::session_store::ApprovalStore;
+
+    /// An orchestrator wired for park mode over an in-memory store, plus the
+    /// store handle and its memory dir.
+    async fn park_orchestrator(
+        memory_dir: &std::path::Path,
+    ) -> (
+        Orchestrator,
+        Arc<crate::session_store::InMemoryApprovalStore>,
+        crate::hitl::PendingApprovals,
+        String,
+    ) {
+        let store = Arc::new(crate::session_store::InMemoryApprovalStore::new());
+        let (orchestrator, registry, run_id) =
+            park_orchestrator_over(store.clone(), memory_dir).await;
+        (orchestrator, store, registry, run_id)
+    }
+
+    /// An orchestrator wired for park mode over an explicit approval-store
+    /// backend, plus its registry and run id.
+    async fn park_orchestrator_over(
+        store: Arc<dyn crate::session_store::ApprovalStore>,
+        memory_dir: &std::path::Path,
+    ) -> (Orchestrator, crate::hitl::PendingApprovals, String) {
+        use crate::hitl::PendingApprovals;
+        use crate::session_store::InMemoryEventBus;
+
+        let registry = PendingApprovals::with_backend(store, Arc::new(InMemoryEventBus::new()));
+        let config = AgentRuntimeConfig {
+            hitl: Some(crate::hitl::HitlRuntime {
+                patterns: Arc::from([aura_config::GlobPattern::new("kubectl_*").unwrap()]),
+                route: Arc::new(crate::hitl::DecisionRoute::Conversational {
+                    registry: registry.clone(),
+                    timeout: Duration::from_secs(3600),
+                }),
+                park_enabled: true,
+            }),
+            memory_dir: Some(memory_dir.to_string_lossy().into_owned()),
+            session_id: Some("park-sess".to_string()),
+            request_id: Some(format!("req_park_{}", uuid::Uuid::new_v4().simple())),
+            ..AgentRuntimeConfig::default()
+        };
+        let orchestrator = Orchestrator::new(config).await.unwrap();
+        let run_id = orchestrator.persistence.lock().await.run_id().to_string();
+        (orchestrator, registry, run_id)
+    }
+
+    /// An awaiting plan plus its park record, with every pending call
+    /// durably parked under the run-scoped owner — the state the gate and
+    /// hook leave behind at the quiescence verdict.
+    async fn awaiting_plan_with_parked_calls(
+        registry: &crate::hitl::PendingApprovals,
+        run_id: &str,
+    ) -> (Plan, ParkedTaskRecords, Vec<TestPendingCall>) {
+        let mut plan = Plan::new("Deploy");
+        plan.add_task(Task::new(0, "Facts", "r"));
+        plan.add_task(Task::new(1, "Gated apply", "r").with_dependency(0));
+        plan.get_task_mut(0).unwrap().complete("facts");
+
+        let now = chrono::Utc::now();
+        let mut pending = Vec::new();
+        for tool in ["kubectl_apply", "kubectl_delete"] {
+            let decision_id = TestDecisionId::generate();
+            registry
+                .register_durable(ParkedApproval {
+                    request: crate::hitl::ApprovalRequest {
+                        version: crate::hitl::PROTOCOL_VERSION,
+                        instance_id: "test-instance".to_string(),
+                        decision_id,
+                        request_id: format!("run:{run_id}"),
+                        scope: crate::hitl::AgentScope::Single { session_id: None },
+                        origin: crate::hitl::ApprovalOrigin::ConfigGate {
+                            matched_pattern: "kubectl_*".to_string(),
+                            agent_name: "test-agent".to_string(),
+                        },
+                        items: vec![ApprovalItem {
+                            tool_name: tool.to_string(),
+                            arguments: serde_json::json!({ "namespace": "prod" }),
+                            tool_call_intent: None,
+                        }],
+                    },
+                    registered_at: now,
+                    expires_at: now + chrono::Duration::hours(1),
+                })
+                .await
+                .unwrap();
+            pending.push(TestPendingCall {
+                decision_id,
+                tool_name: tool.to_string(),
+                arguments: serde_json::json!({ "namespace": "prod" }),
+                call_id: format!("call_{}", pending.len()),
+            });
+        }
+        plan.tasks[1].state = TaskState::AwaitingApproval {
+            pending: pending.clone(),
+        };
+
+        let mut records = ParkedTaskRecords::new();
+        records.insert(
+            1,
+            crate::orchestration::park::ParkedTaskRecord {
+                attempt: 1,
+                snapshot: crate::orchestration::ParkSnapshot {
+                    history: vec![rig::completion::Message::user("apply it")],
+                    current_prompt: rig::completion::Message::user("tool results"),
+                },
+            },
+        );
+        (plan, records, pending)
+    }
+
+    /// Record the fixture's awaiting task on the run guard, as the park arm does.
+    async fn arm_guard(orchestrator: &Orchestrator, plan: &Plan) {
+        let guard = orchestrator
+            .park_guard
+            .as_ref()
+            .expect("park-mode orchestrator");
+        let scope = orchestrator
+            .worker_scope(1, plan.tasks[1].worker.as_deref())
+            .await
+            .expect("worker scope builds");
+        let TaskState::AwaitingApproval { pending } = &plan.tasks[1].state else {
+            unreachable!("the fixture task is awaiting")
+        };
+        guard.record(&scope, pending);
+    }
+
+    fn set_mode(path: &std::path::Path, mode: u32) {
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, mode);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    #[tokio::test]
+    async fn park_run_publishes_document_event_and_keeps_approvals() {
+        let dir = tempfile::tempdir().unwrap();
+        let (orchestrator, store, registry, run_id) = park_orchestrator(dir.path()).await;
+        let (plan, records, pending) = awaiting_plan_with_parked_calls(&registry, &run_id).await;
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(32);
+
+        let chat_history = vec![rig::completion::Message::user("deploy the service")];
+        let message = orchestrator
+            .park_run(
+                "deploy the service",
+                &chat_history,
+                &[],
+                None,
+                1,
+                2_500,
+                &[],
+                &plan,
+                &records,
+                &event_tx,
+            )
+            .await
+            .expect("the park commit succeeds");
+
+        assert!(message.contains(&run_id), "the end message names the run");
+
+        let document_path = dir
+            .path()
+            .join("park-sess")
+            .join("parked")
+            .join(format!("{run_id}.json"));
+        assert!(
+            document_path.try_exists().unwrap(),
+            "the document lands at {{session_id}}/parked/{{run_id}}.json"
+        );
+
+        let document = crate::orchestration::park::load_parked_run(&document_path)
+            .await
+            .unwrap();
+        assert_eq!(document.run_id, run_id);
+        assert_eq!(document.iteration, 1);
+        assert!(document.executed.is_empty());
+        let expected_ids: Vec<String> = pending.iter().map(|c| c.decision_id.to_string()).collect();
+        assert_eq!(
+            document.awaiting_decision_ids(),
+            expected_ids,
+            "the awaiting set re-derives from disk alone"
+        );
+        let awaiting = document
+            .plan
+            .tasks
+            .iter()
+            .find(|t| t.status == TaskStatus::AwaitingApproval)
+            .unwrap();
+        assert_eq!(awaiting.attempt, Some(1));
+        assert!(awaiting.history.is_some() && awaiting.current_prompt.is_some());
+
+        match event_rx.recv().await {
+            Some(Ok(StreamItem::OrchestratorEvent(OrchestratorEvent::RunParked {
+                run_id: event_run,
+                decision_ids,
+                iteration,
+                ..
+            }))) => {
+                assert_eq!(event_run, run_id);
+                assert_eq!(decision_ids, expected_ids);
+                assert_eq!(iteration, 1);
+            }
+            other => panic!("expected a RunParked event, got {other:?}"),
+        }
+
+        for call in &pending {
+            assert!(
+                store.get(&call.decision_id).await.unwrap().is_some(),
+                "a published checkpoint keeps its approvals parked"
+            );
+        }
+        drop(orchestrator);
+    }
+
+    #[tokio::test]
+    async fn park_run_with_every_call_decided_stamps_the_decision_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let (orchestrator, _store, registry, run_id) = park_orchestrator(dir.path()).await;
+        let (plan, records, pending) = awaiting_plan_with_parked_calls(&registry, &run_id).await;
+        for call in &pending {
+            registry
+                .resolve(&call.decision_id, crate::hitl::ApprovalDecision::Approved)
+                .await
+                .unwrap();
+        }
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(32);
+        let chat_history = vec![rig::completion::Message::user("deploy the service")];
+        let before = chrono::Utc::now();
+
+        orchestrator
+            .park_run(
+                "deploy the service",
+                &chat_history,
+                &[],
+                None,
+                1,
+                2_500,
+                &[],
+                &plan,
+                &records,
+                &event_tx,
+            )
+            .await
+            .expect("the park commit succeeds");
+
+        let document = crate::orchestration::park::load_parked_run(
+            &dir.path()
+                .join("park-sess")
+                .join("parked")
+                .join(format!("{run_id}.json")),
+        )
+        .await
+        .unwrap();
+        assert!(document.awaiting_decision_ids().is_empty());
+        let expires_at = chrono::DateTime::parse_from_rfc3339(&document.expires_at).unwrap();
+        // The fixture route timeout is one hour.
+        assert!(
+            expires_at >= before + chrono::Duration::seconds(3600 - 5),
+            "expires_at carries the decision window: {}",
+            document.expires_at
+        );
+        match event_rx.recv().await {
+            Some(Ok(StreamItem::OrchestratorEvent(OrchestratorEvent::RunParked {
+                decision_ids,
+                expires_at: stamp,
+                ..
+            }))) => {
+                assert!(decision_ids.is_empty());
+                assert_eq!(stamp, document.expires_at);
+            }
+            other => panic!("expected a RunParked event, got {other:?}"),
+        }
+        drop(orchestrator);
+    }
+    #[tokio::test]
+    async fn park_run_failure_publishes_nothing_and_cancels_approvals() {
+        let dir = tempfile::tempdir().unwrap();
+        let (orchestrator, store, registry, run_id) = park_orchestrator(dir.path()).await;
+        let (plan, records, pending) = awaiting_plan_with_parked_calls(&registry, &run_id).await;
+        let request_id = orchestrator
+            .agent_config
+            .request_id
+            .clone()
+            .unwrap_or_default();
+        let mut events = crate::approval_event_broker::subscribe(&request_id).await;
+        arm_guard(&orchestrator, &plan).await;
+
+        // A read-only session root makes the checkpoint write fail.
+        let session_root = dir.path().join("park-sess");
+        set_mode(&session_root, 0o555);
+
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(32);
+        let chat_history = vec![rig::completion::Message::user("deploy the service")];
+        let result = orchestrator
+            .park_run(
+                "deploy the service",
+                &chat_history,
+                &[],
+                None,
+                1,
+                2_500,
+                &[],
+                &plan,
+                &records,
+                &event_tx,
+            )
+            .await;
+
+        set_mode(&session_root, 0o755);
+
+        let err = result.expect_err("the commit must fail");
+        assert!(
+            err.to_string().contains("Park commit failed"),
+            "error names the failed commit: {err}"
+        );
+
+        assert!(
+            !dir.path()
+                .join("park-sess")
+                .join("parked")
+                .join(format!("{run_id}.json"))
+                .try_exists()
+                .unwrap(),
+            "no document is published on a failed commit"
+        );
+        for call in &pending {
+            assert!(
+                store.get(&call.decision_id).await.unwrap().is_none(),
+                "approval {} cancelled with the run",
+                call.decision_id
+            );
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), event_rx.recv())
+                .await
+                .is_err(),
+            "no run_parked event fires on a failed commit"
+        );
+
+        // One completed(cancelled) per decision from the immediate sweep…
+        for _ in &pending {
+            match tokio::time::timeout(Duration::from_secs(1), events.recv()).await {
+                Ok(Some(crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
+                    completed,
+                ))) => {
+                    assert!(matches!(
+                        completed.outcome,
+                        aura_events::ApprovalOutcomeWire::Cancelled { .. }
+                    ));
+                }
+                other => panic!("expected one Completed(cancelled) per decision, got {other:?}"),
+            }
+        }
+        // …and the guard's drop sweep adds nothing.
+        drop(orchestrator);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), events.recv())
+                .await
+                .is_err(),
+            "the drop sweep does not double-report cancelled approvals"
+        );
+
+        crate::approval_event_broker::unsubscribe(&request_id).await;
+    }
+
+    #[tokio::test]
+    async fn park_run_failure_spares_decided_approval_and_cancels_sibling() {
+        let dir = tempfile::tempdir().unwrap();
+        let (orchestrator, store, registry, run_id) = park_orchestrator(dir.path()).await;
+        let (plan, records, pending) = awaiting_plan_with_parked_calls(&registry, &run_id).await;
+        let request_id = orchestrator
+            .agent_config
+            .request_id
+            .clone()
+            .unwrap_or_default();
+        let mut events = crate::approval_event_broker::subscribe(&request_id).await;
+
+        // The human decides the first call before the commit is attempted.
+        let decided = pending[0].decision_id;
+        let sibling = pending[1].decision_id;
+        registry
+            .resolve(&decided, crate::hitl::ApprovalDecision::Approved)
+            .await
+            .unwrap();
+
+        arm_guard(&orchestrator, &plan).await;
+
+        // A read-only session root makes the checkpoint write fail.
+        let session_root = dir.path().join("park-sess");
+        set_mode(&session_root, 0o555);
+
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(32);
+        let chat_history = vec![rig::completion::Message::user("deploy the service")];
+        let result = orchestrator
+            .park_run(
+                "deploy the service",
+                &chat_history,
+                &[],
+                None,
+                1,
+                2_500,
+                &[],
+                &plan,
+                &records,
+                &event_tx,
+            )
+            .await;
+
+        set_mode(&session_root, 0o755);
+
+        assert!(result.is_err(), "the commit must fail");
+
+        assert!(
+            store.get(&sibling).await.unwrap().is_none(),
+            "the undecided sibling is cancelled with the run"
+        );
+        assert!(
+            registry.recorded_decision(&decided).await.is_some(),
+            "the recorded decision survives the failed commit's sweep"
+        );
+
+        // Exactly one cancelled event — the sibling's; the decided
+        // approval stays silent.
+        match tokio::time::timeout(Duration::from_secs(1), events.recv()).await {
+            Ok(Some(crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
+                completed,
+            ))) => {
+                assert_eq!(completed.decision_id, sibling.to_string());
+                assert!(matches!(
+                    completed.outcome,
+                    aura_events::ApprovalOutcomeWire::Cancelled { .. }
+                ));
+            }
+            other => panic!("expected the sibling's completed(cancelled), got {other:?}"),
+        }
+
+        // The guard's drop sweep stays silent: the decided approval is
+        // spared, the already-cancelled sibling is not double-reported.
+        drop(orchestrator);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), events.recv())
+                .await
+                .is_err(),
+            "the drop sweep spares the decided approval and does not double-report the sibling"
+        );
+        assert!(
+            registry.recorded_decision(&decided).await.is_some(),
+            "the recorded decision survives the guard's drop"
+        );
+
+        crate::approval_event_broker::unsubscribe(&request_id).await;
+    }
+
+    #[tokio::test]
+    async fn park_run_store_fault_during_refresh_fails_commit_and_sweeps() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(crate::session_store::FaultInjectingStore::failing_first_get());
+        let (orchestrator, registry, run_id) =
+            park_orchestrator_over(store.clone(), dir.path()).await;
+        let (plan, records, pending) = awaiting_plan_with_parked_calls(&registry, &run_id).await;
+        let request_id = orchestrator
+            .agent_config
+            .request_id
+            .clone()
+            .unwrap_or_default();
+        let mut events = crate::approval_event_broker::subscribe(&request_id).await;
+        arm_guard(&orchestrator, &plan).await;
+
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(32);
+        let chat_history = vec![rig::completion::Message::user("deploy the service")];
+        let result = orchestrator
+            .park_run(
+                "deploy the service",
+                &chat_history,
+                &[],
+                None,
+                1,
+                2_500,
+                &[],
+                &plan,
+                &records,
+                &event_tx,
+            )
+            .await;
+
+        let err = result.expect_err("the store fault must fail the commit");
+        assert!(
+            err.to_string().contains("Park commit failed"),
+            "error names the failed commit: {err}"
+        );
+
+        assert!(
+            !dir.path()
+                .join("park-sess")
+                .join("parked")
+                .join(format!("{run_id}.json"))
+                .try_exists()
+                .unwrap(),
+            "no document is published when the refresh faults"
+        );
+        for call in &pending {
+            assert!(
+                store.get(&call.decision_id).await.unwrap().is_none(),
+                "approval {} cancelled by the failed-commit sweep",
+                call.decision_id
+            );
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), event_rx.recv())
+                .await
+                .is_err(),
+            "no run_parked event fires on a faulted refresh"
+        );
+
+        // One completed(cancelled) per decision from the immediate sweep…
+        for _ in &pending {
+            match tokio::time::timeout(Duration::from_secs(1), events.recv()).await {
+                Ok(Some(crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
+                    completed,
+                ))) => {
+                    assert!(matches!(
+                        completed.outcome,
+                        aura_events::ApprovalOutcomeWire::Cancelled { .. }
+                    ));
+                }
+                other => panic!("expected one Completed(cancelled) per decision, got {other:?}"),
+            }
+        }
+        // …and the guard's drop sweep adds nothing.
+        drop(orchestrator);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), events.recv())
+                .await
+                .is_err(),
+            "the drop sweep does not double-report cancelled approvals"
+        );
 
         crate::approval_event_broker::unsubscribe(&request_id).await;
     }

--- a/crates/aura/src/orchestration/park/commit.rs
+++ b/crates/aura/src/orchestration/park/commit.rs
@@ -1,0 +1,662 @@
+//! The park commit: awaiting-set refresh, publication, and the
+//! no-checkpoint cancellation sweep.
+
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+use crate::config::AgentRuntimeConfig;
+use crate::hitl::{AgentScope, DecisionId, PendingApprovals};
+use crate::orchestration::persistence::is_safe_path_component;
+use crate::orchestration::types::{PendingCall, Plan, TaskState};
+
+use super::ParkedTaskRecords;
+use super::document::{
+    PARKED_DOCUMENT_SUFFIX, ParkedRun, RESUMING_DOCUMENT_SUFFIX, RunStateForPark, build_document,
+};
+
+/// The inputs the orchestrator hands the park commit.
+pub(crate) struct ParkCommitInputs<'a> {
+    pub state: RunStateForPark<'a>,
+    pub plan: &'a Plan,
+    pub records: &'a ParkedTaskRecords,
+    pub registry: &'a PendingApprovals,
+    pub memory_dir: &'a str,
+    pub config: &'a AgentRuntimeConfig,
+    /// Decision window stamped on a document with no surviving ticket.
+    pub decision_window: std::time::Duration,
+}
+
+/// The refreshed awaiting set: per-task pending calls still awaiting a
+/// decision, and the earliest expiry among them.
+pub(crate) struct RefreshedAwaiting {
+    pub pending_by_task: HashMap<usize, Vec<PendingCall>>,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Every decision id still awaiting a decision, in plan order.
+    pub decision_ids: Vec<DecisionId>,
+}
+
+/// A completed park commit: the resolved expiry stamp and the refreshed
+/// awaiting set.
+pub(crate) struct ParkCommitOutcome {
+    /// RFC 3339 expiry timestamp.
+    pub expires_at: String,
+    pub refreshed: RefreshedAwaiting,
+}
+
+/// The run-scoped owner id every approval parked by `run_id` is registered
+/// under.
+pub(crate) fn run_owner_id(run_id: &str) -> String {
+    format!("run:{run_id}")
+}
+
+/// Narrow the plan's awaiting tasks to the calls still parked and undecided,
+/// with the earliest surviving ticket expiry. A store fault fails the
+/// refresh, and with it the commit, rather than dropping a still-decidable
+/// approval from the checkpoint.
+pub(crate) async fn refresh_awaiting(
+    plan: &Plan,
+    registry: &PendingApprovals,
+) -> io::Result<RefreshedAwaiting> {
+    let mut pending_by_task = HashMap::new();
+    let mut expires_at = None;
+    let mut decision_ids = Vec::new();
+
+    for task in &plan.tasks {
+        let TaskState::AwaitingApproval { pending } = &task.state else {
+            continue;
+        };
+        let mut surviving = Vec::with_capacity(pending.len());
+        for call in pending {
+            let Some(parked) = registry
+                .try_parked(&call.decision_id)
+                .await
+                .map_err(io::Error::other)?
+            else {
+                tracing::info!(
+                    decision_id = %call.decision_id,
+                    task_id = task.id,
+                    "park approval no longer parked at commit time; dropping from checkpoint",
+                );
+                continue;
+            };
+            if registry
+                .recorded_decision(&call.decision_id)
+                .await
+                .is_some()
+            {
+                tracing::info!(
+                    decision_id = %call.decision_id,
+                    task_id = task.id,
+                    "park approval decided before commit; dropping from checkpoint",
+                );
+                continue;
+            }
+            expires_at = Some(match expires_at {
+                Some(earliest) if parked.expires_at >= earliest => earliest,
+                _ => parked.expires_at,
+            });
+            surviving.push(call.clone());
+            decision_ids.push(call.decision_id);
+        }
+        if !surviving.is_empty() {
+            pending_by_task.insert(task.id, surviving);
+        }
+    }
+
+    Ok(RefreshedAwaiting {
+        pending_by_task,
+        expires_at,
+        decision_ids,
+    })
+}
+
+/// The whole commit: refresh the awaiting set against the store, build the
+/// document, publish it. `expires_at` is resolved once here so the document
+/// and the caller's terminal event carry the same stamp; a refresh with no
+/// surviving ticket stamps `now + decision_window`.
+pub(crate) async fn commit_from_run_state(
+    inputs: &ParkCommitInputs<'_>,
+) -> io::Result<ParkCommitOutcome> {
+    let ParkCommitInputs {
+        state,
+        plan,
+        records,
+        registry,
+        memory_dir,
+        config,
+        decision_window,
+    } = inputs;
+
+    let refreshed = refresh_awaiting(plan, registry).await?;
+    let expires_at = refreshed
+        .expires_at
+        .unwrap_or_else(|| {
+            chrono::Utc::now()
+                + chrono::Duration::from_std(*decision_window).expect("decision window fits chrono")
+        })
+        .to_rfc3339();
+    let document = build_document(
+        state,
+        plan,
+        records,
+        &refreshed.pending_by_task,
+        expires_at.clone(),
+        config_fingerprint(config),
+    )?;
+    let parked_dir = parked_document_dir(memory_dir, state.session_id);
+    publish(&document, &parked_dir, state.run_id).await?;
+    Ok(ParkCommitOutcome {
+        expires_at,
+        refreshed,
+    })
+}
+
+/// Publish a checkpoint by temp write and same-directory rename.
+///
+/// Writes `{parked_dir}/.{run_id}.tmp`, renames it to
+/// `{parked_dir}/{run_id}.json`, then removes `{run_id}.resuming.json` if a
+/// stale one shadows the fresh document. Publish-then-unlink is the
+/// fail-safe order: a crash between the two leaves a correct fresh
+/// checkpoint shadowed by a stale resuming document, which reads as
+/// interrupted rather than corrupt.
+pub(crate) async fn publish(
+    document: &ParkedRun,
+    parked_dir: &Path,
+    run_id: &str,
+) -> io::Result<PathBuf> {
+    if !is_safe_path_component(run_id) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid run id for parked document: {run_id:?}"),
+        ));
+    }
+    let bytes = serde_json::to_vec_pretty(document)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+    // The whole write-rename-unlink sequence runs as one blocking task:
+    // the fail-safe order stays a single unit, and no executor thread
+    // performs file I/O.
+    let parked_dir = parked_dir.to_path_buf();
+    let run_id = run_id.to_string();
+    tokio::task::spawn_blocking(move || {
+        std::fs::create_dir_all(&parked_dir)?;
+
+        let tmp = parked_dir.join(format!(".{run_id}.tmp"));
+        std::fs::write(&tmp, &bytes)?;
+        let dest = parked_dir.join(format!("{run_id}{PARKED_DOCUMENT_SUFFIX}"));
+        std::fs::rename(&tmp, &dest)?;
+
+        let resuming = parked_dir.join(format!("{run_id}{RESUMING_DOCUMENT_SUFFIX}"));
+        if let Err(e) = std::fs::remove_file(&resuming)
+            && e.kind() != io::ErrorKind::NotFound
+        {
+            tracing::warn!(
+                path = %resuming.display(),
+                error = %e,
+                "failed to unlink stale resuming document after publish",
+            );
+        }
+        Ok(dest)
+    })
+    .await
+    .map_err(io::Error::other)?
+}
+
+/// Cancel every undecided approval the run parked: a recorded decision is
+/// spared, an id no longer parked is skipped (the sweep is idempotent), and
+/// each remaining id publishes one `approval_completed(cancelled)` before the
+/// store clears the run's tickets by owner id.
+pub(crate) async fn cancel_run_approvals(
+    registry: &PendingApprovals,
+    run_id: &str,
+    request_id: &str,
+    cancelled: impl Iterator<Item = (DecisionId, AgentScope)>,
+) {
+    for (decision_id, scope) in cancelled {
+        if registry.recorded_decision(&decision_id).await.is_some() {
+            tracing::info!(
+                decision_id = %decision_id,
+                "approval decided before the cancellation sweep; decision spared",
+            );
+            continue;
+        }
+        let parked = registry
+            .try_parked(&decision_id)
+            .await
+            .unwrap_or_else(|err| {
+                tracing::warn!(decision_id = %decision_id, error = %err, "parked approval lookup failed");
+                None
+            });
+        if parked.is_none() {
+            continue;
+        }
+        crate::approval_event_broker::publish(
+            request_id,
+            crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
+                crate::hitl::completed_cancelled(decision_id, &scope, std::time::Duration::ZERO),
+            ),
+        )
+        .await;
+    }
+    // The owner id the park arm stamps on every ticket it registers.
+    registry.cancel_request(&run_owner_id(run_id)).await;
+}
+
+/// The directory checkpoint documents live in:
+/// `{memory_dir}/{session_id}/parked`, or `{memory_dir}/parked` without a
+/// session.
+pub(crate) fn parked_document_dir(memory_dir: &str, session_id: Option<&str>) -> PathBuf {
+    let root = Path::new(memory_dir);
+    match session_id {
+        Some(sid) => root.join(sid).join("parked"),
+        None => root.join("parked"),
+    }
+}
+
+/// Fingerprint the configuration a resume must not drift from: the HITL
+/// gating surface (globs, route, park flag), the agent's model and tool
+/// filter, and the per-worker model and tool configuration.
+pub(crate) fn config_fingerprint(config: &AgentRuntimeConfig) -> String {
+    let hitl = config.hitl.as_ref();
+    let route = hitl.map(|h| match &*h.route {
+        crate::hitl::DecisionRoute::Conversational { timeout, .. } => json!({
+            "kind": "conversational",
+            "timeout_secs": timeout.as_secs(),
+        }),
+        crate::hitl::DecisionRoute::Webhook { timeout, .. } => json!({
+            "kind": "webhook",
+            "timeout_secs": timeout.as_secs(),
+        }),
+    });
+    let source = json!({
+        "hitl": {
+            "patterns": hitl
+                .map(|h| h.patterns.iter().map(|p| p.as_str().to_string())
+                    .collect::<Vec<_>>())
+                .unwrap_or_default(),
+            "route": route,
+            "park_enabled": hitl.is_some_and(|h| h.park_enabled),
+        },
+        "agent": {
+            "llm": serde_json::to_value(&config.llm).ok(),
+            "mcp_filter": &config.agent.mcp_filter,
+        },
+        "workers": config
+            .orchestration
+            .as_ref()
+            .and_then(|o| serde_json::to_value(&o.workers).ok()),
+    });
+    let canonical = serde_json::to_string(&source).unwrap_or_else(|_| source.to_string());
+    hex::encode(Sha256::digest(canonical.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::hitl::{
+        AgentScope, ApprovalItem, ApprovalOrigin, ApprovalRequest, DecisionId, PROTOCOL_VERSION,
+        ParkedApproval, PendingApprovals,
+    };
+    use crate::orchestration::park::document::{ParkedPlan, SCHEMA_VERSION, load_parked_run};
+    use crate::orchestration::types::Task;
+    use crate::session_store::{ApprovalStore, InMemoryApprovalStore, InMemoryEventBus};
+
+    fn conv_registry() -> (PendingApprovals, std::sync::Arc<InMemoryApprovalStore>) {
+        let store = std::sync::Arc::new(InMemoryApprovalStore::new());
+        let registry = PendingApprovals::with_backend(
+            store.clone() as std::sync::Arc<dyn crate::session_store::ApprovalStore>,
+            std::sync::Arc::new(InMemoryEventBus::new()),
+        );
+        (registry, store)
+    }
+
+    fn parked_approval(
+        decision_id: DecisionId,
+        owner: &str,
+        expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> ParkedApproval {
+        ParkedApproval {
+            request: ApprovalRequest {
+                version: PROTOCOL_VERSION,
+                instance_id: "test-instance".to_string(),
+                decision_id,
+                request_id: owner.to_string(),
+                scope: AgentScope::Single { session_id: None },
+                origin: ApprovalOrigin::ConfigGate {
+                    matched_pattern: "kubectl_*".to_string(),
+                    agent_name: "test-agent".to_string(),
+                },
+                items: vec![ApprovalItem {
+                    tool_name: "kubectl_apply".to_string(),
+                    arguments: serde_json::json!({ "namespace": "prod" }),
+                    tool_call_intent: None,
+                }],
+            },
+            registered_at: chrono::Utc::now(),
+            expires_at,
+        }
+    }
+
+    /// Publish lands at `{parked}/{run_id}.json`, leaves no temp file, and
+    /// unlinks the resuming document a re-park supersedes.
+    #[tokio::test]
+    async fn publish_renames_and_unlinks_stale_resuming_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let parked_dir = dir.path().join("parked");
+        tokio::fs::create_dir_all(&parked_dir).await.unwrap();
+        let run_id = "0191e8c0-cccc-7000-8000-000000000001";
+        tokio::fs::write(parked_dir.join(format!("{run_id}.resuming.json")), "stale")
+            .await
+            .unwrap();
+
+        let document = ParkedRun {
+            schema_version: SCHEMA_VERSION,
+            session_id: Some("sess".to_string()),
+            run_id: run_id.to_string(),
+            parked_at: "2026-09-02T14:00:00+00:00".to_string(),
+            expires_at: "2026-09-02T15:00:00+00:00".to_string(),
+            query: "Deploy".to_string(),
+            chat_history: vec![],
+            coordinator_conversation: vec![],
+            routing_decision: None,
+            iteration: 1,
+            planning_ms: 0,
+            failure_history: vec![],
+            plan: ParkedPlan {
+                goal: "Deploy".to_string(),
+                steps: None,
+                tasks: vec![],
+            },
+            executed: vec![],
+            config_fingerprint: "f".to_string(),
+        };
+
+        let dest = publish(&document, &parked_dir, run_id).await.unwrap();
+        assert_eq!(dest, parked_dir.join(format!("{run_id}.json")));
+        assert!(dest.try_exists().unwrap(), "published document exists");
+        assert!(
+            !parked_dir
+                .join(format!(".{run_id}.tmp"))
+                .try_exists()
+                .unwrap(),
+            "no temp residue"
+        );
+        assert!(
+            !parked_dir
+                .join(format!("{run_id}.resuming.json"))
+                .try_exists()
+                .unwrap(),
+            "stale resuming document unlinked"
+        );
+
+        let reloaded = load_parked_run(&dest).await.unwrap();
+        assert_eq!(reloaded.run_id, run_id);
+    }
+
+    /// A read-only parked directory fails the temp write, publishes nothing,
+    /// and leaves no partial document.
+    #[tokio::test]
+    async fn failing_temp_write_publishes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let parked_dir = dir.path().join("parked");
+        tokio::fs::create_dir_all(&parked_dir).await.unwrap();
+        let run_id = "0191e8c0-dddd-7000-8000-000000000002";
+        let document = ParkedRun {
+            schema_version: SCHEMA_VERSION,
+            session_id: None,
+            run_id: run_id.to_string(),
+            parked_at: "2026-09-02T14:00:00+00:00".to_string(),
+            expires_at: "2026-09-02T15:00:00+00:00".to_string(),
+            query: "Deploy".to_string(),
+            chat_history: vec![],
+            coordinator_conversation: vec![],
+            routing_decision: None,
+            iteration: 1,
+            planning_ms: 0,
+            failure_history: vec![],
+            plan: ParkedPlan {
+                goal: "Deploy".to_string(),
+                steps: None,
+                tasks: vec![],
+            },
+            executed: vec![],
+            config_fingerprint: "f".to_string(),
+        };
+
+        let mut perms = tokio::fs::metadata(&parked_dir)
+            .await
+            .unwrap()
+            .permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o555);
+        tokio::fs::set_permissions(&parked_dir, perms)
+            .await
+            .unwrap();
+        let result = publish(&document, &parked_dir, run_id).await;
+        // Restore writability so the tempdir can clean itself up.
+        let mut perms = tokio::fs::metadata(&parked_dir)
+            .await
+            .unwrap()
+            .permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        tokio::fs::set_permissions(&parked_dir, perms)
+            .await
+            .unwrap();
+
+        assert!(result.is_err(), "the temp write must fail");
+        assert!(
+            !parked_dir
+                .join(format!("{run_id}.json"))
+                .try_exists()
+                .unwrap(),
+            "no document is published on a failed temp write"
+        );
+    }
+
+    /// Refresh drops decided and removed approvals, keeps the undecided
+    /// ones, and reports the earliest surviving expiry.
+    #[tokio::test]
+    async fn refresh_drops_decided_and_takes_earliest_expiry() {
+        let (registry, _store) = conv_registry();
+        let owner = "run:0191e8c0-eeee-7000-8000-000000000003";
+        let now = chrono::Utc::now();
+        let decided = DecisionId::generate();
+        let removed = DecisionId::generate();
+        let earliest = DecisionId::generate();
+        let latest = DecisionId::generate();
+
+        registry
+            .register_durable(parked_approval(
+                decided,
+                owner,
+                now + chrono::Duration::hours(2),
+            ))
+            .await
+            .unwrap();
+        registry
+            .register_durable(parked_approval(
+                removed,
+                owner,
+                now + chrono::Duration::hours(2),
+            ))
+            .await
+            .unwrap();
+        registry
+            .register_durable(parked_approval(
+                earliest,
+                owner,
+                now + chrono::Duration::minutes(30),
+            ))
+            .await
+            .unwrap();
+        registry
+            .register_durable(parked_approval(
+                latest,
+                owner,
+                now + chrono::Duration::hours(1),
+            ))
+            .await
+            .unwrap();
+        registry
+            .resolve(&decided, crate::hitl::ApprovalDecision::Approved)
+            .await
+            .unwrap();
+        registry.remove(&removed).await;
+
+        let mut plan = Plan::new("Deploy");
+        plan.add_task(Task::new(0, "Gated apply", "r"));
+        let pending = vec![
+            crate::orchestration::PendingCall {
+                decision_id: decided,
+                tool_name: "kubectl_apply".to_string(),
+                arguments: serde_json::json!({}),
+                call_id: "c1".to_string(),
+            },
+            crate::orchestration::PendingCall {
+                decision_id: removed,
+                tool_name: "kubectl_delete".to_string(),
+                arguments: serde_json::json!({}),
+                call_id: "c2".to_string(),
+            },
+            crate::orchestration::PendingCall {
+                decision_id: earliest,
+                tool_name: "kubectl_scale".to_string(),
+                arguments: serde_json::json!({}),
+                call_id: "c3".to_string(),
+            },
+            crate::orchestration::PendingCall {
+                decision_id: latest,
+                tool_name: "kubectl_rollout".to_string(),
+                arguments: serde_json::json!({}),
+                call_id: "c4".to_string(),
+            },
+        ];
+        plan.tasks[0].state = crate::orchestration::TaskState::AwaitingApproval { pending };
+
+        let refreshed = refresh_awaiting(&plan, &registry).await.unwrap();
+
+        let surviving = &refreshed.pending_by_task[&0];
+        assert_eq!(surviving.len(), 2, "decided and removed drop out");
+        assert_eq!(refreshed.decision_ids, vec![earliest, latest]);
+        let reported = refreshed.expires_at.expect("earliest expiry reported");
+        let expected = now + chrono::Duration::minutes(30);
+        assert!(
+            (reported - expected).num_seconds().abs() < 1,
+            "expiry is the earliest surviving expiry"
+        );
+    }
+
+    /// The sweep spares an id with a recorded decision — no event, no
+    /// removal — while an undecided sibling under the same owner is
+    /// cancelled with exactly one event.
+    #[tokio::test]
+    async fn sweep_spares_recorded_decision_and_cancels_undecided_sibling() {
+        let (registry, store) = conv_registry();
+        let run_id = "0191e8c0-ffff-7000-8000-000000000006";
+        let owner = run_owner_id(run_id);
+        let request_id = format!("req_sweep_{}", uuid::Uuid::new_v4().simple());
+        let mut events = crate::approval_event_broker::subscribe(&request_id).await;
+
+        let now = chrono::Utc::now();
+        let decided = DecisionId::generate();
+        let sibling = DecisionId::generate();
+        let scope = AgentScope::Single { session_id: None };
+        registry
+            .register_durable(parked_approval(
+                decided,
+                &owner,
+                now + chrono::Duration::hours(1),
+            ))
+            .await
+            .unwrap();
+        registry
+            .register_durable(parked_approval(
+                sibling,
+                &owner,
+                now + chrono::Duration::hours(1),
+            ))
+            .await
+            .unwrap();
+        registry
+            .resolve(&decided, crate::hitl::ApprovalDecision::Approved)
+            .await
+            .unwrap();
+
+        cancel_run_approvals(
+            &registry,
+            run_id,
+            &request_id,
+            [(decided, scope.clone()), (sibling, scope)].into_iter(),
+        )
+        .await;
+
+        assert!(
+            store.get(&sibling).await.unwrap().is_none(),
+            "the undecided sibling's parked entry is cleared"
+        );
+        assert_eq!(
+            registry.recorded_decision(&decided).await,
+            Some(crate::hitl::ApprovalDecision::Approved),
+            "the recorded decision survives the sweep"
+        );
+
+        match tokio::time::timeout(Duration::from_secs(1), events.recv()).await {
+            Ok(Some(crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
+                completed,
+            ))) => {
+                assert_eq!(completed.decision_id, sibling.to_string());
+                assert!(matches!(
+                    completed.outcome,
+                    aura_events::ApprovalOutcomeWire::Cancelled { .. }
+                ));
+            }
+            other => panic!("expected the sibling's completed(cancelled), got {other:?}"),
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), events.recv())
+                .await
+                .is_err(),
+            "the decided approval publishes no cancelled event"
+        );
+
+        crate::approval_event_broker::unsubscribe(&request_id).await;
+    }
+
+    /// The fingerprint is stable for an unchanged config and moves when the
+    /// gating or tool surface changes.
+    #[test]
+    fn config_fingerprint_stable_and_sensitive() {
+        use aura_config::GlobPattern;
+
+        fn config(pattern: &str) -> crate::config::AgentRuntimeConfig {
+            crate::config::AgentRuntimeConfig {
+                hitl: Some(crate::hitl::HitlRuntime {
+                    patterns: Arc::from([GlobPattern::new(pattern).unwrap()]),
+                    route: Arc::new(crate::hitl::DecisionRoute::Conversational {
+                        registry: PendingApprovals::new(),
+                        timeout: Duration::from_secs(120),
+                    }),
+                    park_enabled: true,
+                }),
+                ..crate::config::AgentRuntimeConfig::default()
+            }
+        }
+
+        assert_eq!(
+            config_fingerprint(&config("kubectl_*")),
+            config_fingerprint(&config("kubectl_*")),
+            "unchanged config is a stable hash"
+        );
+        assert_ne!(
+            config_fingerprint(&config("kubectl_*")),
+            config_fingerprint(&config("helm_*")),
+            "a changed gate surface changes the hash"
+        );
+    }
+}

--- a/crates/aura/src/orchestration/park/document.rs
+++ b/crates/aura/src/orchestration/park/document.rs
@@ -8,6 +8,7 @@
 //! ever be read back from the approval store, never copied into a document.
 
 use std::io;
+#[cfg(test)]
 use std::path::Path;
 
 use rig::completion::Message;

--- a/crates/aura/src/orchestration/park/guard.rs
+++ b/crates/aura/src/orchestration/park/guard.rs
@@ -1,0 +1,265 @@
+//! The run-scoped park guard (park mode).
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::hitl::{AgentScope, DecisionId, PendingApprovals};
+
+use super::commit::cancel_run_approvals;
+
+/// The decision ids a run parked, swept when the run ends unpublished.
+pub(crate) struct ParkGuard {
+    registry: PendingApprovals,
+    run_id: String,
+    request_id: String,
+    published: AtomicBool,
+    decisions: Mutex<Vec<GuardedDecision>>,
+}
+
+struct GuardedDecision {
+    decision_id: DecisionId,
+    scope: AgentScope,
+}
+
+impl ParkGuard {
+    /// Create the guard for a run; inert until the first [`Self::record`].
+    pub(crate) fn new(registry: PendingApprovals, run_id: String, request_id: String) -> Arc<Self> {
+        Arc::new(Self {
+            registry,
+            run_id,
+            request_id,
+            published: AtomicBool::new(false),
+            decisions: Mutex::new(Vec::new()),
+        })
+    }
+
+    /// Record parked calls; the first record arms the guard.
+    pub(crate) fn record(
+        &self,
+        task_scope: &AgentScope,
+        pending: &[crate::orchestration::PendingCall],
+    ) {
+        if pending.is_empty() {
+            return;
+        }
+        let mut decisions = self.decisions.lock().expect("park guard lock poisoned");
+        for call in pending {
+            decisions.push(GuardedDecision {
+                decision_id: call.decision_id,
+                scope: task_scope.clone(),
+            });
+        }
+    }
+
+    /// Mark the run's checkpoint published; the drop becomes a no-op.
+    pub(crate) fn mark_published(&self) {
+        self.published.store(true, Ordering::Release);
+    }
+}
+
+impl Drop for ParkGuard {
+    fn drop(&mut self) {
+        // An unpublished drop sweeps every recorded id; a process crash inside
+        // the commit is the one accepted window.
+        if self.published.load(Ordering::Acquire) {
+            return;
+        }
+        let mut guard = self.decisions.lock().expect("park guard lock poisoned");
+        let decisions = std::mem::take(&mut *guard);
+        drop(guard);
+        if decisions.is_empty() {
+            return;
+        }
+        let registry = self.registry.clone();
+        let run_id = self.run_id.clone();
+        let request_id = self.request_id.clone();
+        // Drop cannot await; the sweep runs as its own task on the runtime
+        // that dropped the guard. Off-runtime drops (a test teardown) log
+        // and skip.
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                handle.spawn(async move {
+                    cancel_run_approvals(
+                        &registry,
+                        &run_id,
+                        &request_id,
+                        decisions.into_iter().map(|d| (d.decision_id, d.scope)),
+                    )
+                    .await;
+                });
+            }
+            Err(_) => {
+                tracing::warn!(
+                    run_id = %run_id,
+                    "park guard dropped off-runtime; parked approvals left for expiry",
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::hitl::{
+        AgentScope, ApprovalItem, ApprovalOrigin, ApprovalRequest, DecisionId, PROTOCOL_VERSION,
+        ParkedApproval, PendingApprovals,
+    };
+    use crate::orchestration::{RunId, TaskIdentity};
+    use crate::session_store::{ApprovalStore, InMemoryApprovalStore, InMemoryEventBus};
+
+    fn registry_with_store() -> (PendingApprovals, Arc<InMemoryApprovalStore>) {
+        let store = Arc::new(InMemoryApprovalStore::new());
+        let registry = PendingApprovals::with_backend(
+            store.clone() as Arc<dyn ApprovalStore>,
+            Arc::new(InMemoryEventBus::new()),
+        );
+        (registry, store)
+    }
+
+    fn worker_scope(run_id: RunId) -> AgentScope {
+        AgentScope::Worker {
+            run_id,
+            task: TaskIdentity::new(0, Some("operations".to_string())),
+            session_id: None,
+        }
+    }
+
+    fn durable_approval(
+        decision_id: DecisionId,
+        owner: &str,
+        scope: &AgentScope,
+    ) -> ParkedApproval {
+        ParkedApproval {
+            request: ApprovalRequest {
+                version: PROTOCOL_VERSION,
+                instance_id: "test-instance".to_string(),
+                decision_id,
+                request_id: owner.to_string(),
+                scope: scope.clone(),
+                origin: ApprovalOrigin::ConfigGate {
+                    matched_pattern: "kubectl_*".to_string(),
+                    agent_name: "test-agent".to_string(),
+                },
+                items: vec![ApprovalItem {
+                    tool_name: "kubectl_apply".to_string(),
+                    arguments: serde_json::json!({ "namespace": "prod" }),
+                    tool_call_intent: None,
+                }],
+            },
+            registered_at: chrono::Utc::now(),
+            expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+        }
+    }
+
+    fn parked_call(decision_id: DecisionId) -> crate::orchestration::PendingCall {
+        crate::orchestration::PendingCall {
+            decision_id,
+            tool_name: "kubectl_apply".to_string(),
+            arguments: serde_json::json!({ "namespace": "prod" }),
+            call_id: "call_1".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn unpublished_guard_drop_cancels_run_approvals() {
+        let (registry, store) = registry_with_store();
+        let run_id: RunId = "0191e8c0-2222-7000-8000-000000000042".parse().unwrap();
+        let request_id = format!("req_guard_{}", uuid::Uuid::new_v4().simple());
+        let mut events = crate::approval_event_broker::subscribe(&request_id).await;
+
+        let scope = worker_scope(run_id);
+        let decision_id = DecisionId::generate();
+        registry
+            .register_durable(durable_approval(
+                decision_id,
+                &format!("run:{run_id}"),
+                &scope,
+            ))
+            .await
+            .unwrap();
+
+        let guard = ParkGuard::new(registry.clone(), run_id.to_string(), request_id.clone());
+        guard.record(&scope, std::slice::from_ref(&parked_call(decision_id)));
+        drop(guard);
+
+        // The sweep runs as its own task; poll the store until it empties.
+        for _ in 0..200 {
+            if store.get(&decision_id).await.unwrap().is_none() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            store.get(&decision_id).await.unwrap().is_none(),
+            "no decidable approval outlives the unpublished run"
+        );
+
+        match tokio::time::timeout(Duration::from_secs(1), events.recv()).await {
+            Ok(Some(crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
+                completed,
+            ))) => {
+                assert_eq!(completed.decision_id, decision_id.to_string());
+                let outcome = serde_json::to_value(&completed.outcome).unwrap();
+                assert_eq!(outcome["kind"], "cancelled");
+            }
+            other => panic!("expected a completed(cancelled) event, got {other:?}"),
+        }
+
+        crate::approval_event_broker::unsubscribe(&request_id).await;
+    }
+
+    #[tokio::test]
+    async fn published_guard_drop_leaves_approvals_parked() {
+        let (registry, store) = registry_with_store();
+        let run_id: RunId = "0191e8c0-3333-7000-8000-000000000042".parse().unwrap();
+        let scope = worker_scope(run_id);
+        let decision_id = DecisionId::generate();
+        registry
+            .register_durable(durable_approval(
+                decision_id,
+                &format!("run:{run_id}"),
+                &scope,
+            ))
+            .await
+            .unwrap();
+
+        let guard = ParkGuard::new(registry.clone(), run_id.to_string(), "req_x".to_string());
+        guard.record(&scope, std::slice::from_ref(&parked_call(decision_id)));
+        guard.mark_published();
+        drop(guard);
+
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(
+            store.get(&decision_id).await.unwrap().is_some(),
+            "a published run's approvals survive its end"
+        );
+    }
+
+    #[tokio::test]
+    async fn unrecorded_guard_drop_is_inert() {
+        let (registry, store) = registry_with_store();
+        let run_id: RunId = "0191e8c0-4444-7000-8000-000000000042".parse().unwrap();
+        let other = DecisionId::generate();
+        registry
+            .register_durable(durable_approval(
+                other,
+                "run:someone-else",
+                &worker_scope(run_id),
+            ))
+            .await
+            .unwrap();
+
+        let guard = ParkGuard::new(registry.clone(), run_id.to_string(), "req_y".to_string());
+        drop(guard);
+
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(
+            store.get(&other).await.unwrap().is_some(),
+            "an inert guard cancels nothing"
+        );
+    }
+}

--- a/crates/aura/src/orchestration/park/mod.rs
+++ b/crates/aura/src/orchestration/park/mod.rs
@@ -1,14 +1,15 @@
-//! The park checkpoint document (park mode): the types, the builder from run
-//! state, and the load path.
+//! The park checkpoint (park mode): the document, the commit, and the
+//! run-scoped guard.
 
-// No production consumer yet; the park commit drops this allow.
-#![allow(dead_code, unused_imports)]
-
+mod commit;
 mod document;
+mod guard;
 
+pub(crate) use commit::{ParkCommitInputs, cancel_run_approvals, commit_from_run_state};
 #[cfg(test)]
 pub(crate) use document::load_parked_run;
 pub(crate) use document::{PARKED_DOCUMENT_SUFFIX, RESUMING_DOCUMENT_SUFFIX, RunStateForPark};
+pub(crate) use guard::ParkGuard;
 
 use std::collections::HashMap;
 

--- a/crates/aura/src/orchestration/persistence.rs
+++ b/crates/aura/src/orchestration/persistence.rs
@@ -41,6 +41,7 @@ use tokio::fs;
 use tokio::sync::Notify;
 
 use super::events::RoutingMode;
+use super::park::{PARKED_DOCUMENT_SUFFIX, RESUMING_DOCUMENT_SUFFIX};
 use super::types::{Plan, TaskStatus};
 
 // ============================================================================
@@ -76,6 +77,21 @@ pub fn sanitize_filename_component(s: &str) -> String {
 /// into a persistence path.
 pub(crate) fn is_safe_path_component(s: &str) -> bool {
     !s.is_empty() && !s.contains('/') && !s.contains('\\') && !s.contains("..")
+}
+
+/// Whether `run_id` has a parked checkpoint document under `parked_dir`,
+/// under either the published or the resuming filename.
+async fn run_has_parked_document(parked_dir: &Path, run_id: &str) -> bool {
+    for suffix in [PARKED_DOCUMENT_SUFFIX, RESUMING_DOCUMENT_SUFFIX] {
+        if parked_dir
+            .join(format!("{run_id}{suffix}"))
+            .try_exists()
+            .is_ok_and(|e| e)
+        {
+            return true;
+        }
+    }
+    false
 }
 
 // ============================================================================
@@ -342,6 +358,7 @@ impl ExecutionPersistence {
             Some(p) => p.to_path_buf(),
             None => return,
         };
+        let parked_dir = session_dir.join("parked");
 
         let mut run_dirs: Vec<String> = Vec::new();
         let mut entries = match fs::read_dir(&session_dir).await {
@@ -356,7 +373,11 @@ impl ExecutionPersistence {
                 _ => continue,
             }
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                if name == "latest" || name == self.run_id {
+                if name == "latest" || name == "parked" || name == self.run_id {
+                    continue;
+                }
+                if run_has_parked_document(&parked_dir, name).await {
+                    tracing::info!("Skipping prune of run {} with a parked document", name);
                     continue;
                 }
                 run_dirs.push(name.to_string());
@@ -2483,6 +2504,59 @@ mod tests {
     // ========================================================================
     // Parked-Run Checkpoint Tests
     // ========================================================================
+
+    #[tokio::test]
+    async fn test_prune_skips_parked_directory_and_parked_runs() {
+        let temp_dir = TempDir::new().unwrap();
+        let persistence =
+            ExecutionPersistence::new(temp_dir.path().join("memory"), Some("cs_prune".to_string()))
+                .await
+                .unwrap();
+        let session_dir = temp_dir.path().join("memory").join("cs_prune");
+        let oldest = "0191e8c0-0000-7000-8000-000000000001";
+        let second = "0191e8c0-0aaa-7000-8000-000000000005";
+        let parked = "0191e8c0-1111-7000-8000-000000000002";
+        let parked_resuming = "0191e8c0-2222-7000-8000-000000000003";
+        for run in [oldest, second, parked, parked_resuming] {
+            tokio::fs::create_dir_all(session_dir.join(run))
+                .await
+                .unwrap();
+        }
+        let parked_dir = session_dir.join("parked");
+        tokio::fs::create_dir_all(&parked_dir).await.unwrap();
+        tokio::fs::write(parked_dir.join(format!("{parked}.json")), "{}")
+            .await
+            .unwrap();
+        tokio::fs::write(
+            parked_dir.join(format!("{parked_resuming}.resuming.json")),
+            "{}",
+        )
+        .await
+        .unwrap();
+
+        persistence.prune_session_runs(1).await;
+
+        assert!(
+            !session_dir.join(oldest).exists() && !session_dir.join(second).exists(),
+            "plain old runs past the cap are pruned"
+        );
+        assert!(
+            session_dir.join(parked).exists(),
+            "a run with a parked document survives pruning"
+        );
+        assert!(
+            session_dir.join(parked_resuming).exists(),
+            "a run with only a resuming document survives pruning"
+        );
+        assert!(
+            session_dir.join(persistence.run_id()).exists(),
+            "the current run survives pruning"
+        );
+        assert!(
+            parked_dir.join(format!("{parked}.json")).exists(),
+            "the parked directory's documents are never pruned as runs"
+        );
+    }
 
     #[tokio::test]
     async fn test_run_status_parked_serializes_snake_case() {

--- a/crates/aura/src/orchestration/stream_events.rs
+++ b/crates/aura/src/orchestration/stream_events.rs
@@ -9,6 +9,7 @@
 //! - `aura.orchestrator.task_started` - Worker began task execution
 //! - `aura.orchestrator.task_completed` - Worker finished task (success/failure)
 //! - `aura.orchestrator.task_blocked` - Worker parked gated calls (park mode)
+//! - `aura.orchestrator.run_parked` - Run parked with a published checkpoint (park mode)
 //! - `aura.orchestrator.iteration_complete` - Plan-execute-continue cycle done
 //! - `aura.orchestrator.synthesizing` - Consolidating task results for coordinator decision
 //! - `aura.orchestrator.tool_call_started` - Worker tool execution began
@@ -71,6 +72,7 @@ pub mod event_names {
     pub const TASK_STARTED: &str = "aura.orchestrator.task_started";
     pub const TASK_COMPLETED: &str = "aura.orchestrator.task_completed";
     pub const TASK_BLOCKED: &str = "aura.orchestrator.task_blocked";
+    pub const RUN_PARKED: &str = "aura.orchestrator.run_parked";
     pub const ITERATION_COMPLETE: &str = "aura.orchestrator.iteration_complete";
     pub const REPLAN_STARTED: &str = "aura.orchestrator.replan_started";
     pub const SYNTHESIZING: &str = "aura.orchestrator.synthesizing";
@@ -143,6 +145,19 @@ pub enum OrchestrationStreamEvent {
         #[serde(flatten)]
         context: EventContext,
     },
+    /// The run parked with a published checkpoint (park mode); terminal.
+    RunParked {
+        /// The parked run's id.
+        run_id: String,
+        /// The decision ids still awaiting a human decision.
+        decision_ids: Vec<String>,
+        /// RFC 3339 timestamp after which the decisions expire.
+        expires_at: String,
+        /// Which iteration the run parked in (1-indexed).
+        iteration: usize,
+        #[serde(flatten)]
+        context: EventContext,
+    },
     /// Emitted when orchestrator completes an iteration.
     IterationComplete {
         iteration: usize,
@@ -211,6 +226,7 @@ impl OrchestrationStreamEvent {
             Self::TaskStarted { .. } => event_names::TASK_STARTED,
             Self::TaskCompleted { .. } => event_names::TASK_COMPLETED,
             Self::TaskBlocked { .. } => event_names::TASK_BLOCKED,
+            Self::RunParked { .. } => event_names::RUN_PARKED,
             Self::IterationComplete { .. } => event_names::ITERATION_COMPLETE,
             Self::ReplanStarted { .. } => event_names::REPLAN_STARTED,
             Self::Synthesizing { .. } => event_names::SYNTHESIZING,
@@ -339,6 +355,23 @@ impl OrchestrationStreamEvent {
                 orchestrator_id: orchestrator_id.into(),
                 worker_id: worker_id.into(),
             },
+            context,
+        }
+    }
+
+    /// Create a RunParked event (terminal, one per parked run).
+    pub fn run_parked(
+        run_id: impl Into<String>,
+        decision_ids: Vec<String>,
+        expires_at: impl Into<String>,
+        iteration: usize,
+        context: EventContext,
+    ) -> Self {
+        Self::RunParked {
+            run_id: run_id.into(),
+            decision_ids,
+            expires_at: expires_at.into(),
+            iteration,
             context,
         }
     }
@@ -617,6 +650,33 @@ mod tests {
         assert!(sse.contains("\"tool_name\":\"kubectl_apply\""));
         assert!(sse.contains("\"decision_id\":\"0191e8c0-1111-7000-8000-00000000000a\""));
         assert!(sse.contains("\"worker_id\":\"operations\""));
+    }
+
+    #[test]
+    fn test_format_sse_run_parked() {
+        let event = OrchestrationStreamEvent::run_parked(
+            "0191e8c0-1111-7000-8000-0000000000ff",
+            vec![
+                "0191e8c0-1111-7000-8000-00000000000a".to_string(),
+                "0191e8c0-1111-7000-8000-00000000000b".to_string(),
+            ],
+            "2026-09-02T15:03:11+00:00",
+            2,
+            test_ctx(),
+        );
+        let sse = event.format_sse();
+
+        assert!(sse.starts_with("event: aura.orchestrator.run_parked\n"));
+        assert_eq!(
+            event_names::RUN_PARKED,
+            aura_events::orchestration::event_names::RUN_PARKED
+        );
+        assert!(sse.contains("\"run_id\":\"0191e8c0-1111-7000-8000-0000000000ff\""));
+        assert!(sse.contains("\"decision_ids\":["));
+        assert!(sse.contains("\"0191e8c0-1111-7000-8000-00000000000a\""));
+        assert!(sse.contains("\"0191e8c0-1111-7000-8000-00000000000b\""));
+        assert!(sse.contains("\"expires_at\":\"2026-09-02T15:03:11+00:00\""));
+        assert!(sse.contains("\"iteration\":2"));
     }
 
     #[test]

--- a/crates/aura/src/session_store/fault_store.rs
+++ b/crates/aura/src/session_store/fault_store.rs
@@ -1,22 +1,32 @@
 //! An approval-store double for fault injection in tests.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use async_trait::async_trait;
 
 use super::{ApprovalStore, InMemoryApprovalStore, SessionStoreError};
 use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
 
 /// Delegates to an in-memory store; each `fail_*` flag makes that operation
-/// answer `SessionStoreError::Request`.
+/// answer `SessionStoreError::Request` (the `*_once` flag fires one time).
 #[derive(Default)]
 pub(crate) struct FaultInjectingStore {
     inner: InMemoryApprovalStore,
     fail_register: bool,
+    fail_get_once: AtomicBool,
 }
 
 impl FaultInjectingStore {
     pub(crate) fn failing_register() -> Self {
         Self {
             fail_register: true,
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn failing_first_get() -> Self {
+        Self {
+            fail_get_once: AtomicBool::new(true),
             ..Default::default()
         }
     }
@@ -34,6 +44,11 @@ impl ApprovalStore for FaultInjectingStore {
     }
 
     async fn get(&self, id: &DecisionId) -> Result<Option<ParkedApproval>, SessionStoreError> {
+        if self.fail_get_once.swap(false, Ordering::SeqCst) {
+            return Err(SessionStoreError::Request {
+                reason: "transient parked-approval lookup fault".to_string(),
+            });
+        }
         self.inner.get(id).await
     }
 


### PR DESCRIPTION
Part of #271. Stacked on #655; merge last.

The park commit refreshes the awaiting set against the approval store, and a store fault fails the commit before anything is written. The document publishes by temp write and rename. Only after that succeeds does the terminal `run_parked` event fire, carrying the same expiry stamp as the document. When every call was decided before the commit, the stamp is the route's decision window rather than an instant expiry. A failed commit publishes nothing and cancels the run's undecided approvals; a recorded decision is never touched.

A run-scoped guard learns each decision id in the gate the moment the ticket registers, so a run that ends without a checkpoint (including a client disconnect mid-turn) sweeps its own tickets. Pruning skips parked runs and the manifest records the parked status with its timings. All file I/O runs on the blocking pool.

Testing: `cargo test --workspace`, clippy with warnings denied, nightly fmt. Failure suites cover the failed commit, the store fault during refresh, the read-only directory, the guard drop, and the all-decided park.
