### PR TITLE
Derive approval cancellation events from the store's cleared set

### DIFF
--- a/crates/aura-web-server/src/session_store/redis/approval_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/approval_store.rs
@@ -15,10 +15,10 @@
 //! authoritative timeout. Decision records keep a margin past the parked
 //! record's remaining TTL, covering the parking instance's deadline-backstop
 //! read. The request index is refreshed on every register with a margin over
-//! the record TTL and pruned best-effort on resolve/remove; a stale indexed id
-//! only costs `cancel_request` a missed take, and a swept key that is
-//! wrong-typed or missing is silently left in place while a non-UTF-8
-//! record is warned and skipped.
+//! the record TTL and pruned best-effort on resolve/remove; the cancel
+//! sweep's script sweeps taken and stale ids from the index, warns on a
+//! wrong-typed key while leaving it and its index entry in place for a
+//! later sweep, and warns on a non-UTF-8 record it consumed.
 
 use std::sync::LazyLock;
 
@@ -38,12 +38,20 @@ const REQ_INDEX_TTL_MARGIN_SECS: u64 = 60;
 /// Decision TTL margin over the parked record's remaining TTL.
 const DECISION_TTL_MARGIN_MS: u64 = 60_000;
 
-/// Sweep-take script: a key that is not a string comes back as nil instead
-/// of erroring the pipe after EXEC already cleared the index.
+/// Sweep-take script over one approval key (KEYS[1]) and its request index
+/// (KEYS[2]): a string key is GETDEL'd and its id swept from the index; a
+/// present wrong-typed key returns integer 0 with its index entry kept, so
+/// a later sweep retries it; an absent key is a stale index entry, swept.
 static SWEEP_TAKE_SCRIPT: &str = r#"
 if redis.call('TYPE', KEYS[1]).ok == 'string' then
-    return redis.call('GETDEL', KEYS[1])
+    local record = redis.call('GETDEL', KEYS[1])
+    redis.call('SREM', KEYS[2], ARGV[1])
+    return record
 end
+if redis.call('EXISTS', KEYS[1]) == 1 then
+    return 0
+end
+redis.call('SREM', KEYS[2], ARGV[1])
 return nil
 "#;
 
@@ -206,33 +214,42 @@ impl ApprovalStore for RedisApprovalStore {
         }
 
         // One atomic pipe: a mid-sweep failure cannot drop an
-        // already-cleared prefix. The take reports a wrong-typed key as nil
-        // rather than erroring an EXEC that already ran. SREM (not DEL) only
-        // removes the swept ids, so a registration the index gained after
-        // the SMEMBERS stays discoverable by a later sweep.
+        // already-cleared prefix. The script owns index membership and only
+        // sweeps the ids this SMEMBERS saw, so a registration the index
+        // gained after it stays discoverable by a later sweep.
         let mut pipe = redis::pipe();
         pipe.atomic();
         for id in &ids {
             pipe.cmd("EVAL")
                 .arg(SWEEP_TAKE_SCRIPT)
-                .arg(1)
-                .arg(self.approval_key(id));
+                .arg(2)
+                .arg(self.approval_key(id))
+                .arg(&req_key)
+                .arg(id);
         }
-        pipe.srem(&req_key, &ids).ignore();
         let payloads: Vec<Option<redis::Value>> =
             pipe.query_async(&mut conn).await.map_err(request_err)?;
 
         let mut cleared = Vec::new();
         for (id, payload) in ids.into_iter().zip(payloads) {
-            let Some(json) = payload.and_then(|value| swept_record_json(&id, value)) else {
-                continue;
-            };
-            match decode(&json) {
-                Ok(parked) => cleared.push(parked),
-                Err(err) => tracing::warn!(
-                    decision_id = %id, error = %err,
-                    "undecodable approval record skipped by cancel_request"
+            match payload {
+                None => {}
+                Some(redis::Value::Int(0)) => tracing::warn!(
+                    decision_id = %id,
+                    "wrong-typed approval key left in place; index entry kept"
                 ),
+                Some(value) => {
+                    let Some(json) = swept_record_json(&id, value) else {
+                        continue;
+                    };
+                    match decode(&json) {
+                        Ok(parked) => cleared.push(parked),
+                        Err(err) => tracing::warn!(
+                            decision_id = %id, error = %err,
+                            "undecodable approval record skipped by cancel_request"
+                        ),
+                    }
+                }
             }
         }
         Ok(cleared)
@@ -256,8 +273,8 @@ fn decode(json: &str) -> Result<ParkedApproval, SessionStoreError> {
 }
 
 /// Decode one swept reply into record JSON, skipping entries the cancel can
-/// no longer deliver: a missing key, a wrong-typed key, or non-UTF-8 bytes
-/// (that record is consumed unrecoverably, like a decode failure).
+/// no longer deliver: non-UTF-8 bytes (that record is consumed
+/// unrecoverably, like a decode failure) or an unexpected reply kind.
 fn swept_record_json(id: &str, value: redis::Value) -> Option<String> {
     match value {
         redis::Value::BulkString(bytes) => match String::from_utf8(bytes) {

--- a/crates/aura-web-server/src/session_store/redis/approval_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/approval_store.rs
@@ -16,7 +16,7 @@
 //! record's remaining TTL, covering the parking instance's deadline-backstop
 //! read. The request index is refreshed on every register with a margin over
 //! the record TTL and pruned best-effort on resolve/remove; a stale indexed id
-//! only costs `cancel_request` a `DEL` of a missing key.
+//! only costs `cancel_request` a `GETDEL` of a missing key.
 
 use std::sync::LazyLock;
 
@@ -80,12 +80,12 @@ impl RedisApprovalStore {
         format!("{}:approval:req:{request_id}", self.key_prefix)
     }
 
-    /// Atomically take the record (`GETDEL`), pruning the request index
-    /// best-effort. `None` means no live entry existed.
-    async fn take(&self, id: &DecisionId) -> Result<Option<()>, SessionStoreError> {
+    /// Atomically take a record (`GETDEL`) and decode it, pruning the
+    /// request index best-effort. `None` means no live entry existed.
+    async fn take(&self, id: &str) -> Result<Option<ParkedApproval>, SessionStoreError> {
         let mut conn = self.conn.clone();
         let payload: Option<String> = redis::cmd("GETDEL")
-            .arg(self.approval_key(&id.to_string()))
+            .arg(self.approval_key(id))
             .query_async(&mut conn)
             .await
             .map_err(request_err)?;
@@ -93,16 +93,14 @@ impl RedisApprovalStore {
             return Ok(None);
         };
         self.prune_req_index(id, &json).await;
-        Ok(Some(()))
+        decode(&json).map(Some)
     }
 
     /// Drop a taken record's id from its request index, best-effort.
-    async fn prune_req_index(&self, id: &DecisionId, record_json: &str) {
+    async fn prune_req_index(&self, id: &str, record_json: &str) {
         if let Ok(record) = serde_json::from_str::<ParkedApprovalRecord>(record_json) {
             let mut conn = self.conn.clone();
-            let _: Result<(), _> = conn
-                .srem(self.req_key(&record.request_id), id.to_string())
-                .await;
+            let _: Result<(), _> = conn.srem(self.req_key(&record.request_id), id).await;
         }
     }
 }
@@ -157,7 +155,7 @@ impl ApprovalStore for RedisApprovalStore {
         let Some(json) = taken else {
             return Err(ResolveError::NotFound);
         };
-        self.prune_req_index(id, &json).await;
+        self.prune_req_index(&id.to_string(), &json).await;
         Ok(())
     }
 
@@ -182,20 +180,26 @@ impl ApprovalStore for RedisApprovalStore {
     }
 
     async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError> {
-        self.take(id).await.map(|_| ())
+        self.take(&id.to_string()).await.map(|_| ())
     }
 
-    async fn cancel_request(&self, request_id: &str) -> Result<(), SessionStoreError> {
+    async fn cancel_request(
+        &self,
+        request_id: &str,
+    ) -> Result<Vec<ParkedApproval>, SessionStoreError> {
         let req_key = self.req_key(request_id);
         let mut conn = self.conn.clone();
         let ids: Vec<String> = conn.smembers(&req_key).await.map_err(request_err)?;
 
-        let mut pipe = redis::pipe();
+        let mut cleared = Vec::new();
         for id in &ids {
-            pipe.del(self.approval_key(id)).ignore();
+            // A stale indexed id costs one `GETDEL` of a missing key.
+            if let Some(parked) = self.take(id).await? {
+                cleared.push(parked);
+            }
         }
-        pipe.del(&req_key).ignore();
-        pipe.query_async::<()>(&mut conn).await.map_err(request_err)
+        let _: i64 = conn.del(&req_key).await.map_err(request_err)?;
+        Ok(cleared)
     }
 }
 

--- a/crates/aura-web-server/src/session_store/redis/approval_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/approval_store.rs
@@ -16,8 +16,9 @@
 //! record's remaining TTL, covering the parking instance's deadline-backstop
 //! read. The request index is refreshed on every register with a margin over
 //! the record TTL and pruned best-effort on resolve/remove; a stale indexed id
-//! only costs `cancel_request` a missed take, and a swept record that is
-//! wrong-typed or non-UTF-8 at its key is warned and skipped.
+//! only costs `cancel_request` a missed take, and a swept key that is
+//! wrong-typed or missing is silently left in place while a non-UTF-8
+//! record is warned and skipped.
 
 use std::sync::LazyLock;
 
@@ -272,7 +273,7 @@ fn swept_record_json(id: &str, value: redis::Value) -> Option<String> {
         _other => {
             tracing::warn!(
                 decision_id = %id,
-                "wrong-typed approval record skipped by cancel_request"
+                "unexpected approval record value kind skipped by cancel_request"
             );
             None
         }

--- a/crates/aura-web-server/src/session_store/redis/approval_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/approval_store.rs
@@ -16,7 +16,8 @@
 //! record's remaining TTL, covering the parking instance's deadline-backstop
 //! read. The request index is refreshed on every register with a margin over
 //! the record TTL and pruned best-effort on resolve/remove; a stale indexed id
-//! only costs `cancel_request` a `GETDEL` of a missing key.
+//! only costs `cancel_request` a missed take, and a swept record that is
+//! wrong-typed or non-UTF-8 at its key is warned and skipped.
 
 use std::sync::LazyLock;
 
@@ -35,6 +36,15 @@ const MIN_TTL_SECS: u64 = 1;
 const REQ_INDEX_TTL_MARGIN_SECS: u64 = 60;
 /// Decision TTL margin over the parked record's remaining TTL.
 const DECISION_TTL_MARGIN_MS: u64 = 60_000;
+
+/// Sweep-take script: a key that is not a string comes back as nil instead
+/// of erroring the pipe after EXEC already cleared the index.
+static SWEEP_TAKE_SCRIPT: &str = r#"
+if redis.call('TYPE', KEYS[1]).ok == 'string' then
+    return redis.call('GETDEL', KEYS[1])
+end
+return nil
+"#;
 
 /// Atomic script for the at-most-once claim and durable decision write.
 static RESOLVE_SCRIPT: LazyLock<redis::Script> = LazyLock::new(|| {
@@ -195,21 +205,25 @@ impl ApprovalStore for RedisApprovalStore {
         }
 
         // One atomic pipe: a mid-sweep failure cannot drop an
-        // already-cleared prefix. SREM (not DEL) only removes the swept ids,
-        // so a registration the index gained after the SMEMBERS stays
-        // discoverable by a later sweep.
+        // already-cleared prefix. The take reports a wrong-typed key as nil
+        // rather than erroring an EXEC that already ran. SREM (not DEL) only
+        // removes the swept ids, so a registration the index gained after
+        // the SMEMBERS stays discoverable by a later sweep.
         let mut pipe = redis::pipe();
         pipe.atomic();
         for id in &ids {
-            pipe.get_del(self.approval_key(id));
+            pipe.cmd("EVAL")
+                .arg(SWEEP_TAKE_SCRIPT)
+                .arg(1)
+                .arg(self.approval_key(id));
         }
         pipe.srem(&req_key, &ids).ignore();
-        let payloads: Vec<Option<String>> =
+        let payloads: Vec<Option<redis::Value>> =
             pipe.query_async(&mut conn).await.map_err(request_err)?;
 
         let mut cleared = Vec::new();
         for (id, payload) in ids.into_iter().zip(payloads) {
-            let Some(json) = payload else {
+            let Some(json) = payload.and_then(|value| swept_record_json(&id, value)) else {
                 continue;
             };
             match decode(&json) {
@@ -238,4 +252,29 @@ fn decode(json: &str) -> Result<ParkedApproval, SessionStoreError> {
     ParkedApproval::try_from(record).map_err(|e| SessionStoreError::Decode {
         reason: e.to_string(),
     })
+}
+
+/// Decode one swept reply into record JSON, skipping entries the cancel can
+/// no longer deliver: a missing key, a wrong-typed key, or non-UTF-8 bytes
+/// (that record is consumed unrecoverably, like a decode failure).
+fn swept_record_json(id: &str, value: redis::Value) -> Option<String> {
+    match value {
+        redis::Value::BulkString(bytes) => match String::from_utf8(bytes) {
+            Ok(json) => Some(json),
+            Err(err) => {
+                tracing::warn!(
+                    decision_id = %id, error = %err,
+                    "non-UTF-8 approval record skipped by cancel_request"
+                );
+                None
+            }
+        },
+        _other => {
+            tracing::warn!(
+                decision_id = %id,
+                "wrong-typed approval record skipped by cancel_request"
+            );
+            None
+        }
+    }
 }

--- a/crates/aura-web-server/src/session_store/redis/approval_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/approval_store.rs
@@ -190,15 +190,36 @@ impl ApprovalStore for RedisApprovalStore {
         let req_key = self.req_key(request_id);
         let mut conn = self.conn.clone();
         let ids: Vec<String> = conn.smembers(&req_key).await.map_err(request_err)?;
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // One atomic pipe: a mid-sweep failure cannot drop an
+        // already-cleared prefix. SREM (not DEL) only removes the swept ids,
+        // so a registration the index gained after the SMEMBERS stays
+        // discoverable by a later sweep.
+        let mut pipe = redis::pipe();
+        pipe.atomic();
+        for id in &ids {
+            pipe.get_del(self.approval_key(id));
+        }
+        pipe.srem(&req_key, &ids).ignore();
+        let payloads: Vec<Option<String>> =
+            pipe.query_async(&mut conn).await.map_err(request_err)?;
 
         let mut cleared = Vec::new();
-        for id in &ids {
-            // A stale indexed id costs one `GETDEL` of a missing key.
-            if let Some(parked) = self.take(id).await? {
-                cleared.push(parked);
+        for (id, payload) in ids.into_iter().zip(payloads) {
+            let Some(json) = payload else {
+                continue;
+            };
+            match decode(&json) {
+                Ok(parked) => cleared.push(parked),
+                Err(err) => tracing::warn!(
+                    decision_id = %id, error = %err,
+                    "undecodable approval record skipped by cancel_request"
+                ),
             }
         }
-        let _: i64 = conn.del(&req_key).await.map_err(request_err)?;
         Ok(cleared)
     }
 }

--- a/crates/aura-web-server/src/session_store/redis/approval_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/approval_store.rs
@@ -99,20 +99,23 @@ impl RedisApprovalStore {
         format!("{}:approval:req:{request_id}", self.key_prefix)
     }
 
-    /// Atomically take a record (`GETDEL`) and decode it, pruning the
-    /// request index best-effort. `None` means no live entry existed.
-    async fn take(&self, id: &str) -> Result<Option<ParkedApproval>, SessionStoreError> {
+    /// Atomically take a record (`GETDEL`) and prune the request index
+    /// best-effort, returning the raw payload. `None` means no live entry
+    /// existed. No decode: the caller decides what a corrupt payload means.
+    /// A payload that cannot identify its request id keeps its index entry
+    /// (`prune_req_index` cannot find it); the entry dies with the index
+    /// key's TTL.
+    async fn take_json(&self, id: &str) -> Result<Option<String>, SessionStoreError> {
         let mut conn = self.conn.clone();
         let payload: Option<String> = redis::cmd("GETDEL")
             .arg(self.approval_key(id))
             .query_async(&mut conn)
             .await
             .map_err(request_err)?;
-        let Some(json) = payload else {
-            return Ok(None);
-        };
-        self.prune_req_index(id, &json).await;
-        decode(&json).map(Some)
+        if let Some(json) = &payload {
+            self.prune_req_index(id, json).await;
+        }
+        Ok(payload)
     }
 
     /// Drop a taken record's id from its request index, best-effort.
@@ -199,7 +202,9 @@ impl ApprovalStore for RedisApprovalStore {
     }
 
     async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError> {
-        self.take(&id.to_string()).await.map(|_| ())
+        // The record is discarded, so skip the decode: a corrupt payload must
+        // not fail the removal of an entry already GETDEL'd.
+        self.take_json(&id.to_string()).await.map(|_| ())
     }
 
     async fn cancel_request(

--- a/crates/aura-web-server/src/session_store/redis/approval_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/approval_store.rs
@@ -15,10 +15,9 @@
 //! authoritative timeout. Decision records keep a margin past the parked
 //! record's remaining TTL, covering the parking instance's deadline-backstop
 //! read. The request index is refreshed on every register with a margin over
-//! the record TTL and pruned best-effort on resolve/remove; the cancel
-//! sweep's script sweeps taken and stale ids from the index, warns on a
-//! wrong-typed key while leaving it and its index entry in place for a
-//! later sweep, and warns on a non-UTF-8 record it consumed.
+//! the record TTL and pruned best-effort on resolve/remove. The cancel sweep
+//! prunes per id, never the whole index key; `SWEEP_TAKE_SCRIPT` states what
+//! each id yields.
 
 use std::sync::LazyLock;
 
@@ -38,10 +37,10 @@ const REQ_INDEX_TTL_MARGIN_SECS: u64 = 60;
 /// Decision TTL margin over the parked record's remaining TTL.
 const DECISION_TTL_MARGIN_MS: u64 = 60_000;
 
-/// Sweep-take script over one approval key (KEYS[1]) and its request index
-/// (KEYS[2]): a string key is GETDEL'd and its id swept from the index; a
-/// present wrong-typed key returns integer 0 with its index entry kept, so
-/// a later sweep retries it; an absent key is a stale index entry, swept.
+/// Sweep one approval key (KEYS[1]) out of its request index (KEYS[2]):
+/// a string key is GETDEL'd and its id SREM'd; a wrong-typed key returns 0
+/// and keeps its index entry for a later sweep; an absent key is a stale
+/// index entry, SREM'd.
 static SWEEP_TAKE_SCRIPT: &str = r#"
 if redis.call('TYPE', KEYS[1]).ok == 'string' then
     local record = redis.call('GETDEL', KEYS[1])
@@ -99,12 +98,9 @@ impl RedisApprovalStore {
         format!("{}:approval:req:{request_id}", self.key_prefix)
     }
 
-    /// Atomically take a record (`GETDEL`) and prune the request index
-    /// best-effort, returning the raw payload. `None` means no live entry
-    /// existed. No decode: the caller decides what a corrupt payload means.
-    /// A payload that cannot identify its request id keeps its index entry
-    /// (`prune_req_index` cannot find it); the entry dies with the index
-    /// key's TTL.
+    /// `GETDEL` a record and prune its request index best-effort, returning
+    /// the raw payload; `None` means no live entry existed. An unparseable
+    /// payload keeps its index entry until the index key's TTL.
     async fn take_json(&self, id: &str) -> Result<Option<String>, SessionStoreError> {
         let mut conn = self.conn.clone();
         let payload: Option<String> = redis::cmd("GETDEL")
@@ -202,8 +198,7 @@ impl ApprovalStore for RedisApprovalStore {
     }
 
     async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError> {
-        // The record is discarded, so skip the decode: a corrupt payload must
-        // not fail the removal of an entry already GETDEL'd.
+        // No decode: a corrupt payload must not fail a removal already done.
         self.take_json(&id.to_string()).await.map(|_| ())
     }
 

--- a/crates/aura-web-server/tests/common/mod.rs
+++ b/crates/aura-web-server/tests/common/mod.rs
@@ -141,17 +141,26 @@ pub async fn remove_makes_resolve_not_found(instance: &Arc<dyn ApprovalStore>) {
     );
 }
 
-/// Cancelling by owner (request) id removes only that owner's tickets.
+/// Cancelling by owner (request) id removes only that owner's tickets and
+/// returns exactly the cleared set.
 pub async fn cancel_request_removes_only_matching(instance: &Arc<dyn ApprovalStore>) {
     let cancel = make_parked("req-cancel", Duration::from_secs(60));
     let keep = make_parked("req-keep", Duration::from_secs(60));
     let cancel_id = cancel.request.decision_id;
+    let cleared_record = ParkedApprovalRecord::from(&cancel);
     let keep_id = keep.request.decision_id;
     instance.register(cancel).await.unwrap();
     instance.register(keep).await.unwrap();
 
-    instance.cancel_request("req-cancel").await.unwrap();
+    let cleared = instance.cancel_request("req-cancel").await.unwrap();
 
+    assert_eq!(cleared.len(), 1, "exactly the matching ticket is cleared");
+    assert_eq!(
+        ParkedApprovalRecord::from(&cleared[0]),
+        cleared_record,
+        "the cleared record is returned unchanged"
+    );
+    assert_eq!(cleared[0].request.decision_id, cancel_id);
     assert!(instance.get(&cancel_id).await.unwrap().is_none());
     assert!(instance.get(&keep_id).await.unwrap().is_some());
 }

--- a/crates/aura-web-server/tests/file_session_store_test.rs
+++ b/crates/aura-web-server/tests/file_session_store_test.rs
@@ -271,6 +271,84 @@ async fn cancel_request_removes_only_undecided_matching_approvals() {
     assert!(store.get(&other_id).await.unwrap().is_some());
 }
 
+/// The residue of resolve's best-effort approval unlink — a stale approval
+/// file whose decision file exists — is swept by `cancel_request` but absent
+/// from the returned set: the recorded decision owns the outcome.
+#[tokio::test]
+async fn cancel_request_sweeps_a_stale_decided_approval_without_returning_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let undecided = make_parked("req-residue", Duration::from_secs(60));
+    let undecided_id = undecided.request.decision_id;
+    store.register(undecided).await.unwrap();
+    let decided = make_parked("req-residue", Duration::from_secs(60));
+    let decided_id = decided.request.decision_id;
+    let residue = serde_json::to_vec(&ParkedApprovalRecord::from(&decided)).unwrap();
+    store.register(decided).await.unwrap();
+    store
+        .resolve(&decided_id, ApprovalDecision::Approved)
+        .await
+        .unwrap();
+
+    // Resolve's approval unlink failed: put the residue back.
+    std::fs::write(
+        dir.path()
+            .join("approvals")
+            .join(format!("{decided_id}.json")),
+        residue,
+    )
+    .unwrap();
+
+    let cleared = store.cancel_request("req-residue").await.unwrap();
+
+    assert_eq!(cleared.len(), 1, "only the undecided ticket is cleared");
+    assert_eq!(cleared[0].request.decision_id, undecided_id);
+    assert!(
+        !dir.path()
+            .join("approvals")
+            .join(format!("{undecided_id}.json"))
+            .exists()
+    );
+    assert!(
+        !dir.path()
+            .join("approvals")
+            .join(format!("{decided_id}.json"))
+            .exists(),
+        "the stale residue is swept too"
+    );
+    assert_eq!(
+        store.decision(&decided_id).await.unwrap(),
+        Some(ApprovalDecision::Approved),
+        "the recorded decision is retained"
+    );
+}
+
+/// A corrupt record in `approvals/` is warn-and-skipped: `cancel_request`
+/// still returns and removes the decodable files, leaving the corrupt file
+/// in place.
+#[tokio::test]
+async fn cancel_request_skips_an_undecodable_approval_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let parked = make_parked("req-corrupt", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    store.register(parked).await.unwrap();
+    let corrupt = dir.path().join("approvals").join("corrupt.json");
+    std::fs::write(&corrupt, b"not json").unwrap();
+
+    let cleared = store.cancel_request("req-corrupt").await.unwrap();
+
+    assert_eq!(cleared.len(), 1);
+    assert_eq!(cleared[0].request.decision_id, id);
+    assert!(
+        !dir.path()
+            .join("approvals")
+            .join(format!("{id}.json"))
+            .exists()
+    );
+    assert!(corrupt.exists(), "the undecodable file is left in place");
+}
+
 /// A read-only `approvals/` directory must not fail `resolve`: the decision
 /// write and its sync are the commit, and the approval removal past them is
 /// best-effort — the stale approval remains, `get` still returns the record,

--- a/crates/aura-web-server/tests/file_session_store_test.rs
+++ b/crates/aura-web-server/tests/file_session_store_test.rs
@@ -234,8 +234,9 @@ async fn resolve_moves_the_approval_into_the_decision_file() {
     assert_eq!(on_disk["decision"]["reason"], serde_json::Value::Null);
 }
 
-/// §2.5: `cancel_request` removes undecided approvals by owner id; a decided
-/// approval of the same owner and an undecided approval of another owner survive.
+/// §2.5: `cancel_request` removes undecided approvals by owner id and
+/// returns exactly the cleared set; a decided approval of the same owner and
+/// an undecided approval of another owner survive.
 #[tokio::test]
 async fn cancel_request_removes_only_undecided_matching_approvals() {
     let dir = tempfile::tempdir().unwrap();
@@ -254,8 +255,10 @@ async fn cancel_request_removes_only_undecided_matching_approvals() {
     let other_id = other.request.decision_id;
     store.register(other).await.unwrap();
 
-    store.cancel_request("req-owner").await.unwrap();
+    let cleared = store.cancel_request("req-owner").await.unwrap();
 
+    assert_eq!(cleared.len(), 1, "only the undecided ticket is cleared");
+    assert_eq!(cleared[0].request.decision_id, undecided_id);
     assert!(store.get(&undecided_id).await.unwrap().is_none());
     assert!(
         store.get(&decided_id).await.unwrap().is_some(),

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -505,8 +505,9 @@ async fn approval_cancel_request_returns_cleared_set() {
 
 /// One corrupt record must not fail `cancel_request` for its whole request:
 /// with a list planted at one approval key the sweep still returns the valid
-/// sibling and sweeps both ids from the index, and the same holds when the
-/// planted record is non-UTF-8 bytes.
+/// sibling and sweeps its id from the index, while the wrong-typed key and
+/// its index entry stay in place for a later sweep to retry; the same holds
+/// when the planted record is non-UTF-8 bytes, which the sweep consumes.
 #[tokio::test]
 async fn cancel_request_skips_a_wrong_type_value_and_returns_valid_records() {
     let config = test_config(60);
@@ -545,13 +546,60 @@ async fn cancel_request_skips_a_wrong_type_value_and_returns_valid_records() {
     );
     assert!(approvals.get(&valid_id).await.unwrap().is_none());
     assert!(
-        redis::cmd("SMEMBERS")
+        !redis::cmd("SISMEMBER")
             .arg(&req_index_key)
+            .arg(valid_id.to_string())
+            .query_async::<bool>(&mut raw)
+            .await
+            .unwrap(),
+        "the swept record's index entry went with it"
+    );
+    assert!(
+        redis::cmd("SISMEMBER")
+            .arg(&req_index_key)
+            .arg(corrupt_id.to_string())
+            .query_async::<bool>(&mut raw)
+            .await
+            .unwrap(),
+        "the wrong-typed id keeps its index entry"
+    );
+    assert_eq!(
+        redis::cmd("TYPE")
+            .arg(&corrupt_key)
+            .query_async::<String>(&mut raw)
+            .await
+            .unwrap(),
+        "list",
+        "the wrong-typed key is left in place"
+    );
+    assert_eq!(
+        redis::cmd("LRANGE")
+            .arg(&corrupt_key)
+            .arg(0)
+            .arg(-1)
             .query_async::<Vec<String>>(&mut raw)
             .await
-            .unwrap()
-            .is_empty(),
-        "SREM swept both ids from the request index"
+            .unwrap(),
+        ["planted list, not a record"],
+        "the planted list survives the sweep"
+    );
+
+    let cleared_again = approvals
+        .cancel_request("req-wrong-type")
+        .await
+        .expect("a retry over a wrong-typed key must not fail the sweep");
+    assert!(
+        cleared_again.is_empty(),
+        "a wrong-typed key alone clears nothing"
+    );
+    assert!(
+        redis::cmd("SISMEMBER")
+            .arg(&req_index_key)
+            .arg(corrupt_id.to_string())
+            .query_async::<bool>(&mut raw)
+            .await
+            .unwrap(),
+        "the retry keeps the wrong-typed id indexed"
     );
 
     let second_valid = make_parked("req-wrong-type", Duration::from_secs(60));
@@ -579,13 +627,17 @@ async fn cancel_request_skips_a_wrong_type_value_and_returns_valid_records() {
         "the valid record is returned unchanged"
     );
     assert!(
+        approvals.get(&non_utf8_id).await.unwrap().is_none(),
+        "the non-UTF-8 record was consumed"
+    );
+    assert_eq!(
         redis::cmd("SMEMBERS")
             .arg(&req_index_key)
             .query_async::<Vec<String>>(&mut raw)
             .await
-            .unwrap()
-            .is_empty(),
-        "SREM swept both ids from the request index"
+            .unwrap(),
+        vec![corrupt_id.to_string()],
+        "the non-UTF-8 record's index entry was swept; the wrong-typed one remains"
     );
 }
 

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -457,6 +457,34 @@ async fn approval_cancel_request_returns_cleared_set() {
         Err(ResolveError::NotFound),
         "a cleared ticket resolves NotFound"
     );
+
+    // A registration racing the sweep — same request id, added after the
+    // cancel — keeps its index entry: a second cancel still discovers and
+    // takes it.
+    let late = make_parked("req-cancel-return", Duration::from_secs(60));
+    let late_id = late.request.decision_id;
+    let late_record = ParkedApprovalRecord::from(&late);
+    approvals.register(late).await.unwrap();
+
+    let cleared_late = approvals.cancel_request("req-cancel-return").await.unwrap();
+
+    assert_eq!(
+        cleared_late.len(),
+        1,
+        "the post-cancel registration is discoverable"
+    );
+    assert_eq!(
+        ParkedApprovalRecord::from(&cleared_late[0]),
+        late_record,
+        "the late record is returned unchanged"
+    );
+    assert_eq!(
+        approvals
+            .resolve(&late_id, ApprovalDecision::Approved)
+            .await,
+        Err(ResolveError::NotFound),
+        "the second cancel GETDEL'd the late ticket"
+    );
 }
 
 #[tokio::test]

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -425,7 +425,8 @@ async fn approval_cancel_request_removes_only_matching() {
 /// resolve.
 #[tokio::test]
 async fn approval_cancel_request_returns_cleared_set() {
-    let approvals = connect(&test_config(60)).await.approvals();
+    let config = test_config(60);
+    let approvals = connect(&config).await.approvals();
     let undecided = make_parked("req-cancel-return", Duration::from_secs(60));
     let undecided_id = undecided.request.decision_id;
     let cleared_record = ParkedApprovalRecord::from(&undecided);
@@ -465,6 +466,21 @@ async fn approval_cancel_request_returns_cleared_set() {
     let late_id = late.request.decision_id;
     let late_record = ParkedApprovalRecord::from(&late);
     approvals.register(late).await.unwrap();
+    let client = redis::Client::open(redis_url()).unwrap();
+    let mut raw = client.get_multiplexed_async_connection().await.unwrap();
+    let still_indexed: bool = redis::cmd("SISMEMBER")
+        .arg(format!(
+            "{}:approval:req:req-cancel-return",
+            config.key_prefix
+        ))
+        .arg(late_id.to_string())
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(
+        still_indexed,
+        "the first cancel's SREM left the late registration's index entry"
+    );
 
     let cleared_late = approvals.cancel_request("req-cancel-return").await.unwrap();
 
@@ -484,6 +500,92 @@ async fn approval_cancel_request_returns_cleared_set() {
             .await,
         Err(ResolveError::NotFound),
         "the second cancel GETDEL'd the late ticket"
+    );
+}
+
+/// One corrupt record must not fail `cancel_request` for its whole request:
+/// with a list planted at one approval key the sweep still returns the valid
+/// sibling and sweeps both ids from the index, and the same holds when the
+/// planted record is non-UTF-8 bytes.
+#[tokio::test]
+async fn cancel_request_skips_a_wrong_type_value_and_returns_valid_records() {
+    let config = test_config(60);
+    let approvals = connect(&config).await.approvals();
+    let req_index_key = format!("{}:approval:req:req-wrong-type", config.key_prefix);
+    let client = redis::Client::open(redis_url()).unwrap();
+    let mut raw = client.get_multiplexed_async_connection().await.unwrap();
+
+    let valid = make_parked("req-wrong-type", Duration::from_secs(60));
+    let valid_id = valid.request.decision_id;
+    let valid_record = ParkedApprovalRecord::from(&valid);
+    let corrupt = make_parked("req-wrong-type", Duration::from_secs(60));
+    let corrupt_id = corrupt.request.decision_id;
+    approvals.register(valid).await.unwrap();
+    approvals.register(corrupt).await.unwrap();
+    let corrupt_key = format!("{}:approval:{corrupt_id}", config.key_prefix);
+    redis::pipe()
+        .del(&corrupt_key)
+        .ignore()
+        .rpush(&corrupt_key, "planted list, not a record")
+        .ignore()
+        .query_async::<()>(&mut raw)
+        .await
+        .unwrap();
+
+    let cleared = approvals
+        .cancel_request("req-wrong-type")
+        .await
+        .expect("a wrong-typed record must not fail the sweep");
+
+    assert_eq!(cleared.len(), 1, "only the valid record is cleared");
+    assert_eq!(
+        ParkedApprovalRecord::from(&cleared[0]),
+        valid_record,
+        "the valid record is returned unchanged"
+    );
+    assert!(approvals.get(&valid_id).await.unwrap().is_none());
+    assert!(
+        redis::cmd("SMEMBERS")
+            .arg(&req_index_key)
+            .query_async::<Vec<String>>(&mut raw)
+            .await
+            .unwrap()
+            .is_empty(),
+        "SREM swept both ids from the request index"
+    );
+
+    let second_valid = make_parked("req-wrong-type", Duration::from_secs(60));
+    let second_record = ParkedApprovalRecord::from(&second_valid);
+    let non_utf8 = make_parked("req-wrong-type", Duration::from_secs(60));
+    let non_utf8_id = non_utf8.request.decision_id;
+    approvals.register(second_valid).await.unwrap();
+    approvals.register(non_utf8).await.unwrap();
+    redis::cmd("SET")
+        .arg(format!("{}:approval:{non_utf8_id}", config.key_prefix))
+        .arg(vec![0xff_u8, 0xfe, b'{'])
+        .query_async::<()>(&mut raw)
+        .await
+        .unwrap();
+
+    let cleared = approvals
+        .cancel_request("req-wrong-type")
+        .await
+        .expect("a non-UTF-8 record must not fail the sweep");
+
+    assert_eq!(cleared.len(), 1, "only the valid record is cleared");
+    assert_eq!(
+        ParkedApprovalRecord::from(&cleared[0]),
+        second_record,
+        "the valid record is returned unchanged"
+    );
+    assert!(
+        redis::cmd("SMEMBERS")
+            .arg(&req_index_key)
+            .query_async::<Vec<String>>(&mut raw)
+            .await
+            .unwrap()
+            .is_empty(),
+        "SREM swept both ids from the request index"
     );
 }
 

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use a2a::{ListTasksRequest, Message, Part, Role, Task, TaskState, TaskStatus};
 use aura::hitl::{ApprovalDecision, ApprovalOutcome, PendingApprovals, ResolveError};
 use aura::request_cancellation::RequestCancelToken;
+use aura::session_store::ParkedApprovalRecord;
 use aura_config::{RedisSessionStoreConfig, SessionStoreBackend};
 use aura_web_server::session_store::{RedisSessionStore, SessionStore};
 use bytes::Bytes;
@@ -417,6 +418,45 @@ async fn approval_remove_makes_resolve_not_found() {
 async fn approval_cancel_request_removes_only_matching() {
     let approvals = connect(&test_config(60)).await.approvals();
     common::cancel_request_removes_only_matching(&approvals).await;
+}
+
+/// `cancel_request` returns exactly the records it cleared; a decided
+/// sibling of the same owner is absent, and a cleared ticket refuses a later
+/// resolve.
+#[tokio::test]
+async fn approval_cancel_request_returns_cleared_set() {
+    let approvals = connect(&test_config(60)).await.approvals();
+    let undecided = make_parked("req-cancel-return", Duration::from_secs(60));
+    let undecided_id = undecided.request.decision_id;
+    let cleared_record = ParkedApprovalRecord::from(&undecided);
+    let decided = make_parked("req-cancel-return", Duration::from_secs(60));
+    let decided_id = decided.request.decision_id;
+    let keep = make_parked("req-cancel-return-keep", Duration::from_secs(60));
+    let keep_id = keep.request.decision_id;
+    approvals.register(undecided).await.unwrap();
+    approvals.register(decided).await.unwrap();
+    approvals.register(keep).await.unwrap();
+    approvals
+        .resolve(&decided_id, ApprovalDecision::Approved)
+        .await
+        .unwrap();
+
+    let cleared = approvals.cancel_request("req-cancel-return").await.unwrap();
+
+    assert_eq!(cleared.len(), 1, "only the undecided ticket is cleared");
+    assert_eq!(
+        ParkedApprovalRecord::from(&cleared[0]),
+        cleared_record,
+        "the cleared record is returned unchanged"
+    );
+    assert!(approvals.get(&keep_id).await.unwrap().is_some());
+    assert_eq!(
+        approvals
+            .resolve(&undecided_id, ApprovalDecision::Approved)
+            .await,
+        Err(ResolveError::NotFound),
+        "a cleared ticket resolves NotFound"
+    );
 }
 
 #[tokio::test]

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -516,20 +516,15 @@ async fn remove_tolerates_an_undecodable_record() {
     let id = parked.request.decision_id;
     approvals.register(parked).await.unwrap();
 
-    // Corrupt the record in place and bound both keys, atomically, so a
-    // failed plant or assertion cannot leak an immortal key.
-    let approval_key = format!("{}:approval:{id}", config.key_prefix);
-    let req_index_key = format!("{}:approval:req:req-remove-corrupt", config.key_prefix);
+    // Corrupt the record in place, TTL-bounded; its index entry dies with
+    // the index key's own TTL.
     let client = redis::Client::open(redis_url()).unwrap();
     let mut raw = client.get_multiplexed_async_connection().await.unwrap();
-    redis::pipe()
-        .atomic()
-        .set(&approval_key, "{not valid json")
-        .ignore()
-        .expire(&approval_key, 60)
-        .ignore()
-        .expire(&req_index_key, 60)
-        .ignore()
+    redis::cmd("SET")
+        .arg(format!("{}:approval:{id}", config.key_prefix))
+        .arg("{not valid json")
+        .arg("EX")
+        .arg(60)
         .query_async::<()>(&mut raw)
         .await
         .unwrap();
@@ -540,15 +535,6 @@ async fn remove_tolerates_an_undecodable_record() {
         .expect("a corrupt payload must not fail the removal");
 
     assert!(approvals.get(&id).await.unwrap().is_none());
-
-    // The unparseable record kept its index entry (prune cannot find its
-    // request id); clean it up rather than leaving it to the TTL.
-    redis::cmd("SREM")
-        .arg(&req_index_key)
-        .arg(id.to_string())
-        .query_async::<()>(&mut raw)
-        .await
-        .unwrap();
 }
 
 /// One corrupt record must not fail `cancel_request` for its whole request:
@@ -692,17 +678,6 @@ async fn cancel_request_skips_a_wrong_type_value_and_returns_valid_records() {
         vec![corrupt_id.to_string()],
         "the non-UTF-8 record's index entry was swept; the wrong-typed one remains"
     );
-
-    // Success-path cleanup for the one fixture the sweep deliberately
-    // leaves in place; the TTLs bound every other failure path.
-    redis::pipe()
-        .del(&corrupt_key)
-        .ignore()
-        .srem(&req_index_key, corrupt_id.to_string())
-        .ignore()
-        .query_async::<()>(&mut raw)
-        .await
-        .unwrap();
 }
 
 #[tokio::test]
@@ -725,247 +700,174 @@ async fn approval_expires_with_its_record_ttl() {
 // SMEMBERS-hold proxy: pin the sweep's SMEMBERS-to-pipe window
 // ---------------------------------------------------------------------------
 
-/// Shared hold state: armed once, fires once, on the connection that
-/// carries the matching SMEMBERS.
-struct SmembersHold {
-    needle: Vec<u8>,
-    armed: AtomicBool,
-    fired: AtomicBool,
-    captured: tokio::sync::mpsc::Sender<()>,
-    release: tokio::sync::Notify,
-    error: tokio::sync::mpsc::Sender<String>,
+/// What a pump reports: the held SMEMBERS reply is in hand, or it failed.
+#[derive(Debug)]
+enum ProxyEvent {
+    Captured,
+    Failed(String),
 }
 
-/// A lockstep TCP proxy between the store under test and the live server.
-/// Every request frame is forwarded, then its response frame, which keeps
-/// pipelined and MULTI/EXEC traffic ordered without interpreting payloads.
-/// When armed, the first SMEMBERS whose key argument contains the needle
-/// has its *response* withheld until released: the client cannot proceed to
-/// its next command, a hard barrier with no sleeps. The store's pub/sub
-/// dispatcher connection passes through untouched (this scenario creates no
-/// subscriptions, so no unsolicited frames break the lockstep).
+/// A lockstep TCP proxy in front of the test server: each request frame is
+/// forwarded, then its response frame, so pipelined and MULTI/EXEC traffic
+/// stays ordered without interpreting payloads. Once armed, the first
+/// SMEMBERS on `needle` has its response withheld until `release` fires: a
+/// hard barrier with no sleeps. The store's pub/sub connection creates no
+/// subscriptions here, so no unsolicited frame breaks the lockstep. Every
+/// task dies with the test runtime.
 struct SmembersHoldProxy {
     addr: std::net::SocketAddr,
-    hold: std::sync::Arc<SmembersHold>,
-    tasks: std::sync::Arc<std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>>,
-}
-
-impl Drop for SmembersHoldProxy {
-    fn drop(&mut self) {
-        // Abort every proxy task so no pump outlives the test that owns it.
-        for task in self.tasks.lock().unwrap().drain(..) {
-            task.abort();
-        }
-    }
+    armed: AtomicBool,
+    release: tokio::sync::Notify,
+    events: tokio::sync::mpsc::Sender<ProxyEvent>,
 }
 
 impl SmembersHoldProxy {
     async fn start(
-        needle: Vec<u8>,
+        needle: String,
     ) -> (
-        Self,
-        tokio::sync::mpsc::Receiver<()>,
-        tokio::sync::mpsc::Receiver<String>,
+        std::sync::Arc<Self>,
+        tokio::sync::mpsc::Receiver<ProxyEvent>,
     ) {
-        // Parse the test server URL with the client's own parser so
-        // credentials, database selection, and trailing forms resolve
-        // exactly as the store sees them; only the endpoint is proxied.
-        let info = redis::Client::open(redis_url())
-            .unwrap()
-            .get_connection_info()
-            .clone();
-        let (host, port) = match &info.addr {
-            redis::ConnectionAddr::Tcp(host, port) => (host.clone(), *port),
-            other => panic!("the pin proxy expects a plain TCP test server, got {other:?}"),
-        };
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (captured_tx, captured_rx) = tokio::sync::mpsc::channel(1);
-        let (error_tx, error_rx) = tokio::sync::mpsc::channel(1);
-        let hold = std::sync::Arc::new(SmembersHold {
-            needle,
+        let (events, rx) = tokio::sync::mpsc::channel(4);
+        let proxy = std::sync::Arc::new(Self {
+            addr: listener.local_addr().unwrap(),
             armed: AtomicBool::new(false),
-            fired: AtomicBool::new(false),
-            captured: captured_tx,
             release: tokio::sync::Notify::new(),
-            error: error_tx,
+            events,
         });
-        let tasks = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let server_addr = format!("{host}:{port}");
-        let accept = tokio::spawn({
-            let hold = hold.clone();
-            let tasks = tasks.clone();
+        tokio::spawn({
+            let proxy = proxy.clone();
             async move {
-                loop {
-                    match listener.accept().await {
-                        Ok((client, _)) => {
-                            let pump = tokio::spawn(pump_lockstep(
-                                client,
-                                server_addr.clone(),
-                                hold.clone(),
-                            ));
-                            tasks.lock().unwrap().push(pump);
-                        }
-                        Err(err) => {
-                            let _ = hold.error.send(format!("accept: {err}")).await;
-                            return;
-                        }
-                    }
+                while let Ok((client, _)) = listener.accept().await {
+                    tokio::spawn(proxy.clone().pump(client, needle.clone()));
                 }
             }
         });
-        tasks.lock().unwrap().push(accept);
-        (Self { addr, hold, tasks }, captured_rx, error_rx)
+        (proxy, rx)
+    }
+
+    /// The test server URL with only its `host:port` swapped for the proxy's,
+    /// so credentials, database, and options survive byte for byte.
+    fn url(&self) -> String {
+        let url = redis_url();
+        let lower = url.to_ascii_lowercase();
+        assert!(
+            !lower.contains("protocol=resp3") && !lower.contains("protocol=3"),
+            "the pin proxy forwards RESP2 only"
+        );
+        let endpoint = test_server_endpoint();
+        assert!(
+            url.contains(&endpoint),
+            "the test server URL must spell {endpoint}"
+        );
+        url.replacen(&endpoint, &self.addr.to_string(), 1)
+    }
+
+    async fn pump(self: std::sync::Arc<Self>, client: tokio::net::TcpStream, needle: String) {
+        use tokio::io::AsyncBufReadExt;
+        let run = async {
+            let server = tokio::net::TcpStream::connect(test_server_endpoint()).await?;
+            let (client_read, mut client_write) = client.into_split();
+            let (server_read, mut server_write) = server.into_split();
+            let mut client_read = tokio::io::BufReader::new(client_read);
+            let mut server_read = tokio::io::BufReader::new(server_read);
+            let (mut request, mut response) = (Vec::new(), Vec::new());
+            // EOF between frames is normal teardown; mid-frame it is a defect.
+            while !client_read.fill_buf().await?.is_empty() {
+                request.clear();
+                let args = read_frame(&mut client_read, &mut request).await?;
+                let hold = args.len() >= 2
+                    && args[0].eq_ignore_ascii_case(b"SMEMBERS")
+                    && args[1] == needle.as_bytes()
+                    && self.armed.swap(false, Ordering::AcqRel);
+                server_write.write_all(&request).await?;
+                response.clear();
+                read_frame(&mut server_read, &mut response).await?;
+                if hold {
+                    // The store's own response timeout fails the sweep
+                    // loudly if the release never comes.
+                    let _ = self.events.send(ProxyEvent::Captured).await;
+                    self.release.notified().await;
+                }
+                client_write.write_all(&response).await?;
+            }
+            Ok::<(), std::io::Error>(())
+        };
+        if let Err(err) = run.await {
+            let _ = self.events.send(ProxyEvent::Failed(err.to_string())).await;
+        }
     }
 }
 
-/// The test server URL with only its endpoint swapped for the proxy's.
-/// The userinfo and the suffix (path, query, fragment) move verbatim —
-/// never decoded and re-encoded — so escaped credentials, the database
-/// selection, and URL options survive byte-for-byte.
-fn proxied_redis_url(proxy_addr: std::net::SocketAddr) -> String {
-    let url = redis_url();
-    let rest = url.strip_prefix("redis://").unwrap_or(url.as_str());
-    // The lockstep forwarder speaks request-response only; RESP3 push
-    // frames would break it.
-    let lower = rest.to_ascii_lowercase();
-    assert!(
-        !lower.contains("protocol=resp3") && !lower.contains("protocol=3"),
-        "the pin proxy forwards RESP2 only"
-    );
-    let suffix_at = rest.find(['/', '?', '#']).unwrap_or(rest.len());
-    let (authority, suffix) = rest.split_at(suffix_at);
-    let userinfo = match authority.rsplit_once('@') {
-        Some((userinfo, _)) => format!("{userinfo}@"),
-        None => String::new(),
-    };
-    format!("redis://{userinfo}{proxy_addr}{suffix}")
+/// The test server's `host:port`, resolved by the client's own URL parser.
+fn test_server_endpoint() -> String {
+    let info = redis::Client::open(redis_url())
+        .unwrap()
+        .get_connection_info()
+        .clone();
+    match info.addr {
+        redis::ConnectionAddr::Tcp(host, port) => format!("{host}:{port}"),
+        other => panic!("the pin proxy expects a plain TCP test server, got {other:?}"),
+    }
 }
 
-/// Read one RESP frame, returning its raw bytes and, for a flat array of
-/// bulk strings (the shape every command redis-rs sends takes), the
-/// argument contents.
-async fn read_frame<R>(reader: &mut R) -> std::io::Result<(Vec<u8>, Vec<Vec<u8>>)>
-where
-    R: tokio::io::AsyncBufRead + Unpin + Send,
-{
-    let mut raw = Vec::new();
-    let args = read_value(reader, &mut raw).await?;
-    Ok((raw, args))
-}
-
-/// The decoded argument contents of one RESP frame.
-type RespArgs = std::io::Result<Vec<Vec<u8>>>;
-/// One in-flight frame read (boxed for the array recursion).
-type RespRead<'a> = std::pin::Pin<Box<dyn std::future::Future<Output = RespArgs> + Send + 'a>>;
-
-fn read_value<'a, R>(reader: &'a mut R, raw: &'a mut Vec<u8>) -> RespRead<'a>
-where
-    R: tokio::io::AsyncBufRead + Unpin + Send,
-{
-    Box::pin(async move {
-        use tokio::io::{AsyncBufReadExt, AsyncReadExt};
-        let mut line = Vec::new();
-        if reader.read_until(b'\n', &mut line).await? == 0 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "closed",
-            ));
+/// Append one RESP2 frame to `raw`, returning its bulk strings: for a
+/// command, its arguments. Arrays are consumed by element count, so nested
+/// replies (an `EXEC` result) stay one frame.
+async fn read_frame<R: tokio::io::AsyncBufRead + Unpin>(
+    reader: &mut R,
+    raw: &mut Vec<u8>,
+) -> std::io::Result<Vec<Vec<u8>>> {
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt};
+    let invalid = || std::io::Error::new(std::io::ErrorKind::InvalidData, "bad RESP frame");
+    let mut bulks = Vec::new();
+    let mut pending = 1usize;
+    while pending > 0 {
+        pending -= 1;
+        let start = raw.len();
+        if reader.read_until(b'\n', raw).await? == 0 {
+            return Err(std::io::ErrorKind::UnexpectedEof.into());
         }
-        raw.extend_from_slice(&line);
-        let invalid = || std::io::Error::new(std::io::ErrorKind::InvalidData, "bad RESP frame");
-        let len = |line: &[u8]| -> std::io::Result<isize> {
+        let line = &raw[start..];
+        let count = || -> std::io::Result<isize> {
             std::str::from_utf8(&line[1..line.len().saturating_sub(2)])
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .ok_or_else(invalid)
         };
-        match line.first() {
-            Some(b'+' | b'-' | b':') => Ok(Vec::new()),
-            Some(b'$') => {
-                let n = len(&line)?;
-                if n < 0 {
-                    return Ok(Vec::new());
+        match line[0] {
+            b'+' | b'-' | b':' => {}
+            b'$' => {
+                let n = count()?;
+                if n >= 0 {
+                    let at = raw.len();
+                    raw.resize(at + n as usize + 2, 0);
+                    reader.read_exact(&mut raw[at..]).await?;
+                    bulks.push(raw[at..at + n as usize].to_vec());
                 }
-                let mut body = vec![0u8; n as usize + 2];
-                reader.read_exact(&mut body).await?;
-                raw.extend_from_slice(&body);
-                body.truncate(n as usize);
-                Ok(vec![body])
             }
-            Some(b'*') => {
-                let n = len(&line)?;
-                let mut args = Vec::new();
-                for _ in 0..n.max(0) {
-                    args.extend(read_value(reader, raw).await?);
-                }
-                Ok(args)
-            }
-            _ => Err(invalid()),
+            b'*' => pending += count()?.max(0) as usize,
+            _ => return Err(invalid()),
         }
-    })
-}
-
-async fn pump_lockstep(
-    client: tokio::net::TcpStream,
-    server_addr: String,
-    hold: std::sync::Arc<SmembersHold>,
-) {
-    use tokio::io::AsyncBufReadExt;
-    let run = async {
-        let server = tokio::net::TcpStream::connect(server_addr).await?;
-        let (client_read, mut client_write) = client.into_split();
-        let (server_read, mut server_write) = server.into_split();
-        let mut client_read = tokio::io::BufReader::new(client_read);
-        let mut server_read = tokio::io::BufReader::new(server_read);
-        loop {
-            // A closed connection between frames is normal teardown; a
-            // failure mid-frame is a proxy defect and must surface.
-            if client_read.fill_buf().await?.is_empty() {
-                return Ok(());
-            }
-            let (request, args) = read_frame(&mut client_read).await?;
-            let hold_this = hold.armed.load(Ordering::Acquire)
-                && args.len() >= 2
-                && args[0].eq_ignore_ascii_case(b"SMEMBERS")
-                && args[1]
-                    .windows(hold.needle.len())
-                    .any(|w| w == hold.needle.as_slice())
-                && !hold.fired.swap(true, Ordering::AcqRel);
-            server_write.write_all(&request).await?;
-            let (response, _) = read_frame(&mut server_read).await?;
-            if hold_this {
-                // The SMEMBERS reply is captured; wait for the release. The
-                // store's own response timeout (5s in these fixtures) fails
-                // the sweep loudly if the release never comes.
-                let _ = hold.captured.send(()).await;
-                hold.release.notified().await;
-            }
-            client_write.write_all(&response).await?;
-        }
-    };
-    let result: std::io::Result<()> = run.await;
-    if let Err(err) = result {
-        let _ = hold.error.send(format!("pump: {err}")).await;
     }
+    Ok(bulks)
 }
 
 /// The sweep's SMEMBERS-to-pipe window, pinned end to end: a registration
 /// that lands after the sweep read the index but before its pipe executes
-/// keeps its index entry and stays discoverable by a later cancel. The
-/// proxy withholds the production SMEMBERS reply until the late
-/// registration has fully completed on a direct connection — a hard
-/// barrier, not a sleep. Under the old whole-index `DEL` this test fails at
-/// the SISMEMBER assertion every run.
+/// keeps its index entry and stays discoverable by a later cancel. Under
+/// the old whole-index `DEL` this fails at the SISMEMBER assertion.
 #[tokio::test]
 async fn cancel_request_leaves_a_mid_sweep_registration_indexed() {
     tokio::time::timeout(Duration::from_secs(30), async {
         let config = test_config(60);
         let req_index_key = format!("{}:approval:req:req-mid-sweep", config.key_prefix);
-        let (proxy, mut captured, mut proxy_errors) =
-            SmembersHoldProxy::start(req_index_key.clone().into_bytes()).await;
-        let mut proxied = config.clone();
-        proxied.url = proxied_redis_url(proxy.addr);
+        let (proxy, mut events) = SmembersHoldProxy::start(req_index_key.clone()).await;
+        let proxied = RedisSessionStoreConfig {
+            url: proxy.url(),
+            ..config.clone()
+        };
         let approvals = connect(&proxied).await.approvals();
 
         let first = make_parked("req-mid-sweep", Duration::from_secs(60));
@@ -974,31 +876,29 @@ async fn cancel_request_leaves_a_mid_sweep_registration_indexed() {
 
         // Arm after the fixture registration, so the held SMEMBERS is the
         // sweep's own.
-        proxy.hold.armed.store(true, Ordering::Release);
+        proxy.armed.store(true, Ordering::Release);
         let sweep = tokio::spawn({
             let approvals = approvals.clone();
             async move { approvals.cancel_request("req-mid-sweep").await }
         });
-
-        // Production read the index and is parked ahead of its sweep pipe;
-        // a proxy defect instead of a capture fails here, with its cause.
-        tokio::select! {
-            received = captured.recv() => {
-                received.expect("the sweep's SMEMBERS was captured");
-            }
-            err = proxy_errors.recv() => {
-                panic!("the pin proxy failed: {}", err.unwrap());
-            }
+        match events.recv().await {
+            Some(ProxyEvent::Captured) => {}
+            Some(ProxyEvent::Failed(err)) => panic!("the pin proxy failed: {err}"),
+            None => panic!("the pin proxy went away"),
         }
 
         // The racing registration completes end to end on a direct
-        // connection before the sweep's pipe is even sent.
+        // connection while the sweep is parked ahead of its pipe.
         let late = make_parked("req-mid-sweep", Duration::from_secs(60));
         let late_id = late.request.decision_id;
-        let direct = connect(&config).await.approvals();
-        direct.register(late).await.unwrap();
+        connect(&config)
+            .await
+            .approvals()
+            .register(late)
+            .await
+            .unwrap();
+        proxy.release.notify_one();
 
-        proxy.hold.release.notify_one();
         let cleared = sweep.await.unwrap().unwrap();
         assert_eq!(
             cleared.len(),
@@ -1009,15 +909,13 @@ async fn cancel_request_leaves_a_mid_sweep_registration_indexed() {
 
         let client = redis::Client::open(redis_url()).unwrap();
         let mut raw = client.get_multiplexed_async_connection().await.unwrap();
-        assert!(
-            redis::cmd("SISMEMBER")
-                .arg(&req_index_key)
-                .arg(late_id.to_string())
-                .query_async::<bool>(&mut raw)
-                .await
-                .unwrap(),
-            "the mid-sweep registration kept its index entry"
-        );
+        let indexed: bool = redis::cmd("SISMEMBER")
+            .arg(&req_index_key)
+            .arg(late_id.to_string())
+            .query_async(&mut raw)
+            .await
+            .unwrap();
+        assert!(indexed, "the mid-sweep registration kept its index entry");
 
         let cleared_late = approvals.cancel_request("req-mid-sweep").await.unwrap();
         assert_eq!(
@@ -1026,11 +924,8 @@ async fn cancel_request_leaves_a_mid_sweep_registration_indexed() {
             "the mid-sweep registration stays discoverable"
         );
         assert_eq!(cleared_late[0].request.decision_id, late_id);
-
-        // No proxy connection failed at any point in the scenario,
-        // including a failure that raced the capture.
         assert!(
-            proxy_errors.try_recv().is_err(),
+            events.try_recv().is_err(),
             "the pin proxy reported a failure"
         );
     })

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -16,6 +16,7 @@
 
 mod common;
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use a2a::{ListTasksRequest, Message, Part, Role, Task, TaskState, TaskStatus};
@@ -26,6 +27,7 @@ use aura_config::{RedisSessionStoreConfig, SessionStoreBackend};
 use aura_web_server::session_store::{RedisSessionStore, SessionStore};
 use bytes::Bytes;
 use futures_util::StreamExt;
+use tokio::io::AsyncWriteExt;
 
 use common::make_parked;
 
@@ -459,9 +461,10 @@ async fn approval_cancel_request_returns_cleared_set() {
         "a cleared ticket resolves NotFound"
     );
 
-    // A registration racing the sweep — same request id, added after the
-    // cancel — keeps its index entry: a second cancel still discovers and
-    // takes it.
+    // Sequential discoverability, not a race pin: a registration added
+    // after the cancel returned keeps its index entry, and a second cancel
+    // still discovers and takes it. The true SMEMBERS-to-EXEC interleave is
+    // pinned by cancel_request_leaves_a_mid_sweep_registration_indexed.
     let late = make_parked("req-cancel-return", Duration::from_secs(60));
     let late_id = late.request.decision_id;
     let late_record = ParkedApprovalRecord::from(&late);
@@ -503,6 +506,51 @@ async fn approval_cancel_request_returns_cleared_set() {
     );
 }
 
+/// `remove` drops a record it cannot decode: the entry is already GETDEL'd,
+/// so a corrupt payload must not fail the removal with a `Decode` error.
+#[tokio::test]
+async fn remove_tolerates_an_undecodable_record() {
+    let config = test_config(60);
+    let approvals = connect(&config).await.approvals();
+    let parked = make_parked("req-remove-corrupt", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    approvals.register(parked).await.unwrap();
+
+    // Corrupt the record in place and bound both keys, atomically, so a
+    // failed plant or assertion cannot leak an immortal key.
+    let approval_key = format!("{}:approval:{id}", config.key_prefix);
+    let req_index_key = format!("{}:approval:req:req-remove-corrupt", config.key_prefix);
+    let client = redis::Client::open(redis_url()).unwrap();
+    let mut raw = client.get_multiplexed_async_connection().await.unwrap();
+    redis::pipe()
+        .atomic()
+        .set(&approval_key, "{not valid json")
+        .ignore()
+        .expire(&approval_key, 60)
+        .ignore()
+        .expire(&req_index_key, 60)
+        .ignore()
+        .query_async::<()>(&mut raw)
+        .await
+        .unwrap();
+
+    approvals
+        .remove(&id)
+        .await
+        .expect("a corrupt payload must not fail the removal");
+
+    assert!(approvals.get(&id).await.unwrap().is_none());
+
+    // The unparseable record kept its index entry (prune cannot find its
+    // request id); clean it up rather than leaving it to the TTL.
+    redis::cmd("SREM")
+        .arg(&req_index_key)
+        .arg(id.to_string())
+        .query_async::<()>(&mut raw)
+        .await
+        .unwrap();
+}
+
 /// One corrupt record must not fail `cancel_request` for its whole request:
 /// with a list planted at one approval key the sweep still returns the valid
 /// sibling and sweeps its id from the index, while the wrong-typed key and
@@ -525,9 +573,12 @@ async fn cancel_request_skips_a_wrong_type_value_and_returns_valid_records() {
     approvals.register(corrupt).await.unwrap();
     let corrupt_key = format!("{}:approval:{corrupt_id}", config.key_prefix);
     redis::pipe()
+        .atomic()
         .del(&corrupt_key)
         .ignore()
         .rpush(&corrupt_key, "planted list, not a record")
+        .ignore()
+        .expire(&corrupt_key, 60)
         .ignore()
         .query_async::<()>(&mut raw)
         .await
@@ -611,6 +662,8 @@ async fn cancel_request_skips_a_wrong_type_value_and_returns_valid_records() {
     redis::cmd("SET")
         .arg(format!("{}:approval:{non_utf8_id}", config.key_prefix))
         .arg(vec![0xff_u8, 0xfe, b'{'])
+        .arg("EX")
+        .arg(60)
         .query_async::<()>(&mut raw)
         .await
         .unwrap();
@@ -639,6 +692,17 @@ async fn cancel_request_skips_a_wrong_type_value_and_returns_valid_records() {
         vec![corrupt_id.to_string()],
         "the non-UTF-8 record's index entry was swept; the wrong-typed one remains"
     );
+
+    // Success-path cleanup for the one fixture the sweep deliberately
+    // leaves in place; the TTLs bound every other failure path.
+    redis::pipe()
+        .del(&corrupt_key)
+        .ignore()
+        .srem(&req_index_key, corrupt_id.to_string())
+        .ignore()
+        .query_async::<()>(&mut raw)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -655,6 +719,323 @@ async fn approval_expires_with_its_record_ttl() {
         approvals.resolve(&id, ApprovalDecision::Approved).await,
         Err(ResolveError::NotFound)
     );
+}
+
+// ---------------------------------------------------------------------------
+// SMEMBERS-hold proxy: pin the sweep's SMEMBERS-to-pipe window
+// ---------------------------------------------------------------------------
+
+/// Shared hold state: armed once, fires once, on the connection that
+/// carries the matching SMEMBERS.
+struct SmembersHold {
+    needle: Vec<u8>,
+    armed: AtomicBool,
+    fired: AtomicBool,
+    captured: tokio::sync::mpsc::Sender<()>,
+    release: tokio::sync::Notify,
+    error: tokio::sync::mpsc::Sender<String>,
+}
+
+/// A lockstep TCP proxy between the store under test and the live server.
+/// Every request frame is forwarded, then its response frame, which keeps
+/// pipelined and MULTI/EXEC traffic ordered without interpreting payloads.
+/// When armed, the first SMEMBERS whose key argument contains the needle
+/// has its *response* withheld until released: the client cannot proceed to
+/// its next command, a hard barrier with no sleeps. The store's pub/sub
+/// dispatcher connection passes through untouched (this scenario creates no
+/// subscriptions, so no unsolicited frames break the lockstep).
+struct SmembersHoldProxy {
+    addr: std::net::SocketAddr,
+    hold: std::sync::Arc<SmembersHold>,
+    tasks: std::sync::Arc<std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+}
+
+impl Drop for SmembersHoldProxy {
+    fn drop(&mut self) {
+        // Abort every proxy task so no pump outlives the test that owns it.
+        for task in self.tasks.lock().unwrap().drain(..) {
+            task.abort();
+        }
+    }
+}
+
+impl SmembersHoldProxy {
+    async fn start(
+        needle: Vec<u8>,
+    ) -> (
+        Self,
+        tokio::sync::mpsc::Receiver<()>,
+        tokio::sync::mpsc::Receiver<String>,
+    ) {
+        // Parse the test server URL with the client's own parser so
+        // credentials, database selection, and trailing forms resolve
+        // exactly as the store sees them; only the endpoint is proxied.
+        let info = redis::Client::open(redis_url())
+            .unwrap()
+            .get_connection_info()
+            .clone();
+        let (host, port) = match &info.addr {
+            redis::ConnectionAddr::Tcp(host, port) => (host.clone(), *port),
+            other => panic!("the pin proxy expects a plain TCP test server, got {other:?}"),
+        };
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (captured_tx, captured_rx) = tokio::sync::mpsc::channel(1);
+        let (error_tx, error_rx) = tokio::sync::mpsc::channel(1);
+        let hold = std::sync::Arc::new(SmembersHold {
+            needle,
+            armed: AtomicBool::new(false),
+            fired: AtomicBool::new(false),
+            captured: captured_tx,
+            release: tokio::sync::Notify::new(),
+            error: error_tx,
+        });
+        let tasks = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let server_addr = format!("{host}:{port}");
+        let accept = tokio::spawn({
+            let hold = hold.clone();
+            let tasks = tasks.clone();
+            async move {
+                loop {
+                    match listener.accept().await {
+                        Ok((client, _)) => {
+                            let pump = tokio::spawn(pump_lockstep(
+                                client,
+                                server_addr.clone(),
+                                hold.clone(),
+                            ));
+                            tasks.lock().unwrap().push(pump);
+                        }
+                        Err(err) => {
+                            let _ = hold.error.send(format!("accept: {err}")).await;
+                            return;
+                        }
+                    }
+                }
+            }
+        });
+        tasks.lock().unwrap().push(accept);
+        (Self { addr, hold, tasks }, captured_rx, error_rx)
+    }
+}
+
+/// The test server URL with only its endpoint swapped for the proxy's.
+/// The userinfo and the suffix (path, query, fragment) move verbatim —
+/// never decoded and re-encoded — so escaped credentials, the database
+/// selection, and URL options survive byte-for-byte.
+fn proxied_redis_url(proxy_addr: std::net::SocketAddr) -> String {
+    let url = redis_url();
+    let rest = url.strip_prefix("redis://").unwrap_or(url.as_str());
+    // The lockstep forwarder speaks request-response only; RESP3 push
+    // frames would break it.
+    let lower = rest.to_ascii_lowercase();
+    assert!(
+        !lower.contains("protocol=resp3") && !lower.contains("protocol=3"),
+        "the pin proxy forwards RESP2 only"
+    );
+    let suffix_at = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let (authority, suffix) = rest.split_at(suffix_at);
+    let userinfo = match authority.rsplit_once('@') {
+        Some((userinfo, _)) => format!("{userinfo}@"),
+        None => String::new(),
+    };
+    format!("redis://{userinfo}{proxy_addr}{suffix}")
+}
+
+/// Read one RESP frame, returning its raw bytes and, for a flat array of
+/// bulk strings (the shape every command redis-rs sends takes), the
+/// argument contents.
+async fn read_frame<R>(reader: &mut R) -> std::io::Result<(Vec<u8>, Vec<Vec<u8>>)>
+where
+    R: tokio::io::AsyncBufRead + Unpin + Send,
+{
+    let mut raw = Vec::new();
+    let args = read_value(reader, &mut raw).await?;
+    Ok((raw, args))
+}
+
+/// The decoded argument contents of one RESP frame.
+type RespArgs = std::io::Result<Vec<Vec<u8>>>;
+/// One in-flight frame read (boxed for the array recursion).
+type RespRead<'a> = std::pin::Pin<Box<dyn std::future::Future<Output = RespArgs> + Send + 'a>>;
+
+fn read_value<'a, R>(reader: &'a mut R, raw: &'a mut Vec<u8>) -> RespRead<'a>
+where
+    R: tokio::io::AsyncBufRead + Unpin + Send,
+{
+    Box::pin(async move {
+        use tokio::io::{AsyncBufReadExt, AsyncReadExt};
+        let mut line = Vec::new();
+        if reader.read_until(b'\n', &mut line).await? == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "closed",
+            ));
+        }
+        raw.extend_from_slice(&line);
+        let invalid = || std::io::Error::new(std::io::ErrorKind::InvalidData, "bad RESP frame");
+        let len = |line: &[u8]| -> std::io::Result<isize> {
+            std::str::from_utf8(&line[1..line.len().saturating_sub(2)])
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .ok_or_else(invalid)
+        };
+        match line.first() {
+            Some(b'+' | b'-' | b':') => Ok(Vec::new()),
+            Some(b'$') => {
+                let n = len(&line)?;
+                if n < 0 {
+                    return Ok(Vec::new());
+                }
+                let mut body = vec![0u8; n as usize + 2];
+                reader.read_exact(&mut body).await?;
+                raw.extend_from_slice(&body);
+                body.truncate(n as usize);
+                Ok(vec![body])
+            }
+            Some(b'*') => {
+                let n = len(&line)?;
+                let mut args = Vec::new();
+                for _ in 0..n.max(0) {
+                    args.extend(read_value(reader, raw).await?);
+                }
+                Ok(args)
+            }
+            _ => Err(invalid()),
+        }
+    })
+}
+
+async fn pump_lockstep(
+    client: tokio::net::TcpStream,
+    server_addr: String,
+    hold: std::sync::Arc<SmembersHold>,
+) {
+    use tokio::io::AsyncBufReadExt;
+    let run = async {
+        let server = tokio::net::TcpStream::connect(server_addr).await?;
+        let (client_read, mut client_write) = client.into_split();
+        let (server_read, mut server_write) = server.into_split();
+        let mut client_read = tokio::io::BufReader::new(client_read);
+        let mut server_read = tokio::io::BufReader::new(server_read);
+        loop {
+            // A closed connection between frames is normal teardown; a
+            // failure mid-frame is a proxy defect and must surface.
+            if client_read.fill_buf().await?.is_empty() {
+                return Ok(());
+            }
+            let (request, args) = read_frame(&mut client_read).await?;
+            let hold_this = hold.armed.load(Ordering::Acquire)
+                && args.len() >= 2
+                && args[0].eq_ignore_ascii_case(b"SMEMBERS")
+                && args[1]
+                    .windows(hold.needle.len())
+                    .any(|w| w == hold.needle.as_slice())
+                && !hold.fired.swap(true, Ordering::AcqRel);
+            server_write.write_all(&request).await?;
+            let (response, _) = read_frame(&mut server_read).await?;
+            if hold_this {
+                // The SMEMBERS reply is captured; wait for the release. The
+                // store's own response timeout (5s in these fixtures) fails
+                // the sweep loudly if the release never comes.
+                let _ = hold.captured.send(()).await;
+                hold.release.notified().await;
+            }
+            client_write.write_all(&response).await?;
+        }
+    };
+    let result: std::io::Result<()> = run.await;
+    if let Err(err) = result {
+        let _ = hold.error.send(format!("pump: {err}")).await;
+    }
+}
+
+/// The sweep's SMEMBERS-to-pipe window, pinned end to end: a registration
+/// that lands after the sweep read the index but before its pipe executes
+/// keeps its index entry and stays discoverable by a later cancel. The
+/// proxy withholds the production SMEMBERS reply until the late
+/// registration has fully completed on a direct connection — a hard
+/// barrier, not a sleep. Under the old whole-index `DEL` this test fails at
+/// the SISMEMBER assertion every run.
+#[tokio::test]
+async fn cancel_request_leaves_a_mid_sweep_registration_indexed() {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let config = test_config(60);
+        let req_index_key = format!("{}:approval:req:req-mid-sweep", config.key_prefix);
+        let (proxy, mut captured, mut proxy_errors) =
+            SmembersHoldProxy::start(req_index_key.clone().into_bytes()).await;
+        let mut proxied = config.clone();
+        proxied.url = proxied_redis_url(proxy.addr);
+        let approvals = connect(&proxied).await.approvals();
+
+        let first = make_parked("req-mid-sweep", Duration::from_secs(60));
+        let first_id = first.request.decision_id;
+        approvals.register(first).await.unwrap();
+
+        // Arm after the fixture registration, so the held SMEMBERS is the
+        // sweep's own.
+        proxy.hold.armed.store(true, Ordering::Release);
+        let sweep = tokio::spawn({
+            let approvals = approvals.clone();
+            async move { approvals.cancel_request("req-mid-sweep").await }
+        });
+
+        // Production read the index and is parked ahead of its sweep pipe;
+        // a proxy defect instead of a capture fails here, with its cause.
+        tokio::select! {
+            received = captured.recv() => {
+                received.expect("the sweep's SMEMBERS was captured");
+            }
+            err = proxy_errors.recv() => {
+                panic!("the pin proxy failed: {}", err.unwrap());
+            }
+        }
+
+        // The racing registration completes end to end on a direct
+        // connection before the sweep's pipe is even sent.
+        let late = make_parked("req-mid-sweep", Duration::from_secs(60));
+        let late_id = late.request.decision_id;
+        let direct = connect(&config).await.approvals();
+        direct.register(late).await.unwrap();
+
+        proxy.hold.release.notify_one();
+        let cleared = sweep.await.unwrap().unwrap();
+        assert_eq!(
+            cleared.len(),
+            1,
+            "the sweep clears only what its SMEMBERS saw"
+        );
+        assert_eq!(cleared[0].request.decision_id, first_id);
+
+        let client = redis::Client::open(redis_url()).unwrap();
+        let mut raw = client.get_multiplexed_async_connection().await.unwrap();
+        assert!(
+            redis::cmd("SISMEMBER")
+                .arg(&req_index_key)
+                .arg(late_id.to_string())
+                .query_async::<bool>(&mut raw)
+                .await
+                .unwrap(),
+            "the mid-sweep registration kept its index entry"
+        );
+
+        let cleared_late = approvals.cancel_request("req-mid-sweep").await.unwrap();
+        assert_eq!(
+            cleared_late.len(),
+            1,
+            "the mid-sweep registration stays discoverable"
+        );
+        assert_eq!(cleared_late[0].request.decision_id, late_id);
+
+        // No proxy connection failed at any point in the scenario,
+        // including a failure that raced the capture.
+        assert!(
+            proxy_errors.try_recv().is_err(),
+            "the pin proxy reported a failure"
+        );
+    })
+    .await
+    .expect("the interleave pin completed within its budget");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -208,9 +208,9 @@ impl HitlApprovalWrapper {
             arguments: args.clone(),
             call_id,
         };
-        // The guard learns the id now, so a run dropped before the task
-        // returns still sweeps this ticket.
-        park.guard.record(&self.scope, std::slice::from_ref(&call));
+        // The guard sees the parked call now, so a run dropped before the
+        // task returns still sweeps this ticket.
+        park.guard.record(std::slice::from_ref(&call));
 
         // The lifecycle pair goes to the live request's broker, not the owner id.
         crate::approval_event_broker::publish(

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -16,7 +16,9 @@ use super::decision::{AgentScope, ApprovalOrigin, ApprovalOutcome, DecisionId};
 use super::protocol::{ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
 use super::registry::{ParkedApproval, PendingApprovals};
 use super::route::{ApprovalError, DecisionRoute, GateDecision};
-use crate::orchestration::{BlockedCell, CallKey, ParkGuard, PendingCall, RecordedDecisions};
+use crate::orchestration::{
+    BlockedCell, CallKey, ParkGuard, PendingCall, RecordedDecisions, run_owner_id,
+};
 use crate::tool_wrapper::{PreCallOutcome, ToolCallContext, ToolWrapper};
 
 /// The placeholder tool result a parked call returns.
@@ -159,11 +161,12 @@ impl HitlApprovalWrapper {
             version: PROTOCOL_VERSION,
             instance_id: self.instance_id.clone(),
             decision_id,
-            // Owner-id convention: every backend sweeps `cancel_request` by
-            // this field, and request teardown passes the live request id, so
-            // the run-scoped value keeps a parked ticket out of that sweep.
-            // The run's own sweep passes the same value.
-            request_id: format!("run:{run_id}"),
+            // Owner id: every backend sweeps `cancel_request` by this field,
+            // and request teardown passes the live request id, so the
+            // run-scoped value keeps a parked ticket out of that sweep.
+            // `run_owner_id` is the single definition; the run's own sweep
+            // passes the same value.
+            request_id: run_owner_id(&run_id.to_string()),
             scope: self.scope.clone(),
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: matched.to_string(),

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -161,11 +161,9 @@ impl HitlApprovalWrapper {
             version: PROTOCOL_VERSION,
             instance_id: self.instance_id.clone(),
             decision_id,
-            // Owner id: every backend sweeps `cancel_request` by this field,
-            // and request teardown passes the live request id, so the
-            // run-scoped value keeps a parked ticket out of that sweep.
-            // `run_owner_id` is the single definition; the run's own sweep
-            // passes the same value.
+            // Request teardown sweeps `cancel_request` by the live request
+            // id; the run-scoped owner id keeps a parked ticket out of that
+            // sweep. The run's own sweep passes the same `run_owner_id`.
             request_id: run_owner_id(&run_id.to_string()),
             scope: self.scope.clone(),
             origin: ApprovalOrigin::ConfigGate {

--- a/crates/aura/src/hitl/registry.rs
+++ b/crates/aura/src/hitl/registry.rs
@@ -262,11 +262,16 @@ impl PendingApprovals {
     }
 
     /// Cancel every approval parked under a request id (stream drop /
-    /// shutdown); their awaits resolve to `Cancelled`.
-    pub async fn cancel_request(&self, request_id: &str) {
+    /// shutdown); their awaits resolve to `Cancelled`. Returns the approvals
+    /// the store cleared, empty on a store fault.
+    pub async fn cancel_request(&self, request_id: &str) -> Vec<ParkedApproval> {
         self.cancel_request_local(request_id);
-        if let Err(err) = self.0.store.cancel_request(request_id).await {
-            warn!(request_id, error = %err, "approval store cancel_request failed");
+        match self.0.store.cancel_request(request_id).await {
+            Ok(cleared) => cleared,
+            Err(err) => {
+                warn!(request_id, error = %err, "approval store cancel_request failed");
+                Vec::new()
+            }
         }
     }
 }

--- a/crates/aura/src/orchestration/mod.rs
+++ b/crates/aura/src/orchestration/mod.rs
@@ -82,7 +82,7 @@ pub use tools::ReadArtifactTool;
 pub use tools::wait_for::{StopReason, WaitForError, WaitForOutput, WaitForTool};
 pub use tools::{SubmitResultDecision, SubmitResultOutput, SubmitResultTool};
 
-pub(crate) use park::{CallKey, ParkGuard, RecordedDecisions};
+pub(crate) use park::{CallKey, ParkGuard, RecordedDecisions, run_owner_id};
 // The worker-model injection seam: `provider_agent.rs`'s cfg(test) variant
 // wraps the rig's scripted agent type.
 pub use prompt_constants::{context, fields, sections};

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -5194,7 +5194,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 run_id = %run_id,
                 "park commit impossible: no memory_dir configured; cancelling approvals",
             );
-            self.cancel_run_parked_approvals(plan, &run_id).await;
+            self.cancel_run_parked_approvals(&run_id).await;
             return Err(format!(
                 "Run {run_id} parked but no memory_dir is configured, so no \
                  checkpoint can be written. The run's pending approvals were cancelled.",
@@ -5259,7 +5259,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     error = %e,
                     "park commit failed; cancelling the run's approvals",
                 );
-                self.cancel_run_parked_approvals(plan, &run_id).await;
+                self.cancel_run_parked_approvals(&run_id).await;
                 Err(format!(
                     "Park commit failed for run {run_id}: {e}. The run's pending \
                      approvals were cancelled.",
@@ -5269,28 +5269,17 @@ Assign tasks to the worker whose tools best match the required operations."#,
         }
     }
 
-    /// Collect the plan's awaiting decision ids and sweep them, so no
-    /// decidable approval outlives a run that has no checkpoint.
-    async fn cancel_run_parked_approvals(&self, plan: &Plan, run_id: &str) {
+    /// Sweep the run's parked approvals by owner id, so no decidable
+    /// approval outlives a run that has no checkpoint.
+    async fn cancel_run_parked_approvals(&self, run_id: &str) {
         let Some(hitl) = self.agent_config.hitl.clone() else {
             return;
         };
         let crate::hitl::DecisionRoute::Conversational { registry, .. } = &*hitl.route else {
             return;
         };
-        let mut cancelled = Vec::new();
-        for task in &plan.tasks {
-            let TaskState::AwaitingApproval { pending } = &task.state else {
-                continue;
-            };
-            let Some(scope) = self.worker_scope(task.id, task.worker.as_deref()).await else {
-                continue;
-            };
-            cancelled.extend(pending.iter().map(|call| (call.decision_id, scope.clone())));
-        }
         let request_id = self.agent_config.request_id.clone().unwrap_or_default();
-        super::park::cancel_run_approvals(registry, run_id, &request_id, cancelled.into_iter())
-            .await;
+        super::park::cancel_run_approvals(registry, run_id, &request_id).await;
     }
 
     async fn write_run_manifest(
@@ -7636,14 +7625,10 @@ mod tests {
             .park_guard
             .as_ref()
             .expect("park-mode orchestrator");
-        let scope = orchestrator
-            .worker_scope(1, plan.tasks[1].worker.as_deref())
-            .await
-            .expect("worker scope builds");
         let TaskState::AwaitingApproval { pending } = &plan.tasks[1].state else {
             unreachable!("the fixture task is awaiting")
         };
-        guard.record(&scope, pending);
+        guard.record(pending);
     }
 
     fn set_mode(path: &std::path::Path, mode: u32) {

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -5279,7 +5279,9 @@ Assign tasks to the worker whose tools best match the required operations."#,
             return;
         };
         let request_id = self.agent_config.request_id.clone().unwrap_or_default();
-        super::park::cancel_run_approvals(registry, run_id, &request_id).await;
+        super::park::cancel_run_approvals(registry, run_id, &request_id)
+            .await
+            .ok();
     }
 
     async fn write_run_manifest(

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -569,9 +569,7 @@ impl Orchestrator {
         let orchestrator_id = uuid::Uuid::new_v4().to_string();
 
         let run_id_str = persistence.lock().await.run_id().to_string();
-        // One guard per park-mode run; it stays inert until the park arm
-        // records the first parked call, and an unpublished drop sweeps the
-        // run's owner id.
+        // One guard per park-mode run; `ParkGuard` documents arming and drop.
         let park_guard = agent_config
             .hitl
             .as_ref()

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -570,7 +570,8 @@ impl Orchestrator {
 
         let run_id_str = persistence.lock().await.run_id().to_string();
         // One guard per park-mode run; it stays inert until the park arm
-        // records a decision id.
+        // records the first parked call, and an unpublished drop sweeps the
+        // run's owner id.
         let park_guard = agent_config
             .hitl
             .as_ref()

--- a/crates/aura/src/orchestration/park/commit.rs
+++ b/crates/aura/src/orchestration/park/commit.rs
@@ -208,28 +208,38 @@ pub(crate) async fn publish(
 
 /// Cancel every approval the run parked: the store's atomic
 /// `cancel_request` clears the run's remaining tickets by owner id and
-/// returns them; each cleared ticket publishes one
-/// `approval_completed(cancelled)`. A ticket decided before the sweep is
-/// absent from the cleared set by construction — resolve removed it — so the
-/// stream can never disagree with a decision that won the race.
-pub(crate) async fn cancel_run_approvals(
+/// returns them, and each cleared ticket publishes one
+/// `approval_completed(cancelled)`. The whole sequence runs as its own task
+/// on the current runtime, so a caller dropping the returned handle cannot
+/// abandon publication mid-flight: await the handle for ordered teardown,
+/// or drop it and let the sweep finish on its own. A ticket decided before
+/// the sweep is absent from the cleared set by construction — resolve
+/// removed it — so the stream can never disagree with a decision that won
+/// the race. A lost store reply still yields warn-and-empty, the conceded
+/// residual.
+pub(crate) fn cancel_run_approvals(
     registry: &PendingApprovals,
     run_id: &str,
     request_id: &str,
-) {
-    for parked in registry.cancel_request(&run_owner_id(run_id)).await {
-        crate::approval_event_broker::publish(
-            request_id,
-            crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
-                crate::hitl::completed_cancelled(
-                    parked.request.decision_id,
-                    &parked.request.scope,
-                    std::time::Duration::ZERO,
+) -> tokio::task::JoinHandle<()> {
+    let registry = registry.clone();
+    let run_id = run_id.to_string();
+    let request_id = request_id.to_string();
+    tokio::task::spawn(async move {
+        for parked in registry.cancel_request(&run_owner_id(&run_id)).await {
+            crate::approval_event_broker::publish(
+                &request_id,
+                crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
+                    crate::hitl::completed_cancelled(
+                        parked.request.decision_id,
+                        &parked.request.scope,
+                        std::time::Duration::ZERO,
+                    ),
                 ),
-            ),
-        )
-        .await;
-    }
+            )
+            .await;
+        }
+    })
 }
 
 /// The directory checkpoint documents live in:
@@ -574,7 +584,9 @@ mod tests {
             .await
             .unwrap();
 
-        cancel_run_approvals(&registry, run_id, &request_id).await;
+        cancel_run_approvals(&registry, run_id, &request_id)
+            .await
+            .unwrap();
 
         assert!(
             store.get(&sibling).await.unwrap().is_none(),
@@ -637,7 +649,9 @@ mod tests {
             .await
             .unwrap();
 
-        cancel_run_approvals(&registry, run_id, &request_id).await;
+        cancel_run_approvals(&registry, run_id, &request_id)
+            .await
+            .unwrap();
 
         assert!(store.get(&first).await.unwrap().is_none());
         assert!(store.get(&second).await.unwrap().is_none());
@@ -680,7 +694,9 @@ mod tests {
             .await
             .unwrap();
 
-        cancel_run_approvals(&registry, run_id, "req_late_resolve").await;
+        cancel_run_approvals(&registry, run_id, "req_late_resolve")
+            .await
+            .unwrap();
 
         assert_eq!(
             registry

--- a/crates/aura/src/orchestration/park/commit.rs
+++ b/crates/aura/src/orchestration/park/commit.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 
 use crate::config::AgentRuntimeConfig;
-use crate::hitl::{AgentScope, DecisionId, PendingApprovals};
+use crate::hitl::{DecisionId, PendingApprovals};
 use crate::orchestration::persistence::is_safe_path_component;
 use crate::orchestration::types::{PendingCall, Plan, TaskState};
 
@@ -206,44 +206,30 @@ pub(crate) async fn publish(
     .map_err(io::Error::other)?
 }
 
-/// Cancel every undecided approval the run parked: a recorded decision is
-/// spared, an id no longer parked is skipped (the sweep is idempotent), and
-/// each remaining id publishes one `approval_completed(cancelled)` before the
-/// store clears the run's tickets by owner id.
+/// Cancel every approval the run parked: the store's atomic
+/// `cancel_request` clears the run's remaining tickets by owner id and
+/// returns them; each cleared ticket publishes one
+/// `approval_completed(cancelled)`. A ticket decided before the sweep is
+/// absent from the cleared set by construction — resolve removed it — so the
+/// stream can never disagree with a decision that won the race.
 pub(crate) async fn cancel_run_approvals(
     registry: &PendingApprovals,
     run_id: &str,
     request_id: &str,
-    cancelled: impl Iterator<Item = (DecisionId, AgentScope)>,
 ) {
-    for (decision_id, scope) in cancelled {
-        if registry.recorded_decision(&decision_id).await.is_some() {
-            tracing::info!(
-                decision_id = %decision_id,
-                "approval decided before the cancellation sweep; decision spared",
-            );
-            continue;
-        }
-        let parked = registry
-            .try_parked(&decision_id)
-            .await
-            .unwrap_or_else(|err| {
-                tracing::warn!(decision_id = %decision_id, error = %err, "parked approval lookup failed");
-                None
-            });
-        if parked.is_none() {
-            continue;
-        }
+    for parked in registry.cancel_request(&run_owner_id(run_id)).await {
         crate::approval_event_broker::publish(
             request_id,
             crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
-                crate::hitl::completed_cancelled(decision_id, &scope, std::time::Duration::ZERO),
+                crate::hitl::completed_cancelled(
+                    parked.request.decision_id,
+                    &parked.request.scope,
+                    std::time::Duration::ZERO,
+                ),
             ),
         )
         .await;
     }
-    // The owner id the park arm stamps on every ticket it registers.
-    registry.cancel_request(&run_owner_id(run_id)).await;
 }
 
 /// The directory checkpoint documents live in:
@@ -302,7 +288,7 @@ mod tests {
     use super::*;
     use crate::hitl::{
         AgentScope, ApprovalItem, ApprovalOrigin, ApprovalRequest, DecisionId, PROTOCOL_VERSION,
-        ParkedApproval, PendingApprovals,
+        ParkedApproval, PendingApprovals, ResolveError,
     };
     use crate::orchestration::park::document::{ParkedPlan, SCHEMA_VERSION, load_parked_run};
     use crate::orchestration::types::Task;
@@ -552,11 +538,12 @@ mod tests {
         );
     }
 
-    /// The sweep spares an id with a recorded decision — no event, no
-    /// removal — while an undecided sibling under the same owner is
-    /// cancelled with exactly one event.
+    /// The sweep cancels exactly what the store still holds: the undecided
+    /// sibling clears with one event, while the decided sibling — whose
+    /// ticket resolve already removed — is absent from the cleared set and
+    /// publishes nothing.
     #[tokio::test]
-    async fn sweep_spares_recorded_decision_and_cancels_undecided_sibling() {
+    async fn sweep_publishes_cancelled_for_undecided_sibling_only() {
         let (registry, store) = conv_registry();
         let run_id = "0191e8c0-ffff-7000-8000-000000000006";
         let owner = run_owner_id(run_id);
@@ -566,7 +553,6 @@ mod tests {
         let now = chrono::Utc::now();
         let decided = DecisionId::generate();
         let sibling = DecisionId::generate();
-        let scope = AgentScope::Single { session_id: None };
         registry
             .register_durable(parked_approval(
                 decided,
@@ -588,13 +574,7 @@ mod tests {
             .await
             .unwrap();
 
-        cancel_run_approvals(
-            &registry,
-            run_id,
-            &request_id,
-            [(decided, scope.clone()), (sibling, scope)].into_iter(),
-        )
-        .await;
+        cancel_run_approvals(&registry, run_id, &request_id).await;
 
         assert!(
             store.get(&sibling).await.unwrap().is_none(),
@@ -626,6 +606,88 @@ mod tests {
         );
 
         crate::approval_event_broker::unsubscribe(&request_id).await;
+    }
+
+    /// Two tickets under the same owner clear with one cancelled event each.
+    #[tokio::test]
+    async fn sweep_publishes_one_event_per_cleared_ticket() {
+        let (registry, store) = conv_registry();
+        let run_id = "0191e8c0-aaaa-7000-8000-000000000007";
+        let owner = run_owner_id(run_id);
+        let request_id = format!("req_sweep_{}", uuid::Uuid::new_v4().simple());
+        let mut events = crate::approval_event_broker::subscribe(&request_id).await;
+
+        let now = chrono::Utc::now();
+        let first = DecisionId::generate();
+        let second = DecisionId::generate();
+        registry
+            .register_durable(parked_approval(
+                first,
+                &owner,
+                now + chrono::Duration::hours(1),
+            ))
+            .await
+            .unwrap();
+        registry
+            .register_durable(parked_approval(
+                second,
+                &owner,
+                now + chrono::Duration::hours(1),
+            ))
+            .await
+            .unwrap();
+
+        cancel_run_approvals(&registry, run_id, &request_id).await;
+
+        assert!(store.get(&first).await.unwrap().is_none());
+        assert!(store.get(&second).await.unwrap().is_none());
+
+        let mut cancelled_ids = Vec::new();
+        for _ in 0..2 {
+            match tokio::time::timeout(Duration::from_secs(1), events.recv()).await {
+                Ok(Some(crate::approval_event_broker::ApprovalLifecycleEvent::Completed(
+                    completed,
+                ))) => cancelled_ids.push(completed.decision_id),
+                other => panic!("expected a second completed(cancelled), got {other:?}"),
+            }
+        }
+        assert!(cancelled_ids.contains(&first.to_string()));
+        assert!(cancelled_ids.contains(&second.to_string()));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), events.recv())
+                .await
+                .is_err(),
+            "exactly two cancelled events publish"
+        );
+
+        crate::approval_event_broker::unsubscribe(&request_id).await;
+    }
+
+    /// A cleared ticket refuses a late resolve: the sweep is terminal for it.
+    #[tokio::test]
+    async fn late_resolve_after_sweep_is_not_found() {
+        let (registry, _store) = conv_registry();
+        let run_id = "0191e8c0-bbbb-7000-8000-000000000008";
+        let owner = run_owner_id(run_id);
+        let now = chrono::Utc::now();
+        let ticket = DecisionId::generate();
+        registry
+            .register_durable(parked_approval(
+                ticket,
+                &owner,
+                now + chrono::Duration::hours(1),
+            ))
+            .await
+            .unwrap();
+
+        cancel_run_approvals(&registry, run_id, "req_late_resolve").await;
+
+        assert_eq!(
+            registry
+                .resolve(&ticket, crate::hitl::ApprovalDecision::Approved)
+                .await,
+            Err(ResolveError::NotFound),
+        );
     }
 
     /// The fingerprint is stable for an unchanged config and moves when the

--- a/crates/aura/src/orchestration/park/commit.rs
+++ b/crates/aura/src/orchestration/park/commit.rs
@@ -213,10 +213,10 @@ pub(crate) async fn publish(
 /// on the current runtime, so a caller dropping the returned handle cannot
 /// abandon publication mid-flight: await the handle for ordered teardown,
 /// or drop it and let the sweep finish on its own. A ticket decided before
-/// the sweep is absent from the cleared set by construction — resolve
-/// removed it — so the stream can never disagree with a decision that won
-/// the race. A lost store reply still yields warn-and-empty, the conceded
-/// residual.
+/// the sweep is absent from the cleared set by construction (the store
+/// returns only what it cleared), so the stream can never disagree with a
+/// decision that won the race. A lost store reply still yields
+/// warn-and-empty, the conceded residual.
 pub(crate) fn cancel_run_approvals(
     registry: &PendingApprovals,
     run_id: &str,

--- a/crates/aura/src/orchestration/park/commit.rs
+++ b/crates/aura/src/orchestration/park/commit.rs
@@ -206,17 +206,13 @@ pub(crate) async fn publish(
     .map_err(io::Error::other)?
 }
 
-/// Cancel every approval the run parked: the store's atomic
-/// `cancel_request` clears the run's remaining tickets by owner id and
-/// returns them, and each cleared ticket publishes one
-/// `approval_completed(cancelled)`. The whole sequence runs as its own task
-/// on the current runtime, so a caller dropping the returned handle cannot
-/// abandon publication mid-flight: await the handle for ordered teardown,
-/// or drop it and let the sweep finish on its own. A ticket decided before
-/// the sweep is absent from the cleared set by construction (the store
-/// returns only what it cleared), so the stream can never disagree with a
-/// decision that won the race. A lost store reply still yields
-/// warn-and-empty, the conceded residual.
+/// Cancel every approval the run parked: `cancel_request` clears the run's
+/// tickets by owner id, and each returned ticket publishes one
+/// `approval_completed(cancelled)`. The sweep runs as its own task, so a
+/// dropped handle cannot abandon publication mid-flight; await it for
+/// ordered teardown. A decided ticket is never in the cleared set, so the
+/// stream cannot disagree with a decision that won the race. A lost store
+/// reply yields warn-and-empty, the conceded residual.
 pub(crate) fn cancel_run_approvals(
     registry: &PendingApprovals,
     run_id: &str,

--- a/crates/aura/src/orchestration/park/guard.rs
+++ b/crates/aura/src/orchestration/park/guard.rs
@@ -55,14 +55,12 @@ impl Drop for ParkGuard {
         let registry = self.registry.clone();
         let run_id = self.run_id.clone();
         let request_id = self.request_id.clone();
-        // Drop cannot await; the sweep runs as its own task on the runtime
+        // Drop cannot await; the sweep spawns its own task on the runtime
         // that dropped the guard. Off-runtime drops (a test teardown) log
         // and skip.
         match tokio::runtime::Handle::try_current() {
-            Ok(handle) => {
-                handle.spawn(async move {
-                    cancel_run_approvals(&registry, &run_id, &request_id).await;
-                });
+            Ok(_) => {
+                cancel_run_approvals(&registry, &run_id, &request_id);
             }
             Err(_) => {
                 tracing::warn!(

--- a/crates/aura/src/orchestration/park/guard.rs
+++ b/crates/aura/src/orchestration/park/guard.rs
@@ -3,22 +3,17 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use crate::hitl::{AgentScope, DecisionId, PendingApprovals};
+use crate::hitl::PendingApprovals;
 
 use super::commit::cancel_run_approvals;
 
-/// The decision ids a run parked, swept when the run ends unpublished.
+/// Arms the unpublished-end sweep once the run has parked a call.
 pub(crate) struct ParkGuard {
     registry: PendingApprovals,
     run_id: String,
     request_id: String,
     published: AtomicBool,
-    decisions: Mutex<Vec<GuardedDecision>>,
-}
-
-struct GuardedDecision {
-    decision_id: DecisionId,
-    scope: AgentScope,
+    parked_calls: Mutex<usize>,
 }
 
 impl ParkGuard {
@@ -29,26 +24,16 @@ impl ParkGuard {
             run_id,
             request_id,
             published: AtomicBool::new(false),
-            decisions: Mutex::new(Vec::new()),
+            parked_calls: Mutex::new(0),
         })
     }
 
     /// Record parked calls; the first record arms the guard.
-    pub(crate) fn record(
-        &self,
-        task_scope: &AgentScope,
-        pending: &[crate::orchestration::PendingCall],
-    ) {
+    pub(crate) fn record(&self, pending: &[crate::orchestration::PendingCall]) {
         if pending.is_empty() {
             return;
         }
-        let mut decisions = self.decisions.lock().expect("park guard lock poisoned");
-        for call in pending {
-            decisions.push(GuardedDecision {
-                decision_id: call.decision_id,
-                scope: task_scope.clone(),
-            });
-        }
+        *self.parked_calls.lock().expect("park guard lock poisoned") += pending.len();
     }
 
     /// Mark the run's checkpoint published; the drop becomes a no-op.
@@ -59,15 +44,12 @@ impl ParkGuard {
 
 impl Drop for ParkGuard {
     fn drop(&mut self) {
-        // An unpublished drop sweeps every recorded id; a process crash inside
-        // the commit is the one accepted window.
+        // An unpublished drop sweeps the run's parked tickets by owner id; a
+        // process crash inside the commit is the one accepted window.
         if self.published.load(Ordering::Acquire) {
             return;
         }
-        let mut guard = self.decisions.lock().expect("park guard lock poisoned");
-        let decisions = std::mem::take(&mut *guard);
-        drop(guard);
-        if decisions.is_empty() {
+        if *self.parked_calls.lock().expect("park guard lock poisoned") == 0 {
             return;
         }
         let registry = self.registry.clone();
@@ -79,13 +61,7 @@ impl Drop for ParkGuard {
         match tokio::runtime::Handle::try_current() {
             Ok(handle) => {
                 handle.spawn(async move {
-                    cancel_run_approvals(
-                        &registry,
-                        &run_id,
-                        &request_id,
-                        decisions.into_iter().map(|d| (d.decision_id, d.scope)),
-                    )
-                    .await;
+                    cancel_run_approvals(&registry, &run_id, &request_id).await;
                 });
             }
             Err(_) => {
@@ -183,7 +159,7 @@ mod tests {
             .unwrap();
 
         let guard = ParkGuard::new(registry.clone(), run_id.to_string(), request_id.clone());
-        guard.record(&scope, std::slice::from_ref(&parked_call(decision_id)));
+        guard.record(std::slice::from_ref(&parked_call(decision_id)));
         drop(guard);
 
         // The sweep runs as its own task; poll the store until it empties.
@@ -228,7 +204,7 @@ mod tests {
             .unwrap();
 
         let guard = ParkGuard::new(registry.clone(), run_id.to_string(), "req_x".to_string());
-        guard.record(&scope, std::slice::from_ref(&parked_call(decision_id)));
+        guard.record(std::slice::from_ref(&parked_call(decision_id)));
         guard.mark_published();
         drop(guard);
 

--- a/crates/aura/src/orchestration/park/guard.rs
+++ b/crates/aura/src/orchestration/park/guard.rs
@@ -1,7 +1,7 @@
 //! The run-scoped park guard (park mode).
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 
 use crate::hitl::PendingApprovals;
 
@@ -13,7 +13,7 @@ pub(crate) struct ParkGuard {
     run_id: String,
     request_id: String,
     published: AtomicBool,
-    parked_calls: Mutex<usize>,
+    armed: AtomicBool,
 }
 
 impl ParkGuard {
@@ -24,16 +24,15 @@ impl ParkGuard {
             run_id,
             request_id,
             published: AtomicBool::new(false),
-            parked_calls: Mutex::new(0),
+            armed: AtomicBool::new(false),
         })
     }
 
     /// Record parked calls; the first record arms the guard.
     pub(crate) fn record(&self, pending: &[crate::orchestration::PendingCall]) {
-        if pending.is_empty() {
-            return;
+        if !pending.is_empty() {
+            self.armed.store(true, Ordering::Release);
         }
-        *self.parked_calls.lock().expect("park guard lock poisoned") += pending.len();
     }
 
     /// Mark the run's checkpoint published; the drop becomes a no-op.
@@ -49,7 +48,7 @@ impl Drop for ParkGuard {
         if self.published.load(Ordering::Acquire) {
             return;
         }
-        if *self.parked_calls.lock().expect("park guard lock poisoned") == 0 {
+        if !self.armed.load(Ordering::Acquire) {
             return;
         }
         let registry = self.registry.clone();
@@ -82,7 +81,7 @@ mod tests {
         AgentScope, ApprovalItem, ApprovalOrigin, ApprovalRequest, DecisionId, PROTOCOL_VERSION,
         ParkedApproval, PendingApprovals,
     };
-    use crate::orchestration::{RunId, TaskIdentity};
+    use crate::orchestration::{RunId, TaskIdentity, run_owner_id};
     use crate::session_store::{ApprovalStore, InMemoryApprovalStore, InMemoryEventBus};
 
     fn registry_with_store() -> (PendingApprovals, Arc<InMemoryApprovalStore>) {
@@ -218,10 +217,12 @@ mod tests {
         let (registry, store) = registry_with_store();
         let run_id: RunId = "0191e8c0-4444-7000-8000-000000000042".parse().unwrap();
         let other = DecisionId::generate();
+        // The ticket belongs to this run's owner id, so the arming condition
+        // is load-bearing: an armed guard's drop would sweep and clear it.
         registry
             .register_durable(durable_approval(
                 other,
-                "run:someone-else",
+                &run_owner_id(&run_id.to_string()),
                 &worker_scope(run_id),
             ))
             .await

--- a/crates/aura/src/orchestration/park/mod.rs
+++ b/crates/aura/src/orchestration/park/mod.rs
@@ -7,7 +7,9 @@ mod document;
 mod guard;
 mod recorded_decisions;
 
-pub(crate) use commit::{ParkCommitInputs, cancel_run_approvals, commit_from_run_state};
+pub(crate) use commit::{
+    ParkCommitInputs, cancel_run_approvals, commit_from_run_state, run_owner_id,
+};
 // The rehydrate entry points: consumed by commit 3's tests; the P45 resume
 // endpoint consumes them in production.
 #[allow(unused_imports)]

--- a/crates/aura/src/session_store/fault_store.rs
+++ b/crates/aura/src/session_store/fault_store.rs
@@ -71,7 +71,10 @@ impl ApprovalStore for FaultInjectingStore {
         self.inner.remove(id).await
     }
 
-    async fn cancel_request(&self, request_id: &str) -> Result<(), SessionStoreError> {
+    async fn cancel_request(
+        &self,
+        request_id: &str,
+    ) -> Result<Vec<ParkedApproval>, SessionStoreError> {
         self.inner.cancel_request(request_id).await
     }
 }

--- a/crates/aura/src/session_store/file.rs
+++ b/crates/aura/src/session_store/file.rs
@@ -254,12 +254,16 @@ impl Inner {
         request_id: &str,
     ) -> Result<Vec<ParkedApproval>, SessionStoreError> {
         let _guard = self.lock();
-        let mut cleared = Vec::new();
         let entries = match fs::read_dir(self.approvals_dir()) {
             Ok(entries) => entries,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(cleared),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
             Err(err) => return Err(request_err(err)),
         };
+
+        // Phase 1 classifies without mutating, so a fault past an earlier
+        // file cannot strand an already-removed approval.
+        let mut candidates = Vec::new();
+        let mut stale_decided = Vec::new();
         for entry in entries {
             let entry = entry.map_err(request_err)?;
             let path = entry.path();
@@ -272,18 +276,51 @@ impl Inner {
                 Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
                 Err(err) => return Err(request_err(err)),
             };
-            match serde_json::from_slice::<ParkedApprovalRecord>(&bytes) {
-                Ok(record) if record.request_id == request_id => {
-                    fs::remove_file(&path).map_err(request_err)?;
-                    cleared.push(restore_approval(record)?);
-                }
-                Ok(_) => {}
+            let parked = match decode_approval(&bytes) {
+                Ok(parked) => parked,
                 Err(err) => {
                     tracing::warn!(
                         path = %path.display(), error = %err,
                         "undecodable approval file skipped by cancel_request"
                     );
+                    continue;
                 }
+            };
+            if parked.request.request_id != request_id {
+                continue;
+            }
+            // resolve writes the decision before its best-effort approval
+            // unlink, so a decision file here marks the residue of an
+            // already-decided id: the recorded decision owns the outcome.
+            if self
+                .decision_path(&parked.request.decision_id.to_string())
+                .try_exists()
+                .map_err(request_err)?
+            {
+                stale_decided.push(path);
+                continue;
+            }
+            candidates.push((path, parked));
+        }
+
+        // Phase 2 removes; a file that survives drops its record from the
+        // returned set so a later cancel can clear it again.
+        let mut cleared = Vec::new();
+        for (path, parked) in candidates {
+            match fs::remove_file(&path) {
+                Ok(()) => cleared.push(parked),
+                Err(err) => tracing::warn!(
+                    path = %path.display(), decision_id = %parked.request.decision_id, error = %err,
+                    "approval file not removed by cancel_request; a later cancel can clear it"
+                ),
+            }
+        }
+        for path in stale_decided {
+            if let Err(err) = fs::remove_file(&path) {
+                tracing::warn!(
+                    path = %path.display(), error = %err,
+                    "stale decided approval file not removed by cancel_request"
+                );
             }
         }
         Ok(cleared)

--- a/crates/aura/src/session_store/file.rs
+++ b/crates/aura/src/session_store/file.rs
@@ -17,8 +17,9 @@
 //!   returns the recorded decision, and both are retained until `remove`.
 //! - At-most-once `resolve` is the `File::create_new` claim on the decision
 //!   file: `AlreadyExists` reads as `NotFound`.
-//! - `cancel_request` removes undecided approvals by owner (request) id;
-//!   decided entries are retained until their consumer removes them.
+//! - `cancel_request` removes undecided approvals by owner (request) id and
+//!   returns them; decided entries are retained until their consumer removes
+//!   them.
 //!
 //! Decision ids are validated as UUIDs before path building, so none address
 //! outside the root.
@@ -248,11 +249,15 @@ impl Inner {
         Ok(())
     }
 
-    fn cancel_request_sync(&self, request_id: &str) -> Result<(), SessionStoreError> {
+    fn cancel_request_sync(
+        &self,
+        request_id: &str,
+    ) -> Result<Vec<ParkedApproval>, SessionStoreError> {
         let _guard = self.lock();
+        let mut cleared = Vec::new();
         let entries = match fs::read_dir(self.approvals_dir()) {
             Ok(entries) => entries,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(cleared),
             Err(err) => return Err(request_err(err)),
         };
         for entry in entries {
@@ -270,6 +275,7 @@ impl Inner {
             match serde_json::from_slice::<ParkedApprovalRecord>(&bytes) {
                 Ok(record) if record.request_id == request_id => {
                     fs::remove_file(&path).map_err(request_err)?;
+                    cleared.push(restore_approval(record)?);
                 }
                 Ok(_) => {}
                 Err(err) => {
@@ -280,7 +286,7 @@ impl Inner {
                 }
             }
         }
-        Ok(())
+        Ok(cleared)
     }
 }
 
@@ -332,7 +338,10 @@ impl ApprovalStore for FileApprovalStore {
             .map_err(join_err)?
     }
 
-    async fn cancel_request(&self, request_id: &str) -> Result<(), SessionStoreError> {
+    async fn cancel_request(
+        &self,
+        request_id: &str,
+    ) -> Result<Vec<ParkedApproval>, SessionStoreError> {
         let inner = Arc::clone(&self.inner);
         let request_id = request_id.to_owned();
         spawn_blocking(move || inner.cancel_request_sync(&request_id))

--- a/crates/aura/src/session_store/memory.rs
+++ b/crates/aura/src/session_store/memory.rs
@@ -102,10 +102,16 @@ impl ApprovalStore for InMemoryApprovalStore {
         Ok(())
     }
 
-    async fn cancel_request(&self, request_id: &str) -> Result<(), SessionStoreError> {
-        self.lock()
-            .retain(|_, parked| parked.request.request_id != request_id);
-        Ok(())
+    async fn cancel_request(
+        &self,
+        request_id: &str,
+    ) -> Result<Vec<ParkedApproval>, SessionStoreError> {
+        let cleared: Vec<ParkedApproval> = self
+            .lock()
+            .extract_if(.., |_, parked| parked.request.request_id == request_id)
+            .map(|(_, parked)| parked)
+            .collect();
+        Ok(cleared)
     }
 }
 
@@ -313,13 +319,16 @@ mod tests {
     async fn approval_store_cancel_request_removes_only_matching() {
         let store = InMemoryApprovalStore::new();
         let cancel = parked("req-cancel");
+        let cancel_id = cancel.request.decision_id;
         let keep = parked("req-keep");
         let keep_id = keep.request.decision_id;
         store.register(cancel).await.unwrap();
         store.register(keep).await.unwrap();
 
-        store.cancel_request("req-cancel").await.unwrap();
+        let cleared = store.cancel_request("req-cancel").await.unwrap();
 
+        assert_eq!(cleared.len(), 1, "only the matching ticket is cleared");
+        assert_eq!(cleared[0].request.decision_id, cancel_id);
         assert!(store.get(&keep_id).await.unwrap().is_some());
         assert_eq!(store.lock().len(), 1);
     }

--- a/crates/aura/src/session_store/mod.rs
+++ b/crates/aura/src/session_store/mod.rs
@@ -84,8 +84,14 @@ pub trait ApprovalStore: Send + Sync {
     /// Remove a parked entry.
     async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError>;
 
-    /// Remove every approval parked under a request id.
-    async fn cancel_request(&self, request_id: &str) -> Result<(), SessionStoreError>;
+    /// Remove every approval parked under a request id, returning the
+    /// approvals actually cleared. A ticket decided before the sweep is
+    /// absent — resolve removed it — so the return is the authoritative
+    /// record of what the cancellation applies to.
+    async fn cancel_request(
+        &self,
+        request_id: &str,
+    ) -> Result<Vec<ParkedApproval>, SessionStoreError>;
 }
 
 /// The payload stream returned by [`EventBus::subscribe`].

--- a/crates/aura/src/session_store/mod.rs
+++ b/crates/aura/src/session_store/mod.rs
@@ -84,13 +84,10 @@ pub trait ApprovalStore: Send + Sync {
     /// Remove a parked entry.
     async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError>;
 
-    /// Remove every approval parked under a request id, returning the
-    /// approvals actually cleared. A ticket decided before the sweep is
-    /// absent from the return, so the return is the authoritative record
-    /// of what the cancellation applies to. Each backend achieves that
-    /// its own way: memory and Redis consume the ticket at resolve,
-    /// while the file backend classifies decision-file residue as stale
-    /// and sweeps it without returning it.
+    /// Remove every approval parked under a request id and return the
+    /// approvals cleared. A ticket with a recorded decision is never in
+    /// the return: the cleared set is the authoritative record of what
+    /// the cancellation applies to.
     async fn cancel_request(
         &self,
         request_id: &str,

--- a/crates/aura/src/session_store/mod.rs
+++ b/crates/aura/src/session_store/mod.rs
@@ -86,8 +86,11 @@ pub trait ApprovalStore: Send + Sync {
 
     /// Remove every approval parked under a request id, returning the
     /// approvals actually cleared. A ticket decided before the sweep is
-    /// absent — resolve removed it — so the return is the authoritative
-    /// record of what the cancellation applies to.
+    /// absent from the return, so the return is the authoritative record
+    /// of what the cancellation applies to. Each backend achieves that
+    /// its own way: memory and Redis consume the ticket at resolve,
+    /// while the file backend classifies decision-file residue as stale
+    /// and sweeps it without returning it.
     async fn cancel_request(
         &self,
         request_id: &str,

--- a/docs/design/session-storage.md
+++ b/docs/design/session-storage.md
@@ -222,8 +222,12 @@ pub trait ApprovalStore: Send + Sync {
     /// Remove a parked entry (timeout / cancellation).
     async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError>;
 
-    /// Remove every approval parked under a request id (stream drop / shutdown).
-    async fn cancel_request(&self, request_id: &str) -> Result<(), SessionStoreError>;
+    /// Remove every approval parked under a request id (stream drop / shutdown),
+    /// returning the approvals actually cleared. The returned set is the sole
+    /// source of `approval_completed(cancelled)` events; a ticket decided before
+    /// the sweep is absent from it.
+    async fn cancel_request(&self, request_id: &str)
+        -> Result<Vec<ParkedApproval>, SessionStoreError>;
 }
 ```
 
@@ -329,8 +333,10 @@ Changes:
 - The `POST /v1/approvals/{id}` handler calls `approvals.resolve()` then
   `bus.publish("approval:{id}", decision)`. It no longer needs the parked entry to be
   local — it may run on any pod.
-- `cancel_request()` deletes matching store entries and (optionally) publishes a cancel so
-  the parking pod stops waiting.
+- `cancel_request()` deletes matching store entries and returns the records it cleared;
+  the caller publishes one `approval_completed(cancelled)` lifecycle event per returned
+  record (stream-facing: the parking pod's own waiters are cancelled locally, not woken
+  through the bus).
 - **Default backend = in-memory** collapses this back to exactly today's behavior:
   `resolve()` finds the local entry and fires the `oneshot` directly; `subscribe`/`publish`
   are a local broadcast. Single-pod and CLI standalone are unchanged.
@@ -428,6 +434,12 @@ Notes:
   nor a resolver crash between claim and publish can lose a granted approval
   (#474). The decision record's TTL keeps a margin past the parked record's
   remaining TTL, covering the parking pod's deadline-backstop read.
+- `cancel_request` reads the request index (`SMEMBERS`) and sweeps each id it saw in
+  one atomic pipe (per-id take plus `SREM`). A registration the index gains mid-sweep
+  keeps its index entry and stays discoverable by a later cancel: the sweep prunes per
+  id, never a whole-key `DEL`. (`SREM` on the last member deletes the emptied set, so
+  what survives is the unobserved member, not the key itself.) A wrong-typed approval
+  key is left in place with its index entry kept, so a later sweep can retry it.
 - Each task create/update is one Lua script covering the exists-check, `version`
   bump, terminal-state gate (updates to a terminal task are rejected, except a
   rewrite of the state already recorded, which leaves it alone), record

--- a/docs/design/session-storage.md
+++ b/docs/design/session-storage.md
@@ -334,9 +334,8 @@ Changes:
   `bus.publish("approval:{id}", decision)`. It no longer needs the parked entry to be
   local — it may run on any pod.
 - `cancel_request()` deletes matching store entries and returns the records it cleared;
-  the caller publishes one `approval_completed(cancelled)` lifecycle event per returned
-  record (stream-facing: the parking pod's own waiters are cancelled locally, not woken
-  through the bus).
+  the caller publishes one `approval_completed(cancelled)` event per returned record.
+  No cancel travels the bus: the parking pod cancels its own waiters locally.
 - **Default backend = in-memory** collapses this back to exactly today's behavior:
   `resolve()` finds the local entry and fires the `oneshot` directly; `subscribe`/`publish`
   are a local broadcast. Single-pod and CLI standalone are unchanged.
@@ -434,12 +433,10 @@ Notes:
   nor a resolver crash between claim and publish can lose a granted approval
   (#474). The decision record's TTL keeps a margin past the parked record's
   remaining TTL, covering the parking pod's deadline-backstop read.
-- `cancel_request` reads the request index (`SMEMBERS`) and sweeps each id it saw in
-  one atomic pipe (per-id take plus `SREM`). A registration the index gains mid-sweep
-  keeps its index entry and stays discoverable by a later cancel: the sweep prunes per
-  id, never a whole-key `DEL`. (`SREM` on the last member deletes the emptied set, so
-  what survives is the unobserved member, not the key itself.) A wrong-typed approval
-  key is left in place with its index entry kept, so a later sweep can retry it.
+- `cancel_request` reads the request index (`SMEMBERS`), then takes each id it saw and
+  `SREM`s it in one atomic pipe. The index key is never deleted whole, so a registration
+  that lands mid-sweep keeps its entry for a later cancel. A wrong-typed approval key
+  stays, with its index entry, for a later sweep to retry.
 - Each task create/update is one Lua script covering the exists-check, `version`
   bump, terminal-state gate (updates to a terminal task are rejected, except a
   rewrite of the state already recorded, which leaves it alone), record


### PR DESCRIPTION
## What

`ApprovalStore::cancel_request` now returns the approvals it actually cleared, and the park sweep publishes one `approval_completed(cancelled)` event per returned record - replacing the old check-then-act sweep whose pre-check windows could publish `cancelled` for a ticket a human had already decided (204 stands, stream disagreed). The sweep runs as its own spawned task, so an abandoned caller await cannot stop publication mid-flight.

Backend notes:

- File: two-phase classify-then-remove under the lock; a decision file present marks resolve residue (removed, never returned); per-file remove failures stay retryable.
- Redis: the sweep take is a type-guarded script inside one MULTI pipe (string -> GETDEL + in-script SREM; wrong-typed key -> warn, left in place with its index entry kept for retry; stale id -> SREM). Resolve's atomic Lua claim is untouched.

## Conceded boundary (ruled on the board)

A lost EXEC reply, a process crash, or runtime shutdown can still lose those cancellation events (registry warn-and-empty; the task dies). Recorded as the V1 residual after five review rounds converged; the registration-data fallback was evaluated and rejected as unsafe.

## Review history

Five rounds on the board ledger: two in-harness Gate A passes, two external adversarial rounds (findings fixed in-range), and a final full-range Gate A pass over this exact head. Tests: the four sweep interleaving pins, wrong-type/invalid-UTF-8 redis legs against a live server, and the file-store residue legs.

Card: P48 (park/reify V1 line)