### PR TITLE
feat(hitl): rename ticket vocabulary and add the recorded-decisions consult seam

### DIFF
--- a/crates/aura-web-server/tests/file_session_store_test.rs
+++ b/crates/aura-web-server/tests/file_session_store_test.rs
@@ -1,8 +1,8 @@
 //! Conformance and contract tests for the file-backed approval store
 //! (`AURA_SESSION_STORE=file`): the shared backend-agnostic battery plus the
 //! §2.5 contract points specific to durable, retention-until-remove storage —
-//! expiry refusal, retention past the decision, the ticket's move into the
-//! decision file, owner-scoped cancel of undecided tickets, and survival of a
+//! expiry refusal, retention past the decision, the approval's move into the
+//! decision file, owner-scoped cancel of undecided approvals, and survival of a
 //! process restart. The same battery runs against the memory backend to pin
 //! the uniform contract. No Docker: every test gets its own tempdir.
 
@@ -125,18 +125,18 @@ async fn memory_battery_cancel_request_removes_only_matching() {
 
 /// The constructor creates the layout's two directories.
 #[test]
-fn open_creates_the_ticket_and_decision_directories() {
+fn open_creates_the_approval_and_decision_directories() {
     let dir = tempfile::tempdir().unwrap();
     FileApprovalStore::open(dir.path()).unwrap();
-    assert!(dir.path().join("tickets").is_dir());
+    assert!(dir.path().join("approvals").is_dir());
     assert!(dir.path().join("decisions").is_dir());
 }
 
-/// §2.5: `resolve` refuses past the ticket's `expires_at`, uniformly with an
-/// unknown id; nothing is decided, and the expired ticket stays readable
+/// §2.5: `resolve` refuses past the approval's `expires_at`, uniformly with an
+/// unknown id; nothing is decided, and the expired approval stays readable
 /// through `get` until `remove`.
 #[tokio::test]
-async fn expired_resolve_is_not_found_and_ticket_is_retained() {
+async fn expired_resolve_is_not_found_and_approval_is_retained() {
     let dir = tempfile::tempdir().unwrap();
     let store = FileApprovalStore::open(dir.path()).unwrap();
     let mut parked = make_parked("req-expired", Duration::from_secs(60));
@@ -153,15 +153,15 @@ async fn expired_resolve_is_not_found_and_ticket_is_retained() {
         .get(&id)
         .await
         .unwrap()
-        .expect("expired ticket retained until remove");
+        .expect("expired approval retained until remove");
     assert_eq!(restored.request.decision_id, id);
 }
 
-/// §2.5: retention is until remove — `get` returns the ticket before and
+/// §2.5: retention is until remove — `get` returns the approval before and
 /// after the decision, `decision` returns the record, and only `remove`
 /// clears both.
 #[tokio::test]
-async fn ticket_and_decision_are_retained_until_remove() {
+async fn approval_and_decision_are_retained_until_remove() {
     let dir = tempfile::tempdir().unwrap();
     let store = FileApprovalStore::open(dir.path()).unwrap();
     let parked = make_parked("req-retain", Duration::from_secs(60));
@@ -185,7 +185,7 @@ async fn ticket_and_decision_are_retained_until_remove() {
                 .get(&id)
                 .await
                 .unwrap()
-                .expect("ticket survives its decision")
+                .expect("approval survives its decision")
         ),
         expected
     );
@@ -203,11 +203,11 @@ async fn ticket_and_decision_are_retained_until_remove() {
     );
 }
 
-/// §2.5: `resolve` moves the ticket into the decision file rather than
-/// deleting it — on disk the ticket file is gone and the decision file
-/// carries both the ticket record and the decision.
+/// §2.5: `resolve` moves the approval into the decision file rather than
+/// deleting it — on disk the approval file is gone and the decision file
+/// carries both the approval record and the decision.
 #[tokio::test]
-async fn resolve_moves_the_ticket_into_the_decision_file() {
+async fn resolve_moves_the_approval_into_the_decision_file() {
     let dir = tempfile::tempdir().unwrap();
     let store = FileApprovalStore::open(dir.path()).unwrap();
     let parked = make_parked("req-move", Duration::from_secs(60));
@@ -221,23 +221,23 @@ async fn resolve_moves_the_ticket_into_the_decision_file() {
 
     assert!(
         !dir.path()
-            .join("tickets")
+            .join("approvals")
             .join(format!("{id}.json"))
             .exists()
     );
     let decision_path = dir.path().join("decisions").join(format!("{id}.json"));
     let on_disk: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(decision_path).unwrap()).unwrap();
-    assert_eq!(on_disk["ticket"]["decision_id"], id.to_string());
-    assert_eq!(on_disk["ticket"]["request_id"], "req-move");
+    assert_eq!(on_disk["approval"]["decision_id"], id.to_string());
+    assert_eq!(on_disk["approval"]["request_id"], "req-move");
     assert_eq!(on_disk["decision"]["approved"], true);
     assert_eq!(on_disk["decision"]["reason"], serde_json::Value::Null);
 }
 
-/// §2.5: `cancel_request` removes undecided tickets by owner id; a decided
-/// ticket of the same owner and an undecided ticket of another owner survive.
+/// §2.5: `cancel_request` removes undecided approvals by owner id; a decided
+/// approval of the same owner and an undecided approval of another owner survive.
 #[tokio::test]
-async fn cancel_request_removes_only_undecided_matching_tickets() {
+async fn cancel_request_removes_only_undecided_matching_approvals() {
     let dir = tempfile::tempdir().unwrap();
     let store = FileApprovalStore::open(dir.path()).unwrap();
     let undecided = make_parked("req-owner", Duration::from_secs(60));
@@ -259,7 +259,7 @@ async fn cancel_request_removes_only_undecided_matching_tickets() {
     assert!(store.get(&undecided_id).await.unwrap().is_none());
     assert!(
         store.get(&decided_id).await.unwrap().is_some(),
-        "decided ticket is retained until remove"
+        "decided approval is retained until remove"
     );
     assert_eq!(
         store.decision(&decided_id).await.unwrap(),
@@ -268,13 +268,13 @@ async fn cancel_request_removes_only_undecided_matching_tickets() {
     assert!(store.get(&other_id).await.unwrap().is_some());
 }
 
-/// A read-only `tickets/` directory must not fail `resolve`: the decision
-/// write and its sync are the commit, and the ticket removal past them is
-/// best-effort — the stale ticket remains, `get` still returns the record,
+/// A read-only `approvals/` directory must not fail `resolve`: the decision
+/// write and its sync are the commit, and the approval removal past them is
+/// best-effort — the stale approval remains, `get` still returns the record,
 /// and the claim still holds against a repeat resolve.
 #[cfg(unix)]
 #[tokio::test]
-async fn resolve_succeeds_when_the_ticket_file_cannot_be_removed() {
+async fn resolve_succeeds_when_the_approval_file_cannot_be_removed() {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = tempfile::tempdir().unwrap();
@@ -283,13 +283,13 @@ async fn resolve_succeeds_when_the_ticket_file_cannot_be_removed() {
     let id = parked.request.decision_id;
     store.register(parked).await.unwrap();
 
-    let tickets = dir.path().join("tickets");
-    std::fs::set_permissions(&tickets, std::fs::Permissions::from_mode(0o500)).unwrap();
-    let _restore = Restore(&tickets);
+    let approvals = dir.path().join("approvals");
+    std::fs::set_permissions(&approvals, std::fs::Permissions::from_mode(0o500)).unwrap();
+    let _restore = Restore(&approvals);
 
     // Root bypasses directory permission bits; the fault this test pins
     // cannot be established there, so skip rather than pass vacuously.
-    let probe = tickets.join(".write-probe");
+    let probe = approvals.join(".write-probe");
     if std::fs::write(&probe, b"x").is_ok() {
         let _ = std::fs::remove_file(&probe);
         eprintln!("skipping: process bypasses directory permissions (running as root?)");
@@ -299,7 +299,7 @@ async fn resolve_succeeds_when_the_ticket_file_cannot_be_removed() {
     store
         .resolve(&id, ApprovalDecision::Approved)
         .await
-        .expect("resolve commits without the ticket removal");
+        .expect("resolve commits without the approval removal");
     assert_eq!(
         store.decision(&id).await.unwrap(),
         Some(ApprovalDecision::Approved)
@@ -308,7 +308,7 @@ async fn resolve_succeeds_when_the_ticket_file_cannot_be_removed() {
         .get(&id)
         .await
         .unwrap()
-        .expect("ticket record survives the failed removal");
+        .expect("approval record survives the failed removal");
     assert_eq!(restored.request.decision_id, id);
     assert_eq!(
         store.resolve(&id, ApprovalDecision::Approved).await,
@@ -366,11 +366,11 @@ async fn open_fails_when_a_store_directory_is_not_writable() {
 
     let dir = tempfile::tempdir().unwrap();
     drop(FileApprovalStore::open(dir.path()).unwrap());
-    let tickets = dir.path().join("tickets");
-    std::fs::set_permissions(&tickets, std::fs::Permissions::from_mode(0o500)).unwrap();
-    let _restore = Restore(&tickets);
+    let approvals = dir.path().join("approvals");
+    std::fs::set_permissions(&approvals, std::fs::Permissions::from_mode(0o500)).unwrap();
+    let _restore = Restore(&approvals);
 
-    let probe = tickets.join(".write-probe");
+    let probe = approvals.join(".write-probe");
     if std::fs::write(&probe, b"x").is_ok() {
         let _ = std::fs::remove_file(&probe);
         eprintln!("skipping: process bypasses directory permissions (running as root?)");
@@ -399,7 +399,7 @@ async fn ping_reports_an_unwritable_store_directory() {
     let store = FileApprovalStore::open(dir.path()).unwrap();
     store.probe_writable().await.expect("healthy store pings");
 
-    for name in ["tickets", "decisions"] {
+    for name in ["approvals", "decisions"] {
         let locked = dir.path().join(name);
         std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o500)).unwrap();
         let restore = Restore(&locked);

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -12,11 +12,11 @@ use aura_config::GlobPattern;
 use rig::tool::ToolError;
 use serde_json::Value;
 
-use super::decision::{AgentScope, ApprovalOrigin, DecisionId};
+use super::decision::{AgentScope, ApprovalOrigin, ApprovalOutcome, DecisionId};
 use super::protocol::{ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
 use super::registry::{ParkedApproval, PendingApprovals};
 use super::route::{ApprovalError, DecisionRoute, GateDecision};
-use crate::orchestration::{BlockedCell, ParkGuard, PendingCall};
+use crate::orchestration::{BlockedCell, CallKey, ParkGuard, PendingCall, RecordedDecisions};
 use crate::tool_wrapper::{PreCallOutcome, ToolCallContext, ToolWrapper};
 
 /// The placeholder tool result a parked call returns.
@@ -52,6 +52,11 @@ pub struct HitlApprovalWrapper {
     instance_id: String,
     /// Park arm state.
     park: Option<ParkContext>,
+    /// The run's recorded decisions for its parked calls; `None` on the live
+    /// path so behavior is unchanged. When present, a recorded decision is
+    /// consumed before the park arm; a miss while the task is strict is a
+    /// resume fault, and a miss otherwise re-parks.
+    recorded_decisions: Option<Arc<RecordedDecisions>>,
 }
 
 impl HitlApprovalWrapper {
@@ -72,6 +77,7 @@ impl HitlApprovalWrapper {
             agent_name,
             instance_id,
             park: None,
+            recorded_decisions: None,
         }
     }
 
@@ -88,6 +94,17 @@ impl HitlApprovalWrapper {
             cell,
             guard,
         });
+        self
+    }
+
+    /// Arm the recorded-decisions consult: a glob-matched call checks the
+    /// run's recorded decisions before the park arm. `None` (the default)
+    /// leaves the live path byte-identical. Wired by the orchestrator
+    /// continuation (P44 commit 3).
+    #[allow(dead_code)]
+    #[must_use]
+    pub(crate) fn with_recorded_decisions(mut self, recorded: Arc<RecordedDecisions>) -> Self {
+        self.recorded_decisions = Some(recorded);
         self
     }
 
@@ -235,6 +252,42 @@ impl ToolWrapper for HitlApprovalWrapper {
         let Some(matched) = self.matched_pattern(&ctx.tool_name) else {
             return Ok(PreCallOutcome::Proceed { overrides: None });
         };
+        // Recorded-decisions consult: a resumed worker's gated call may
+        // already carry a stored decision. A hit maps through the same
+        // mapping the live route uses (so an approval proceeds and a denial
+        // produces the live path's denial feedback); a miss while the task is
+        // strict is a resume fault; a miss otherwise falls through to the park
+        // arm (or the live route when park is unset) and re-parks.
+        if let Some(recorded) = &self.recorded_decisions {
+            // A resumed worker's tools always carry a task id. A gated call
+            // without one on the resume path is a wiring fault, and falling
+            // through to the park arm would re-ask the human for a decided
+            // call.
+            let Some(task_id) = ctx.task_id else {
+                return Err(ToolError::ToolCallError(
+                    "resume mismatch: no task id".to_string().into(),
+                ));
+            };
+            match recorded.take(&CallKey::new(task_id, &ctx.tool_name, args)) {
+                Some(decision) => {
+                    return approval_result_to_pre_call(Ok(GateDecision::without_overrides(
+                        ApprovalOutcome::Decided(decision),
+                    )));
+                }
+                // A continuation invocation that misses is a resume fault,
+                // never a fresh park: the recorded call no longer matches what
+                // the chain produced. Fail the call closed and let the resume
+                // stream fail.
+                None if recorded.is_strict(task_id) => {
+                    return Err(ToolError::ToolCallError(
+                        "resume mismatch".to_string().into(),
+                    ));
+                }
+                // A model-issued gated call after the continuation re-parks
+                // normally: fall through to the park arm (or the live route).
+                None => {}
+            }
+        }
         if let Some(park) = &self.park {
             return self.park_pre_call(park, matched, args, ctx).await;
         }
@@ -670,6 +723,180 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(5)).await;
             }
             assert!(store.get(&decision_id).await.unwrap().is_none());
+        }
+    }
+
+    // ====================================================================
+    // Recorded-decisions consult
+    // ====================================================================
+
+    mod recorded {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use super::*;
+        use crate::hitl::ApprovalDecision;
+
+        /// A route whose webhook is unreachable, so a fall-through to the
+        /// route fails closed rather than hanging. A recorded hit
+        /// short-circuits before the route, so it never sees this.
+        fn discard_route() -> Arc<DecisionRoute> {
+            Arc::new(DecisionRoute::Webhook {
+                client: WebhookClient::new(
+                    build_webhook_client(),
+                    // Discard port: nothing listens, so the POST fails closed.
+                    WebhookUrl::new("http://127.0.0.1:9").unwrap(),
+                ),
+                timeout: Duration::from_secs(2),
+            })
+        }
+
+        /// A gate armed with `recorded_decisions` and no park arm, so a miss
+        /// falls through to the live route (the contract path the brief calls
+        /// out for these tests).
+        fn recorded_gate(
+            recorded: Arc<RecordedDecisions>,
+            route: Arc<DecisionRoute>,
+        ) -> HitlApprovalWrapper {
+            HitlApprovalWrapper::new(
+                Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
+                route,
+                AgentScope::Single { session_id: None },
+                "req-recorded".to_string(),
+                "test-agent".to_string(),
+                "test-instance".to_string(),
+            )
+            .with_recorded_decisions(recorded)
+        }
+
+        fn ctx_for(tool: &str, task_id: Option<usize>) -> ToolCallContext {
+            let mut ctx = ToolCallContext::new(tool);
+            ctx.task_id = task_id;
+            ctx
+        }
+
+        /// A recorded approval proceeds through the same mapping the live
+        /// route uses, without ever consulting the (unreachable) route.
+        #[tokio::test]
+        async fn recorded_hit_proceeds_without_invoking_route() {
+            let recorded = Arc::new(RecordedDecisions::default());
+            let args = serde_json::json!({"namespace": "prod"});
+            recorded.push(
+                CallKey::new(1, "kubectl_apply", &args),
+                ApprovalDecision::Approved,
+            );
+
+            let gate = recorded_gate(recorded, discard_route());
+            let outcome = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", Some(1)))
+                .await
+                .unwrap();
+
+            assert_eq!(outcome, PreCallOutcome::Proceed { overrides: None });
+        }
+
+        /// A recorded denial produces the live path's denial feedback string,
+        /// through the shared mapping — the denial string is not duplicated
+        /// in the consult.
+        #[tokio::test]
+        async fn recorded_denial_produces_live_path_denial_feedback() {
+            let recorded = Arc::new(RecordedDecisions::default());
+            let args = serde_json::json!({"namespace": "prod"});
+            recorded.push(
+                CallKey::new(1, "kubectl_apply", &args),
+                ApprovalDecision::Denied {
+                    reason: Some("too risky".to_string()),
+                },
+            );
+
+            let gate = recorded_gate(recorded, discard_route());
+            let outcome = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", Some(1)))
+                .await
+                .unwrap();
+
+            assert_eq!(
+                outcome,
+                PreCallOutcome::ShortCircuit {
+                    output: "Tool call blocked by human approval denial: too risky. Do not execute this action."
+                        .to_string(),
+                },
+            );
+        }
+
+        /// A miss while the task is strict is a resume fault, never a fresh
+        /// park: the route is not consulted (no "approval channel error").
+        #[tokio::test]
+        async fn recorded_miss_while_strict_fails_closed_with_resume_mismatch() {
+            let recorded = Arc::new(RecordedDecisions::default());
+            recorded.set_strict(1, true);
+
+            let gate = recorded_gate(recorded, discard_route());
+            let args = serde_json::json!({"namespace": "prod"});
+            let err = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", Some(1)))
+                .await
+                .expect_err("a strict miss must fail closed");
+
+            let msg = err.to_string();
+            assert!(
+                msg.contains("resume mismatch"),
+                "a strict miss must report a resume mismatch, got: {msg}",
+            );
+            assert!(
+                !msg.contains("approval channel error"),
+                "the route must not be consulted on a strict miss, got: {msg}",
+            );
+        }
+
+        /// A miss when the task is not strict falls through to the live route
+        /// (park is unset), proving the consult did not short-circuit. The
+        /// contrast with the strict-miss test is the error class.
+        #[tokio::test]
+        async fn recorded_miss_not_strict_falls_through_to_route() {
+            let recorded = Arc::new(RecordedDecisions::default());
+
+            let gate = recorded_gate(recorded, discard_route());
+            let args = serde_json::json!({"namespace": "prod"});
+            let err = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", Some(1)))
+                .await
+                .expect_err("the unreachable route must fail closed");
+
+            let msg = err.to_string();
+            assert!(
+                msg.contains("approval channel error"),
+                "a non-strict miss must fall through to the route, got: {msg}",
+            );
+            assert!(
+                !msg.contains("resume mismatch"),
+                "a non-strict miss must not report a resume mismatch, got: {msg}",
+            );
+        }
+
+        /// A gated call on the resume path with no task id is a wiring fault,
+        /// not a fall-through to the park arm (which would re-ask the human
+        /// for a decided call).
+        #[tokio::test]
+        async fn recorded_consult_without_task_id_is_a_resume_fault() {
+            let recorded = Arc::new(RecordedDecisions::default());
+
+            let gate = recorded_gate(recorded, discard_route());
+            let args = serde_json::json!({});
+            let err = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", None))
+                .await
+                .expect_err("a gated resume call without a task id must fail");
+
+            let msg = err.to_string();
+            assert!(
+                msg.contains("resume mismatch: no task id"),
+                "expected the no-task-id wiring fault, got: {msg}",
+            );
+            assert!(
+                !msg.contains("approval channel error"),
+                "the route must not be consulted on the no-task-id fault, got: {msg}",
+            );
         }
     }
 

--- a/crates/aura/src/orchestration/mod.rs
+++ b/crates/aura/src/orchestration/mod.rs
@@ -80,7 +80,7 @@ pub use tools::ReadArtifactTool;
 pub use tools::wait_for::{StopReason, WaitForError, WaitForOutput, WaitForTool};
 pub use tools::{SubmitResultDecision, SubmitResultOutput, SubmitResultTool};
 
-pub(crate) use park::ParkGuard;
+pub(crate) use park::{CallKey, ParkGuard, RecordedDecisions};
 pub use prompt_constants::{context, fields, sections};
 pub use types::{
     BlockedCell, CellOutcome, ParkSnapshot, PendingCall, Plan, PlanningResponse, RunId, StepInput,

--- a/crates/aura/src/orchestration/park/mod.rs
+++ b/crates/aura/src/orchestration/park/mod.rs
@@ -4,12 +4,14 @@
 mod commit;
 mod document;
 mod guard;
+mod recorded_decisions;
 
 pub(crate) use commit::{ParkCommitInputs, cancel_run_approvals, commit_from_run_state};
 #[cfg(test)]
 pub(crate) use document::load_parked_run;
 pub(crate) use document::{PARKED_DOCUMENT_SUFFIX, RESUMING_DOCUMENT_SUFFIX, RunStateForPark};
 pub(crate) use guard::ParkGuard;
+pub(crate) use recorded_decisions::{CallKey, RecordedDecisions};
 
 use std::collections::HashMap;
 

--- a/crates/aura/src/orchestration/park/recorded_decisions.rs
+++ b/crates/aura/src/orchestration/park/recorded_decisions.rs
@@ -1,0 +1,291 @@
+//! The recorded-decisions set: decisions already recorded for a run's parked
+//! calls, consumed at most once each at the resume gate.
+//!
+//! Vocabulary bounding line: the approval *request* is raised by the park arm;
+//! the *decision* recorded against it is what this set holds. "Ticket" is
+//! retired vocabulary (DECISIONS-2026-09-03 item 2).
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::hitl::ApprovalDecision;
+
+/// Decisions already recorded for this run's parked calls, consumed at most
+/// once each. `strict_tasks` holds the task ids whose continuation is
+/// mid-invocation: a miss for one of those tasks is a resume fault, not a
+/// fresh park. Per task, because sibling continuations run concurrently in
+/// one wave. It lives here, behind the `Arc` the gate already holds, because
+/// `pre_call` runs in a spawned task (the `pre_handle` spawn in the tool
+/// wrapper) and a task-local would not cross that boundary. The continuation
+/// drives `set_strict` through a drop guard so every exit path (error, panic,
+/// mismatch) clears the task's entry.
+#[derive(Default)]
+pub(crate) struct RecordedDecisions {
+    entries: Mutex<HashMap<CallKey, VecDeque<ApprovalDecision>>>,
+    strict_tasks: Mutex<HashSet<usize>>,
+}
+
+impl RecordedDecisions {
+    /// Record a decision for a key, appending to that key's recorded-order
+    /// queue so two same-turn calls with identical arguments keep their own
+    /// decisions. Wired by the orchestrator continuation (P44 commit 3).
+    #[allow(dead_code)]
+    pub(crate) fn push(&self, key: CallKey, decision: ApprovalDecision) {
+        self.entries
+            .lock()
+            .expect("recorded-decisions lock")
+            .entry(key)
+            .or_default()
+            .push_back(decision);
+    }
+
+    /// Mark a task's continuation as in-flight (`on = true`) or clear it. A
+    /// miss for a strict task is a resume fault; a miss otherwise re-parks.
+    #[allow(dead_code)]
+    pub(crate) fn set_strict(&self, task_id: usize, on: bool) {
+        let mut strict = self.strict_tasks.lock().expect("recorded-decisions lock");
+        if on {
+            strict.insert(task_id);
+        } else {
+            strict.remove(&task_id);
+        }
+    }
+
+    /// Whether a task's continuation is in-flight, and so a recorded-decisions
+    /// miss must fail closed rather than re-park.
+    pub(crate) fn is_strict(&self, task_id: usize) -> bool {
+        self.strict_tasks
+            .lock()
+            .expect("recorded-decisions lock")
+            .contains(&task_id)
+    }
+
+    /// Consume one decision for a key in recorded order; the next call returns
+    /// the following decision, and an empty queue returns `None`.
+    pub(crate) fn take(&self, key: &CallKey) -> Option<ApprovalDecision> {
+        self.entries
+            .lock()
+            .expect("recorded-decisions lock")
+            .get_mut(key)
+            .and_then(VecDeque::pop_front)
+    }
+
+    /// Arm a drop guard that holds `task_id` strict until the guard is
+    /// dropped, then clears it. Holds a clone of the `Arc` so the clear runs
+    /// on every exit path (normal return, `?`-early-return, error, and panic
+    /// unwind) regardless of the recorder's own lifetime. Wired by the
+    /// orchestrator continuation (P44 commit 3).
+    #[allow(dead_code)]
+    pub(crate) fn strict_guard(self: &Arc<Self>, task_id: usize) -> StrictGuard {
+        self.set_strict(task_id, true);
+        StrictGuard {
+            recorded: Arc::clone(self),
+            task_id,
+        }
+    }
+}
+
+/// Key for a recorded decision: the task the call belongs to, the tool name,
+/// and a digest of the canonical arguments. `serde_json` in this workspace is
+/// built without `preserve_order`, so `Value::to_string` is BTreeMap-ordered
+/// and canonical; a test pins that. The separator byte (`0x00`) keeps the tool
+/// name and the arguments from aliasing across names that end where another
+/// begins.
+#[derive(Hash, PartialEq, Eq)]
+pub(crate) struct CallKey {
+    task_id: usize,
+    tool_name: String,
+    args_digest: [u8; 32],
+}
+
+impl CallKey {
+    /// Build a key from the task id, the tool name, and a digest of
+    /// `tool_name || 0x00 || canonical_json(args)`.
+    pub(crate) fn new(task_id: usize, tool_name: &str, args: &Value) -> Self {
+        let mut h = Sha256::new();
+        h.update(tool_name.as_bytes());
+        h.update([0u8]);
+        h.update(args.to_string().as_bytes());
+        Self {
+            task_id,
+            tool_name: tool_name.to_owned(),
+            args_digest: h.finalize().into(),
+        }
+    }
+}
+
+/// RAII guard for a task's strict entry: clears the task from
+/// `strict_tasks` on drop, so a leaked strict entry can never silently
+/// convert a model-issued re-park into a resume fault. Constructed via
+/// [`RecordedDecisions::strict_guard`]. Wired by the orchestrator
+/// continuation (P44 commit 3).
+#[allow(dead_code)]
+pub(crate) struct StrictGuard {
+    recorded: Arc<RecordedDecisions>,
+    task_id: usize,
+}
+
+impl Drop for StrictGuard {
+    fn drop(&mut self) {
+        self.recorded.set_strict(self.task_id, false);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use super::*;
+
+    fn key(task_id: usize, tool_name: &str, args: &Value) -> CallKey {
+        CallKey::new(task_id, tool_name, args)
+    }
+
+    /// Two same-key decisions consume in recorded order; a third take is
+    /// `None` (the queue is per-key and exhausted by consumption).
+    #[test]
+    fn take_consumes_per_key_queue_in_recorded_order() {
+        let recorded = RecordedDecisions::default();
+        let args = serde_json::json!({"namespace": "prod"});
+
+        recorded.push(key(1, "kubectl_apply", &args), ApprovalDecision::Approved);
+        recorded.push(
+            key(1, "kubectl_apply", &args),
+            ApprovalDecision::Denied {
+                reason: Some("too risky".to_string()),
+            },
+        );
+
+        let probe = key(1, "kubectl_apply", &args);
+        assert_eq!(
+            recorded.take(&probe),
+            Some(ApprovalDecision::Approved),
+            "first take returns the first recorded decision",
+        );
+        assert_eq!(
+            recorded
+                .take(&probe)
+                .map(|d| matches!(d, ApprovalDecision::Denied { .. })),
+            Some(true),
+            "second take returns the second recorded decision, in order",
+        );
+        assert!(
+            recorded.take(&probe).is_none(),
+            "third take exhausts the queue"
+        );
+    }
+
+    /// `set_strict` toggles membership; `is_strict` reports it verbatim.
+    #[test]
+    fn strict_set_toggles_membership() {
+        let recorded = RecordedDecisions::default();
+        assert!(!recorded.is_strict(1));
+        recorded.set_strict(1, true);
+        assert!(recorded.is_strict(1), "set_strict(true) enters the task");
+        assert!(
+            !recorded.is_strict(2),
+            "a sibling task is unaffected by another's strict entry",
+        );
+        recorded.set_strict(1, false);
+        assert!(!recorded.is_strict(1), "set_strict(false) clears the task");
+    }
+
+    /// The drop guard clears the task's strict entry on a normal drop, so a
+    /// scope exit (early return, error, end of block) cannot leak the entry.
+    #[test]
+    fn strict_guard_clears_on_normal_drop() {
+        let recorded = std::sync::Arc::new(RecordedDecisions::default());
+        {
+            let _guard = recorded.strict_guard(1);
+            assert!(recorded.is_strict(1), "guard arms the strict entry");
+        }
+        assert!(
+            !recorded.is_strict(1),
+            "guard's drop clears the entry after the scope ends",
+        );
+    }
+
+    /// An early return out of a scope that holds the guard still drops the
+    /// guard, so the strict entry is cleared.
+    #[test]
+    fn strict_guard_clears_on_early_return() {
+        let recorded = std::sync::Arc::new(RecordedDecisions::default());
+
+        fn drive(recorded: &std::sync::Arc<RecordedDecisions>) -> Result<(), &'static str> {
+            let _guard = recorded.strict_guard(1);
+            // An early-return path the continuation might take on a non-fatal
+            // error: the guard drops here, not at the end of the function.
+            Err("simulated non-fatal error")
+        }
+
+        assert!(drive(&recorded).is_err());
+        assert!(
+            !recorded.is_strict(1),
+            "an early return drops the guard and clears strict",
+        );
+    }
+
+    /// A panic unwinds through the guard's scope, so its `Drop` runs and
+    /// clears the strict entry; the recorder is left consistent.
+    #[test]
+    fn strict_guard_clears_on_panic_unwind() {
+        let recorded = std::sync::Arc::new(RecordedDecisions::default());
+        let guard = recorded.strict_guard(1);
+        assert!(recorded.is_strict(1));
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _held = guard;
+            panic!("simulated continuation fault");
+        }));
+        assert!(result.is_err(), "the panic must be caught");
+        assert!(
+            !recorded.is_strict(1),
+            "the guard's drop must clear strict even when unwinding",
+        );
+    }
+
+    /// The same arguments in different insertion order digests to the same
+    /// key: `serde_json` without `preserve_order` serializes `Value::Object`
+    /// BTreeMap-ordered, so `to_string` is canonical. A test pins that.
+    #[test]
+    fn digest_is_stable_across_argument_key_order() {
+        let a = key(1, "kubectl_apply", &serde_json::json!({"a": 1, "b": 2}));
+        let b = key(1, "kubectl_apply", &serde_json::json!({"b": 2, "a": 1}));
+        assert_eq!(
+            a.args_digest, b.args_digest,
+            "canonical json: key order must not affect the digest",
+        );
+        assert!(a == b, "the whole key compares equal when the digest does");
+    }
+
+    /// Different arguments produce different digests, so two distinct calls
+    /// do not collide on the same key.
+    #[test]
+    fn different_arguments_digest_differ() {
+        let a = key(
+            1,
+            "kubectl_apply",
+            &serde_json::json!({"namespace": "prod"}),
+        );
+        let b = key(
+            1,
+            "kubectl_apply",
+            &serde_json::json!({"namespace": "stage"}),
+        );
+        assert_ne!(a.args_digest, b.args_digest);
+        assert!(a != b);
+    }
+
+    /// Different tool names produce different digests even for the same
+    /// arguments: the name is part of the hashed bytes.
+    #[test]
+    fn different_tool_names_digest_differ() {
+        let args = serde_json::json!({"namespace": "prod"});
+        let a = key(1, "kubectl_apply", &args);
+        let b = key(1, "kubectl_delete", &args);
+        assert!(a != b);
+    }
+}

--- a/crates/aura/src/session_store/file.rs
+++ b/crates/aura/src/session_store/file.rs
@@ -1,23 +1,23 @@
 //! File-backed HITL approval store: one JSON file per decision id.
-//! Tickets survive process restart on a single host.
+//! Parked approvals survive process restart on a single host.
 //!
 //! Layout:
 //!
 //! | Path                                 | Content                                                    |
 //! | ----------------------------------- | ---------------------------------------------------------- |
-//! | `{root}/tickets/{decision_id}.json`   | `ParkedApprovalRecord` (the undecided ticket)              |
-//! | `{root}/decisions/{decision_id}.json` | the resolved envelope: the ticket record plus the decision |
+//! | `{root}/approvals/{decision_id}.json` | `ParkedApprovalRecord` (the undecided approval)            |
+//! | `{root}/decisions/{decision_id}.json` | the resolved envelope: the approval record plus the decision |
 //!
 //! Store contract (park/reify §2.5):
 //!
-//! - `resolve` refuses past the ticket's `expires_at`, uniformly with an
+//! - `resolve` refuses past the approval's `expires_at`, uniformly with an
 //!   unknown id; expiry is enforced only by `resolve`.
-//! - `resolve` *moves* the ticket into the decision file rather than deleting
-//!   it: `get` returns the ticket before and after the decision, `decision`
+//! - `resolve` *moves* the approval into the decision file rather than deleting
+//!   it: `get` returns the approval before and after the decision, `decision`
 //!   returns the recorded decision, and both are retained until `remove`.
 //! - At-most-once `resolve` is the `File::create_new` claim on the decision
 //!   file: `AlreadyExists` reads as `NotFound`.
-//! - `cancel_request` removes undecided tickets by owner (request) id;
+//! - `cancel_request` removes undecided approvals by owner (request) id;
 //!   decided entries are retained until their consumer removes them.
 //!
 //! Decision ids are validated as UUIDs before path building, so none address
@@ -33,7 +33,7 @@
 //!
 //! Crash window: claim-then-write leaves an empty file if process dies
 //! mid-resolve. The aftermath fails closed; `decision` reports decode
-//! fault, `get` returns ticket. Recovery is deleting the empty file.
+//! fault, `get` returns the approval. Recovery is deleting the empty file.
 //! `decision()` consumers treat `Err(Decode)` on a known id as this
 //! recoverable state, not as an unknown id.
 
@@ -50,18 +50,18 @@ use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
 
 use super::{ApprovalStore, DecisionRecord, ParkedApprovalRecord, SessionStoreError};
 
-/// Undecided tickets, one `{decision_id}.json` file per ticket.
-const TICKETS_DIR: &str = "tickets";
+/// Undecided approvals, one `{decision_id}.json` file per approval.
+const APPROVALS_DIR: &str = "approvals";
 /// Recorded decisions, one `{decision_id}.json` file per decision.
 const DECISIONS_DIR: &str = "decisions";
 
-/// The on-disk shape of a resolved approval: the ticket record carried over
-/// from `tickets/` plus the recorded decision. Field names are a persisted
-/// contract shared by every instance reading the store — rename only with a
-/// migration.
+/// The on-disk shape of a resolved approval: the approval record carried
+/// over from `approvals/` plus the recorded decision. Field names are a
+/// persisted contract shared by every instance reading the store — rename
+/// only with a migration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct ResolvedEntry {
-    ticket: ParkedApprovalRecord,
+    approval: ParkedApprovalRecord,
     decision: DecisionRecord,
 }
 
@@ -82,7 +82,7 @@ impl FileApprovalStore {
     /// cannot hold files must fail at startup, not on the first approval.
     pub fn open(root: impl AsRef<Path>) -> Result<Self, SessionStoreError> {
         let root = root.as_ref();
-        fs::create_dir_all(root.join(TICKETS_DIR)).map_err(connect_err)?;
+        fs::create_dir_all(root.join(APPROVALS_DIR)).map_err(connect_err)?;
         fs::create_dir_all(root.join(DECISIONS_DIR)).map_err(connect_err)?;
         let inner = Arc::new(Inner {
             root: root.to_path_buf(),
@@ -102,16 +102,16 @@ impl FileApprovalStore {
 }
 
 impl Inner {
-    fn tickets_dir(&self) -> PathBuf {
-        self.root.join(TICKETS_DIR)
+    fn approvals_dir(&self) -> PathBuf {
+        self.root.join(APPROVALS_DIR)
     }
 
     fn decisions_dir(&self) -> PathBuf {
         self.root.join(DECISIONS_DIR)
     }
 
-    fn ticket_path(&self, id: &str) -> PathBuf {
-        self.tickets_dir().join(format!("{id}.json"))
+    fn approval_path(&self, id: &str) -> PathBuf {
+        self.approvals_dir().join(format!("{id}.json"))
     }
 
     fn decision_path(&self, id: &str) -> PathBuf {
@@ -125,7 +125,7 @@ impl Inner {
     /// Create and unlink an empty probe file in each store directory. This
     /// catches permission and mount faults, not a full disk.
     fn probe_writable_sync(&self) -> io::Result<()> {
-        for dir in [self.tickets_dir(), self.decisions_dir()] {
+        for dir in [self.approvals_dir(), self.decisions_dir()] {
             let probe = dir.join(format!(".{}.probe", uuid::Uuid::new_v4()));
             fs::write(&probe, b"")
                 .and_then(|()| fs::remove_file(&probe))
@@ -141,21 +141,21 @@ impl Inner {
         let id = canonical_id(&parked.request.decision_id)?;
         let payload = serde_json::to_vec(&ParkedApprovalRecord::from(&parked))
             .expect("approval record serializes to JSON");
-        publish(&self.ticket_path(&id), &payload)
+        publish(&self.approval_path(&id), &payload)
     }
 
     fn get_sync(&self, id: &DecisionId) -> Result<Option<ParkedApproval>, SessionStoreError> {
         let _guard = self.lock();
         let id = canonical_id(id)?;
-        match fs::read(self.ticket_path(&id)) {
-            Ok(bytes) => return decode_ticket(&bytes).map(Some),
+        match fs::read(self.approval_path(&id)) {
+            Ok(bytes) => return decode_approval(&bytes).map(Some),
             Err(err) if err.kind() == io::ErrorKind::NotFound => {}
             Err(err) => return Err(request_err(err)),
         }
         match fs::read(self.decision_path(&id)) {
             Ok(bytes) => {
                 let entry: ResolvedEntry = serde_json::from_slice(&bytes).map_err(decode_err)?;
-                restore_ticket(entry.ticket).map(Some)
+                restore_approval(entry.approval).map(Some)
             }
             Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
             Err(err) => Err(request_err(err)),
@@ -170,12 +170,12 @@ impl Inner {
         let _guard = self.lock();
         let id = canonical_id(id).map_err(ResolveError::Store)?;
 
-        // Read ticket before claiming avoids claiming unknown ids.
-        let record = match fs::read(self.ticket_path(&id)) {
+        // Reading the approval before claiming avoids claiming unknown ids.
+        let record = match fs::read(self.approval_path(&id)) {
             Ok(bytes) => serde_json::from_slice::<ParkedApprovalRecord>(&bytes)
                 .map_err(|e| ResolveError::Store(decode_err(e)))?,
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
-                // No ticket: unknown, resolved, or removed all return `NotFound`.
+                // No approval: unknown, resolved, or removed all return `NotFound`.
                 return Err(ResolveError::NotFound);
             }
             Err(err) => return Err(ResolveError::Store(request_err(err))),
@@ -184,7 +184,7 @@ impl Inner {
             return Err(ResolveError::NotFound);
         }
         let payload = serde_json::to_vec(&ResolvedEntry {
-            ticket: record,
+            approval: record,
             decision: DecisionRecord::from(&decision),
         })
         .expect("resolved entry serializes to JSON");
@@ -204,15 +204,15 @@ impl Inner {
             let _ = fs::remove_file(&decision_path);
             return Err(ResolveError::Store(request_err(err)));
         }
-        // After sync commit, ticket removal is best-effort. Failure leaves
-        // a stale ticket; resolve succeeded.
-        match fs::remove_file(self.ticket_path(&id)) {
+        // After sync commit, removing the approval file is best-effort.
+        // Failure leaves a stale approval file; resolve succeeded.
+        match fs::remove_file(self.approval_path(&id)) {
             Ok(()) => {}
             Err(err) if err.kind() == io::ErrorKind::NotFound => {}
             Err(err) => tracing::warn!(
                 decision_id = %id,
                 error = %err,
-                "stale ticket file remains after resolve; it is benign"
+                "stale approval file remains after resolve; it is benign"
             ),
         }
         Ok(())
@@ -238,7 +238,7 @@ impl Inner {
         let _guard = self.lock();
         let id = canonical_id(id)?;
         // Remove both halves; missing halves are fine (idempotent).
-        for path in [self.ticket_path(&id), self.decision_path(&id)] {
+        for path in [self.approval_path(&id), self.decision_path(&id)] {
             if let Err(err) = fs::remove_file(&path)
                 && err.kind() != io::ErrorKind::NotFound
             {
@@ -250,7 +250,7 @@ impl Inner {
 
     fn cancel_request_sync(&self, request_id: &str) -> Result<(), SessionStoreError> {
         let _guard = self.lock();
-        let entries = match fs::read_dir(self.tickets_dir()) {
+        let entries = match fs::read_dir(self.approvals_dir()) {
             Ok(entries) => entries,
             Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
             Err(err) => return Err(request_err(err)),
@@ -259,7 +259,7 @@ impl Inner {
             let entry = entry.map_err(request_err)?;
             let path = entry.path();
             if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
-                // A mid-publish temp file, never a ticket.
+                // A mid-publish temp file, never a stored approval.
                 continue;
             }
             let bytes = match fs::read(&path) {
@@ -275,7 +275,7 @@ impl Inner {
                 Err(err) => {
                     tracing::warn!(
                         path = %path.display(), error = %err,
-                        "undecodable ticket file skipped by cancel_request"
+                        "undecodable approval file skipped by cancel_request"
                     );
                 }
             }
@@ -370,14 +370,14 @@ fn publish(path: &Path, payload: &[u8]) -> Result<(), SessionStoreError> {
     Ok(())
 }
 
-/// Decode stored ticket file.
-fn decode_ticket(bytes: &[u8]) -> Result<ParkedApproval, SessionStoreError> {
+/// Decode a stored approval file.
+fn decode_approval(bytes: &[u8]) -> Result<ParkedApproval, SessionStoreError> {
     let record: ParkedApprovalRecord = serde_json::from_slice(bytes).map_err(decode_err)?;
-    restore_ticket(record)
+    restore_approval(record)
 }
 
-/// Restore ticket record.
-fn restore_ticket(record: ParkedApprovalRecord) -> Result<ParkedApproval, SessionStoreError> {
+/// Restore an approval record.
+fn restore_approval(record: ParkedApprovalRecord) -> Result<ParkedApproval, SessionStoreError> {
     ParkedApproval::try_from(record).map_err(decode_err)
 }
 


### PR DESCRIPTION
## Summary

First slice of the park/reify resume work (follows #656). Two commits, zero behavior change:

- **8806054f** retires the ticket vocabulary in the storage layer: `tickets/` becomes `approvals/`, `TICKETS_DIR`/`ticket_path` become `APPROVALS_DIR`/`approval_path`, and the persisted `ResolvedEntry.ticket` field becomes `approval`. The bounding line is now enacted on disk: an approval request, once ruled, becomes a decision, moving from `approvals/{id}.json` into `decisions/{id}.json`. No consumers of the old names exist yet - park mode is default-off and the park line consumes the store only through the trait API.
- **34f3d4cf** adds the recorded-decisions consult seam: `RecordedDecisions`/`CallKey` in the park module, keyed by `(task_id, tool_name, sha256(tool_name || 0x00 || canonical_json(arguments)))` with one queue per key consumed in recorded order, plus a `StrictGuard` drop guard clearing a task's strict entry on every exit path. The gate consumes it immediately after glob matching when armed via `with_recorded_decisions` (`None` on the live path, so behavior is unchanged): a hit maps through the existing approval mapping - denial feedback identical to the live path - a miss while the task's continuation is in flight fails closed as a resume mismatch, and a miss otherwise falls through to the park arm.

The seam is the consult the resume path (next PR) consults instead of re-asking the human.

## Test plan

13 new unit tests (queue order, strict toggling, drop-guard clears on early return and panic unwind, digest canonicalization, gate consult hit/miss/strict/no-task-id). `cargo test -p aura` green with the rest of the stack; clippy `-D warnings` and fmt clean. CI runs per-commit green on this branch.

Part of #271