### PR TITLE
feat(orchestration): reify and continue parked runs

### DIFF
--- a/crates/aura-web-server/tests/file_session_store_test.rs
+++ b/crates/aura-web-server/tests/file_session_store_test.rs
@@ -1,8 +1,8 @@
 //! Conformance and contract tests for the file-backed approval store
 //! (`AURA_SESSION_STORE=file`): the shared backend-agnostic battery plus the
 //! §2.5 contract points specific to durable, retention-until-remove storage —
-//! expiry refusal, retention past the decision, the ticket's move into the
-//! decision file, owner-scoped cancel of undecided tickets, and survival of a
+//! expiry refusal, retention past the decision, the approval's move into the
+//! decision file, owner-scoped cancel of undecided approvals, and survival of a
 //! process restart. The same battery runs against the memory backend to pin
 //! the uniform contract. No Docker: every test gets its own tempdir.
 
@@ -125,18 +125,18 @@ async fn memory_battery_cancel_request_removes_only_matching() {
 
 /// The constructor creates the layout's two directories.
 #[test]
-fn open_creates_the_ticket_and_decision_directories() {
+fn open_creates_the_approval_and_decision_directories() {
     let dir = tempfile::tempdir().unwrap();
     FileApprovalStore::open(dir.path()).unwrap();
-    assert!(dir.path().join("tickets").is_dir());
+    assert!(dir.path().join("approvals").is_dir());
     assert!(dir.path().join("decisions").is_dir());
 }
 
-/// §2.5: `resolve` refuses past the ticket's `expires_at`, uniformly with an
-/// unknown id; nothing is decided, and the expired ticket stays readable
+/// §2.5: `resolve` refuses past the approval's `expires_at`, uniformly with an
+/// unknown id; nothing is decided, and the expired approval stays readable
 /// through `get` until `remove`.
 #[tokio::test]
-async fn expired_resolve_is_not_found_and_ticket_is_retained() {
+async fn expired_resolve_is_not_found_and_approval_is_retained() {
     let dir = tempfile::tempdir().unwrap();
     let store = FileApprovalStore::open(dir.path()).unwrap();
     let mut parked = make_parked("req-expired", Duration::from_secs(60));
@@ -153,15 +153,15 @@ async fn expired_resolve_is_not_found_and_ticket_is_retained() {
         .get(&id)
         .await
         .unwrap()
-        .expect("expired ticket retained until remove");
+        .expect("expired approval retained until remove");
     assert_eq!(restored.request.decision_id, id);
 }
 
-/// §2.5: retention is until remove — `get` returns the ticket before and
+/// §2.5: retention is until remove — `get` returns the approval before and
 /// after the decision, `decision` returns the record, and only `remove`
 /// clears both.
 #[tokio::test]
-async fn ticket_and_decision_are_retained_until_remove() {
+async fn approval_and_decision_are_retained_until_remove() {
     let dir = tempfile::tempdir().unwrap();
     let store = FileApprovalStore::open(dir.path()).unwrap();
     let parked = make_parked("req-retain", Duration::from_secs(60));
@@ -185,7 +185,7 @@ async fn ticket_and_decision_are_retained_until_remove() {
                 .get(&id)
                 .await
                 .unwrap()
-                .expect("ticket survives its decision")
+                .expect("approval survives its decision")
         ),
         expected
     );
@@ -203,11 +203,11 @@ async fn ticket_and_decision_are_retained_until_remove() {
     );
 }
 
-/// §2.5: `resolve` moves the ticket into the decision file rather than
-/// deleting it — on disk the ticket file is gone and the decision file
-/// carries both the ticket record and the decision.
+/// §2.5: `resolve` moves the approval into the decision file rather than
+/// deleting it — on disk the approval file is gone and the decision file
+/// carries both the approval record and the decision.
 #[tokio::test]
-async fn resolve_moves_the_ticket_into_the_decision_file() {
+async fn resolve_moves_the_approval_into_the_decision_file() {
     let dir = tempfile::tempdir().unwrap();
     let store = FileApprovalStore::open(dir.path()).unwrap();
     let parked = make_parked("req-move", Duration::from_secs(60));
@@ -221,23 +221,23 @@ async fn resolve_moves_the_ticket_into_the_decision_file() {
 
     assert!(
         !dir.path()
-            .join("tickets")
+            .join("approvals")
             .join(format!("{id}.json"))
             .exists()
     );
     let decision_path = dir.path().join("decisions").join(format!("{id}.json"));
     let on_disk: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(decision_path).unwrap()).unwrap();
-    assert_eq!(on_disk["ticket"]["decision_id"], id.to_string());
-    assert_eq!(on_disk["ticket"]["request_id"], "req-move");
+    assert_eq!(on_disk["approval"]["decision_id"], id.to_string());
+    assert_eq!(on_disk["approval"]["request_id"], "req-move");
     assert_eq!(on_disk["decision"]["approved"], true);
     assert_eq!(on_disk["decision"]["reason"], serde_json::Value::Null);
 }
 
-/// §2.5: `cancel_request` removes undecided tickets by owner id; a decided
-/// ticket of the same owner and an undecided ticket of another owner survive.
+/// §2.5: `cancel_request` removes undecided approvals by owner id; a decided
+/// approval of the same owner and an undecided approval of another owner survive.
 #[tokio::test]
-async fn cancel_request_removes_only_undecided_matching_tickets() {
+async fn cancel_request_removes_only_undecided_matching_approvals() {
     let dir = tempfile::tempdir().unwrap();
     let store = FileApprovalStore::open(dir.path()).unwrap();
     let undecided = make_parked("req-owner", Duration::from_secs(60));
@@ -259,7 +259,7 @@ async fn cancel_request_removes_only_undecided_matching_tickets() {
     assert!(store.get(&undecided_id).await.unwrap().is_none());
     assert!(
         store.get(&decided_id).await.unwrap().is_some(),
-        "decided ticket is retained until remove"
+        "decided approval is retained until remove"
     );
     assert_eq!(
         store.decision(&decided_id).await.unwrap(),
@@ -268,13 +268,13 @@ async fn cancel_request_removes_only_undecided_matching_tickets() {
     assert!(store.get(&other_id).await.unwrap().is_some());
 }
 
-/// A read-only `tickets/` directory must not fail `resolve`: the decision
-/// write and its sync are the commit, and the ticket removal past them is
-/// best-effort — the stale ticket remains, `get` still returns the record,
+/// A read-only `approvals/` directory must not fail `resolve`: the decision
+/// write and its sync are the commit, and the approval removal past them is
+/// best-effort — the stale approval remains, `get` still returns the record,
 /// and the claim still holds against a repeat resolve.
 #[cfg(unix)]
 #[tokio::test]
-async fn resolve_succeeds_when_the_ticket_file_cannot_be_removed() {
+async fn resolve_succeeds_when_the_approval_file_cannot_be_removed() {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = tempfile::tempdir().unwrap();
@@ -283,13 +283,13 @@ async fn resolve_succeeds_when_the_ticket_file_cannot_be_removed() {
     let id = parked.request.decision_id;
     store.register(parked).await.unwrap();
 
-    let tickets = dir.path().join("tickets");
-    std::fs::set_permissions(&tickets, std::fs::Permissions::from_mode(0o500)).unwrap();
-    let _restore = Restore(&tickets);
+    let approvals = dir.path().join("approvals");
+    std::fs::set_permissions(&approvals, std::fs::Permissions::from_mode(0o500)).unwrap();
+    let _restore = Restore(&approvals);
 
     // Root bypasses directory permission bits; the fault this test pins
     // cannot be established there, so skip rather than pass vacuously.
-    let probe = tickets.join(".write-probe");
+    let probe = approvals.join(".write-probe");
     if std::fs::write(&probe, b"x").is_ok() {
         let _ = std::fs::remove_file(&probe);
         eprintln!("skipping: process bypasses directory permissions (running as root?)");
@@ -299,7 +299,7 @@ async fn resolve_succeeds_when_the_ticket_file_cannot_be_removed() {
     store
         .resolve(&id, ApprovalDecision::Approved)
         .await
-        .expect("resolve commits without the ticket removal");
+        .expect("resolve commits without the approval removal");
     assert_eq!(
         store.decision(&id).await.unwrap(),
         Some(ApprovalDecision::Approved)
@@ -308,7 +308,7 @@ async fn resolve_succeeds_when_the_ticket_file_cannot_be_removed() {
         .get(&id)
         .await
         .unwrap()
-        .expect("ticket record survives the failed removal");
+        .expect("approval record survives the failed removal");
     assert_eq!(restored.request.decision_id, id);
     assert_eq!(
         store.resolve(&id, ApprovalDecision::Approved).await,
@@ -366,11 +366,11 @@ async fn open_fails_when_a_store_directory_is_not_writable() {
 
     let dir = tempfile::tempdir().unwrap();
     drop(FileApprovalStore::open(dir.path()).unwrap());
-    let tickets = dir.path().join("tickets");
-    std::fs::set_permissions(&tickets, std::fs::Permissions::from_mode(0o500)).unwrap();
-    let _restore = Restore(&tickets);
+    let approvals = dir.path().join("approvals");
+    std::fs::set_permissions(&approvals, std::fs::Permissions::from_mode(0o500)).unwrap();
+    let _restore = Restore(&approvals);
 
-    let probe = tickets.join(".write-probe");
+    let probe = approvals.join(".write-probe");
     if std::fs::write(&probe, b"x").is_ok() {
         let _ = std::fs::remove_file(&probe);
         eprintln!("skipping: process bypasses directory permissions (running as root?)");
@@ -399,7 +399,7 @@ async fn ping_reports_an_unwritable_store_directory() {
     let store = FileApprovalStore::open(dir.path()).unwrap();
     store.probe_writable().await.expect("healthy store pings");
 
-    for name in ["tickets", "decisions"] {
+    for name in ["approvals", "decisions"] {
         let locked = dir.path().join(name);
         std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o500)).unwrap();
         let restore = Restore(&locked);

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -12,11 +12,11 @@ use aura_config::GlobPattern;
 use rig::tool::ToolError;
 use serde_json::Value;
 
-use super::decision::{AgentScope, ApprovalOrigin, DecisionId};
+use super::decision::{AgentScope, ApprovalOrigin, ApprovalOutcome, DecisionId};
 use super::protocol::{ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
 use super::registry::{ParkedApproval, PendingApprovals};
 use super::route::{ApprovalError, DecisionRoute, GateDecision};
-use crate::orchestration::{BlockedCell, ParkGuard, PendingCall};
+use crate::orchestration::{BlockedCell, CallKey, ParkGuard, PendingCall, RecordedDecisions};
 use crate::tool_wrapper::{PreCallOutcome, ToolCallContext, ToolWrapper};
 
 /// The placeholder tool result a parked call returns.
@@ -52,6 +52,11 @@ pub struct HitlApprovalWrapper {
     instance_id: String,
     /// Park arm state.
     park: Option<ParkContext>,
+    /// The run's recorded decisions for its parked calls; `None` on the live
+    /// path so behavior is unchanged. When present, a recorded decision is
+    /// consumed before the park arm; a miss while the task is strict is a
+    /// resume fault, and a miss otherwise re-parks.
+    recorded_decisions: Option<Arc<RecordedDecisions>>,
 }
 
 impl HitlApprovalWrapper {
@@ -72,6 +77,7 @@ impl HitlApprovalWrapper {
             agent_name,
             instance_id,
             park: None,
+            recorded_decisions: None,
         }
     }
 
@@ -88,6 +94,17 @@ impl HitlApprovalWrapper {
             cell,
             guard,
         });
+        self
+    }
+
+    /// Arm the recorded-decisions consult: a glob-matched call checks the
+    /// run's recorded decisions before the park arm. `None` (the default)
+    /// leaves the live path byte-identical. Wired by the orchestrator
+    /// continuation (P44 commit 3).
+    #[allow(dead_code)]
+    #[must_use]
+    pub(crate) fn with_recorded_decisions(mut self, recorded: Arc<RecordedDecisions>) -> Self {
+        self.recorded_decisions = Some(recorded);
         self
     }
 
@@ -235,6 +252,42 @@ impl ToolWrapper for HitlApprovalWrapper {
         let Some(matched) = self.matched_pattern(&ctx.tool_name) else {
             return Ok(PreCallOutcome::Proceed { overrides: None });
         };
+        // Recorded-decisions consult: a resumed worker's gated call may
+        // already carry a stored decision. A hit maps through the same
+        // mapping the live route uses (so an approval proceeds and a denial
+        // produces the live path's denial feedback); a miss while the task is
+        // strict is a resume fault; a miss otherwise falls through to the park
+        // arm (or the live route when park is unset) and re-parks.
+        if let Some(recorded) = &self.recorded_decisions {
+            // A resumed worker's tools always carry a task id. A gated call
+            // without one on the resume path is a wiring fault, and falling
+            // through to the park arm would re-ask the human for a decided
+            // call.
+            let Some(task_id) = ctx.task_id else {
+                return Err(ToolError::ToolCallError(
+                    "resume mismatch: no task id".to_string().into(),
+                ));
+            };
+            match recorded.take(&CallKey::new(task_id, &ctx.tool_name, args)) {
+                Some(decision) => {
+                    return approval_result_to_pre_call(Ok(GateDecision::without_overrides(
+                        ApprovalOutcome::Decided(decision),
+                    )));
+                }
+                // A continuation invocation that misses is a resume fault,
+                // never a fresh park: the recorded call no longer matches what
+                // the chain produced. Fail the call closed and let the resume
+                // stream fail.
+                None if recorded.is_strict(task_id) => {
+                    return Err(ToolError::ToolCallError(
+                        "resume mismatch".to_string().into(),
+                    ));
+                }
+                // A model-issued gated call after the continuation re-parks
+                // normally: fall through to the park arm (or the live route).
+                None => {}
+            }
+        }
         if let Some(park) = &self.park {
             return self.park_pre_call(park, matched, args, ctx).await;
         }
@@ -670,6 +723,180 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(5)).await;
             }
             assert!(store.get(&decision_id).await.unwrap().is_none());
+        }
+    }
+
+    // ====================================================================
+    // Recorded-decisions consult
+    // ====================================================================
+
+    mod recorded {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use super::*;
+        use crate::hitl::ApprovalDecision;
+
+        /// A route whose webhook is unreachable, so a fall-through to the
+        /// route fails closed rather than hanging. A recorded hit
+        /// short-circuits before the route, so it never sees this.
+        fn discard_route() -> Arc<DecisionRoute> {
+            Arc::new(DecisionRoute::Webhook {
+                client: WebhookClient::new(
+                    build_webhook_client(),
+                    // Discard port: nothing listens, so the POST fails closed.
+                    WebhookUrl::new("http://127.0.0.1:9").unwrap(),
+                ),
+                timeout: Duration::from_secs(2),
+            })
+        }
+
+        /// A gate armed with `recorded_decisions` and no park arm, so a miss
+        /// falls through to the live route (the contract path the brief calls
+        /// out for these tests).
+        fn recorded_gate(
+            recorded: Arc<RecordedDecisions>,
+            route: Arc<DecisionRoute>,
+        ) -> HitlApprovalWrapper {
+            HitlApprovalWrapper::new(
+                Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
+                route,
+                AgentScope::Single { session_id: None },
+                "req-recorded".to_string(),
+                "test-agent".to_string(),
+                "test-instance".to_string(),
+            )
+            .with_recorded_decisions(recorded)
+        }
+
+        fn ctx_for(tool: &str, task_id: Option<usize>) -> ToolCallContext {
+            let mut ctx = ToolCallContext::new(tool);
+            ctx.task_id = task_id;
+            ctx
+        }
+
+        /// A recorded approval proceeds through the same mapping the live
+        /// route uses, without ever consulting the (unreachable) route.
+        #[tokio::test]
+        async fn recorded_hit_proceeds_without_invoking_route() {
+            let recorded = Arc::new(RecordedDecisions::default());
+            let args = serde_json::json!({"namespace": "prod"});
+            recorded.push(
+                CallKey::new(1, "kubectl_apply", &args),
+                ApprovalDecision::Approved,
+            );
+
+            let gate = recorded_gate(recorded, discard_route());
+            let outcome = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", Some(1)))
+                .await
+                .unwrap();
+
+            assert_eq!(outcome, PreCallOutcome::Proceed { overrides: None });
+        }
+
+        /// A recorded denial produces the live path's denial feedback string,
+        /// through the shared mapping — the denial string is not duplicated
+        /// in the consult.
+        #[tokio::test]
+        async fn recorded_denial_produces_live_path_denial_feedback() {
+            let recorded = Arc::new(RecordedDecisions::default());
+            let args = serde_json::json!({"namespace": "prod"});
+            recorded.push(
+                CallKey::new(1, "kubectl_apply", &args),
+                ApprovalDecision::Denied {
+                    reason: Some("too risky".to_string()),
+                },
+            );
+
+            let gate = recorded_gate(recorded, discard_route());
+            let outcome = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", Some(1)))
+                .await
+                .unwrap();
+
+            assert_eq!(
+                outcome,
+                PreCallOutcome::ShortCircuit {
+                    output: "Tool call blocked by human approval denial: too risky. Do not execute this action."
+                        .to_string(),
+                },
+            );
+        }
+
+        /// A miss while the task is strict is a resume fault, never a fresh
+        /// park: the route is not consulted (no "approval channel error").
+        #[tokio::test]
+        async fn recorded_miss_while_strict_fails_closed_with_resume_mismatch() {
+            let recorded = Arc::new(RecordedDecisions::default());
+            recorded.set_strict(1, true);
+
+            let gate = recorded_gate(recorded, discard_route());
+            let args = serde_json::json!({"namespace": "prod"});
+            let err = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", Some(1)))
+                .await
+                .expect_err("a strict miss must fail closed");
+
+            let msg = err.to_string();
+            assert!(
+                msg.contains("resume mismatch"),
+                "a strict miss must report a resume mismatch, got: {msg}",
+            );
+            assert!(
+                !msg.contains("approval channel error"),
+                "the route must not be consulted on a strict miss, got: {msg}",
+            );
+        }
+
+        /// A miss when the task is not strict falls through to the live route
+        /// (park is unset), proving the consult did not short-circuit. The
+        /// contrast with the strict-miss test is the error class.
+        #[tokio::test]
+        async fn recorded_miss_not_strict_falls_through_to_route() {
+            let recorded = Arc::new(RecordedDecisions::default());
+
+            let gate = recorded_gate(recorded, discard_route());
+            let args = serde_json::json!({"namespace": "prod"});
+            let err = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", Some(1)))
+                .await
+                .expect_err("the unreachable route must fail closed");
+
+            let msg = err.to_string();
+            assert!(
+                msg.contains("approval channel error"),
+                "a non-strict miss must fall through to the route, got: {msg}",
+            );
+            assert!(
+                !msg.contains("resume mismatch"),
+                "a non-strict miss must not report a resume mismatch, got: {msg}",
+            );
+        }
+
+        /// A gated call on the resume path with no task id is a wiring fault,
+        /// not a fall-through to the park arm (which would re-ask the human
+        /// for a decided call).
+        #[tokio::test]
+        async fn recorded_consult_without_task_id_is_a_resume_fault() {
+            let recorded = Arc::new(RecordedDecisions::default());
+
+            let gate = recorded_gate(recorded, discard_route());
+            let args = serde_json::json!({});
+            let err = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", None))
+                .await
+                .expect_err("a gated resume call without a task id must fail");
+
+            let msg = err.to_string();
+            assert!(
+                msg.contains("resume mismatch: no task id"),
+                "expected the no-task-id wiring fault, got: {msg}",
+            );
+            assert!(
+                !msg.contains("approval channel error"),
+                "the route must not be consulted on the no-task-id fault, got: {msg}",
+            );
         }
     }
 

--- a/crates/aura/src/orchestration/mod.rs
+++ b/crates/aura/src/orchestration/mod.rs
@@ -55,6 +55,8 @@ pub(crate) mod persistence_wrapper;
 mod prompt_constants;
 mod stream_events;
 mod templates;
+#[cfg(test)]
+mod test_rig;
 pub mod tools;
 mod types;
 

--- a/crates/aura/src/orchestration/mod.rs
+++ b/crates/aura/src/orchestration/mod.rs
@@ -83,7 +83,11 @@ pub use tools::wait_for::{StopReason, WaitForError, WaitForOutput, WaitForTool};
 pub use tools::{SubmitResultDecision, SubmitResultOutput, SubmitResultTool};
 
 pub(crate) use park::{CallKey, ParkGuard, RecordedDecisions};
+// The worker-model injection seam: `provider_agent.rs`'s cfg(test) variant
+// wraps the rig's scripted agent type.
 pub use prompt_constants::{context, fields, sections};
+#[cfg(test)]
+pub(crate) use test_rig::ScriptedAgent;
 pub use types::{
     BlockedCell, CellOutcome, ParkSnapshot, PendingCall, Plan, PlanningResponse, RunId, StepInput,
     StructuredTaskOutput, Task, TaskIdentity, TaskJson, TaskState, TaskStatus,

--- a/crates/aura/src/orchestration/mod.rs
+++ b/crates/aura/src/orchestration/mod.rs
@@ -80,7 +80,7 @@ pub use tools::ReadArtifactTool;
 pub use tools::wait_for::{StopReason, WaitForError, WaitForOutput, WaitForTool};
 pub use tools::{SubmitResultDecision, SubmitResultOutput, SubmitResultTool};
 
-pub(crate) use park::ParkGuard;
+pub(crate) use park::{CallKey, ParkGuard, RecordedDecisions};
 pub use prompt_constants::{context, fields, sections};
 pub use types::{
     BlockedCell, CellOutcome, ParkSnapshot, PendingCall, Plan, PlanningResponse, RunId, StepInput,

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -62,7 +62,10 @@ use super::tools::{InspectToolParamsTool, ListToolsTool, ReadArtifactTool};
 
 use super::config::OrchestrationConfig;
 use super::events::OrchestratorEvent;
-use super::park::{ParkGuard, ParkedTaskRecord, ParkedTaskRecords};
+use super::park::{
+    ParkGuard, ParkedTaskRecord, ParkedTaskRecords, RecordedDecisions, ResumeContext,
+    TaskContinuation,
+};
 use super::persistence::ExecutionPersistence;
 use super::types::{
     BlockedCell, CellOutcome, FailedTaskRecord, FailureCategory, FailureSummary, IterationContext,
@@ -619,13 +622,16 @@ impl Orchestrator {
     /// If a specialized worker is assigned via `worker_name`, it uses that worker's
     /// custom preamble and MCP filter. Otherwise uses generic worker with all tools.
     ///
-    /// `park_cell` arms the gate's park arm for this worker.
+    /// `park_cell` arms the gate's park arm for this worker. `recorded`
+    /// arms the recorded-decisions consult (the resume path); `None` on the
+    /// live path leaves the gate byte-identical.
     async fn create_worker(
         &self,
         task_id: usize,
         attempt: usize,
         worker_name: Option<&str>,
         park_cell: Option<&Arc<BlockedCell>>,
+        recorded: Option<&Arc<RecordedDecisions>>,
     ) -> Result<AgentWithPreamble, Box<dyn std::error::Error + Send + Sync>> {
         use super::duplicate_call_guard::DuplicateCallGuard;
         use super::observer_wrapper::ObserverWrapper;
@@ -882,6 +888,9 @@ impl Orchestrator {
             ) = (park_cell, self.park_guard.as_ref(), &*hitl.route)
             {
                 gate = gate.with_park(registry.clone(), cell.clone(), Arc::clone(guard));
+            }
+            if let Some(recorded) = recorded {
+                gate = gate.with_recorded_decisions(Arc::clone(recorded));
             }
             wrappers.insert(0, Arc::new(gate));
             worker_config.hitl_request_approval_tool = Some(crate::hitl::RequestApprovalTool::new(
@@ -2911,6 +2920,53 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 .unwrap_or_default()
         };
 
+        // Test-only model injection (park/reify rig): a queued override builds
+        // this worker from a scripted model. The override's extra tools go
+        // through the worker's own wrapper chain — `worker_config.tool_wrapper`
+        // carries the composed chain (observer, duplicate guard, persistence,
+        // HITL gate) create_worker assembled — so a scripted worker's gated
+        // calls park exactly like live ones. No override queued: unchanged
+        // behavior.
+        #[cfg(test)]
+        if let Some(worker_override) = crate::orchestration::test_rig::take_worker_override() {
+            use rig::tool::Tool as _;
+
+            use crate::orchestration::test_rig::DynToolAsTool;
+            use crate::tool_wrapper::WrappedTool;
+
+            let mut builder = rig::agent::AgentBuilder::new(worker_override.model);
+            builder = builder.name(&worker_config.agent.name);
+            builder = builder.provider_name(llm_provider).model_name(llm_model);
+            builder = builder.preamble(preamble);
+            let mut state = BuilderState::Initial(builder);
+            for tool in worker_override.extra_tools {
+                let shim = DynToolAsTool::new(tool);
+                match (
+                    &worker_config.tool_wrapper,
+                    &worker_config.tool_context_factory,
+                ) {
+                    (Some(wrapper), Some(factory)) => {
+                        let factory = factory.clone();
+                        let tool_name = shim.name();
+                        state = state.add_tool(
+                            WrappedTool::new(shim, wrapper.clone())
+                                .with_context_factory(move |_| factory(&tool_name)),
+                        );
+                    }
+                    (Some(wrapper), None) => {
+                        state = state.add_tool(WrappedTool::new(shim, wrapper.clone()));
+                    }
+                    (None, _) => state = state.add_tool(shim),
+                }
+            }
+            let state =
+                Agent::add_all_tools(state, worker_config, &shared_mcp, wait_for_tools()).await?;
+            return Ok((
+                ProviderAgent::Scripted(state.build()),
+                "scripted".to_string(),
+            ));
+        }
+
         match &worker_config.llm {
             LlmConfig::OpenAI {
                 api_key,
@@ -3238,7 +3294,9 @@ Assign tasks to the worker whose tools best match the required operations."#,
                             task_context: &task_context,
                             worker_name: worker_name.as_deref(),
                         };
-                        let result = self.execute_task(task_id, &params, Some(event_tx)).await;
+                        let result = self
+                            .execute_task(task_id, &params, Some(event_tx), None, None)
+                            .await;
                         let duration_ms = start_time.elapsed().as_millis() as u64;
                         (task_id, result, duration_ms, worker_name, task_desc)
                     },
@@ -3478,7 +3536,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
         }
     }
 
-    /// Execute a single task using a worker agent.
+    /// Execute a single task using a worker agent. `continuation` carries a
+    /// parked task's checkpointed conversation (the resume path) and `resume`
+    /// the recorded decisions + resuming document it drives; both are `None`
+    /// on the live path.
     #[tracing::instrument(
         name = "orchestration.worker",
         skip_all,
@@ -3493,12 +3554,27 @@ Assign tasks to the worker whose tools best match the required operations."#,
         task_id: usize,
         params: &TaskExecutionParams<'_>,
         event_tx: Option<&tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>>,
+        continuation: Option<&TaskContinuation>,
+        resume: Option<&ResumeContext>,
     ) -> Result<TaskOutcome, StreamError> {
         let TaskExecutionParams {
             task_description,
             task_context,
             worker_name,
         } = params;
+
+        // The resume path: the checkpointed conversation drives everything,
+        // so the live prompt-building and retry loop below do not apply.
+        if let (Some(continuation), Some(resume)) = (continuation, resume) {
+            return self
+                .resume_task(task_id, *worker_name, continuation, resume, event_tx)
+                .await;
+        }
+        if continuation.is_some() != resume.is_some() {
+            return Err("task resume state is incomplete: continuation and \
+                        resume context must be provided together"
+                .into());
+        }
 
         {
             let span = tracing::Span::current();
@@ -3570,6 +3646,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     attempt,
                     *worker_name,
                     park.as_ref().map(|p| &p.cell),
+                    None,
                 )
                 .await?;
 
@@ -3838,6 +3915,182 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 structured_output: None,
             }))
         }
+    }
+
+    /// The continuation arm (design doc sections 2.7–2.8): finish a parked
+    /// task from its checkpoint. Rebuilds the worker for the recorded
+    /// attempt with the run's recorded decisions at the gate, tombstones and
+    /// invokes each pending call in recorded order through the wrapper
+    /// chain, replaces the checkpointed sentinel tool results with the real
+    /// ones, then hands the conversation back to the normal multi-turn loop
+    /// via `stream_chat`. Consumed decisions are removed from the store
+    /// after the task completes. The task execution record is not re-persisted
+    /// here: the resuming document's executed list is the resume's record.
+    async fn resume_task(
+        &self,
+        task_id: usize,
+        worker_name: Option<&str>,
+        continuation: &TaskContinuation,
+        resume: &ResumeContext,
+        event_tx: Option<&tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>>,
+    ) -> Result<TaskOutcome, StreamError> {
+        let attempt = continuation.attempt;
+        let Some(park) = self.worker_park(task_id, attempt) else {
+            return Err("cannot resume a task without park mode enabled".into());
+        };
+
+        let AgentWithPreamble {
+            agent: worker,
+            preamble: _,
+            escalation_flag: _,
+            submit_result_decision,
+        } = self
+            .create_worker(
+                task_id,
+                attempt,
+                worker_name,
+                Some(&park.cell),
+                Some(&resume.recorded),
+            )
+            .await?;
+
+        let mut current_prompt = continuation.current_prompt.clone();
+        // Strict arm: a continuation invocation that misses the recorded set
+        // is a resume fault, never a fresh park. The drop guard clears the
+        // task's entry on every exit path (error, panic, and the normal drop
+        // after the last pending call, before the loop resumes).
+        let strict = resume.recorded.strict_guard(task_id);
+        for call in &continuation.pending {
+            // The tombstone precedes the invocation: a crash after this
+            // write shows the call as executed, never re-asks the human.
+            resume
+                .document
+                .append_executed_and_publish(&call.call_id)
+                .await
+                .map_err(|e| -> StreamError {
+                    format!(
+                        "resume tombstone write for call {} failed: {e}",
+                        call.call_id
+                    )
+                    .into()
+                })?;
+            let wire = worker
+                .inner
+                .call_tool(&call.tool_name, &call.arguments.to_string())
+                .await
+                .map_err(|e| -> StreamError {
+                    format!("resume invocation of {} failed: {e}", call.tool_name).into()
+                })?;
+            if !super::park::replace_tool_result(&mut current_prompt, &call.call_id, &wire) {
+                return Err(format!(
+                    "continuation prompt has no tool result for call {}",
+                    call.call_id
+                )
+                .into());
+            }
+        }
+        drop(strict);
+
+        // stream_chat(current_prompt, history): the normal multi-turn loop,
+        // to submit_result or depth exhaustion — park-aware, so a
+        // model-issued gated call re-parks through the live arm.
+        let srd = submit_result_decision.clone();
+        let park_registration =
+            crate::streaming_request_hook::ParkCellRegistration::new(&park.key, park.cell.clone());
+        let (stream, _cancel_tx, _usage_state) = worker
+            .inner
+            .stream_chat_message_with_timeout(
+                current_prompt,
+                continuation.history.clone(),
+                worker.max_depth,
+                Duration::MAX,
+                &park.key,
+                worker.scratchpad_budget.clone(),
+                worker.client_tool_names.clone(),
+            )
+            .await;
+        let stream_result = Self::drive_forward_loop(
+            stream,
+            &self.usage_state,
+            self.config.stream_inactivity_timeout_secs(),
+            worker.scratchpad_budget.as_ref(),
+            "Worker resume",
+            event_tx,
+            worker_name.map(|name| StreamContext {
+                task_id,
+                worker_id: name,
+            }),
+            || {
+                let srd = srd.clone();
+                Box::pin(async move { srd.lock().await.is_some() })
+            },
+        )
+        .await;
+        drop(park_registration);
+
+        // Same cell contract as the live path: the cell is the source of
+        // truth after any stream end.
+        match park.cell.outcome() {
+            CellOutcome::Blocked { pending } => {
+                let snapshot = park
+                    .cell
+                    .snapshot()
+                    .expect("cell outcome Blocked implies a captured snapshot");
+                return Ok(TaskOutcome::Blocked {
+                    pending,
+                    attempt,
+                    snapshot,
+                });
+            }
+            CellOutcome::Orphaned { pending } => {
+                self.cancel_parked_approvals(task_id, worker_name, &pending)
+                    .await;
+                let underlying = match stream_result.as_ref() {
+                    Err(e) => format!(" Underlying error: {e}"),
+                    Ok(_) => String::new(),
+                };
+                return Err(format!(
+                    "Worker resume stream ended before the parked approval snapshot \
+                     was captured for task {task_id}; {} pending approval(s) \
+                     cancelled.{underlying}",
+                    pending.len()
+                )
+                .into());
+            }
+            CellOutcome::Normal => {}
+        }
+
+        let raw_response = match stream_result {
+            Ok(run) => run.response.content,
+            Err(e) => {
+                return Err(format!("Worker resume failed for task {task_id}: {e}").into());
+            }
+        };
+        let structured = submit_result_decision.lock().await.take();
+        let (result, structured_output) = match structured {
+            Some(output) => (
+                output.result,
+                Some(super::types::StructuredTaskOutput {
+                    summary: output.summary,
+                    confidence: output.confidence,
+                }),
+            ),
+            None => (raw_response, None),
+        };
+
+        // Step 5: the consumed decisions leave the store with the task.
+        if let Some(hitl) = self.agent_config.hitl.clone()
+            && let crate::hitl::DecisionRoute::Conversational { registry, .. } = &*hitl.route
+        {
+            for call in &continuation.pending {
+                registry.remove(&call.decision_id).await;
+            }
+        }
+
+        Ok(TaskOutcome::Completed(TaskExecutionResult {
+            result,
+            structured_output,
+        }))
     }
 
     /// Persist a single worker execution attempt to the persistence store.
@@ -7806,5 +8059,832 @@ mod tests {
         );
 
         crate::approval_event_broker::unsubscribe(&request_id).await;
+    }
+
+    // ====================================================================
+    // Orphan dual-trigger (P42 → P43 → P44 handoff): execute_task through
+    // CellOutcome::Orphaned, via the worker-model injection seam.
+    // ====================================================================
+
+    use crate::orchestration::test_rig;
+    use test_rig::{ScriptedToolCall, ScriptedTurn, WorkerOverride};
+
+    /// Serializes the override-using tests: the override queue is
+    /// process-global, and two parallel installs could cross-consume each
+    /// other's scripted workers. Async-aware so the guard may cross awaits.
+    static WORKER_OVERRIDE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// A park-mode orchestrator whose `operations` worker is built through
+    /// the override seam: the gate glob matches the stub tool, and the
+    /// worker's turn depth is settable for the depth-exhaustion trigger.
+    async fn override_park_orchestrator(
+        memory_dir: &std::path::Path,
+        turn_depth: usize,
+    ) -> (
+        Orchestrator,
+        Arc<crate::session_store::InMemoryApprovalStore>,
+        crate::hitl::PendingApprovals,
+        String,
+    ) {
+        use crate::hitl::PendingApprovals;
+        use crate::session_store::{InMemoryApprovalStore, InMemoryEventBus};
+
+        let store = Arc::new(InMemoryApprovalStore::new());
+        let registry = PendingApprovals::with_backend(
+            store.clone() as Arc<dyn crate::session_store::ApprovalStore>,
+            Arc::new(InMemoryEventBus::new()),
+        );
+        let workers = std::collections::HashMap::from([(
+            "operations".to_string(),
+            crate::orchestration::WorkerConfig {
+                description: "Runs the scripted tool".to_string(),
+                preamble: "You apply changes with the echo tool.".to_string(),
+                mcp_filter: Some(vec![]),
+                vector_stores: vec![],
+                turn_depth: Some(turn_depth),
+                llm: None,
+                scratchpad: None,
+                skills: None,
+            },
+        )]);
+        let request_id = format!("req_orphan_{}", uuid::Uuid::new_v4().simple());
+        let config = AgentRuntimeConfig {
+            hitl: Some(crate::hitl::HitlRuntime {
+                patterns: Arc::from([aura_config::GlobPattern::new("echo_tool").unwrap()]),
+                route: Arc::new(crate::hitl::DecisionRoute::Conversational {
+                    registry: registry.clone(),
+                    timeout: Duration::from_secs(3600),
+                }),
+                park_enabled: true,
+            }),
+            memory_dir: Some(memory_dir.to_string_lossy().into_owned()),
+            session_id: Some("orphan-sess".to_string()),
+            request_id: Some(request_id.clone()),
+            orchestration: Some(OrchestrationConfig {
+                enabled: true,
+                workers,
+                ..Default::default()
+            }),
+            ..AgentRuntimeConfig::default()
+        };
+        let orchestrator = Orchestrator::new(config).await.unwrap();
+        (orchestrator, store, registry, request_id)
+    }
+
+    /// Queue one override: a scripted model plus the gated stub tool and an
+    /// ungated sibling (for scripts that must burn turns without parking).
+    /// Returns the model handle (request log) and the gated tool's
+    /// invocation log.
+    fn gated_worker_override(
+        turns: Vec<ScriptedTurn>,
+    ) -> (
+        test_rig::ScriptedCompletionModel,
+        Arc<std::sync::Mutex<Vec<test_rig::ToolInvocation>>>,
+    ) {
+        let model = test_rig::ScriptedCompletionModel::new(turns);
+        let gated_invocations: Arc<std::sync::Mutex<Vec<test_rig::ToolInvocation>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let gated_tool = Box::new(test_rig::RecordingTool::new(Arc::clone(&gated_invocations)))
+            as Box<dyn rig::tool::ToolDyn>;
+        let setup_tool = Box::new(
+            test_rig::RecordingTool::new(Arc::new(std::sync::Mutex::new(Vec::new())))
+                .with_name("setup_tool"),
+        ) as Box<dyn rig::tool::ToolDyn>;
+        test_rig::install_worker_overrides(vec![WorkerOverride {
+            model: model.clone(),
+            extra_tools: vec![setup_tool, gated_tool],
+        }]);
+        (model, gated_invocations)
+    }
+
+    /// Assert the orphaned task's outcome: the task fails naming the
+    /// cancelled approvals, every parked decision id is swept from the store,
+    /// one `approval_completed(cancelled)` fires per decision, and nothing
+    /// decidable remains.
+    async fn assert_orphaned(
+        result: Result<TaskOutcome, StreamError>,
+        store: &Arc<crate::session_store::InMemoryApprovalStore>,
+        events: &mut tokio::sync::mpsc::Receiver<
+            crate::approval_event_broker::ApprovalLifecycleEvent,
+        >,
+        expected_events: usize,
+        underlying: &str,
+    ) {
+        let err = match result {
+            Ok(_) => panic!("the orphaned task must fail"),
+            Err(e) => e,
+        };
+        let message = err.to_string();
+        assert!(
+            message.contains("pending approval(s) cancelled"),
+            "the task failure must name the cancelled approvals: {message}"
+        );
+        assert!(
+            message.contains(underlying),
+            "the task failure must carry the {underlying} trigger: {message}"
+        );
+
+        let mut decision_ids = Vec::new();
+        while decision_ids.len() < expected_events {
+            match tokio::time::timeout(Duration::from_secs(1), events.recv()).await {
+                Ok(Some(crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
+                    completed,
+                ))) => {
+                    assert!(matches!(
+                        completed.outcome,
+                        aura_events::ApprovalOutcomeWire::Cancelled { .. }
+                    ));
+                    decision_ids.push(completed.decision_id);
+                }
+                // The park arm's Requested/Pending pair precedes the sweep's
+                // Completed events on the same broker.
+                Ok(Some(_)) => continue,
+                other => panic!("expected completed(cancelled), got {other:?}"),
+            }
+        }
+        assert_eq!(
+            decision_ids.len(),
+            expected_events,
+            "one cancelled event per parked decision"
+        );
+        for id in &decision_ids {
+            let parsed = crate::hitl::DecisionId::parse(id).expect("wire decision id parses");
+            assert!(
+                store.get(&parsed).await.unwrap().is_none(),
+                "parked decision {id} must be removed from the store"
+            );
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), events.recv())
+                .await
+                .is_err(),
+            "no further approval events fire after the sweep"
+        );
+    }
+
+    /// Depth exhaustion: the scripted model parks a gated call on the loop's
+    /// final turn, so the stream ends at the depth break before the next
+    /// `on_completion_call` could snapshot. The task fails and every parked
+    /// decision is cancelled.
+    #[tokio::test]
+    async fn orphan_depth_exhaustion_cancels_parked_approvals_and_fails_the_task() {
+        let _serial = WORKER_OVERRIDE_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let (orchestrator, store, _registry, request_id) =
+            override_park_orchestrator(dir.path(), 1).await;
+        let mut events = crate::approval_event_broker::subscribe(&request_id).await;
+
+        // Depth 1 gives the loop three turns (the rig's +1 safety net), so
+        // the gated call must land on the third: the first two turns burn
+        // ungated setup calls, and the depth break fires right after the
+        // park, before the next hook snapshot.
+        let (_model, gated_invocations) = gated_worker_override(vec![
+            ScriptedTurn::tool_calls(vec![ScriptedToolCall::new(
+                "call_s0",
+                "setup_tool",
+                serde_json::json!({"step": 1}),
+            )]),
+            ScriptedTurn::tool_calls(vec![ScriptedToolCall::new(
+                "call_s1",
+                "setup_tool",
+                serde_json::json!({"step": 2}),
+            )]),
+            ScriptedTurn::tool_calls(vec![
+                ScriptedToolCall::new(
+                    "call_2",
+                    test_rig::ECHO_TOOL_NAME,
+                    serde_json::json!({"namespace": "prod"}),
+                )
+                .with_call_id("call_id_2"),
+            ]),
+        ]);
+
+        let mut plan = Plan::new("Deploy");
+        plan.add_task(Task::new(0, "Gated apply", "r").with_worker("operations"));
+        let params = TaskExecutionParams {
+            task_description: "apply the manifest",
+            task_context: &None,
+            worker_name: Some("operations"),
+        };
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(32);
+        let result = orchestrator
+            .execute_task(0, &params, Some(&event_tx), None, None)
+            .await;
+
+        assert_orphaned(result, &store, &mut events, 1, "MaxDepthError").await;
+        assert!(
+            gated_invocations.lock().unwrap().is_empty(),
+            "the parked call must never have reached the inner tool"
+        );
+
+        crate::approval_event_broker::unsubscribe(&request_id).await;
+    }
+
+    /// Provider stream error: the scripted turn issues the gated call and
+    /// then fails the stream mid-turn, ending it before the next
+    /// `on_completion_call`. Same orphan contract as depth exhaustion.
+    #[tokio::test]
+    async fn orphan_provider_stream_error_cancels_parked_approvals_and_fails_the_task() {
+        let _serial = WORKER_OVERRIDE_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let (orchestrator, store, _registry, request_id) =
+            override_park_orchestrator(dir.path(), 4).await;
+        let mut events = crate::approval_event_broker::subscribe(&request_id).await;
+
+        let (_model, gated_invocations) =
+            gated_worker_override(vec![ScriptedTurn::tool_calls_then_stream_failure(vec![
+                ScriptedToolCall::new(
+                    "call_0",
+                    test_rig::ECHO_TOOL_NAME,
+                    serde_json::json!({"namespace": "prod"}),
+                )
+                .with_call_id("call_id_0"),
+            ])]);
+
+        let mut plan = Plan::new("Deploy");
+        plan.add_task(Task::new(0, "Gated apply", "r").with_worker("operations"));
+        let params = TaskExecutionParams {
+            task_description: "apply the manifest",
+            task_context: &None,
+            worker_name: Some("operations"),
+        };
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(32);
+        let result = orchestrator
+            .execute_task(0, &params, Some(&event_tx), None, None)
+            .await;
+
+        assert_orphaned(
+            result,
+            &store,
+            &mut events,
+            1,
+            "provider stream failed mid-turn",
+        )
+        .await;
+        assert!(
+            gated_invocations.lock().unwrap().is_empty(),
+            "the parked call must never have reached the inner tool"
+        );
+
+        crate::approval_event_broker::unsubscribe(&request_id).await;
+    }
+
+    // ====================================================================
+    // Reify and continuation proofs (P44 commit 3)
+    // ====================================================================
+
+    use crate::hitl::{ApprovalDecision, PendingApprovals};
+    use crate::orchestration::CallKey;
+    use crate::orchestration::ObserverWrapper;
+    use crate::orchestration::duplicate_call_guard::DuplicateCallGuard;
+    use crate::orchestration::persistence_wrapper::{PersistenceWrapper, PersistenceWrapperParams};
+    use crate::tool_wrapper::ToolCallContext;
+
+    /// The denial feedback the gate produces, quoted for the wire (rig
+    /// JSON-serializes tool outputs). Mirrors `approval_result_to_pre_call`'s
+    /// denial arm in `gate.rs` verbatim.
+    fn denial_feedback_wire(reason: &str) -> String {
+        serde_json::to_string(&format!(
+            "Tool call blocked by human approval denial: {reason}. Do not execute this action."
+        ))
+        .expect("a plain string serializes")
+    }
+
+    /// The tool-result text carried by a chat-history message, decoded —
+    /// assertions compare the actual content, not a serialization level.
+    fn tool_result_text(message: &rig::completion::Message) -> String {
+        let rig::completion::Message::User { content } = message else {
+            return String::new();
+        };
+        content
+            .iter()
+            .filter_map(|item| match item {
+                rig::message::UserContent::ToolResult(tr) => Some(
+                    tr.content
+                        .iter()
+                        .map(|c| match c {
+                            rig::message::ToolResultContent::Text(t) => t.text.clone(),
+                            rig::message::ToolResultContent::Image(_) => String::new(),
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                ),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// A park-mode orchestrator over a file-backed approval store (the park
+    /// contract's backend: `get` returns the approval before and after the
+    /// decision), sharing the given registry.
+    async fn file_backed_park_orchestrator(
+        registry: &PendingApprovals,
+        memory_dir: &std::path::Path,
+        session_id: &str,
+    ) -> (Orchestrator, String) {
+        let workers = std::collections::HashMap::from([(
+            "operations".to_string(),
+            crate::orchestration::WorkerConfig {
+                description: "Runs the scripted tool".to_string(),
+                preamble: "You apply changes with the echo tool.".to_string(),
+                mcp_filter: Some(vec![]),
+                vector_stores: vec![],
+                turn_depth: None,
+                llm: None,
+                scratchpad: None,
+                skills: None,
+            },
+        )]);
+        let config = AgentRuntimeConfig {
+            hitl: Some(crate::hitl::HitlRuntime {
+                patterns: Arc::from([aura_config::GlobPattern::new("echo_tool").unwrap()]),
+                route: Arc::new(crate::hitl::DecisionRoute::Conversational {
+                    registry: registry.clone(),
+                    timeout: Duration::from_secs(3600),
+                }),
+                park_enabled: true,
+            }),
+            memory_dir: Some(memory_dir.to_string_lossy().into_owned()),
+            session_id: Some(session_id.to_string()),
+            request_id: Some(format!("req_resume_{}", uuid::Uuid::new_v4().simple())),
+            orchestration: Some(OrchestrationConfig {
+                enabled: true,
+                workers,
+                ..Default::default()
+            }),
+            ..AgentRuntimeConfig::default()
+        };
+        let orchestrator = Orchestrator::new(config).await.unwrap();
+        let run_id = orchestrator.persistence.lock().await.run_id().to_string();
+        (orchestrator, run_id)
+    }
+
+    fn file_store_registry(
+        root: &std::path::Path,
+    ) -> (
+        PendingApprovals,
+        Arc<dyn crate::session_store::ApprovalStore>,
+    ) {
+        let store = crate::session_store::FileApprovalStore::open(root).unwrap();
+        let store: Arc<dyn crate::session_store::ApprovalStore> = Arc::new(store);
+        let registry = PendingApprovals::with_backend(
+            store.clone(),
+            Arc::new(crate::session_store::InMemoryEventBus::new()),
+        );
+        (registry, store)
+    }
+
+    /// The routed decision the coordinator records before the park, so the
+    /// document carries a non-trivial `routing_decision` for the round trip.
+    fn routed_plan() -> PlanningResponse {
+        PlanningResponse::StepsPlan {
+            goal: "Deploy the service".to_string(),
+            steps: vec![],
+            routing_rationale: "the gated apply needs a human decision".to_string(),
+            planning_summary: String::new(),
+        }
+    }
+
+    /// Open is `pub(crate)` through the park module; this thin wrapper keeps
+    /// the test honest about the error type while staying inside the crate.
+    async fn open_resuming_document(
+        path: &std::path::Path,
+    ) -> crate::orchestration::park::ResumingDocumentHandle {
+        crate::orchestration::park::ResumingDocumentHandle::open(path)
+            .await
+            .expect("the published document opens")
+    }
+
+    /// The shared full-loop harness: park over the file-backed store, drop
+    /// the in-memory state, record `decision` in the store, rehydrate from
+    /// disk, and drive the continuation with `resume_turns`. Returns the
+    /// task outcome plus the handles the proofs assert through.
+    async fn park_then_resume(
+        decision: ApprovalDecision,
+        resume_turns: Vec<ScriptedTurn>,
+    ) -> (
+        Result<TaskOutcome, StreamError>,
+        test_rig::ScriptedCompletionModel,
+        Arc<std::sync::Mutex<Vec<test_rig::ToolInvocation>>>,
+        Arc<std::sync::Mutex<Vec<test_rig::ToolInvocation>>>,
+        Arc<crate::orchestration::park::ResumingDocumentHandle>,
+        Arc<dyn crate::session_store::ApprovalStore>,
+        crate::hitl::DecisionId,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let (registry, store) = file_store_registry(&dir.path().join("approvals"));
+        let (orchestrator, run_id) =
+            file_backed_park_orchestrator(&registry, dir.path(), "loop-sess").await;
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(64);
+
+        let (park_model, park_invocations) =
+            gated_worker_override(vec![ScriptedTurn::tool_calls(vec![ScriptedToolCall::new(
+                "call_apply_1",
+                test_rig::ECHO_TOOL_NAME,
+                serde_json::json!({"namespace": "prod"}),
+            )])]);
+        let _ = park_model;
+
+        let mut plan = Plan::new("Deploy");
+        plan.add_task(Task::new(0, "Gated apply", "r").with_worker("operations"));
+        let (_compute_ms, park_records) = orchestrator.execute(&mut plan, &event_tx).await.unwrap();
+        let TaskState::AwaitingApproval { pending } = &plan.tasks[0].state else {
+            unreachable!("the fixture task is awaiting")
+        };
+        let decision_id = pending[0].decision_id;
+
+        let chat_history = vec![rig::completion::Message::user("deploy the service")];
+        let coordinator_conversation = vec![rig::completion::Message::user("plan the deploy")];
+        let routing_decision = routed_plan();
+        orchestrator
+            .park_run(
+                "deploy the service",
+                &chat_history,
+                &coordinator_conversation,
+                Some(&routing_decision),
+                2,
+                1_234,
+                &[],
+                &plan,
+                &park_records,
+                &event_tx,
+            )
+            .await
+            .expect("the park commit succeeds");
+        drop(orchestrator);
+
+        registry.resolve(&decision_id, decision).await.unwrap();
+
+        let document_path = dir
+            .path()
+            .join("loop-sess")
+            .join("parked")
+            .join(format!("{run_id}.json"));
+        let document = crate::orchestration::park::load_parked_run(&document_path)
+            .await
+            .unwrap();
+        // The replan state round-trips: iteration, planning latency, the
+        // coordinator conversation, and the routing decision all re-derive
+        // from the document alone.
+        assert_eq!(
+            document.iteration, 2,
+            "the iteration survives the round trip"
+        );
+        assert_eq!(document.planning_ms, 1_234);
+        assert_eq!(
+            document.coordinator_conversation.len(),
+            1,
+            "the coordinator conversation survives the round trip"
+        );
+        assert_eq!(
+            serde_json::to_value(&document.routing_decision).unwrap(),
+            serde_json::to_value(Some(routing_decision)).unwrap(),
+            "the routing decision survives the round trip"
+        );
+        let (recorded, consumed_ids) =
+            crate::orchestration::park::load_recorded_decisions(&registry, &document)
+                .await
+                .unwrap();
+        assert_eq!(consumed_ids, vec![decision_id]);
+
+        let node = document
+            .plan
+            .tasks
+            .iter()
+            .find(|t| t.status == TaskStatus::AwaitingApproval)
+            .expect("the awaiting node is in the document");
+        let continuation = TaskContinuation {
+            attempt: node.attempt.expect("the recorded attempt"),
+            history: node.history.clone().expect("the captured history"),
+            current_prompt: node.current_prompt.clone().expect("the sentinel prompt"),
+            pending: node.pending.clone().expect("the pending calls"),
+        };
+        let document_handle = Arc::new(open_resuming_document(&document_path).await);
+        let resume_ctx = ResumeContext {
+            recorded,
+            document: Arc::clone(&document_handle),
+        };
+
+        let (orchestrator2, _run_id2) =
+            file_backed_park_orchestrator(&registry, dir.path(), "loop-sess").await;
+        let (resume_model, resume_invocations) = gated_worker_override(resume_turns);
+        let params = TaskExecutionParams {
+            task_description: "apply the manifest",
+            task_context: &None,
+            worker_name: Some("operations"),
+        };
+        let (event_tx2, _event_rx2) = tokio::sync::mpsc::channel(64);
+        let outcome = orchestrator2
+            .execute_task(
+                0,
+                &params,
+                Some(&event_tx2),
+                Some(&continuation),
+                Some(&resume_ctx),
+            )
+            .await;
+
+        (
+            outcome,
+            resume_model,
+            resume_invocations,
+            park_invocations,
+            document_handle,
+            store,
+            decision_id,
+            dir,
+        )
+    }
+
+    /// FULL LOOP, zero human input: the scripted worker parks, the document
+    /// publishes, in-memory state drops, the store holds the approval, and
+    /// the rehydrated continuation completes the task — the tool running
+    /// exactly once with the recorded arguments, the executed tombstone
+    /// landing, the consumed decision removed, and no sentinel surviving in
+    /// the resumed conversation.
+    #[tokio::test]
+    async fn full_loop_park_rehydrate_and_resume_completes() {
+        let _serial = WORKER_OVERRIDE_LOCK.lock().await;
+
+        let (
+            outcome,
+            resume_model,
+            resume_invocations,
+            park_invocations,
+            document_handle,
+            store,
+            decision_id,
+            _dir,
+        ) = park_then_resume(
+            ApprovalDecision::Approved,
+            vec![ScriptedTurn::tool_calls(vec![ScriptedToolCall::new(
+                "call_final",
+                "submit_result",
+                serde_json::json!({
+                    "summary": "applied the manifest",
+                    "result": "applied successfully to prod",
+                    "confidence": "high",
+                }),
+            )])],
+        )
+        .await;
+
+        // The replan state survived the round trip and the task completes
+        // with the injected tool result flowing through submit_result.
+        let outcome = outcome.expect("the resumed task completes");
+        let TaskOutcome::Completed(execution) = outcome else {
+            panic!("the resumed task must complete");
+        };
+        assert_eq!(
+            execution
+                .structured_output
+                .as_ref()
+                .map(|s| s.summary.as_str()),
+            Some("applied the manifest"),
+            "the submit_result structured output flows through"
+        );
+
+        // The tool ran exactly once, with the recorded arguments — on the
+        // resume side only.
+        assert_eq!(
+            resume_invocations.lock().unwrap().len(),
+            1,
+            "exactly one resumed invocation"
+        );
+        assert_eq!(
+            resume_invocations.lock().unwrap()[0].arguments,
+            serde_json::json!({"namespace": "prod"})
+        );
+        assert!(
+            park_invocations.lock().unwrap().is_empty(),
+            "the gated action did not run at park time"
+        );
+
+        // The tombstone published: the resuming document's executed list is
+        // non-empty and terminal.
+        let executed = document_handle.executed().await;
+        assert_eq!(executed, vec!["call_apply_1".to_string()]);
+        let resuming: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(document_handle.publish_path()).unwrap())
+                .unwrap();
+        assert_eq!(resuming["executed"][0], "call_apply_1");
+
+        // The consumed decision left the store.
+        assert!(
+            store.get(&decision_id).await.unwrap().is_none(),
+            "the consumed decision is removed"
+        );
+
+        // No sentinel remains in the resumed conversation: the resume turn's
+        // prompt carries the real tool result in the wire form.
+        let requests = resume_model.requests();
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 1, "the resume turn is the only model turn");
+        let last = requests[0]
+            .chat_history
+            .iter()
+            .last()
+            .expect("the prompt is in the history");
+        let tool_text = tool_result_text(last);
+        assert!(
+            tool_text.contains(&test_rig::echo_tool_result_wire()),
+            "the resumed prompt must carry the tool result wire text: {tool_text}"
+        );
+        assert!(
+            !tool_text.contains("parked pending human approval"),
+            "no sentinel may survive the sentinel replacement: {tool_text}"
+        );
+    }
+
+    /// RACE (b): concurrent takes on one recorded key — two decisions
+    /// consumed exactly once each, in recorded order, regardless of which
+    /// consumer wins the race.
+    #[tokio::test]
+    async fn concurrent_takes_consume_one_key_exactly_once_in_recorded_order() {
+        let recorded = Arc::new(RecordedDecisions::default());
+        let args = serde_json::json!({ "namespace": "prod" });
+        recorded.push(
+            CallKey::new(1, "kubectl_apply", &args),
+            ApprovalDecision::Approved,
+        );
+        recorded.push(
+            CallKey::new(1, "kubectl_apply", &args),
+            ApprovalDecision::Denied {
+                reason: Some("no".to_string()),
+            },
+        );
+
+        let taken = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let consumers = (0..2).map(|consumer| {
+            let recorded = Arc::clone(&recorded);
+            let taken = Arc::clone(&taken);
+            let args = args.clone();
+            tokio::spawn(async move {
+                let key = CallKey::new(1, "kubectl_apply", &args);
+                while let Some(decision) = recorded.take(&key) {
+                    taken.lock().unwrap().push((consumer, decision));
+                }
+            })
+        });
+        for consumer in consumers {
+            consumer.await.unwrap();
+        }
+
+        let taken = taken.lock().unwrap();
+        assert_eq!(
+            taken.len(),
+            2,
+            "two decisions consumed exactly once each: {taken:?}"
+        );
+        assert!(
+            matches!(taken[0].1, ApprovalDecision::Approved),
+            "recorded order holds across consumers: the approval is consumed first"
+        );
+        assert!(matches!(
+            &taken[1].1,
+            ApprovalDecision::Denied {
+                reason: Some(reason),
+            } if reason == "no"
+        ));
+    }
+
+    /// RACE (c): strict isolation — two StrictGuards on different task ids,
+    /// and an early drop of one leaves the other strict.
+    #[tokio::test]
+    async fn strict_guards_are_isolated_per_task() {
+        let recorded = Arc::new(RecordedDecisions::default());
+        let guard_a = recorded.strict_guard(1);
+        let guard_b = recorded.strict_guard(2);
+        assert!(recorded.is_strict(1) && recorded.is_strict(2));
+
+        drop(guard_a);
+        assert!(
+            !recorded.is_strict(1),
+            "the early drop clears only its own task"
+        );
+        assert!(
+            recorded.is_strict(2),
+            "the sibling continuation stays strict"
+        );
+        drop(guard_b);
+        assert!(!recorded.is_strict(2));
+    }
+
+    /// RACE-set companion: the transform_args idempotence pin — the worker
+    /// chain (composed as `create_worker` composes it) leaves already-clean
+    /// arguments untouched, so a recorded call re-entering the chain digests
+    /// to the same CallKey the gate consults.
+    #[test]
+    fn transform_args_is_idempotent_on_clean_arguments_for_the_worker_chain() {
+        use crate::tool_wrapper::{ComposedWrapper, ToolWrapper};
+        use std::sync::atomic::AtomicBool;
+        use std::sync::atomic::AtomicUsize;
+
+        let (observer, _rx) = ToolCallObserver::new(32);
+        let persistence = Arc::new(Mutex::new(ExecutionPersistence::disabled()));
+        let chain = Arc::new(ComposedWrapper::new(vec![
+            Arc::new(ObserverWrapper::new(observer, 1)),
+            Arc::new(DuplicateCallGuard::new(
+                3,
+                5,
+                Arc::new(AtomicBool::new(false)),
+            )),
+            Arc::new(PersistenceWrapper::new(PersistenceWrapperParams {
+                persistence,
+                in_flight: Arc::new(AtomicUsize::new(0)),
+                drain_notify: Arc::new(tokio::sync::Notify::new()),
+                worker_name: Some("operations".to_string()),
+                iteration: 1,
+                persistence_enabled: false,
+                size_threshold: 0,
+                duration_threshold_ms: 0,
+            })),
+        ]));
+
+        let args = serde_json::json!({ "namespace": "prod" });
+        let ctx = ToolCallContext::new(test_rig::ECHO_TOOL_NAME);
+        let first = chain.transform_args(args.clone(), &ctx);
+        let second = chain.transform_args(first.args.clone(), &ctx);
+
+        assert_eq!(
+            first.args, args,
+            "clean arguments pass through the chain unchanged"
+        );
+        assert_eq!(
+            second.args, first.args,
+            "re-entering the chain is a no-op on already-clean arguments"
+        );
+        assert_eq!(
+            CallKey::new(1, test_rig::ECHO_TOOL_NAME, &args),
+            CallKey::new(1, test_rig::ECHO_TOOL_NAME, &second.args),
+            "the recorded call digests to the same key after re-entering the chain"
+        );
+    }
+
+    /// DENIAL PARITY: a denial recorded in the store produces the live
+    /// path's denial feedback string as the tool result, byte-identical to
+    /// the gate's denial arm, and the inner tool never runs.
+    #[tokio::test]
+    async fn denial_parity_the_recorded_denial_produces_the_live_denial_feedback() {
+        let _serial = WORKER_OVERRIDE_LOCK.lock().await;
+
+        let (
+            outcome,
+            resume_model,
+            resume_invocations,
+            park_invocations,
+            _document_handle,
+            _store,
+            _decision_id,
+            _dir,
+        ) = park_then_resume(
+            ApprovalDecision::Denied {
+                reason: Some("too risky".to_string()),
+            },
+            vec![ScriptedTurn::tool_calls(vec![ScriptedToolCall::new(
+                "call_final",
+                "submit_result",
+                serde_json::json!({
+                    "summary": "blocked, moving on",
+                    "result": "the apply was denied; reporting back",
+                    "confidence": "low",
+                }),
+            )])],
+        )
+        .await;
+
+        let outcome = outcome.expect("the resumed task completes");
+        let TaskOutcome::Completed(execution) = outcome else {
+            panic!("the resumed task must complete even on a denial");
+        };
+        assert_eq!(
+            execution.result, "the apply was denied; reporting back",
+            "the worker continues past the denial"
+        );
+
+        // The denial feedback reached the model's prompt in the wire form,
+        // identical to the live path's denial arm — and no tool invocation
+        // happened on either side.
+        let requests = resume_model.requests();
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 1, "the resume turn is the only model turn");
+        let last = requests[0]
+            .chat_history
+            .iter()
+            .last()
+            .expect("the prompt is in the history");
+        let tool_text = tool_result_text(last);
+        assert!(
+            tool_text.contains(&denial_feedback_wire("too risky")),
+            "the denial feedback must appear in the resumed prompt verbatim: {tool_text}"
+        );
+        assert!(
+            !tool_text.contains("parked pending human approval"),
+            "no sentinel may survive the sentinel replacement: {tool_text}"
+        );
+        assert!(resume_invocations.lock().unwrap().is_empty());
+        assert!(park_invocations.lock().unwrap().is_empty());
     }
 }

--- a/crates/aura/src/orchestration/park/continuation.rs
+++ b/crates/aura/src/orchestration/park/continuation.rs
@@ -246,9 +246,15 @@ pub(crate) async fn load_recorded_decisions(
                         )));
                     }
                 }
-                other => {
+                crate::hitl::AgentScope::Single { .. } => {
                     return Err(RehydrateError::Mismatch(format!(
-                        "approval {} carries a non-worker scope {other:?}",
+                        "approval {} carries a single-agent scope",
+                        call.decision_id
+                    )));
+                }
+                crate::hitl::AgentScope::Coordinator { .. } => {
+                    return Err(RehydrateError::Mismatch(format!(
+                        "approval {} carries a coordinator scope",
                         call.decision_id
                     )));
                 }
@@ -508,6 +514,61 @@ mod tests {
         doc.expires_at = (chrono::Utc::now() - chrono::Duration::seconds(1)).to_rfc3339();
         let err = load_recorded_decisions(&registry, &doc).await.unwrap_err();
         assert!(err.to_string().contains("expired"), "got: {err}");
+    }
+
+    /// The stored approval's scope must name this run and this checkpoint
+    /// node: wrong run, wrong task, and non-worker scopes are each the
+    /// mismatch row (the other-run/other-task borrow of T1).
+    #[tokio::test]
+    async fn scope_mismatch_refuses_the_borrowed_approval() {
+        let (registry, _dir) = file_store();
+        let decision_id = DecisionId::generate();
+        let args = serde_json::json!({ "namespace": "prod" });
+
+        let mut other_run = approval(decision_id, args.clone());
+        other_run.request.scope = crate::hitl::AgentScope::Worker {
+            run_id: "0191e8c0-bbbb-7000-8000-00000000c0de".parse().unwrap(),
+            task: crate::orchestration::types::TaskIdentity::new(3, None),
+            session_id: None,
+        };
+        registry.register_durable(other_run).await.unwrap();
+        let err = load_recorded_decisions(
+            &registry,
+            &parked_run(vec![pending_call(decision_id, args.clone())]),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("not this run"), "got: {err}");
+
+        let (registry, _dir) = file_store();
+        let mut other_task = approval(decision_id, args.clone());
+        other_task.request.scope = crate::hitl::AgentScope::Worker {
+            run_id: "0191e8c0-aaaa-7000-8000-00000000c0de".parse().unwrap(),
+            task: crate::orchestration::types::TaskIdentity::new(7, None),
+            session_id: None,
+        };
+        registry.register_durable(other_task).await.unwrap();
+        let err = load_recorded_decisions(
+            &registry,
+            &parked_run(vec![pending_call(decision_id, args.clone())]),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("not task 3"), "got: {err}");
+
+        let (registry, _dir) = file_store();
+        let mut coordinator_scope = approval(decision_id, args);
+        coordinator_scope.request.scope = crate::hitl::AgentScope::Coordinator {
+            run_id: "0191e8c0-aaaa-7000-8000-00000000c0de".parse().unwrap(),
+        };
+        registry.register_durable(coordinator_scope).await.unwrap();
+        let err = load_recorded_decisions(
+            &registry,
+            &parked_run(vec![pending_call(decision_id, serde_json::json!({}))]),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("coordinator scope"), "got: {err}");
     }
 
     /// Decision-during-refresh correction: the document's pending set still

--- a/crates/aura/src/orchestration/park/continuation.rs
+++ b/crates/aura/src/orchestration/park/continuation.rs
@@ -59,9 +59,18 @@ pub(crate) enum RehydrateError {
     /// the resumer.
     Expired,
     /// Condition row "mismatch": the store and the document disagree — the
-    /// stored approval is missing, its recorded call differs from the
-    /// document's, or a call the resume needs has no recorded decision.
+    /// stored approval is missing, its scope names another run or task than
+    /// the checkpoint node, or its recorded call differs from the
+    /// document's.
     Mismatch(String),
+    /// Condition row "parked": a pending call still has no recorded
+    /// decision inside the decision window. The resume endpoint answers
+    /// 409 `parked` with the outstanding ids and `expires_at`; an
+    /// all-decided resume never sees this.
+    Parked {
+        outstanding: Vec<DecisionId>,
+        expires_at: chrono::DateTime<chrono::Utc>,
+    },
     /// Condition row "config_changed": the fingerprint no longer matches the
     /// rebuilt configuration. Checked by the resume endpoint against a
     /// header-resolved config entry point (P45 adoption).
@@ -80,6 +89,11 @@ impl std::fmt::Display for RehydrateError {
             Self::NotFound => write!(f, "no checkpoint document for the run"),
             Self::Expired => write!(f, "the run's decision window has expired"),
             Self::Mismatch(detail) => write!(f, "resume mismatch: {detail}"),
+            Self::Parked { outstanding, .. } => write!(
+                f,
+                "{} approval(s) still await a decision inside the window",
+                outstanding.len()
+            ),
             Self::ConfigChanged => write!(f, "configuration changed since the run parked"),
             Self::Store(detail) => write!(f, "approval store read failed: {detail}"),
             Self::Document(detail) => write!(f, "checkpoint document read failed: {detail}"),
@@ -189,6 +203,7 @@ pub(crate) async fn load_recorded_decisions(
 ) -> Result<(Arc<RecordedDecisions>, Vec<DecisionId>), RehydrateError> {
     let recorded = Arc::new(RecordedDecisions::default());
     let mut decision_ids = Vec::new();
+    let mut outstanding = Vec::new();
     // The document's expiry stamp is the run's decision window the 2.6
     // expired row is evaluated against.
     let expires_at = chrono::DateTime::parse_from_rfc3339(&doc.expires_at)
@@ -213,6 +228,31 @@ pub(crate) async fn load_recorded_decisions(
                     call.decision_id
                 )));
             };
+            // The stored approval must name this run and this checkpoint
+            // node: an approval borrowed from another run or task cannot
+            // decide this document's call (the 2.6 mismatch row).
+            match &parked.request.scope {
+                crate::hitl::AgentScope::Worker { run_id, task, .. } => {
+                    if run_id.to_string() != doc.run_id {
+                        return Err(RehydrateError::Mismatch(format!(
+                            "approval {} belongs to run {run_id}, not this run",
+                            call.decision_id
+                        )));
+                    }
+                    if task.task_id != node.task_id {
+                        return Err(RehydrateError::Mismatch(format!(
+                            "approval {} belongs to task {}, not task {}",
+                            call.decision_id, task.task_id, node.task_id
+                        )));
+                    }
+                }
+                other => {
+                    return Err(RehydrateError::Mismatch(format!(
+                        "approval {} carries a non-worker scope {other:?}",
+                        call.decision_id
+                    )));
+                }
+            }
             // The approval is single-item by construction (one parked call
             // raises one request); items[0] is the call the human decided on.
             let Some(item) = parked.request.items.first() else {
@@ -228,15 +268,14 @@ pub(crate) async fn load_recorded_decisions(
                 )));
             }
             let Some(decision) = store.recorded_decision(&call.decision_id).await else {
-                // No decision yet: expired past the window, still parked
-                // otherwise — both fail the all-decided resume.
+                // No decision yet: expired past the window (the 2.6 expired
+                // row outranks parked), still parked otherwise — collected
+                // so the 409 body can carry every outstanding id.
                 if chrono::Utc::now() > expires_at {
                     return Err(RehydrateError::Expired);
                 }
-                return Err(RehydrateError::Mismatch(format!(
-                    "approval {} has no recorded decision",
-                    call.decision_id
-                )));
+                outstanding.push(call.decision_id);
+                continue;
             };
             // The key's task id comes from the awaiting node, the tool name
             // and arguments from the store's approval record.
@@ -246,6 +285,12 @@ pub(crate) async fn load_recorded_decisions(
             );
             decision_ids.push(call.decision_id);
         }
+    }
+    if !outstanding.is_empty() {
+        return Err(RehydrateError::Parked {
+            outstanding,
+            expires_at,
+        });
     }
 
     Ok((recorded, decision_ids))
@@ -337,7 +382,11 @@ mod tests {
                 instance_id: "test-instance".to_string(),
                 decision_id,
                 request_id: "run:test".to_string(),
-                scope: AgentScope::Single { session_id: None },
+                scope: AgentScope::Worker {
+                    run_id: "0191e8c0-aaaa-7000-8000-00000000c0de".parse().unwrap(),
+                    task: crate::orchestration::types::TaskIdentity::new(3, None),
+                    session_id: None,
+                },
                 origin: ApprovalOrigin::ConfigGate {
                     matched_pattern: "kubectl_*".to_string(),
                     agent_name: "test-agent".to_string(),
@@ -416,7 +465,8 @@ mod tests {
 
     /// A pending call whose approval is gone from the store is a mismatch
     /// (the 2.6 mismatch row names a missing approval); one still parked but
-    /// undecided is a mismatch in time and expired past the window.
+    /// undecided is the parked row inside the window and the expired row
+    /// past it.
     #[tokio::test]
     async fn missing_approval_is_mismatch_and_undecided_follows_the_window() {
         let (registry, _dir) = file_store();
@@ -445,10 +495,12 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(
-            err.to_string().contains("no recorded decision"),
-            "got: {err}"
-        );
+        match err {
+            RehydrateError::Parked { outstanding, .. } => {
+                assert_eq!(outstanding, vec![undecided]);
+            }
+            other => panic!("expected Parked with the outstanding id, got: {other}"),
+        }
 
         // The same undecided call past the document's expiry is the expired
         // row.

--- a/crates/aura/src/orchestration/park/continuation.rs
+++ b/crates/aura/src/orchestration/park/continuation.rs
@@ -1,0 +1,600 @@
+//! The continuation surfaces: the checkpointed worker conversation a resume
+//! drives, the per-run resuming-document handle, and the typed rehydrate
+//! errors.
+//!
+//! Distinct-owner note (P44 frontier finding): [`ResumingDocumentHandle`] is
+//! the park-module's per-run handle for appending tombstones to a resuming
+//! document. It is **not** the endpoint-owned claim table (P45), which tracks
+//! which endpoint holds a run's resume; the two surfaces stay separate on
+//! purpose.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rig::completion::Message;
+
+use crate::hitl::{DecisionId, PendingApprovals};
+use crate::orchestration::park::document::{ParkedRun, RESUMING_DOCUMENT_SUFFIX, load_parked_run};
+use crate::orchestration::park::recorded_decisions::{CallKey, RecordedDecisions};
+use crate::orchestration::persistence::is_safe_path_component;
+use crate::orchestration::types::PendingCall;
+
+/// One parked task's continuation payload: the recorded attempt, the
+/// conversation captured when the worker parked, and the calls awaiting a
+/// decision in recorded order. Built by the resume path from a checkpoint
+/// document (and so carries the restored coordinator-facing state's
+/// worker-side half).
+#[derive(Debug, Clone)]
+pub(crate) struct TaskContinuation {
+    /// The worker attempt that blocked; the resume rebuilds the worker for
+    /// the same attempt number.
+    pub attempt: usize,
+    /// Everything before the final worker turn.
+    pub history: Vec<Message>,
+    /// The final worker turn's aggregated tool-result prompt, still carrying
+    /// one sentinel per parked call id.
+    pub current_prompt: Message,
+    /// The parked calls, in the order the continuation invokes them.
+    pub pending: Vec<PendingCall>,
+}
+
+/// Everything the continuation arm needs besides the checkpoint itself: the
+/// run's recorded decisions (behind the `Arc` the gate already holds) and the
+/// resuming document every tombstone appends through.
+#[derive(Clone)]
+pub(crate) struct ResumeContext {
+    pub recorded: Arc<RecordedDecisions>,
+    pub document: Arc<ResumingDocumentHandle>,
+}
+
+/// Why a run could not rehydrate, mapped to the section 2.6 condition rows.
+#[allow(dead_code)] // P45 resume endpoint consumes the rehydrate entry points
+#[derive(Debug)]
+pub(crate) enum RehydrateError {
+    /// Condition row "not found": no checkpoint document exists for the run.
+    NotFound,
+    /// Condition row "expired": a pending call has no recorded decision and
+    /// the run is past `expires_at`. A run whose decisions were all recorded
+    /// in time resumes after expiry — the window bounds the decision, not
+    /// the resumer.
+    Expired,
+    /// Condition row "mismatch": the store and the document disagree — the
+    /// stored approval is missing, its recorded call differs from the
+    /// document's, or a call the resume needs has no recorded decision.
+    Mismatch(String),
+    /// Condition row "config_changed": the fingerprint no longer matches the
+    /// rebuilt configuration. Checked by the resume endpoint against a
+    /// header-resolved config entry point (P45 adoption).
+    ConfigChanged,
+    /// Condition row carried as a store fault: the approval store failed
+    /// mid-read.
+    Store(String),
+    /// Condition row carried as a document fault: the document could not be
+    /// read or decoded.
+    Document(String),
+}
+
+impl std::fmt::Display for RehydrateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "no checkpoint document for the run"),
+            Self::Expired => write!(f, "the run's decision window has expired"),
+            Self::Mismatch(detail) => write!(f, "resume mismatch: {detail}"),
+            Self::ConfigChanged => write!(f, "configuration changed since the run parked"),
+            Self::Store(detail) => write!(f, "approval store read failed: {detail}"),
+            Self::Document(detail) => write!(f, "checkpoint document read failed: {detail}"),
+        }
+    }
+}
+
+/// The per-run mutex over a resuming document plus its append-and-publish
+/// API. `open` loads the published parked document; every
+/// [`Self::append_executed_and_publish`] serializes the mutated document to a
+/// temp file and renames it over `{run_id}.resuming.json`, holding the
+/// per-run lock across clone-mutate-write so concurrent sibling continuations
+/// in one wave cannot lose each other's entries.
+///
+/// This is the park-module handle, distinct from P45's endpoint-owned claim
+/// table (see the module docs).
+#[derive(Debug)]
+pub(crate) struct ResumingDocumentHandle {
+    document: tokio::sync::Mutex<ParkedRun>,
+    /// The file appends publish to: `{parked_dir}/{run_id}.resuming.json`.
+    publish_path: PathBuf,
+}
+
+impl ResumingDocumentHandle {
+    /// Load the parked document at `path` and arm the handle. Appends publish
+    /// to the sibling `{run_id}.resuming.json`; the parked document itself is
+    /// left untouched.
+    #[allow(dead_code)] // P45 resume endpoint consumes the rehydrate entry points
+    pub(crate) async fn open(path: &Path) -> Result<Self, RehydrateError> {
+        let document = match load_parked_run(path).await {
+            Ok(document) => document,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(RehydrateError::NotFound);
+            }
+            Err(e) => return Err(RehydrateError::Document(e.to_string())),
+        };
+        let run_id = document.run_id.clone();
+        if !is_safe_path_component(&run_id) {
+            return Err(RehydrateError::Document(format!(
+                "invalid run id for parked document: {run_id:?}"
+            )));
+        }
+        let parked_dir = path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        let publish_path = parked_dir.join(format!("{run_id}{RESUMING_DOCUMENT_SUFFIX}"));
+        Ok(Self {
+            document: tokio::sync::Mutex::new(document),
+            publish_path,
+        })
+    }
+
+    /// Append one executed call id and publish the document: lock, push,
+    /// temp write, same-directory rename. The lock is held across the write,
+    /// so the published document is always the full executed set and no
+    /// sibling append can interleave.
+    pub(crate) async fn append_executed_and_publish(&self, call_id: &str) -> std::io::Result<()> {
+        let mut document = self.document.lock().await;
+        document.executed.push(call_id.to_string());
+        let bytes = serde_json::to_vec_pretty(&*document)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+        let publish_path = self.publish_path.clone();
+        let tmp = publish_path.with_file_name(format!(
+            ".{}.tmp",
+            publish_path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        ));
+        tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            std::fs::write(&tmp, &bytes)?;
+            std::fs::rename(&tmp, &publish_path)
+        })
+        .await
+        .map_err(std::io::Error::other)??;
+        Ok(())
+    }
+
+    /// The executed tombstones recorded so far.
+    #[cfg(test)]
+    pub(crate) async fn executed(&self) -> Vec<String> {
+        self.document.lock().await.executed.clone()
+    }
+
+    /// The publish path, for tests asserting the resuming document on disk.
+    #[cfg(test)]
+    pub(crate) fn publish_path(&self) -> &Path {
+        &self.publish_path
+    }
+}
+
+/// Read the run's recorded decisions out of the store, keyed the way the
+/// resume gate consumes them. For each awaiting node's pending call the
+/// stored approval (`try_parked`, the `items[0]` the human saw) and the
+/// recorded decision (`recorded_decision`) come from the **store**, never the
+/// document's copy — the store corrects the document at resume (the P43
+/// lenient-refresh ruling's backing condition). The document's recorded call
+/// must still match the stored approval, or the resume is a mismatch. The
+/// approval must be a park-retained one: park mode requires the file-backed
+/// store, whose `get` returns the approval before and after the decision.
+#[allow(dead_code)] // P45 resume endpoint consumes the rehydrate entry points
+pub(crate) async fn load_recorded_decisions(
+    store: &PendingApprovals,
+    doc: &ParkedRun,
+) -> Result<(Arc<RecordedDecisions>, Vec<DecisionId>), RehydrateError> {
+    let recorded = Arc::new(RecordedDecisions::default());
+    let mut decision_ids = Vec::new();
+    // The document's expiry stamp is the run's decision window the 2.6
+    // expired row is evaluated against.
+    let expires_at = chrono::DateTime::parse_from_rfc3339(&doc.expires_at)
+        .map_err(|e| RehydrateError::Document(format!("bad expiry stamp: {e}")))?
+        .with_timezone(&chrono::Utc);
+
+    for node in &doc.plan.tasks {
+        let crate::orchestration::types::TaskStatus::AwaitingApproval = node.status else {
+            continue;
+        };
+        let Some(pending) = &node.pending else {
+            continue;
+        };
+        for call in pending {
+            let parked = store
+                .try_parked(&call.decision_id)
+                .await
+                .map_err(|e| RehydrateError::Store(e.to_string()))?;
+            let Some(parked) = parked else {
+                return Err(RehydrateError::Mismatch(format!(
+                    "store approval {} is missing",
+                    call.decision_id
+                )));
+            };
+            // The approval is single-item by construction (one parked call
+            // raises one request); items[0] is the call the human decided on.
+            let Some(item) = parked.request.items.first() else {
+                return Err(RehydrateError::Mismatch(format!(
+                    "approval {} carries no approval item",
+                    call.decision_id
+                )));
+            };
+            if item.tool_name != call.tool_name || item.arguments != call.arguments {
+                return Err(RehydrateError::Mismatch(format!(
+                    "documented call {}({}) does not match the stored approval",
+                    call.tool_name, call.decision_id
+                )));
+            }
+            let Some(decision) = store.recorded_decision(&call.decision_id).await else {
+                // No decision yet: expired past the window, still parked
+                // otherwise — both fail the all-decided resume.
+                if chrono::Utc::now() > expires_at {
+                    return Err(RehydrateError::Expired);
+                }
+                return Err(RehydrateError::Mismatch(format!(
+                    "approval {} has no recorded decision",
+                    call.decision_id
+                )));
+            };
+            // The key's task id comes from the awaiting node, the tool name
+            // and arguments from the store's approval record.
+            recorded.push(
+                CallKey::new(node.task_id, &item.tool_name, &item.arguments),
+                decision,
+            );
+            decision_ids.push(call.decision_id);
+        }
+    }
+
+    Ok((recorded, decision_ids))
+}
+
+/// Replace the sentinel tool result for `call_id` in `current_prompt` with
+/// `wire` — the result text as the loop delivers it to the model (rig
+/// JSON-serializes tool outputs, so a plain string arrives JSON-quoted).
+/// Returns whether an entry was replaced; the continuation fails the resume
+/// when none was, so no sentinel can survive into the resumed conversation.
+pub(crate) fn replace_tool_result(current_prompt: &mut Message, call_id: &str, wire: &str) -> bool {
+    let Message::User { content } = current_prompt else {
+        return false;
+    };
+    let mut replaced = false;
+    for item in content.iter_mut() {
+        if let rig::message::UserContent::ToolResult(tr) = item
+            && tr.id == call_id
+        {
+            tr.content =
+                rig::OneOrMany::one(rig::message::ToolResultContent::text(wire.to_string()));
+            replaced = true;
+        }
+    }
+    replaced
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hitl::{
+        AgentScope, ApprovalDecision, ApprovalItem, ApprovalOrigin, ApprovalRequest,
+        PROTOCOL_VERSION, ParkedApproval,
+    };
+    use crate::orchestration::park::document::{ParkedPlan, ParkedTaskNode, SCHEMA_VERSION};
+    use crate::orchestration::types::TaskStatus;
+
+    fn parked_run(pending: Vec<PendingCall>) -> ParkedRun {
+        ParkedRun {
+            schema_version: SCHEMA_VERSION,
+            session_id: Some("sess".to_string()),
+            run_id: "0191e8c0-aaaa-7000-8000-00000000c0de".to_string(),
+            parked_at: "2026-09-02T14:00:00+00:00".to_string(),
+            expires_at: (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339(),
+            query: "Deploy".to_string(),
+            chat_history: vec![],
+            coordinator_conversation: vec![],
+            routing_decision: None,
+            iteration: 1,
+            planning_ms: 0,
+            failure_history: vec![],
+            plan: ParkedPlan {
+                goal: "Deploy".to_string(),
+                steps: None,
+                tasks: vec![ParkedTaskNode {
+                    task_id: 3,
+                    description: "Gated apply".to_string(),
+                    dependencies: vec![],
+                    worker: Some("operations".to_string()),
+                    rationale: String::new(),
+                    status: TaskStatus::AwaitingApproval,
+                    result: None,
+                    error: None,
+                    failure_category: None,
+                    attempt: Some(1),
+                    history: None,
+                    current_prompt: None,
+                    pending: Some(pending),
+                }],
+            },
+            executed: vec![],
+            config_fingerprint: "f".to_string(),
+        }
+    }
+
+    fn pending_call(decision_id: DecisionId, args: serde_json::Value) -> PendingCall {
+        PendingCall {
+            decision_id,
+            tool_name: "kubectl_apply".to_string(),
+            arguments: args,
+            call_id: "call_1".to_string(),
+        }
+    }
+
+    fn approval(decision_id: DecisionId, args: serde_json::Value) -> ParkedApproval {
+        ParkedApproval {
+            request: ApprovalRequest {
+                version: PROTOCOL_VERSION,
+                instance_id: "test-instance".to_string(),
+                decision_id,
+                request_id: "run:test".to_string(),
+                scope: AgentScope::Single { session_id: None },
+                origin: ApprovalOrigin::ConfigGate {
+                    matched_pattern: "kubectl_*".to_string(),
+                    agent_name: "test-agent".to_string(),
+                },
+                items: vec![ApprovalItem {
+                    tool_name: "kubectl_apply".to_string(),
+                    arguments: args,
+                    tool_call_intent: None,
+                }],
+            },
+            registered_at: chrono::Utc::now(),
+            expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+        }
+    }
+
+    fn file_store() -> (PendingApprovals, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = crate::session_store::FileApprovalStore::open(dir.path()).unwrap();
+        (
+            PendingApprovals::with_backend(
+                Arc::new(store),
+                Arc::new(crate::session_store::InMemoryEventBus::new()),
+            ),
+            dir,
+        )
+    }
+
+    /// Entries are built from the store's approval record: a hit with the
+    /// store's tool name/arguments consumes at the gate, the decision
+    /// survives the resolve (the file backend moves the approval into the
+    /// decision record), and the returned ids carry every consumed id.
+    #[tokio::test]
+    async fn load_builds_entries_from_the_store_not_the_document() {
+        let (registry, _dir) = file_store();
+        let decision_id = DecisionId::generate();
+        let args = serde_json::json!({ "namespace": "prod" });
+        registry
+            .register_durable(approval(decision_id, args.clone()))
+            .await
+            .unwrap();
+        registry
+            .resolve(&decision_id, ApprovalDecision::Approved)
+            .await
+            .unwrap();
+
+        // The document's copy disagrees on the arguments: the mismatch row
+        // refuses the divergence before any entry is built.
+        let mismatched = parked_run(vec![pending_call(
+            decision_id,
+            serde_json::json!({ "namespace": "stage" }),
+        )]);
+        let err = load_recorded_decisions(&registry, &mismatched)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not match the stored approval"),
+            "got: {err}"
+        );
+
+        // The matching shape: the entry consumes at the resume gate.
+        let doc = parked_run(vec![pending_call(decision_id, args.clone())]);
+        let (recorded, ids) = load_recorded_decisions(&registry, &doc).await.unwrap();
+        assert_eq!(ids, vec![decision_id]);
+        assert_eq!(
+            recorded.take(&CallKey::new(3, "kubectl_apply", &args)),
+            Some(ApprovalDecision::Approved),
+            "the recorded decision is consumable at the resume gate"
+        );
+        assert!(
+            recorded
+                .take(&CallKey::new(3, "kubectl_apply", &args))
+                .is_none()
+        );
+    }
+
+    /// A pending call whose approval is gone from the store is a mismatch
+    /// (the 2.6 mismatch row names a missing approval); one still parked but
+    /// undecided is a mismatch in time and expired past the window.
+    #[tokio::test]
+    async fn missing_approval_is_mismatch_and_undecided_follows_the_window() {
+        let (registry, _dir) = file_store();
+        let vanished = DecisionId::generate();
+        let undecided = DecisionId::generate();
+        let args = serde_json::json!({});
+        registry
+            .register_durable(approval(undecided, args.clone()))
+            .await
+            .unwrap();
+
+        let err = load_recorded_decisions(
+            &registry,
+            &parked_run(vec![pending_call(vanished, args.clone())]),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("store approval") && err.to_string().contains("missing"),
+            "got: {err}"
+        );
+
+        let err = load_recorded_decisions(
+            &registry,
+            &parked_run(vec![pending_call(undecided, args.clone())]),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("no recorded decision"),
+            "got: {err}"
+        );
+
+        // The same undecided call past the document's expiry is the expired
+        // row.
+        let mut doc = parked_run(vec![pending_call(undecided, args)]);
+        doc.expires_at = (chrono::Utc::now() - chrono::Duration::seconds(1)).to_rfc3339();
+        let err = load_recorded_decisions(&registry, &doc).await.unwrap_err();
+        assert!(err.to_string().contains("expired"), "got: {err}");
+    }
+
+    /// Decision-during-refresh correction: the document's pending set still
+    /// says undecided, but the store holds the decision —
+    /// `load_recorded_decisions` returns it (the store corrects the document
+    /// at resume, the P43 lenient-refresh ruling's backing condition).
+    #[tokio::test]
+    async fn store_decision_corrects_a_document_left_pending() {
+        let (registry, _dir) = file_store();
+        let decision_id = DecisionId::generate();
+        let args = serde_json::json!({ "namespace": "prod" });
+        registry
+            .register_durable(approval(decision_id, args.clone()))
+            .await
+            .unwrap();
+        // The decision lands after the document was committed.
+        registry
+            .resolve(&decision_id, ApprovalDecision::Approved)
+            .await
+            .unwrap();
+
+        let doc = parked_run(vec![pending_call(decision_id, args.clone())]);
+        let (recorded, ids) = load_recorded_decisions(&registry, &doc).await.unwrap();
+        assert_eq!(ids, vec![decision_id]);
+        assert_eq!(
+            recorded.take(&CallKey::new(3, "kubectl_apply", &args)),
+            Some(ApprovalDecision::Approved)
+        );
+    }
+
+    /// The sentinel replacement: matching call ids swap in the wire result;
+    /// an absent call id reports false so the continuation fails instead of
+    /// shipping a sentinel back to the model.
+    #[test]
+    fn replace_tool_result_swaps_only_the_matching_call() {
+        let mut prompt = Message::User {
+            content: rig::OneOrMany::many(vec![
+                rig::message::UserContent::Text(rig::message::Text {
+                    text: "context".to_string(),
+                }),
+                rig::message::UserContent::ToolResult(rig::message::ToolResult {
+                    id: "call_a".to_string(),
+                    call_id: None,
+                    content: rig::OneOrMany::one(rig::message::ToolResultContent::text("sentinel")),
+                }),
+                rig::message::UserContent::ToolResult(rig::message::ToolResult {
+                    id: "call_b".to_string(),
+                    call_id: None,
+                    content: rig::OneOrMany::one(rig::message::ToolResultContent::text("sentinel")),
+                }),
+            ])
+            .unwrap(),
+        };
+
+        assert!(replace_tool_result(&mut prompt, "call_a", "\"applied\""));
+        let Message::User { content } = &prompt else {
+            unreachable!()
+        };
+        for item in content.iter() {
+            let rig::message::UserContent::ToolResult(tr) = item else {
+                continue;
+            };
+            let text = tr
+                .content
+                .iter()
+                .map(|c| match c {
+                    rig::message::ToolResultContent::Text(t) => t.text.clone(),
+                    rig::message::ToolResultContent::Image(_) => "[image]".to_string(),
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            if tr.id == "call_a" {
+                assert_eq!(text, "\"applied\"");
+            } else {
+                assert_eq!(text, "sentinel", "siblings are untouched");
+            }
+        }
+
+        assert!(
+            !replace_tool_result(&mut prompt, "call_missing", "\"x\""),
+            "an unknown call id must not silently succeed"
+        );
+    }
+
+    /// Two concurrent appends serialize through the per-run lock: both
+    /// entries land, the published document carries the full executed set,
+    /// and no temp residue is left.
+    #[tokio::test]
+    async fn concurrent_appends_serialize_through_the_per_run_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let parked_path = dir.path().join("0191e8c0-aaaa-7000-8000-00000000c0de.json");
+        std::fs::write(
+            &parked_path,
+            serde_json::to_vec(&parked_run(vec![])).unwrap(),
+        )
+        .unwrap();
+
+        let handle = Arc::new(ResumingDocumentHandle::open(&parked_path).await.unwrap());
+        let h1 = Arc::clone(&handle);
+        let h2 = Arc::clone(&handle);
+        let (a, b) = tokio::join!(
+            h1.append_executed_and_publish("call_a"),
+            h2.append_executed_and_publish("call_b")
+        );
+        a.unwrap();
+        b.unwrap();
+
+        let mut executed = handle.executed().await;
+        executed.sort();
+        assert_eq!(executed, vec!["call_a".to_string(), "call_b".to_string()]);
+
+        let published: ParkedRun =
+            serde_json::from_str(&std::fs::read_to_string(handle.publish_path()).unwrap()).unwrap();
+        assert_eq!(published.executed.len(), 2, "no lost sibling entries");
+        assert_eq!(
+            handle.publish_path().file_name().unwrap().to_string_lossy(),
+            format!("0191e8c0-aaaa-7000-8000-00000000c0de{RESUMING_DOCUMENT_SUFFIX}")
+        );
+        assert!(
+            parked_path.try_exists().unwrap(),
+            "the parked document is untouched"
+        );
+        let residue = dir
+            .path()
+            .read_dir()
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().ends_with(".tmp"));
+        assert!(!residue, "no temp file residue");
+    }
+
+    /// A missing document opens as NotFound — the section 2.6 "not found"
+    /// row.
+    #[tokio::test]
+    async fn open_reports_not_found_for_a_missing_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = ResumingDocumentHandle::open(&dir.path().join("absent.json"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RehydrateError::NotFound));
+    }
+}

--- a/crates/aura/src/orchestration/park/document.rs
+++ b/crates/aura/src/orchestration/park/document.rs
@@ -8,7 +8,6 @@
 //! ever be read back from the approval store, never copied into a document.
 
 use std::io;
-#[cfg(test)]
 use std::path::Path;
 
 use rig::completion::Message;
@@ -222,8 +221,9 @@ pub(crate) fn build_document(
 }
 
 /// Load a checkpoint document from `path`, rejecting unknown schema
-/// versions. The read runs on the blocking pool.
-#[cfg(test)]
+/// versions. The read runs on the blocking pool. Used by the park commit's
+/// tests and by the resume path's [`super::continuation::ResumingDocumentHandle::open`].
+#[allow(dead_code)] // P45 resume endpoint consumes the rehydrate entry points
 pub(crate) async fn load_parked_run(path: &Path) -> io::Result<ParkedRun> {
     let display = path.display().to_string();
     let path = path.to_path_buf();

--- a/crates/aura/src/orchestration/park/mod.rs
+++ b/crates/aura/src/orchestration/park/mod.rs
@@ -4,12 +4,14 @@
 mod commit;
 mod document;
 mod guard;
+mod recorded_decisions;
 
 pub(crate) use commit::{ParkCommitInputs, cancel_run_approvals, commit_from_run_state};
 #[cfg(test)]
 pub(crate) use document::load_parked_run;
 pub(crate) use document::{PARKED_DOCUMENT_SUFFIX, RESUMING_DOCUMENT_SUFFIX, RunStateForPark};
 pub(crate) use guard::ParkGuard;
+pub(crate) use recorded_decisions::{CallKey, RecordedDecisions};
 
 use std::collections::HashMap;
 

--- a/crates/aura/src/orchestration/park/mod.rs
+++ b/crates/aura/src/orchestration/park/mod.rs
@@ -1,15 +1,24 @@
-//! The park checkpoint (park mode): the document, the commit, and the
-//! run-scoped guard.
+//! The park checkpoint (park mode): the document, the commit, the
+//! run-scoped guard, and the resume-side continuation surfaces.
 
 mod commit;
+mod continuation;
 mod document;
 mod guard;
 mod recorded_decisions;
 
 pub(crate) use commit::{ParkCommitInputs, cancel_run_approvals, commit_from_run_state};
-#[cfg(test)]
-pub(crate) use document::load_parked_run;
-pub(crate) use document::{PARKED_DOCUMENT_SUFFIX, RESUMING_DOCUMENT_SUFFIX, RunStateForPark};
+// The rehydrate entry points: consumed by commit 3's tests; the P45 resume
+// endpoint consumes them in production.
+#[allow(unused_imports)]
+pub(crate) use continuation::{
+    RehydrateError, ResumeContext, ResumingDocumentHandle, TaskContinuation,
+    load_recorded_decisions, replace_tool_result,
+};
+#[allow(unused_imports)]
+pub(crate) use document::{
+    PARKED_DOCUMENT_SUFFIX, ParkedRun, RESUMING_DOCUMENT_SUFFIX, RunStateForPark, load_parked_run,
+};
 pub(crate) use guard::ParkGuard;
 pub(crate) use recorded_decisions::{CallKey, RecordedDecisions};
 

--- a/crates/aura/src/orchestration/park/recorded_decisions.rs
+++ b/crates/aura/src/orchestration/park/recorded_decisions.rs
@@ -1,0 +1,291 @@
+//! The recorded-decisions set: decisions already recorded for a run's parked
+//! calls, consumed at most once each at the resume gate.
+//!
+//! Vocabulary bounding line: the approval *request* is raised by the park arm;
+//! the *decision* recorded against it is what this set holds. "Ticket" is
+//! retired vocabulary (DECISIONS-2026-09-03 item 2).
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::hitl::ApprovalDecision;
+
+/// Decisions already recorded for this run's parked calls, consumed at most
+/// once each. `strict_tasks` holds the task ids whose continuation is
+/// mid-invocation: a miss for one of those tasks is a resume fault, not a
+/// fresh park. Per task, because sibling continuations run concurrently in
+/// one wave. It lives here, behind the `Arc` the gate already holds, because
+/// `pre_call` runs in a spawned task (the `pre_handle` spawn in the tool
+/// wrapper) and a task-local would not cross that boundary. The continuation
+/// drives `set_strict` through a drop guard so every exit path (error, panic,
+/// mismatch) clears the task's entry.
+#[derive(Default)]
+pub(crate) struct RecordedDecisions {
+    entries: Mutex<HashMap<CallKey, VecDeque<ApprovalDecision>>>,
+    strict_tasks: Mutex<HashSet<usize>>,
+}
+
+impl RecordedDecisions {
+    /// Record a decision for a key, appending to that key's recorded-order
+    /// queue so two same-turn calls with identical arguments keep their own
+    /// decisions. Wired by the orchestrator continuation (P44 commit 3).
+    #[allow(dead_code)]
+    pub(crate) fn push(&self, key: CallKey, decision: ApprovalDecision) {
+        self.entries
+            .lock()
+            .expect("recorded-decisions lock")
+            .entry(key)
+            .or_default()
+            .push_back(decision);
+    }
+
+    /// Mark a task's continuation as in-flight (`on = true`) or clear it. A
+    /// miss for a strict task is a resume fault; a miss otherwise re-parks.
+    #[allow(dead_code)]
+    pub(crate) fn set_strict(&self, task_id: usize, on: bool) {
+        let mut strict = self.strict_tasks.lock().expect("recorded-decisions lock");
+        if on {
+            strict.insert(task_id);
+        } else {
+            strict.remove(&task_id);
+        }
+    }
+
+    /// Whether a task's continuation is in-flight, and so a recorded-decisions
+    /// miss must fail closed rather than re-park.
+    pub(crate) fn is_strict(&self, task_id: usize) -> bool {
+        self.strict_tasks
+            .lock()
+            .expect("recorded-decisions lock")
+            .contains(&task_id)
+    }
+
+    /// Consume one decision for a key in recorded order; the next call returns
+    /// the following decision, and an empty queue returns `None`.
+    pub(crate) fn take(&self, key: &CallKey) -> Option<ApprovalDecision> {
+        self.entries
+            .lock()
+            .expect("recorded-decisions lock")
+            .get_mut(key)
+            .and_then(VecDeque::pop_front)
+    }
+
+    /// Arm a drop guard that holds `task_id` strict until the guard is
+    /// dropped, then clears it. Holds a clone of the `Arc` so the clear runs
+    /// on every exit path (normal return, `?`-early-return, error, and panic
+    /// unwind) regardless of the recorder's own lifetime. Wired by the
+    /// orchestrator continuation (P44 commit 3).
+    #[allow(dead_code)]
+    pub(crate) fn strict_guard(self: &Arc<Self>, task_id: usize) -> StrictGuard {
+        self.set_strict(task_id, true);
+        StrictGuard {
+            recorded: Arc::clone(self),
+            task_id,
+        }
+    }
+}
+
+/// Key for a recorded decision: the task the call belongs to, the tool name,
+/// and a digest of the canonical arguments. `serde_json` in this workspace is
+/// built without `preserve_order`, so `Value::to_string` is BTreeMap-ordered
+/// and canonical; a test pins that. The separator byte (`0x00`) keeps the tool
+/// name and the arguments from aliasing across names that end where another
+/// begins.
+#[derive(Hash, PartialEq, Eq)]
+pub(crate) struct CallKey {
+    task_id: usize,
+    tool_name: String,
+    args_digest: [u8; 32],
+}
+
+impl CallKey {
+    /// Build a key from the task id, the tool name, and a digest of
+    /// `tool_name || 0x00 || canonical_json(args)`.
+    pub(crate) fn new(task_id: usize, tool_name: &str, args: &Value) -> Self {
+        let mut h = Sha256::new();
+        h.update(tool_name.as_bytes());
+        h.update([0u8]);
+        h.update(args.to_string().as_bytes());
+        Self {
+            task_id,
+            tool_name: tool_name.to_owned(),
+            args_digest: h.finalize().into(),
+        }
+    }
+}
+
+/// RAII guard for a task's strict entry: clears the task from
+/// `strict_tasks` on drop, so a leaked strict entry can never silently
+/// convert a model-issued re-park into a resume fault. Constructed via
+/// [`RecordedDecisions::strict_guard`]. Wired by the orchestrator
+/// continuation (P44 commit 3).
+#[allow(dead_code)]
+pub(crate) struct StrictGuard {
+    recorded: Arc<RecordedDecisions>,
+    task_id: usize,
+}
+
+impl Drop for StrictGuard {
+    fn drop(&mut self) {
+        self.recorded.set_strict(self.task_id, false);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use super::*;
+
+    fn key(task_id: usize, tool_name: &str, args: &Value) -> CallKey {
+        CallKey::new(task_id, tool_name, args)
+    }
+
+    /// Two same-key decisions consume in recorded order; a third take is
+    /// `None` (the queue is per-key and exhausted by consumption).
+    #[test]
+    fn take_consumes_per_key_queue_in_recorded_order() {
+        let recorded = RecordedDecisions::default();
+        let args = serde_json::json!({"namespace": "prod"});
+
+        recorded.push(key(1, "kubectl_apply", &args), ApprovalDecision::Approved);
+        recorded.push(
+            key(1, "kubectl_apply", &args),
+            ApprovalDecision::Denied {
+                reason: Some("too risky".to_string()),
+            },
+        );
+
+        let probe = key(1, "kubectl_apply", &args);
+        assert_eq!(
+            recorded.take(&probe),
+            Some(ApprovalDecision::Approved),
+            "first take returns the first recorded decision",
+        );
+        assert_eq!(
+            recorded
+                .take(&probe)
+                .map(|d| matches!(d, ApprovalDecision::Denied { .. })),
+            Some(true),
+            "second take returns the second recorded decision, in order",
+        );
+        assert!(
+            recorded.take(&probe).is_none(),
+            "third take exhausts the queue"
+        );
+    }
+
+    /// `set_strict` toggles membership; `is_strict` reports it verbatim.
+    #[test]
+    fn strict_set_toggles_membership() {
+        let recorded = RecordedDecisions::default();
+        assert!(!recorded.is_strict(1));
+        recorded.set_strict(1, true);
+        assert!(recorded.is_strict(1), "set_strict(true) enters the task");
+        assert!(
+            !recorded.is_strict(2),
+            "a sibling task is unaffected by another's strict entry",
+        );
+        recorded.set_strict(1, false);
+        assert!(!recorded.is_strict(1), "set_strict(false) clears the task");
+    }
+
+    /// The drop guard clears the task's strict entry on a normal drop, so a
+    /// scope exit (early return, error, end of block) cannot leak the entry.
+    #[test]
+    fn strict_guard_clears_on_normal_drop() {
+        let recorded = std::sync::Arc::new(RecordedDecisions::default());
+        {
+            let _guard = recorded.strict_guard(1);
+            assert!(recorded.is_strict(1), "guard arms the strict entry");
+        }
+        assert!(
+            !recorded.is_strict(1),
+            "guard's drop clears the entry after the scope ends",
+        );
+    }
+
+    /// An early return out of a scope that holds the guard still drops the
+    /// guard, so the strict entry is cleared.
+    #[test]
+    fn strict_guard_clears_on_early_return() {
+        let recorded = std::sync::Arc::new(RecordedDecisions::default());
+
+        fn drive(recorded: &std::sync::Arc<RecordedDecisions>) -> Result<(), &'static str> {
+            let _guard = recorded.strict_guard(1);
+            // An early-return path the continuation might take on a non-fatal
+            // error: the guard drops here, not at the end of the function.
+            Err("simulated non-fatal error")
+        }
+
+        assert!(drive(&recorded).is_err());
+        assert!(
+            !recorded.is_strict(1),
+            "an early return drops the guard and clears strict",
+        );
+    }
+
+    /// A panic unwinds through the guard's scope, so its `Drop` runs and
+    /// clears the strict entry; the recorder is left consistent.
+    #[test]
+    fn strict_guard_clears_on_panic_unwind() {
+        let recorded = std::sync::Arc::new(RecordedDecisions::default());
+        let guard = recorded.strict_guard(1);
+        assert!(recorded.is_strict(1));
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _held = guard;
+            panic!("simulated continuation fault");
+        }));
+        assert!(result.is_err(), "the panic must be caught");
+        assert!(
+            !recorded.is_strict(1),
+            "the guard's drop must clear strict even when unwinding",
+        );
+    }
+
+    /// The same arguments in different insertion order digests to the same
+    /// key: `serde_json` without `preserve_order` serializes `Value::Object`
+    /// BTreeMap-ordered, so `to_string` is canonical. A test pins that.
+    #[test]
+    fn digest_is_stable_across_argument_key_order() {
+        let a = key(1, "kubectl_apply", &serde_json::json!({"a": 1, "b": 2}));
+        let b = key(1, "kubectl_apply", &serde_json::json!({"b": 2, "a": 1}));
+        assert_eq!(
+            a.args_digest, b.args_digest,
+            "canonical json: key order must not affect the digest",
+        );
+        assert!(a == b, "the whole key compares equal when the digest does");
+    }
+
+    /// Different arguments produce different digests, so two distinct calls
+    /// do not collide on the same key.
+    #[test]
+    fn different_arguments_digest_differ() {
+        let a = key(
+            1,
+            "kubectl_apply",
+            &serde_json::json!({"namespace": "prod"}),
+        );
+        let b = key(
+            1,
+            "kubectl_apply",
+            &serde_json::json!({"namespace": "stage"}),
+        );
+        assert_ne!(a.args_digest, b.args_digest);
+        assert!(a != b);
+    }
+
+    /// Different tool names produce different digests even for the same
+    /// arguments: the name is part of the hashed bytes.
+    #[test]
+    fn different_tool_names_digest_differ() {
+        let args = serde_json::json!({"namespace": "prod"});
+        let a = key(1, "kubectl_apply", &args);
+        let b = key(1, "kubectl_delete", &args);
+        assert!(a != b);
+    }
+}

--- a/crates/aura/src/orchestration/park/recorded_decisions.rs
+++ b/crates/aura/src/orchestration/park/recorded_decisions.rs
@@ -22,7 +22,7 @@ use crate::hitl::ApprovalDecision;
 /// wrapper) and a task-local would not cross that boundary. The continuation
 /// drives `set_strict` through a drop guard so every exit path (error, panic,
 /// mismatch) clears the task's entry.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct RecordedDecisions {
     entries: Mutex<HashMap<CallKey, VecDeque<ApprovalDecision>>>,
     strict_tasks: Mutex<HashSet<usize>>,
@@ -94,7 +94,7 @@ impl RecordedDecisions {
 /// and canonical; a test pins that. The separator byte (`0x00`) keeps the tool
 /// name and the arguments from aliasing across names that end where another
 /// begins.
-#[derive(Hash, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq)]
 pub(crate) struct CallKey {
     task_id: usize,
     tool_name: String,

--- a/crates/aura/src/orchestration/test_rig.rs
+++ b/crates/aura/src/orchestration/test_rig.rs
@@ -1,0 +1,774 @@
+//! Stubbed-model test rig for park/reify (P44, commit 2). Test-only: a
+//! scripted [`rig::completion::CompletionModel`], a recording stub tool, and
+//! the harness that drives them through the same worker-stream shape
+//! production uses.
+//!
+//! # Contract (the verified seam)
+//!
+//! - Turn boundaries are deterministic: the streaming hook's
+//!   `on_completion_call` fires before *every* model turn, and tools execute
+//!   sequentially within a turn (rig fork, the streaming multi-turn loop).
+//!   One [`ScriptedTurn`] is one model turn: `stream()` pops the next turn and
+//!   delivers it as a `StreamingCompletionResponse`, so turn *n* of the loop
+//!   always sees scripted turn *n*, and turn *n+1* always sees turn *n*'s
+//!   tool results in its request history.
+//! - A gated call's lifecycle, when commit 3 wires it, is: the park arm
+//!   raises the approval request, the recorded decision rules the resume
+//!   consult. Bounding-line vocabulary (DECISIONS-2026-09-03 item 2):
+//!   approvals **request**, decisions **rule**; "ticket" is retired.
+//!
+//! # Fidelity boundary
+//!
+//! [`drive_worker`] runs the exact shape
+//! [`crate::orchestration::orchestrator::Orchestrator::stream_and_forward`]
+//! reaches for a park-mode worker — `stream_chat` + the park-aware
+//! [`crate::streaming_request_hook::StreamingRequestHook`] + the rig tool
+//! server (`tool_server_handle.call_tool`) — over the scripted model. It does
+//! **not** reach `execute_task`: `create_worker` →
+//! `build_worker_provider_agent` builds the model from `LlmConfig` with no
+//! injection seam, so a scripted model cannot enter the worker path without a
+//! production change (reported to the board owner for commit 3). The
+//! orchestrator fixture below therefore assembles the park-mode scaffolding
+//! only; execute_task-level tests live in the orchestrator's own test module.
+
+use std::collections::VecDeque;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use futures::StreamExt;
+use rig::agent::MultiTurnStreamItem;
+use rig::completion::{
+    CompletionError, CompletionModel, CompletionRequest, CompletionResponse, GetTokenUsage, Usage,
+};
+use rig::message::{AssistantContent, ToolCall, ToolFunction};
+use rig::streaming::{
+    RawStreamingChoice, RawStreamingToolCall, StreamedUserContent, StreamingChat,
+    StreamingCompletionResponse,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{Notify, watch};
+
+use crate::streaming_request_hook::{StreamingRequestHook, UsageState};
+
+/// The stub tool's registered name: innocuous by construction, matching no
+/// `require_approval` glob, so the smoke run exercises zero park machinery.
+pub(crate) const ECHO_TOOL_NAME: &str = "echo_tool";
+
+/// Result text the stub tool returns for every invocation.
+pub(crate) const ECHO_TOOL_RESULT: &str = "applied successfully";
+
+/// The stub tool's result as the loop delivers it back to the model: rig
+/// JSON-serializes tool outputs, so a plain string arrives quoted. What the
+/// gate's sentinel replacement and denial feedback must produce to be
+/// indistinguishable from a live chain result.
+pub(crate) fn echo_tool_result_wire() -> String {
+    serde_json::to_string(ECHO_TOOL_RESULT).expect("a plain string serializes")
+}
+
+// ============================================================================
+// Scripted model
+// ============================================================================
+
+/// One model turn: the full assistant response the loop consumes before the
+/// next turn boundary. `text` streams as `Message` chunks (before any tool
+/// calls, mirroring real providers); `tool_calls` stream as complete
+/// `ToolCall` chunks and are executed sequentially by the loop in script
+/// order.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ScriptedTurn {
+    text: Option<String>,
+    tool_calls: Vec<ScriptedToolCall>,
+}
+
+impl ScriptedTurn {
+    /// A turn that answers with final text (the loop terminates on it).
+    pub(crate) fn text(text: impl Into<String>) -> Self {
+        Self {
+            text: Some(text.into()),
+            tool_calls: Vec::new(),
+        }
+    }
+
+    /// A turn that issues tool calls (the loop executes them and starts the
+    /// next turn).
+    pub(crate) fn tool_calls(calls: Vec<ScriptedToolCall>) -> Self {
+        Self {
+            text: None,
+            tool_calls: calls,
+        }
+    }
+
+    /// Attach text alongside this turn's tool calls.
+    #[allow(dead_code)] // commit 3: text+tool-call turns in continuation scripts
+    pub(crate) fn with_text(mut self, text: impl Into<String>) -> Self {
+        self.text = Some(text.into());
+        self
+    }
+}
+
+/// One scripted tool call, delivered as a complete `RawStreamingToolCall`.
+#[derive(Clone, Debug)]
+pub(crate) struct ScriptedToolCall {
+    id: String,
+    call_id: Option<String>,
+    name: String,
+    arguments: serde_json::Value,
+}
+
+impl ScriptedToolCall {
+    /// A tool call with the rig-assigned `id` the loop keys tool results by.
+    pub(crate) fn new(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        arguments: serde_json::Value,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            call_id: None,
+            name: name.into(),
+            arguments,
+        }
+    }
+
+    /// Set the provider-side `call_id` (what the park gate records on a
+    /// pending call and what the continuation's sentinel replacement keys on).
+    pub(crate) fn with_call_id(mut self, call_id: impl Into<String>) -> Self {
+        self.call_id = Some(call_id.into());
+        self
+    }
+}
+
+/// The streaming response payload the scripted model reports per turn.
+/// Fixed figures keep usage assertions deterministic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ScriptedFinalResponse;
+
+impl GetTokenUsage for ScriptedFinalResponse {
+    fn token_usage(&self) -> Option<Usage> {
+        Some(Usage {
+            input_tokens: 10,
+            output_tokens: 5,
+            total_tokens: 15,
+        })
+    }
+}
+
+/// A completion model playing a fixed script of turns. Each `stream()` (or
+/// `completion()`) call serves the next [`ScriptedTurn`]; every served
+/// request is recorded for turn-boundary assertions. An exhausted script is a
+/// provider error — the deterministic stand-in for a provider stream failure.
+#[derive(Clone, Default)]
+pub(crate) struct ScriptedCompletionModel {
+    script: Arc<Mutex<VecDeque<ScriptedTurn>>>,
+    requests: Arc<Mutex<Vec<CompletionRequest>>>,
+}
+
+impl ScriptedCompletionModel {
+    pub(crate) fn new(turns: Vec<ScriptedTurn>) -> Self {
+        Self {
+            script: Arc::new(Mutex::new(VecDeque::from(turns))),
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Every request the loop built, in turn order. `len()` is the number of
+    /// turns the hook's `on_completion_call` fronted.
+    pub(crate) fn requests(&self) -> Arc<Mutex<Vec<CompletionRequest>>> {
+        Arc::clone(&self.requests)
+    }
+
+    fn record_and_take(&self, request: CompletionRequest) -> Result<ScriptedTurn, CompletionError> {
+        self.requests
+            .lock()
+            .expect("scripted-model request log")
+            .push(request);
+        self.script
+            .lock()
+            .expect("scripted-model script")
+            .pop_front()
+            .ok_or_else(|| {
+                CompletionError::ProviderError(
+                    "scripted model: script exhausted before the loop finished".to_string(),
+                )
+            })
+    }
+
+    fn turn_stream(turn: &ScriptedTurn) -> StreamingCompletionResponse<ScriptedFinalResponse> {
+        let mut items =
+            Vec::<Result<RawStreamingChoice<ScriptedFinalResponse>, CompletionError>>::new();
+        if let Some(text) = &turn.text {
+            items.push(Ok(RawStreamingChoice::Message(text.clone())));
+        }
+        for call in &turn.tool_calls {
+            items.push(Ok(RawStreamingChoice::ToolCall(RawStreamingToolCall {
+                id: call.id.clone(),
+                call_id: call.call_id.clone(),
+                name: call.name.clone(),
+                arguments: call.arguments.clone(),
+                signature: None,
+                additional_params: None,
+            })));
+        }
+        items.push(Ok(RawStreamingChoice::FinalResponse(ScriptedFinalResponse)));
+        StreamingCompletionResponse::stream(Box::pin(futures::stream::iter(items)))
+    }
+
+    fn turn_choice(turn: &ScriptedTurn) -> rig::OneOrMany<AssistantContent> {
+        let mut choice = Vec::<AssistantContent>::new();
+        if let Some(text) = &turn.text {
+            choice.push(AssistantContent::text(text));
+        }
+        for call in &turn.tool_calls {
+            choice.push(AssistantContent::ToolCall(ToolCall {
+                id: call.id.clone(),
+                call_id: call.call_id.clone(),
+                function: ToolFunction {
+                    name: call.name.clone(),
+                    arguments: call.arguments.clone(),
+                },
+                signature: None,
+                additional_params: None,
+            }));
+        }
+        if choice.is_empty() {
+            choice.push(AssistantContent::text(""));
+        }
+        rig::OneOrMany::many(choice).expect("scripted turn always yields one content item")
+    }
+}
+
+impl CompletionModel for ScriptedCompletionModel {
+    type Response = ();
+    type StreamingResponse = ScriptedFinalResponse;
+    type Client = ();
+
+    fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+        Self::default()
+    }
+
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        let turn = self.record_and_take(request)?;
+        Ok(CompletionResponse {
+            choice: Self::turn_choice(&turn),
+            usage: Usage::new(),
+            raw_response: (),
+        })
+    }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        let turn = self.record_and_take(request)?;
+        Ok(Self::turn_stream(&turn))
+    }
+}
+
+// ============================================================================
+// Stub tool
+// ============================================================================
+
+/// One recorded invocation of the stub tool. The rig's `call_id` correlation
+/// lives in [`StreamRun::tool_results`] — rig's `Tool::call` receives only the
+/// arguments, so the tool itself cannot observe the call id.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ToolInvocation {
+    pub(crate) arguments: serde_json::Value,
+    pub(crate) result: String,
+}
+
+/// Permissive argument shape: any JSON object round-trips, so scripts can
+/// carry arbitrary tool payloads (e.g. a `kubectl_apply`-shaped call) without
+/// a schema per test.
+#[derive(Debug, Deserialize)]
+pub(crate) struct FreeformArgs {
+    #[serde(flatten)]
+    pub(crate) fields: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Holds one stub-tool invocation open until [`StallHook::release`], for the
+/// commit-3 race tests that need a mid-invocation observation point. Inert
+/// unless the tool was built `with_stall`.
+#[derive(Clone, Default)]
+pub(crate) struct StallHook {
+    inner: Arc<StallInner>,
+}
+
+#[derive(Default)]
+struct StallInner {
+    /// Fired when an invocation has been recorded and is about to hold.
+    entered: Notify,
+    /// Flipped before waking every waiter; the flag makes the release
+    /// idempotent and races on it impossible.
+    released: AtomicBool,
+    release: Notify,
+}
+
+impl StallHook {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolves once an invocation is recorded and holding. Permits fired
+    /// before the waiter registers are honored (`Notify` stores one).
+    pub(crate) async fn wait_entered(&self) {
+        self.inner.entered.notified().await;
+    }
+
+    /// Let the held invocation return.
+    pub(crate) fn release(&self) {
+        self.inner.released.store(true, Ordering::Release);
+        self.inner.release.notify_waiters();
+    }
+}
+
+/// The stub tool: records every invocation (arguments, returned result) into
+/// a shared log the test keeps a handle to, and returns a fixed result
+/// string. Implements the same `rig::tool::Tool` shape the orchestration
+/// tools (`submit_result`, `read_artifact`, …) register through.
+pub(crate) struct RecordingTool {
+    result: String,
+    invocations: Arc<Mutex<Vec<ToolInvocation>>>,
+    stall: Option<StallHook>,
+}
+
+impl RecordingTool {
+    pub(crate) fn new(invocations: Arc<Mutex<Vec<ToolInvocation>>>) -> Self {
+        Self {
+            result: ECHO_TOOL_RESULT.to_string(),
+            invocations,
+            stall: None,
+        }
+    }
+
+    /// Arm the stall hook: invocations record, then hold until
+    /// [`StallHook::release`]. Opt-in — the default tool never holds.
+    pub(crate) fn with_stall(mut self, stall: StallHook) -> Self {
+        self.stall = Some(stall);
+        self
+    }
+}
+
+impl rig::tool::Tool for RecordingTool {
+    const NAME: &'static str = ECHO_TOOL_NAME;
+
+    type Error = std::convert::Infallible;
+    type Args = FreeformArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> rig::completion::ToolDefinition {
+        rig::completion::ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Test stand-in: records the call and echoes a fixed result.".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {},
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let arguments = serde_json::Value::Object(args.fields);
+        self.invocations
+            .lock()
+            .expect("tool invocation log")
+            .push(ToolInvocation {
+                arguments: arguments.clone(),
+                result: self.result.clone(),
+            });
+
+        if let Some(stall) = &self.stall {
+            stall.inner.entered.notify_one();
+            if !stall.inner.released.load(Ordering::Acquire) {
+                let notified = stall.inner.release.notified();
+                // Re-check after registering the waiter so a release racing
+                // this await cannot be missed.
+                if !stall.inner.released.load(Ordering::Acquire) {
+                    notified.await;
+                }
+            }
+        }
+
+        Ok(self.result.clone())
+    }
+}
+
+// ============================================================================
+// Worker harness
+// ============================================================================
+
+/// A worker rig: the scripted-model agent with the stub tool registered on
+/// the rig tool server, plus the shared handles tests assert through.
+pub(crate) struct WorkerRig {
+    pub(crate) agent: rig::agent::Agent<ScriptedCompletionModel>,
+    pub(crate) model: ScriptedCompletionModel,
+    pub(crate) invocations: Arc<Mutex<Vec<ToolInvocation>>>,
+    /// Handle to the tool's stall hook; only live when built via
+    /// [`worker_rig_with_stall`]. Commit 3's race tests drive it.
+    #[allow(dead_code)] // commit 3: mid-invocation race tests
+    pub(crate) stall: StallHook,
+}
+
+/// Assemble a worker rig from a script of turns. The stub tool never stalls.
+pub(crate) fn worker_rig(turns: Vec<ScriptedTurn>) -> WorkerRig {
+    worker_rig_inner(turns, false)
+}
+
+/// A worker rig whose stub tool holds every invocation open until
+/// [`StallHook::release`]. The rig's `stall` handle shares the hook the
+/// tool holds; tests synchronize on it instead of sleeping.
+#[allow(dead_code)] // commit 3: race tests
+pub(crate) fn worker_rig_with_stall(turns: Vec<ScriptedTurn>) -> WorkerRig {
+    worker_rig_inner(turns, true)
+}
+
+fn worker_rig_inner(turns: Vec<ScriptedTurn>, stalled: bool) -> WorkerRig {
+    let model = ScriptedCompletionModel::new(turns);
+    let invocations = Arc::new(Mutex::new(Vec::new()));
+    let stall = StallHook::new();
+    let mut tool = RecordingTool::new(invocations.clone());
+    if stalled {
+        tool = tool.with_stall(stall.clone());
+    }
+    let agent = rig::agent::AgentBuilder::new(model.clone())
+        .name("rig-worker")
+        .preamble("test worker preamble")
+        .tool(tool)
+        .build();
+    WorkerRig {
+        agent,
+        model,
+        invocations,
+        stall,
+    }
+}
+
+/// One tool execution as the loop reported it, with the call-id correlation
+/// the tool itself cannot see.
+#[derive(Clone, Debug)]
+pub(crate) struct ToolResultRecord {
+    pub(crate) id: String,
+    pub(crate) call_id: Option<String>,
+    pub(crate) result: String,
+}
+
+/// Outcome of one [`drive_worker`] run: the worker-stream equivalent of a
+/// task execution. Reaching [`MultiTurnStreamItem::FinalResponse`] is the
+/// loop's completion signal; its text is what survives into the task result
+/// upstream.
+pub(crate) struct StreamRun {
+    pub(crate) final_text: Option<String>,
+    /// The loop's aggregated usage (`FinalResponse.usage`).
+    pub(crate) usage: Usage,
+    pub(crate) tool_results: Vec<ToolResultRecord>,
+    /// External cancellation handle (the hook's watch channel), for the
+    /// commit-3 race tests.
+    #[allow(dead_code)] // commit 3: race tests cancel mid-stream
+    pub(crate) cancel_tx: watch::Sender<bool>,
+    /// The park-aware hook's usage state, asserting hook compatibility.
+    pub(crate) usage_state: UsageState,
+}
+
+impl std::fmt::Debug for StreamRun {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamRun")
+            .field("final_text", &self.final_text)
+            .field("usage", &self.usage)
+            .field("tool_results", &self.tool_results)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Drive one worker stream the way `stream_and_forward` drives a park-mode
+/// worker: `stream_chat` with the park-aware `StreamingRequestHook` attached,
+/// full multi-turn depth. The hook is inert here — no blocked cell is
+/// registered under the stream's request id.
+pub(crate) async fn drive_worker(
+    rig: &WorkerRig,
+    prompt: &str,
+    history: Vec<rig::completion::Message>,
+    max_depth: usize,
+) -> Result<StreamRun, Box<dyn std::error::Error + Send + Sync>> {
+    let request_id = format!("rig_{}", uuid::Uuid::new_v4().simple());
+    let (hook, cancel_tx, usage_state) =
+        StreamingRequestHook::with_scratchpad_budget(Duration::from_secs(60), request_id, None);
+
+    let mut stream = rig
+        .agent
+        .stream_chat(prompt, history)
+        .with_hook(hook)
+        .multi_turn(max_depth)
+        .await;
+
+    let mut run = StreamRun {
+        final_text: None,
+        usage: Usage::new(),
+        tool_results: Vec::new(),
+        cancel_tx,
+        usage_state,
+    };
+
+    while let Some(item) = stream.next().await {
+        match item.map_err(Box::<dyn std::error::Error + Send + Sync>::from)? {
+            MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult(tr)) => {
+                run.tool_results.push(ToolResultRecord {
+                    id: tr.id,
+                    call_id: tr.call_id,
+                    result: tool_result_text(&tr.content),
+                });
+            }
+            MultiTurnStreamItem::FinalResponse(final_response) => {
+                run.final_text = Some(final_response.response().to_string());
+                run.usage = final_response.usage();
+            }
+            _ => {}
+        }
+    }
+
+    Ok(run)
+}
+
+fn tool_result_text(content: &rig::OneOrMany<rig::message::ToolResultContent>) -> String {
+    content
+        .iter()
+        .map(|c| match c {
+            rig::message::ToolResultContent::Text(text) => text.text.clone(),
+            rig::message::ToolResultContent::Image(_) => "[Image content]".to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// ============================================================================
+// Orchestrator fixture (commit 3 scaffolding)
+// ============================================================================
+
+/// A worker definition wired for the rig: no MCP tools (`mcp_filter = []`),
+/// default depth, no overrides. Returns `(name, config)` for insertion into
+/// [`OrchestrationConfig::workers`].
+#[allow(dead_code)] // commit 3: execute_task-level tests
+pub(crate) fn worker_definition(
+    name: &str,
+    description: &str,
+    preamble: &str,
+) -> (String, super::WorkerConfig) {
+    (
+        name.to_string(),
+        super::WorkerConfig {
+            description: description.to_string(),
+            preamble: preamble.to_string(),
+            mcp_filter: Some(vec![]),
+            vector_stores: vec![],
+            turn_depth: None,
+            llm: None,
+            scratchpad: None,
+            skills: None,
+        },
+    )
+}
+
+/// A park-mode orchestrator over an in-memory approval store, persisted under
+/// `memory_dir` — the construction pattern the orchestrator's own park tests
+/// use, minus the run id (that lives behind the orchestrator's private
+/// persistence handle, readable only from the orchestrator's own test
+/// module). Commit 3's rehydrate/continuation fixtures start here.
+#[allow(dead_code)] // commit 3: rehydrate/continuation fixtures
+pub(crate) async fn park_orchestrator_in(
+    memory_dir: &Path,
+) -> (
+    super::Orchestrator,
+    Arc<crate::session_store::InMemoryApprovalStore>,
+    crate::hitl::PendingApprovals,
+) {
+    use crate::hitl::PendingApprovals;
+    use crate::session_store::InMemoryEventBus;
+
+    let store = Arc::new(crate::session_store::InMemoryApprovalStore::new());
+    let registry = PendingApprovals::with_backend(store.clone(), Arc::new(InMemoryEventBus::new()));
+    let (worker_name, worker) = worker_definition(
+        "operations",
+        "Runs the scripted tool",
+        "You apply changes with the echo tool.",
+    );
+    let mut workers = std::collections::HashMap::new();
+    workers.insert(worker_name, worker);
+    let config = crate::config::AgentRuntimeConfig {
+        hitl: Some(crate::hitl::HitlRuntime {
+            patterns: Arc::from([aura_config::GlobPattern::new("kubectl_*").unwrap()]),
+            route: Arc::new(crate::hitl::DecisionRoute::Conversational {
+                registry: registry.clone(),
+                timeout: Duration::from_secs(3600),
+            }),
+            park_enabled: true,
+        }),
+        memory_dir: Some(memory_dir.to_string_lossy().into_owned()),
+        session_id: Some("park-sess".to_string()),
+        request_id: Some(format!("req_rig_{}", uuid::Uuid::new_v4().simple())),
+        orchestration: Some(super::OrchestrationConfig {
+            enabled: true,
+            workers,
+            ..Default::default()
+        }),
+        ..crate::config::AgentRuntimeConfig::default()
+    };
+    let orchestrator = super::Orchestrator::new(config)
+        .await
+        .expect("orchestrator builds");
+    (orchestrator, store, registry)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// The consuming smoke test (P44 pull addendum 2026-09-03): the rig is never
+/// dead infrastructure, and Gate A gets its fidelity baseline. One worker,
+/// one ungated tool, zero park machinery: turn 1 emits the tool call, turn 2
+/// (seeing the tool result) emits the final text. Asserts the tool ran
+/// exactly once with the scripted arguments, the loop completed, and the
+/// final result text survived.
+#[tokio::test]
+async fn smoke_scripted_worker_ungated_tool_round_trip() {
+    let rig = worker_rig(vec![
+        ScriptedTurn::tool_calls(vec![
+            ScriptedToolCall::new(
+                "call_0",
+                ECHO_TOOL_NAME,
+                serde_json::json!({"namespace": "prod"}),
+            )
+            .with_call_id("call_id_0"),
+        ]),
+        ScriptedTurn::text("applied the manifest to prod"),
+    ]);
+
+    let run = drive_worker(&rig, "apply the manifest", Vec::new(), 4)
+        .await
+        .expect("the scripted worker stream completes");
+
+    // The tool ran exactly once, with the scripted arguments, and returned
+    // the scripted result.
+    let invocations = rig.invocations.lock().expect("tool invocation log");
+    assert_eq!(invocations.len(), 1, "exactly one tool invocation");
+    assert_eq!(
+        invocations[0].arguments,
+        serde_json::json!({"namespace": "prod"})
+    );
+    assert_eq!(invocations[0].result, ECHO_TOOL_RESULT);
+    drop(invocations);
+
+    // Turn boundaries are deterministic: the hook fronted exactly two model
+    // turns, and the second turn's request carries the tool result — the
+    // model saw what the tool returned before answering.
+    let request_log = rig.model.requests();
+    let requests = request_log.lock().expect("request log");
+    assert_eq!(requests.len(), 2, "one request per scripted turn");
+    let second_turn_saw_result = requests[1].chat_history.iter().any(|m| {
+        serde_json::to_string(m)
+            .expect("message serializes")
+            .contains(ECHO_TOOL_RESULT)
+    });
+    assert!(
+        second_turn_saw_result,
+        "turn 2 must see the tool result text in its prompt/history"
+    );
+    drop(requests);
+
+    // Call-id correlation survives the loop.
+    assert_eq!(run.tool_results.len(), 1, "one tool result round trip");
+    assert_eq!(run.tool_results[0].id, "call_0");
+    assert_eq!(run.tool_results[0].call_id.as_deref(), Some("call_id_0"));
+    assert_eq!(run.tool_results[0].result, echo_tool_result_wire());
+
+    // The task completed: the loop reached FinalResponse, and the final
+    // result text is the turn-2 answer.
+    assert_eq!(
+        run.final_text.as_deref(),
+        Some("applied the manifest to prod")
+    );
+
+    // Loop aggregation sums both turns' fixed usage.
+    assert_eq!(run.usage.input_tokens, 20);
+    assert_eq!(run.usage.output_tokens, 10);
+
+    // The park-aware hook fired (compatibility) and captured the final text
+    // turn's usage — inert otherwise: no blocked cell was registered, so the
+    // stream ran to completion instead of parking.
+    assert_eq!(run.usage_state.get_final_usage(), (10, 5, 15));
+}
+
+/// The provider-error trigger commit 3's dual-trigger orphan coverage needs:
+/// an exhausted script surfaces as a provider stream error through the hook
+/// after the tools it served have already run.
+#[tokio::test]
+async fn script_exhaustion_surfaces_as_a_provider_stream_error() {
+    let rig = worker_rig(vec![
+        ScriptedTurn::tool_calls(vec![ScriptedToolCall::new(
+            "call_0",
+            ECHO_TOOL_NAME,
+            serde_json::json!({"attempt": 1}),
+        )]),
+        ScriptedTurn::tool_calls(vec![ScriptedToolCall::new(
+            "call_1",
+            ECHO_TOOL_NAME,
+            serde_json::json!({"attempt": 2}),
+        )]),
+    ]);
+
+    let error = drive_worker(&rig, "keep applying", Vec::new(), 4)
+        .await
+        .expect_err("an exhausted script fails the stream");
+
+    assert!(
+        error.to_string().contains("script exhausted"),
+        "the provider error must be the script-exhaustion one, got: {error}"
+    );
+    let invocations = rig.invocations.lock().expect("tool invocation log");
+    assert_eq!(invocations.len(), 2, "both scripted tool calls executed");
+}
+
+/// The stall hook: a held invocation is observable (recorded, stream
+/// suspended) and releasable, with no sleeps — the race tests synchronize on
+/// the hook's notifications alone.
+#[tokio::test]
+async fn stall_hook_holds_and_releases_a_tool_invocation() {
+    let rig = worker_rig_with_stall(vec![
+        ScriptedTurn::tool_calls(vec![ScriptedToolCall::new(
+            "call_0",
+            ECHO_TOOL_NAME,
+            serde_json::json!({"namespace": "staging"}),
+        )]),
+        ScriptedTurn::text("released and finished"),
+    ]);
+
+    let invocations = rig.invocations.clone();
+    let stall = rig.stall.clone();
+    let drive =
+        tokio::spawn(async move { drive_worker(&rig, "hold the apply", Vec::new(), 4).await });
+
+    // The invocation records and holds before the next turn starts.
+    tokio::time::timeout(Duration::from_secs(5), stall.wait_entered())
+        .await
+        .expect("the tool invocation registers itself while held");
+    assert_eq!(
+        invocations.lock().expect("tool invocation log").len(),
+        1,
+        "the invocation is recorded while the call is held open"
+    );
+
+    stall.release();
+    let run = tokio::time::timeout(Duration::from_secs(5), drive)
+        .await
+        .expect("the stream finishes after release")
+        .expect("drive task joins")
+        .expect("the stream completes after release");
+
+    assert_eq!(run.final_text.as_deref(), Some("released and finished"));
+    assert_eq!(run.tool_results.len(), 1);
+    assert_eq!(run.tool_results[0].result, echo_tool_result_wire());
+}

--- a/crates/aura/src/orchestration/test_rig.rs
+++ b/crates/aura/src/orchestration/test_rig.rs
@@ -23,18 +23,18 @@
 //! [`crate::orchestration::orchestrator::Orchestrator::stream_and_forward`]
 //! reaches for a park-mode worker — `stream_chat` + the park-aware
 //! [`crate::streaming_request_hook::StreamingRequestHook`] + the rig tool
-//! server (`tool_server_handle.call_tool`) — over the scripted model. It does
-//! **not** reach `execute_task`: `create_worker` →
-//! `build_worker_provider_agent` builds the model from `LlmConfig` with no
-//! injection seam, so a scripted model cannot enter the worker path without a
-//! production change (reported to the board owner for commit 3). The
-//! orchestrator fixture below therefore assembles the park-mode scaffolding
-//! only; execute_task-level tests live in the orchestrator's own test module.
+//! server (`tool_server_handle.call_tool`) — over the scripted model. Full
+//! `execute_task` runs go through the worker-model injection seam
+//! ([`install_worker_overrides`]): the orchestrator's cfg(test) prelude in
+//! `build_worker_provider_agent` builds the worker from a queued override's
+//! scripted model and registers its tools through the worker's own wrapper
+//! chain, so execute_task-level tests drive the production path unmodified.
 
 use std::collections::VecDeque;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -81,6 +81,11 @@ pub(crate) fn echo_tool_result_wire() -> String {
 pub(crate) struct ScriptedTurn {
     text: Option<String>,
     tool_calls: Vec<ScriptedToolCall>,
+    /// Fail the provider stream after this turn's tool calls ran, instead of
+    /// completing the turn. The pinned loop yields the error and ends the
+    /// stream without another `on_completion_call`, which is the
+    /// provider-error orphan window.
+    stream_failed: bool,
 }
 
 impl ScriptedTurn {
@@ -89,6 +94,7 @@ impl ScriptedTurn {
         Self {
             text: Some(text.into()),
             tool_calls: Vec::new(),
+            stream_failed: false,
         }
     }
 
@@ -98,11 +104,24 @@ impl ScriptedTurn {
         Self {
             text: None,
             tool_calls: calls,
+            stream_failed: false,
+        }
+    }
+
+    /// A turn that issues tool calls and then fails the provider stream
+    /// mid-turn, before the loop's next `on_completion_call` can fire — the
+    /// deterministic stand-in for a provider stream error after tools have
+    /// run (the pinned loop's mid-turn error break).
+    pub(crate) fn tool_calls_then_stream_failure(calls: Vec<ScriptedToolCall>) -> Self {
+        Self {
+            text: None,
+            tool_calls: calls,
+            stream_failed: true,
         }
     }
 
     /// Attach text alongside this turn's tool calls.
-    #[allow(dead_code)] // commit 3: text+tool-call turns in continuation scripts
+    #[allow(dead_code)] // reserved: text+tool-call turn scripts, not yet consumed
     pub(crate) fn with_text(mut self, text: impl Into<String>) -> Self {
         self.text = Some(text.into());
         self
@@ -212,7 +231,13 @@ impl ScriptedCompletionModel {
                 additional_params: None,
             })));
         }
-        items.push(Ok(RawStreamingChoice::FinalResponse(ScriptedFinalResponse)));
+        if turn.stream_failed {
+            items.push(Err(CompletionError::ProviderError(
+                "scripted model: provider stream failed mid-turn".to_string(),
+            )));
+        } else {
+            items.push(Ok(RawStreamingChoice::FinalResponse(ScriptedFinalResponse)));
+        }
         StreamingCompletionResponse::stream(Box::pin(futures::stream::iter(items)))
     }
 
@@ -267,6 +292,93 @@ impl CompletionModel for ScriptedCompletionModel {
     ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
         let turn = self.record_and_take(request)?;
         Ok(Self::turn_stream(&turn))
+    }
+}
+
+// ============================================================================
+// Worker-model injection seam (commit 3)
+// ============================================================================
+
+/// A scripted rig agent — the concrete type the `#[cfg(test)]` variant of
+/// `ProviderAgent` wraps.
+pub(crate) type ScriptedAgent = rig::agent::Agent<ScriptedCompletionModel>;
+
+/// One queued worker-model override: the scripted model the next
+/// `build_worker_provider_agent` call builds the worker from, plus tools
+/// registered alongside it. The orchestrator's cfg(test) prelude wraps each
+/// extra tool in the worker's own wrapper chain (gate included) before
+/// registering it, so a scripted worker's tool calls are gated exactly like
+/// live ones.
+pub(crate) struct WorkerOverride {
+    pub(crate) model: ScriptedCompletionModel,
+    pub(crate) extra_tools: Vec<Box<dyn rig::tool::ToolDyn>>,
+}
+
+/// Take-once override queue: a test installs one override per worker build
+/// it will drive, in order.
+static WORKER_OVERRIDES: OnceLock<Mutex<VecDeque<WorkerOverride>>> = OnceLock::new();
+
+/// Queue worker-model overrides. FIFO: the *n*-th worker build after this
+/// call consumes the *n*-th override. Tests that use the seam must serialize
+/// against each other — the queue is process-global.
+pub(crate) fn install_worker_overrides(overrides: Vec<WorkerOverride>) {
+    let queue = WORKER_OVERRIDES.get_or_init(|| Mutex::new(VecDeque::new()));
+    queue
+        .lock()
+        .expect("worker-override lock")
+        .extend(overrides);
+}
+
+/// Pop the next override, if one is queued. Consumed by the orchestrator's
+/// cfg(test) prelude in `build_worker_provider_agent`.
+pub(crate) fn take_worker_override() -> Option<WorkerOverride> {
+    let queue = WORKER_OVERRIDES.get_or_init(|| Mutex::new(VecDeque::new()));
+    queue.lock().expect("worker-override lock").pop_front()
+}
+
+/// Adapter presenting a boxed dynamic tool as a concrete [`rig::tool::Tool`]
+/// with the `Value`/`String`/`ToolError` shape the worker wrapper chain
+/// wraps, so an override's tools re-enter the same `WrappedTool` path the
+/// MCP tools take. `Clone` over an `Arc` because `WrappedTool` requires it.
+#[derive(Clone)]
+pub(crate) struct DynToolAsTool(Arc<dyn rig::tool::ToolDyn>);
+
+impl DynToolAsTool {
+    pub(crate) fn new(tool: Box<dyn rig::tool::ToolDyn>) -> Self {
+        Self(Arc::from(tool))
+    }
+}
+
+impl rig::tool::Tool for DynToolAsTool {
+    const NAME: &'static str = "dyn_tool_as_tool";
+
+    type Error = rig::tool::ToolError;
+    type Args = serde_json::Value;
+    type Output = String;
+
+    fn name(&self) -> String {
+        rig::tool::ToolDyn::name(&*self.0)
+    }
+
+    async fn definition(&self, prompt: String) -> rig::completion::ToolDefinition {
+        // The boxed dyn future is only `Send`; `Shared` makes awaiting it
+        // satisfy the `Tool` trait's `Sync` future bound (the shared state is
+        // behind an `Arc` + mutex, so the wrapper future is `Sync`).
+        use futures::FutureExt as _;
+        self.0.definition(prompt).shared().await
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        // The inner ToolDyn result is already JSON-encoded (the blanket impl
+        // serializes the tool's output on the way out). Decode string outputs
+        // so the wrapper boundary's own serialization is the only one applied
+        // — byte-identical to a concrete `Tool` registration. Non-string
+        // outputs keep their encoded text.
+        let encoded = self.0.call(args.to_string()).await?;
+        match serde_json::from_str::<serde_json::Value>(&encoded) {
+            Ok(serde_json::Value::String(text)) => Ok(text),
+            _ => Ok(encoded),
+        }
     }
 }
 
@@ -336,6 +448,9 @@ pub(crate) struct RecordingTool {
     result: String,
     invocations: Arc<Mutex<Vec<ToolInvocation>>>,
     stall: Option<StallHook>,
+    /// The name the tool registers under. Defaults to [`ECHO_TOOL_NAME`];
+    /// renamed instances give scripts an ungated sibling tool.
+    registered_name: String,
 }
 
 impl RecordingTool {
@@ -344,7 +459,16 @@ impl RecordingTool {
             result: ECHO_TOOL_RESULT.to_string(),
             invocations,
             stall: None,
+            registered_name: ECHO_TOOL_NAME.to_string(),
         }
+    }
+
+    /// Register under a different name: the default name is what the park
+    /// tests' glob matches, so a depth-exhaustion script needs an ungated
+    /// sibling tool to burn turns with.
+    pub(crate) fn with_name(mut self, name: &str) -> Self {
+        self.registered_name = name.to_string();
+        self
     }
 
     /// Arm the stall hook: invocations record, then hold until
@@ -364,7 +488,7 @@ impl rig::tool::Tool for RecordingTool {
 
     async fn definition(&self, _prompt: String) -> rig::completion::ToolDefinition {
         rig::completion::ToolDefinition {
-            name: Self::NAME.to_string(),
+            name: self.name(),
             description: "Test stand-in: records the call and echoes a fixed result.".to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -410,8 +534,9 @@ pub(crate) struct WorkerRig {
     pub(crate) model: ScriptedCompletionModel,
     pub(crate) invocations: Arc<Mutex<Vec<ToolInvocation>>>,
     /// Handle to the tool's stall hook; only live when built via
-    /// [`worker_rig_with_stall`]. Commit 3's race tests drive it.
-    #[allow(dead_code)] // commit 3: mid-invocation race tests
+    /// [`worker_rig_with_stall`]. Reserved for race tests driving the
+    /// worker-stream level directly.
+    #[allow(dead_code)] // reserved: stall-driven race tests
     pub(crate) stall: StallHook,
 }
 
@@ -423,7 +548,7 @@ pub(crate) fn worker_rig(turns: Vec<ScriptedTurn>) -> WorkerRig {
 /// A worker rig whose stub tool holds every invocation open until
 /// [`StallHook::release`]. The rig's `stall` handle shares the hook the
 /// tool holds; tests synchronize on it instead of sleeping.
-#[allow(dead_code)] // commit 3: race tests
+#[allow(dead_code)] // reserved: stall-driven race tests
 pub(crate) fn worker_rig_with_stall(turns: Vec<ScriptedTurn>) -> WorkerRig {
     worker_rig_inner(turns, true)
 }
@@ -551,8 +676,10 @@ fn tool_result_text(content: &rig::OneOrMany<rig::message::ToolResultContent>) -
 
 /// A worker definition wired for the rig: no MCP tools (`mcp_filter = []`),
 /// default depth, no overrides. Returns `(name, config)` for insertion into
-/// [`OrchestrationConfig::workers`].
-#[allow(dead_code)] // commit 3: execute_task-level tests
+/// [`OrchestrationConfig::workers`]. The execute_task-level tests build their
+/// worker configs inline (they need a settable turn depth), so this stays
+/// reserved.
+#[allow(dead_code)] // reserved: rig-level worker definition fixture
 pub(crate) fn worker_definition(
     name: &str,
     description: &str,
@@ -577,8 +704,9 @@ pub(crate) fn worker_definition(
 /// `memory_dir` — the construction pattern the orchestrator's own park tests
 /// use, minus the run id (that lives behind the orchestrator's private
 /// persistence handle, readable only from the orchestrator's own test
-/// module). Commit 3's rehydrate/continuation fixtures start here.
-#[allow(dead_code)] // commit 3: rehydrate/continuation fixtures
+/// module). The execute_task-level fixtures live in that test module for the
+/// same reason, so this stays reserved.
+#[allow(dead_code)] // reserved: rig-level orchestrator fixture
 pub(crate) async fn park_orchestrator_in(
     memory_dir: &Path,
 ) -> (

--- a/crates/aura/src/provider_agent.rs
+++ b/crates/aura/src/provider_agent.rs
@@ -54,6 +54,12 @@ pub(crate) enum ProviderAgent {
     Gemini(GeminiAgent),
     Ollama(OllamaAgent),
     OpenRouter(OpenRouterAgent),
+    /// Scripted-model agent (test-only): the worker-model injection seam the
+    /// park/reify rig queues through `install_worker_overrides` and the
+    /// orchestrator's cfg(test) prelude consumes. Never constructed outside
+    /// `cfg(test)`.
+    #[cfg(test)]
+    Scripted(crate::orchestration::ScriptedAgent),
 }
 
 impl ProviderAgent {
@@ -66,6 +72,142 @@ impl ProviderAgent {
             Self::Gemini(_) => "gemini",
             Self::Ollama(_) => "ollama",
             Self::OpenRouter(_) => "openrouter",
+            #[cfg(test)]
+            Self::Scripted(_) => "scripted",
+        }
+    }
+
+    /// Invoke a registered tool by name through the agent's tool server —
+    /// the same dynamic-tool path the multi-turn loop uses, so the tool's
+    /// full wrapper chain (persistence, observer, HITL gate) runs. The
+    /// returned string is the tool output as the loop delivers it to the
+    /// model: rig JSON-serializes tool outputs, so a plain string arrives
+    /// JSON-quoted.
+    pub async fn call_tool(
+        &self,
+        tool_name: &str,
+        args: &str,
+    ) -> Result<String, rig::tool::server::ToolServerError> {
+        match self {
+            Self::OpenAI(agent) => agent.tool_server_handle.call_tool(tool_name, args).await,
+            Self::Anthropic(agent) => agent.tool_server_handle.call_tool(tool_name, args).await,
+            Self::Bedrock(agent) => agent.tool_server_handle.call_tool(tool_name, args).await,
+            Self::Gemini(agent) => agent.tool_server_handle.call_tool(tool_name, args).await,
+            Self::Ollama(agent) => agent.tool_server_handle.call_tool(tool_name, args).await,
+            Self::OpenRouter(agent) => agent.tool_server_handle.call_tool(tool_name, args).await,
+            #[cfg(test)]
+            Self::Scripted(agent) => agent.tool_server_handle.call_tool(tool_name, args).await,
+        }
+    }
+
+    /// Stream a chat whose prompt is a full message — the continuation
+    /// resume submits the checkpointed tool-result prompt, not a plain
+    /// string. Carries the park-aware hook like [`Self::stream_chat_with_timeout`].
+    #[allow(clippy::too_many_arguments)]
+    pub async fn stream_chat_message_with_timeout(
+        &self,
+        prompt: rig::completion::Message,
+        chat_history: Vec<rig::completion::Message>,
+        max_depth: usize,
+        timeout: Duration,
+        request_id: &str,
+        scratchpad_budget: Option<ContextBudget>,
+        client_tool_names: HashSet<String>,
+    ) -> (
+        Pin<Box<dyn futures::Stream<Item = Result<StreamItem, StreamError>> + Send>>,
+        watch::Sender<bool>,
+        crate::streaming_request_hook::UsageState,
+    ) {
+        let (hook, cancel_tx, usage_state) =
+            StreamingRequestHook::with_scratchpad_budget(timeout, request_id, scratchpad_budget);
+        let hook = hook.with_client_tool_names(client_tool_names);
+
+        match self {
+            Self::OpenAI(agent) => {
+                let stream = agent
+                    .stream_chat(prompt, chat_history)
+                    .with_hook(hook)
+                    .multi_turn(max_depth)
+                    .await;
+                (
+                    Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item)),
+                    cancel_tx,
+                    usage_state,
+                )
+            }
+            Self::Anthropic(agent) => {
+                let stream = agent
+                    .stream_chat(prompt, chat_history)
+                    .with_hook(hook)
+                    .multi_turn(max_depth)
+                    .await;
+                (
+                    Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item)),
+                    cancel_tx,
+                    usage_state,
+                )
+            }
+            Self::Bedrock(agent) => {
+                let stream = agent
+                    .stream_chat(prompt, chat_history)
+                    .with_hook(hook)
+                    .multi_turn(max_depth)
+                    .await;
+                (
+                    Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item)),
+                    cancel_tx,
+                    usage_state,
+                )
+            }
+            Self::Gemini(agent) => {
+                let stream = agent
+                    .stream_chat(prompt, chat_history)
+                    .with_hook(hook)
+                    .multi_turn(max_depth)
+                    .await;
+                (
+                    Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item)),
+                    cancel_tx,
+                    usage_state,
+                )
+            }
+            Self::Ollama(agent) => {
+                let stream = agent
+                    .stream_chat(prompt, chat_history)
+                    .with_hook(hook)
+                    .multi_turn(max_depth)
+                    .await;
+                (
+                    Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item)),
+                    cancel_tx,
+                    usage_state,
+                )
+            }
+            Self::OpenRouter(agent) => {
+                let stream = agent
+                    .stream_chat(prompt, chat_history)
+                    .with_hook(hook)
+                    .multi_turn(max_depth)
+                    .await;
+                (
+                    Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item)),
+                    cancel_tx,
+                    usage_state,
+                )
+            }
+            #[cfg(test)]
+            Self::Scripted(agent) => {
+                let stream = agent
+                    .stream_chat(prompt, chat_history)
+                    .with_hook(hook)
+                    .multi_turn(max_depth)
+                    .await;
+                (
+                    Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item)),
+                    cancel_tx,
+                    usage_state,
+                )
+            }
         }
     }
 
@@ -100,6 +242,11 @@ impl ProviderAgent {
                 Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item))
             }
             Self::OpenRouter(agent) => {
+                let stream = agent.stream_prompt(query).multi_turn(max_depth).await;
+                Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item))
+            }
+            #[cfg(test)]
+            Self::Scripted(agent) => {
                 let stream = agent.stream_prompt(query).multi_turn(max_depth).await;
                 Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item))
             }
@@ -150,6 +297,14 @@ impl ProviderAgent {
                 Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item))
             }
             Self::OpenRouter(agent) => {
+                let stream = agent
+                    .stream_chat(query, chat_history)
+                    .multi_turn(max_depth)
+                    .await;
+                Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item))
+            }
+            #[cfg(test)]
+            Self::Scripted(agent) => {
                 let stream = agent
                     .stream_chat(query, chat_history)
                     .multi_turn(max_depth)
@@ -255,6 +410,19 @@ impl ProviderAgent {
                     usage_state,
                 )
             }
+            #[cfg(test)]
+            Self::Scripted(agent) => {
+                let stream = agent
+                    .stream_prompt(query)
+                    .with_hook(hook)
+                    .multi_turn(max_depth)
+                    .await;
+                (
+                    Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item)),
+                    cancel_tx,
+                    usage_state,
+                )
+            }
         }
     }
 
@@ -345,6 +513,19 @@ impl ProviderAgent {
                 )
             }
             Self::OpenRouter(agent) => {
+                let stream = agent
+                    .stream_chat(query, chat_history)
+                    .with_hook(hook)
+                    .multi_turn(max_depth)
+                    .await;
+                (
+                    Box::pin(stream.map::<Result<StreamItem, StreamError>, _>(map_stream_item)),
+                    cancel_tx,
+                    usage_state,
+                )
+            }
+            #[cfg(test)]
+            Self::Scripted(agent) => {
                 let stream = agent
                     .stream_chat(query, chat_history)
                     .with_hook(hook)

--- a/crates/aura/src/session_store/file.rs
+++ b/crates/aura/src/session_store/file.rs
@@ -1,23 +1,23 @@
 //! File-backed HITL approval store: one JSON file per decision id.
-//! Tickets survive process restart on a single host.
+//! Parked approvals survive process restart on a single host.
 //!
 //! Layout:
 //!
 //! | Path                                 | Content                                                    |
 //! | ----------------------------------- | ---------------------------------------------------------- |
-//! | `{root}/tickets/{decision_id}.json`   | `ParkedApprovalRecord` (the undecided ticket)              |
-//! | `{root}/decisions/{decision_id}.json` | the resolved envelope: the ticket record plus the decision |
+//! | `{root}/approvals/{decision_id}.json` | `ParkedApprovalRecord` (the undecided approval)            |
+//! | `{root}/decisions/{decision_id}.json` | the resolved envelope: the approval record plus the decision |
 //!
 //! Store contract (park/reify §2.5):
 //!
-//! - `resolve` refuses past the ticket's `expires_at`, uniformly with an
+//! - `resolve` refuses past the approval's `expires_at`, uniformly with an
 //!   unknown id; expiry is enforced only by `resolve`.
-//! - `resolve` *moves* the ticket into the decision file rather than deleting
-//!   it: `get` returns the ticket before and after the decision, `decision`
+//! - `resolve` *moves* the approval into the decision file rather than deleting
+//!   it: `get` returns the approval before and after the decision, `decision`
 //!   returns the recorded decision, and both are retained until `remove`.
 //! - At-most-once `resolve` is the `File::create_new` claim on the decision
 //!   file: `AlreadyExists` reads as `NotFound`.
-//! - `cancel_request` removes undecided tickets by owner (request) id;
+//! - `cancel_request` removes undecided approvals by owner (request) id;
 //!   decided entries are retained until their consumer removes them.
 //!
 //! Decision ids are validated as UUIDs before path building, so none address
@@ -33,7 +33,7 @@
 //!
 //! Crash window: claim-then-write leaves an empty file if process dies
 //! mid-resolve. The aftermath fails closed; `decision` reports decode
-//! fault, `get` returns ticket. Recovery is deleting the empty file.
+//! fault, `get` returns the approval. Recovery is deleting the empty file.
 //! `decision()` consumers treat `Err(Decode)` on a known id as this
 //! recoverable state, not as an unknown id.
 
@@ -50,18 +50,18 @@ use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
 
 use super::{ApprovalStore, DecisionRecord, ParkedApprovalRecord, SessionStoreError};
 
-/// Undecided tickets, one `{decision_id}.json` file per ticket.
-const TICKETS_DIR: &str = "tickets";
+/// Undecided approvals, one `{decision_id}.json` file per approval.
+const APPROVALS_DIR: &str = "approvals";
 /// Recorded decisions, one `{decision_id}.json` file per decision.
 const DECISIONS_DIR: &str = "decisions";
 
-/// The on-disk shape of a resolved approval: the ticket record carried over
-/// from `tickets/` plus the recorded decision. Field names are a persisted
-/// contract shared by every instance reading the store — rename only with a
-/// migration.
+/// The on-disk shape of a resolved approval: the approval record carried
+/// over from `approvals/` plus the recorded decision. Field names are a
+/// persisted contract shared by every instance reading the store — rename
+/// only with a migration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct ResolvedEntry {
-    ticket: ParkedApprovalRecord,
+    approval: ParkedApprovalRecord,
     decision: DecisionRecord,
 }
 
@@ -82,7 +82,7 @@ impl FileApprovalStore {
     /// cannot hold files must fail at startup, not on the first approval.
     pub fn open(root: impl AsRef<Path>) -> Result<Self, SessionStoreError> {
         let root = root.as_ref();
-        fs::create_dir_all(root.join(TICKETS_DIR)).map_err(connect_err)?;
+        fs::create_dir_all(root.join(APPROVALS_DIR)).map_err(connect_err)?;
         fs::create_dir_all(root.join(DECISIONS_DIR)).map_err(connect_err)?;
         let inner = Arc::new(Inner {
             root: root.to_path_buf(),
@@ -102,16 +102,16 @@ impl FileApprovalStore {
 }
 
 impl Inner {
-    fn tickets_dir(&self) -> PathBuf {
-        self.root.join(TICKETS_DIR)
+    fn approvals_dir(&self) -> PathBuf {
+        self.root.join(APPROVALS_DIR)
     }
 
     fn decisions_dir(&self) -> PathBuf {
         self.root.join(DECISIONS_DIR)
     }
 
-    fn ticket_path(&self, id: &str) -> PathBuf {
-        self.tickets_dir().join(format!("{id}.json"))
+    fn approval_path(&self, id: &str) -> PathBuf {
+        self.approvals_dir().join(format!("{id}.json"))
     }
 
     fn decision_path(&self, id: &str) -> PathBuf {
@@ -125,7 +125,7 @@ impl Inner {
     /// Create and unlink an empty probe file in each store directory. This
     /// catches permission and mount faults, not a full disk.
     fn probe_writable_sync(&self) -> io::Result<()> {
-        for dir in [self.tickets_dir(), self.decisions_dir()] {
+        for dir in [self.approvals_dir(), self.decisions_dir()] {
             let probe = dir.join(format!(".{}.probe", uuid::Uuid::new_v4()));
             fs::write(&probe, b"")
                 .and_then(|()| fs::remove_file(&probe))
@@ -141,21 +141,21 @@ impl Inner {
         let id = canonical_id(&parked.request.decision_id)?;
         let payload = serde_json::to_vec(&ParkedApprovalRecord::from(&parked))
             .expect("approval record serializes to JSON");
-        publish(&self.ticket_path(&id), &payload)
+        publish(&self.approval_path(&id), &payload)
     }
 
     fn get_sync(&self, id: &DecisionId) -> Result<Option<ParkedApproval>, SessionStoreError> {
         let _guard = self.lock();
         let id = canonical_id(id)?;
-        match fs::read(self.ticket_path(&id)) {
-            Ok(bytes) => return decode_ticket(&bytes).map(Some),
+        match fs::read(self.approval_path(&id)) {
+            Ok(bytes) => return decode_approval(&bytes).map(Some),
             Err(err) if err.kind() == io::ErrorKind::NotFound => {}
             Err(err) => return Err(request_err(err)),
         }
         match fs::read(self.decision_path(&id)) {
             Ok(bytes) => {
                 let entry: ResolvedEntry = serde_json::from_slice(&bytes).map_err(decode_err)?;
-                restore_ticket(entry.ticket).map(Some)
+                restore_approval(entry.approval).map(Some)
             }
             Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
             Err(err) => Err(request_err(err)),
@@ -170,12 +170,12 @@ impl Inner {
         let _guard = self.lock();
         let id = canonical_id(id).map_err(ResolveError::Store)?;
 
-        // Read ticket before claiming avoids claiming unknown ids.
-        let record = match fs::read(self.ticket_path(&id)) {
+        // Reading the approval before claiming avoids claiming unknown ids.
+        let record = match fs::read(self.approval_path(&id)) {
             Ok(bytes) => serde_json::from_slice::<ParkedApprovalRecord>(&bytes)
                 .map_err(|e| ResolveError::Store(decode_err(e)))?,
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
-                // No ticket: unknown, resolved, or removed all return `NotFound`.
+                // No approval: unknown, resolved, or removed all return `NotFound`.
                 return Err(ResolveError::NotFound);
             }
             Err(err) => return Err(ResolveError::Store(request_err(err))),
@@ -184,7 +184,7 @@ impl Inner {
             return Err(ResolveError::NotFound);
         }
         let payload = serde_json::to_vec(&ResolvedEntry {
-            ticket: record,
+            approval: record,
             decision: DecisionRecord::from(&decision),
         })
         .expect("resolved entry serializes to JSON");
@@ -204,15 +204,15 @@ impl Inner {
             let _ = fs::remove_file(&decision_path);
             return Err(ResolveError::Store(request_err(err)));
         }
-        // After sync commit, ticket removal is best-effort. Failure leaves
-        // a stale ticket; resolve succeeded.
-        match fs::remove_file(self.ticket_path(&id)) {
+        // After sync commit, removing the approval file is best-effort.
+        // Failure leaves a stale approval file; resolve succeeded.
+        match fs::remove_file(self.approval_path(&id)) {
             Ok(()) => {}
             Err(err) if err.kind() == io::ErrorKind::NotFound => {}
             Err(err) => tracing::warn!(
                 decision_id = %id,
                 error = %err,
-                "stale ticket file remains after resolve; it is benign"
+                "stale approval file remains after resolve; it is benign"
             ),
         }
         Ok(())
@@ -238,7 +238,7 @@ impl Inner {
         let _guard = self.lock();
         let id = canonical_id(id)?;
         // Remove both halves; missing halves are fine (idempotent).
-        for path in [self.ticket_path(&id), self.decision_path(&id)] {
+        for path in [self.approval_path(&id), self.decision_path(&id)] {
             if let Err(err) = fs::remove_file(&path)
                 && err.kind() != io::ErrorKind::NotFound
             {
@@ -250,7 +250,7 @@ impl Inner {
 
     fn cancel_request_sync(&self, request_id: &str) -> Result<(), SessionStoreError> {
         let _guard = self.lock();
-        let entries = match fs::read_dir(self.tickets_dir()) {
+        let entries = match fs::read_dir(self.approvals_dir()) {
             Ok(entries) => entries,
             Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
             Err(err) => return Err(request_err(err)),
@@ -259,7 +259,7 @@ impl Inner {
             let entry = entry.map_err(request_err)?;
             let path = entry.path();
             if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
-                // A mid-publish temp file, never a ticket.
+                // A mid-publish temp file, never a stored approval.
                 continue;
             }
             let bytes = match fs::read(&path) {
@@ -275,7 +275,7 @@ impl Inner {
                 Err(err) => {
                     tracing::warn!(
                         path = %path.display(), error = %err,
-                        "undecodable ticket file skipped by cancel_request"
+                        "undecodable approval file skipped by cancel_request"
                     );
                 }
             }
@@ -370,14 +370,14 @@ fn publish(path: &Path, payload: &[u8]) -> Result<(), SessionStoreError> {
     Ok(())
 }
 
-/// Decode stored ticket file.
-fn decode_ticket(bytes: &[u8]) -> Result<ParkedApproval, SessionStoreError> {
+/// Decode a stored approval file.
+fn decode_approval(bytes: &[u8]) -> Result<ParkedApproval, SessionStoreError> {
     let record: ParkedApprovalRecord = serde_json::from_slice(bytes).map_err(decode_err)?;
-    restore_ticket(record)
+    restore_approval(record)
 }
 
-/// Restore ticket record.
-fn restore_ticket(record: ParkedApprovalRecord) -> Result<ParkedApproval, SessionStoreError> {
+/// Restore an approval record.
+fn restore_approval(record: ParkedApprovalRecord) -> Result<ParkedApproval, SessionStoreError> {
     ParkedApproval::try_from(record).map_err(decode_err)
 }
 


### PR DESCRIPTION
## Summary

Stacks on #656. Four slices plus review fixes, park mode stays default-off throughout:

- **86cd0d1f** retires the ticket vocabulary in the storage layer: `tickets/` becomes `approvals/`, `ResolvedEntry.ticket` becomes `approval` (no consumers of the old names yet - park mode is default-off and the park line consumes the store only through the trait API).
- **b2bcf88c** adds the recorded-decisions consult seam: `RecordedDecisions`/`CallKey` in the park module, consumed at the gate immediately after glob matching when armed via `with_recorded_decisions` (`None` on the live path, zero behavior change). A hit maps through the existing approval mapping so denial feedback is identical to the live path; a miss while the task's continuation is in flight fails closed; otherwise the call re-parks. A drop guard clears the strict entry on every exit path.
- **8ede9494** adds the stubbed-model test rig (scripted turns, per-turn request capture, a stall hook for deterministic race windows) and an ungated smoke test pinning model fidelity end to end.
- **c9f85791** lands reify: `load_recorded_decisions` builds the consult set from the store's approvals and recorded decisions (never the checkpoint copy), `ResumingDocumentHandle` tombstones each call before its invocation, `execute_task` takes the optional continuation and resumes the normal loop after sentinel replacement, and consumed decisions leave the store with the task. `RehydrateError` maps to the resume endpoint's condition rows, including the parked row carrying every outstanding id.
- **4f3dc809 / fa6ccf89** carry the Gate A fix round (parked row, scope-borrow refusals with negative tests) .

A `#[cfg(test)]` seam injects scripted models through a `ProviderAgent::Scripted` variant so `execute_task` is drivable end to end; with no override installed the build is unchanged.

## Proof coverage

Orphan dual-trigger (depth exhaustion and the mid-turn stream break - on the pinned rig, turn-start exhaustion ends blocked, not orphaned), the full park -> drop -> rehydrate -> resume loop with zero human input and replan state round-tripping, denial parity, concurrent tombstone appends, exactly-once ordered consumption, strict isolation between sibling tasks, and the store correcting a stale document.

## Test plan

`cargo test -p aura` (1156 passed), `cargo test -p aura-web-server` (167 passed), `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean.

Closes part of #271