### PR TITLE
Name the missing response header when HITL approver capture fails

### DIFF
--- a/crates/aura-cli/src/backend/direct.rs
+++ b/crates/aura-cli/src/backend/direct.rs
@@ -110,10 +110,16 @@ impl DirectBackend {
                     .context("Invalid HITL webhook configuration")?;
                 aura::hitl::warn_on_cleartext_capture(hitl);
                 // The CLI's tracing subscriber is a no-op unless `log_file`
-                // is set, so the warning rides stderr as well — silent by
-                // default here would contradict the posture the ADR records.
+                // is set, so the warning and the forwarding summary ride
+                // stderr as well — silent by default here would contradict
+                // the posture the ADR records.
                 if let Some(warning) = aura::hitl::cleartext_capture_warning(hitl) {
                     eprintln!("warning: {warning}");
+                }
+                if let Some(summary) = aura::hitl::approver_forwarding_summary(hitl) {
+                    for line in summary.lines() {
+                        eprintln!("{line}");
+                    }
                 }
             }
         }

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -1482,7 +1482,10 @@ pub enum DecisionRouteConfig {
         /// Outbound header name → inbound request header name mapping.
         #[serde(default)]
         headers_from_request: HashMap<String, String>,
-        /// Outbound MCP header name → webhook approval-response header name.
+        /// Forward the approver's identity onto gated tool calls. TOML keys
+        /// are outbound MCP tool header names; TOML values are webhook
+        /// approval-response header names. Every value-side header must be
+        /// present on an approved response or the gated call fails closed.
         #[serde(default, skip_serializing_if = "ToolHeaderMappings::is_empty")]
         tool_headers_from_response: ToolHeaderMappings,
     },
@@ -1499,12 +1502,12 @@ pub const RESERVED_TOOL_HEADER_NAMES: [&str; 6] = [
     "transfer-encoding",
 ];
 
-/// Validated `tool_headers_from_response` mapping: outbound MCP header
-/// name → webhook approval-response header name, both sides lowercased.
-/// Syntactically invalid header names, duplicates after lowercasing, and
-/// reserved transport-owned names (see [`RESERVED_TOOL_HEADER_NAMES`])
-/// are rejected at construction, so downstream code never holds an
-/// unvalidated map.
+/// Validated `tool_headers_from_response` mapping: TOML keys are outbound
+/// MCP tool header names; TOML values are webhook approval-response header
+/// names, both sides lowercased. Syntactically invalid header names,
+/// duplicates after lowercasing, and reserved transport-owned names (see
+/// [`RESERVED_TOOL_HEADER_NAMES`]) are rejected at construction, so
+/// downstream code never holds an unvalidated map.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct ToolHeaderMappings(HashMap<String, String>);
 

--- a/crates/aura-web-server/src/server.rs
+++ b/crates/aura-web-server/src/server.rs
@@ -425,6 +425,11 @@ async fn run(args: ServerArgs) -> std::io::Result<()> {
                 },
             )?;
             aura::hitl::warn_on_cleartext_capture(hitl);
+            if let Some(summary) = aura::hitl::approver_forwarding_summary(hitl) {
+                for line in summary.lines() {
+                    info!("{line}");
+                }
+            }
         }
     }
 

--- a/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
+++ b/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
@@ -480,7 +480,8 @@ async fn override_forwarded_to_the_gated_call() {
 }
 
 /// Case 2: an approved decision missing the mapped header fails the gated
-/// call closed; the error names the header, never any value.
+/// call closed; the error names the missing response header and the tool
+/// header it maps to, never any value.
 #[tokio::test]
 async fn missing_mapped_header_fails_the_call_by_name_only() {
     let (approver, server) = gated_server(ApproverReply::ApproveBare).await;
@@ -493,9 +494,12 @@ async fn missing_mapped_header_fails_the_call_by_name_only() {
     .await;
     let text = assistant_text(&response);
 
+    let expected_clause = "webhook response missing header \"x-approver-token\" \
+                           (mapped to tool header \"authorization\")";
     assert!(
-        text.to_lowercase().contains("authorization"),
-        "the error must name the missing header, got: {text}"
+        text.to_lowercase().contains(expected_clause),
+        "the error must name the missing response header and the tool header \
+         it maps to, got: {text}"
     );
     assert!(
         !text.contains("legacy-frozen-identity"),

--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -44,12 +44,15 @@ impl ApproverHeaders {
                         .expect("outbound names validated at config parse");
                     headers.insert(name, value.clone());
                 }
-                None => missing.push(outbound.to_owned()),
+                None => missing.push(MissingMapping {
+                    response_name: response_name.to_owned(),
+                    outbound_name: outbound.to_owned(),
+                }),
             }
         }
         if !missing.is_empty() {
             missing.sort_unstable();
-            return Err(CaptureError::MissingHeaders { names: missing });
+            return Err(CaptureError::MissingHeaders { missing });
         }
         Ok(Self { headers })
     }
@@ -93,21 +96,71 @@ impl PartialEq for ApproverHeaders {
 
 impl Eq for ApproverHeaders {}
 
+/// One missing pair in a capture failure: the approved webhook response
+/// lacked the response header a configured mapping expected, so no value
+/// could be captured under the outbound tool header's name.
+///
+/// Both fields are header names and only header names — the audit surface
+/// never carries values. Both are lowercase, normalized at config parse by
+/// `ToolHeaderMappings`; response lookup remains case-insensitive.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MissingMapping {
+    /// The configured response header that was absent from the approved response.
+    pub response_name: String,
+    /// The outbound MCP tool header the value would have been captured under.
+    pub outbound_name: String,
+}
+
+impl std::fmt::Display for MissingMapping {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "\"{}\" (mapped to tool header \"{}\")",
+            self.response_name, self.outbound_name
+        )
+    }
+}
+
 /// Capture-time failures: the approved webhook response could not yield
 /// the configured approver headers (fail closed).
 ///
-/// The `names` payload is diagnostic-only text for the error message and
+/// The `missing` payload is diagnostic-only text for the error message and
 /// the event-level audit signal: always non-empty by construction (capture
-/// fails only when at least one name is missing), lowercased outbound
-/// header names, never values, and no domain logic branches on it.
+/// fails only when at least one mapping is missing), sorted by response
+/// header name then outbound header name (the derived field order of
+/// `MissingMapping`) so the audit string is deterministic, both sides of
+/// every mapping carried as header names and never values, and no domain
+/// logic branches on it.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum CaptureError {
     /// Mapped response headers absent from the approved response. Invalid
     /// values cannot occur here: capture reads a parsed `HeaderMap`, whose
     /// values are already syntactically valid; invalid outbound names are
     /// rejected earlier, at config parse.
-    #[error("approver identity capture failed: response missing mapped headers {names:?}")]
-    MissingHeaders { names: Vec<String> },
+    MissingHeaders { missing: Vec<MissingMapping> },
+}
+
+impl std::fmt::Display for CaptureError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CaptureError::MissingHeaders { missing } => {
+                if let [one] = missing.as_slice() {
+                    write!(
+                        f,
+                        "approver identity capture failed: webhook response missing header {one}"
+                    )
+                } else {
+                    let clauses: Vec<String> =
+                        missing.iter().map(MissingMapping::to_string).collect();
+                    write!(
+                        f,
+                        "approver identity capture failed: webhook response missing headers [{}]",
+                        clauses.join("; ")
+                    )
+                }
+            }
+        }
+    }
 }
 
 /// Application-time failures at the execution seam (double override,
@@ -291,8 +344,8 @@ pub(crate) mod tests {
         );
     }
 
-    /// Every missing name is reported at once, sorted, so one failing
-    /// response always produces the same audit string.
+    /// Every missing mapping is reported at once, sorted by response header
+    /// name, so one failing response always produces the same audit string.
     #[test]
     fn missing_names_are_all_reported_and_sorted() {
         let err = ApproverHeaders::from_captured(
@@ -308,18 +361,93 @@ pub(crate) mod tests {
         assert_eq!(
             err,
             CaptureError::MissingHeaders {
-                names: vec!["authorization".to_owned(), "x-forwarded-user".to_owned()],
+                missing: vec![
+                    MissingMapping {
+                        response_name: "x-approver-id".to_owned(),
+                        outbound_name: "x-forwarded-user".to_owned(),
+                    },
+                    MissingMapping {
+                        response_name: "x-approver-token".to_owned(),
+                        outbound_name: "authorization".to_owned(),
+                    },
+                ],
             }
         );
 
-        // Event-level audit signal: the Display text names every missing header and carries no value.
+        // Event-level audit signal: the Display text names both sides of
+        // every missing mapping and carries no value.
         let message = err.to_string();
         assert_eq!(
             message,
-            "approver identity capture failed: response missing mapped headers \
-             [\"authorization\", \"x-forwarded-user\"]"
+            "approver identity capture failed: webhook response missing headers \
+             [\"x-approver-id\" (mapped to tool header \"x-forwarded-user\"); \
+             \"x-approver-token\" (mapped to tool header \"authorization\")]"
         );
         assert!(!message.contains("acme"), "message was: {message}");
+    }
+
+    /// The same logical set of missing mappings renders identically however
+    /// the config map enumerates them: the audit string is deterministic.
+    #[test]
+    fn display_is_deterministic_regardless_of_construction_order() {
+        let pairs = [
+            ("x-forwarded-user", "x-approver-id"),
+            ("authorization", "x-approver-token"),
+            ("x-tenant", "x-approver-tenant"),
+        ];
+        let mut reversed = pairs;
+        reversed.reverse();
+
+        let forward = ApproverHeaders::from_captured(&mappings(&pairs), &response(&[]))
+            .expect_err("an empty response must fail every mapping");
+        let backward = ApproverHeaders::from_captured(&mappings(&reversed), &response(&[]))
+            .expect_err("an empty response must fail every mapping");
+
+        assert_eq!(forward.to_string(), backward.to_string());
+    }
+
+    /// Mappings that read the same response header tie on response name;
+    /// the outbound name breaks the tie, so the sort total-orders every
+    /// payload and the audit string is deterministic even under ties.
+    #[test]
+    fn equal_response_names_tie_break_on_outbound_name() {
+        let err = ApproverHeaders::from_captured(
+            &mappings(&[
+                ("x-second-tool", "x-shared-response"),
+                ("x-first-tool", "x-shared-response"),
+            ]),
+            &response(&[]),
+        )
+        .expect_err("an empty response must fail every mapping");
+
+        assert_eq!(
+            err.to_string(),
+            "approver identity capture failed: webhook response missing headers \
+             [\"x-shared-response\" (mapped to tool header \"x-first-tool\"); \
+             \"x-shared-response\" (mapped to tool header \"x-second-tool\")]"
+        );
+    }
+
+    /// The failure names the response header as what was missing and the
+    /// tool header as what it maps to — never the value the response did carry.
+    #[test]
+    fn missing_pair_error_names_both_sides_and_never_the_value() {
+        let err = ApproverHeaders::from_captured(
+            &mappings(&[("x-source-header", "x-dest-header")]),
+            &response(&[("x-source-header", "my forwarded value")]),
+        )
+        .expect_err("a response lacking the mapped response header must fail closed");
+
+        let message = err.to_string();
+        assert_eq!(
+            message,
+            "approver identity capture failed: webhook response missing header \
+             \"x-dest-header\" (mapped to tool header \"x-source-header\")"
+        );
+        assert!(
+            !message.contains("my forwarded value"),
+            "message was: {message}"
+        );
     }
 
     #[test]

--- a/crates/aura/src/hitl/mod.rs
+++ b/crates/aura/src/hitl/mod.rs
@@ -47,7 +47,8 @@ pub use protocol::{ApprovalDecisionWire, ApprovalItem, ApprovalRequest, PROTOCOL
 pub use registry::{ParkedApproval, PendingApprovals, ResolveError};
 pub use route::{
     ApprovalError, DecisionRoute, HitlRuntime, PlaintextWebhookUrlError, WebhookClient,
-    cleartext_capture_warning, validate_webhook_signing_config, warn_on_cleartext_capture,
+    approver_forwarding_summary, cleartext_capture_warning, validate_webhook_signing_config,
+    warn_on_cleartext_capture,
 };
 pub use signing::{
     ConfigError, PrimarySecret, SIGNATURE_HEADER, SignedHeaders, SigningContext, TIMESTAMP_HEADER,

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -121,10 +121,11 @@ pub enum ApprovalError {
     /// ingress). The decision inside is untrusted and discarded.
     #[error("approval webhook response failed signature verification: {0}")]
     ResponseUnverified(String),
-    /// Approver identity capture failed closed: the approved response was
-    /// missing mapped headers. Names only, never values; the message is
-    /// the event-level audit signal. Wraps only the capture kind, so
-    /// application-time failures cannot be mislabeled as capture failures.
+    /// Approver identity capture failed closed: the approved webhook
+    /// response was missing a mapped response header. Names only, never
+    /// values; the message is the event-level audit signal. Wraps only
+    /// the capture kind, so application-time failures cannot be
+    /// mislabeled as capture failures.
     #[error("{0}")]
     CaptureFailed(#[from] crate::approver_headers::CaptureError),
 }
@@ -518,10 +519,22 @@ impl WebhookClient {
                 let overrides = if self.tool_header_mappings.is_empty() {
                     None
                 } else {
-                    Some(crate::approver_headers::ApproverHeaders::from_captured(
-                        &self.tool_header_mappings,
-                        &response_headers,
-                    )?)
+                    Some(
+                        crate::approver_headers::ApproverHeaders::from_captured(
+                            &self.tool_header_mappings,
+                            &response_headers,
+                        )
+                        .map_err(|err| {
+                            let decision_id = request.decision_id;
+                            tracing::warn!(
+                                target: "aura::hitl",
+                                %decision_id,
+                                "HITL approver header forwarding blocked: {err}; the gated \
+                                 call was not executed"
+                            );
+                            ApprovalError::CaptureFailed(err)
+                        })?,
+                    )
                 };
                 Ok(GateDecision::Approved { overrides })
             }
@@ -738,23 +751,54 @@ pub fn cleartext_capture_warning(config: &HitlConfig) -> Option<String> {
     }
     Some(format!(
         "HITL webhook route {} captures approver response headers over cleartext http, so \
-         this route's tool_headers_from_response values are readable by any network \
-         observer; intended for trusted-gateway or service-to-service deployments",
+         the values captured from these webhook response headers are readable by any \
+         network observer; intended for trusted-gateway or service-to-service \
+         deployments; the route remains enabled",
         redact_to_origin(url.as_str())
     ))
 }
 
-/// `scheme://host[:port]` of `url`, dropping userinfo, path, query, and fragment. These are parts a log line must never carry, since a webhook URL may embed a token in any of them.
+/// The boot-time approver-forwarding summary for `config`, rendered as newline-joined lines (one per `tool_headers_from_response` mapping, sorted by outbound tool header name so the text is deterministic) so a binary with silent default tracing (aura-cli without `log_file`) can print them on a channel it owns, such as stderr. `None` for every configuration with no mapping to summarize; each line carries the redacted origin and both header names of its pair, never the full URL and never any header value.
+pub fn approver_forwarding_summary(config: &HitlConfig) -> Option<String> {
+    let DecisionRouteConfig::Webhook {
+        url,
+        tool_headers_from_response,
+        ..
+    } = &config.route
+    else {
+        return None;
+    };
+    if tool_headers_from_response.is_empty() {
+        return None;
+    }
+    let mut mappings: Vec<_> = tool_headers_from_response.iter().collect();
+    mappings.sort_unstable();
+    let origin = redact_to_origin(url.as_str());
+    Some(
+        mappings
+            .iter()
+            .map(|(outbound, response)| {
+                format!(
+                    "HITL approver identity forwarding on {origin}: tool header \"{outbound}\" \
+                     <- webhook response header \"{response}\""
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+}
+
+/// `scheme://host[:port]` of `url`, dropping userinfo, path, query, and fragment. These are parts a log line must never carry, since a webhook URL may embed a token in any of them. Parsing follows the HTTP client's own URL grammar, under which a backslash separates the path on http(s) URLs, so a token hidden behind a backslash is dropped too. An unparsable URL redacts to a constant rather than echoing raw input.
 fn redact_to_origin(url: &str) -> String {
-    let (scheme, rest) = url.split_once("://").unwrap_or(("", url));
-    let authority = &rest[..rest.find(['/', '?', '#']).unwrap_or(rest.len())];
-    let host_port = authority
-        .rsplit_once('@')
-        .map_or(authority, |(_, host)| host);
-    if scheme.is_empty() {
-        host_port.to_string()
-    } else {
-        format!("{scheme}://{host_port}")
+    match url::Url::parse(url) {
+        Ok(parsed) => {
+            let host = parsed.host_str().unwrap_or_default();
+            match parsed.port() {
+                Some(port) => format!("{}://{host}:{port}", parsed.scheme()),
+                None => format!("{}://{host}", parsed.scheme()),
+            }
+        }
+        Err(_) => "<unparsable webhook url>".to_string(),
     }
 }
 
@@ -1273,7 +1317,7 @@ mod tests {
             ApprovalError, ApprovalOutcome, EgressSigning, GateDecision, WebhookClient,
             build_webhook_client,
         };
-        use crate::approver_headers::CaptureError;
+        use crate::approver_headers::{CaptureError, MissingMapping};
 
         fn test_hmac() -> WebhookHmac {
             WebhookHmac::new(
@@ -1779,7 +1823,7 @@ mod tests {
         fn warn_on_cleartext_capture_warns_once_and_redacts_the_url() {
             let log = captured_warn_log(|| {
                 super::super::warn_on_cleartext_capture(&webhook_config(
-                    "http://token:secret@approvals.example.com:8443/aura/hook?key=shh",
+                    "http://token:secret@approvals.example.com:8443\\private-token?key=shh",
                     user_mapping(),
                 ));
                 super::super::warn_on_cleartext_capture(&webhook_config(
@@ -1792,10 +1836,14 @@ mod tests {
                 "the warning must name the risk, got log: {log}"
             );
             assert!(
+                log.trim_end().ends_with("the route remains enabled"),
+                "the warning must end by saying the route remains enabled, got log: {log}"
+            );
+            assert!(
                 log.contains("http://approvals.example.com:8443"),
                 "the warning must name the origin, got log: {log}"
             );
-            for secret in ["token", "secret", "aura/hook", "key=shh"] {
+            for secret in ["token", "secret", "private-token", "key=shh"] {
                 assert!(
                     !log.contains(secret),
                     "the warning must never carry userinfo, path, or query, got: {log}"
@@ -1811,7 +1859,7 @@ mod tests {
         #[test]
         fn cleartext_capture_warning_redacts_the_url() {
             let warning = super::super::cleartext_capture_warning(&webhook_config(
-                "http://token:secret@approvals.example.com:8443/aura/hook?key=shh",
+                "http://token:secret@approvals.example.com:8443\\private-token?key=shh",
                 user_mapping(),
             ))
             .expect("a mapped cleartext route must warn");
@@ -1820,7 +1868,7 @@ mod tests {
                 warning.contains("http://approvals.example.com:8443"),
                 "the warning must name the origin, got: {warning}"
             );
-            for secret in ["token", "secret", "aura/hook", "key=shh"] {
+            for secret in ["token", "secret", "private-token", "key=shh"] {
                 assert!(
                     !warning.contains(secret),
                     "the warning must never carry userinfo, path, or query, got: {warning}"
@@ -1861,6 +1909,148 @@ mod tests {
             assert!(
                 log.is_empty(),
                 "no map means nothing to warn about, got: {log}"
+            );
+        }
+
+        /// The summary is quiet exactly when nothing is configured to forward: a conversational route and a mapping-less webhook route both return `None`.
+        #[test]
+        fn approver_forwarding_summary_is_none_without_mappings() {
+            assert!(
+                super::super::approver_forwarding_summary(&webhook_config(
+                    "http://approvals.example.com/aura",
+                    aura_config::ToolHeaderMappings::default(),
+                ))
+                .is_none(),
+                "an empty mapping is the legacy path and needs no summary"
+            );
+            let conversational = aura_config::HitlConfig {
+                require_approval: vec![],
+                park: aura_config::ParkConfig::default(),
+                route: aura_config::DecisionRouteConfig::Conversational { timeout_secs: 60 },
+            };
+            assert!(
+                super::super::approver_forwarding_summary(&conversational).is_none(),
+                "a conversational route has no response-header forwarding"
+            );
+        }
+
+        /// One mapping, one line, quoting both names as the capture error does: the summary names the direction so an operator can see the webhook response is the value source.
+        #[test]
+        fn approver_forwarding_summary_renders_one_line_per_mapping() {
+            let summary = super::super::approver_forwarding_summary(&webhook_config(
+                "https://approvals.example.com",
+                user_mapping(),
+            ))
+            .expect("a mapped route must summarize");
+
+            assert_eq!(
+                summary,
+                "HITL approver identity forwarding on https://approvals.example.com: \
+                 tool header \"x-forwarded-user\" <- webhook response header \"x-approver-id\""
+            );
+        }
+
+        /// Several mappings render one line each, sorted by outbound tool header name: the config map's iteration order must not show.
+        #[test]
+        fn approver_forwarding_summary_sorts_lines_by_outbound_name() {
+            let mappings = crate::approver_headers::tests::mappings(&[
+                ("x-tenant", "x-approver-tenant"),
+                ("authorization", "x-approver-token"),
+                ("x-forwarded-user", "x-approver-id"),
+            ]);
+            let summary = super::super::approver_forwarding_summary(&webhook_config(
+                "https://approvals.example.com",
+                mappings,
+            ))
+            .expect("a mapped route must summarize");
+
+            assert_eq!(
+                summary,
+                format!(
+                    "HITL approver identity forwarding on https://approvals.example.com: \
+                     tool header \"authorization\" <- webhook response header \"x-approver-token\"\n\
+                     HITL approver identity forwarding on https://approvals.example.com: \
+                     tool header \"x-forwarded-user\" <- webhook response header \"x-approver-id\"\n\
+                     HITL approver identity forwarding on https://approvals.example.com: \
+                     tool header \"x-tenant\" <- webhook response header \"x-approver-tenant\""
+                )
+            );
+            assert_eq!(summary.lines().count(), 3, "one line per mapping");
+        }
+
+        /// The summary carries the redacted origin and header names only: userinfo, path, and query never appear.
+        #[test]
+        fn approver_forwarding_summary_redacts_the_url() {
+            let summary = super::super::approver_forwarding_summary(&webhook_config(
+                "https://token:secret@approvals.example.com:8443\\private-token?key=shh",
+                user_mapping(),
+            ))
+            .expect("a mapped route must summarize");
+
+            assert!(
+                summary.contains("https://approvals.example.com:8443"),
+                "the summary must name the origin, got: {summary}"
+            );
+            for secret in ["token", "secret", "private-token", "key=shh"] {
+                assert!(
+                    !summary.contains(secret),
+                    "the summary must never carry userinfo, path, or query, got: {summary}"
+                );
+            }
+        }
+
+        /// The one failure-time line an operator sees under the default filter: the capture warn carries the decision id and the both-sides error text, and never a header value. A sync capture scope cannot wrap an await, so the same subscriber is installed as a scoped thread default for the poll.
+        #[tokio::test]
+        async fn gate_capture_failure_warns_with_decision_id_and_names_only() {
+            let decision_id = DecisionId::generate();
+            // The approved response carries the OUTBOUND header's name with a value: a leak would print this value, whose header is not the mapped response one and captures nothing.
+            let (url, _received) = one_shot_receiver(
+                vec![("x-forwarded-user".to_owned(), "alice".to_owned())],
+                r#"{"approved":true}"#.to_owned(),
+            )
+            .await;
+
+            let buf = std::sync::Arc::new(super::CapturedLog(std::sync::Mutex::new(Vec::new())));
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(buf.clone())
+                .with_max_level(tracing::Level::WARN)
+                .with_ansi(false)
+                .finish();
+            let _guard = tracing::subscriber::set_default(subscriber);
+
+            let err = loopback_client(&url, EgressSigning::Disabled, user_mapping())
+                .request_approval_for_gate(&test_request(decision_id), Duration::from_secs(5))
+                .await
+                .expect_err("the approved response lacks the mapped header and must fail closed");
+            drop(_guard);
+            let log = String::from_utf8_lossy(&buf.0.lock().unwrap()).to_string();
+
+            assert!(
+                matches!(err, ApprovalError::CaptureFailed(_)),
+                "expected CaptureFailed, got {err:?}"
+            );
+            assert!(
+                log.contains("aura::hitl"),
+                "the warn must target aura::hitl, got: {log}"
+            );
+            assert!(
+                log.contains("HITL approver header forwarding blocked"),
+                "the warn must fire on the capture-failure path, got: {log}"
+            );
+            assert!(
+                log.contains(&decision_id.to_string()),
+                "the warn must carry the decision id, got: {log}"
+            );
+            assert!(
+                log.contains(
+                    "webhook response missing header \"x-approver-id\" \
+                     (mapped to tool header \"x-forwarded-user\")"
+                ),
+                "the warn must quote the both-sides error text, got: {log}"
+            );
+            assert!(
+                !log.contains("alice"),
+                "the warn must never carry a header value, got: {log}"
             );
         }
 
@@ -2121,11 +2311,18 @@ mod tests {
                         Expected::CaptureFailed(name),
                         Err(
                             ref err @ ApprovalError::CaptureFailed(CaptureError::MissingHeaders {
-                                ref names,
+                                ref missing,
                             }),
                         ),
                     ) => {
-                        assert_eq!(names, &[name.to_owned()], "{case}");
+                        assert_eq!(
+                            missing,
+                            &[MissingMapping {
+                                response_name: "x-approver-id".to_owned(),
+                                outbound_name: name.to_owned(),
+                            }],
+                            "{case}"
+                        );
                         assert!(
                             err.to_string().contains(name),
                             "{case}: the audit message must name the missing header: {err}"

--- a/docs/design/hitl.md
+++ b/docs/design/hitl.md
@@ -463,7 +463,7 @@ substitute the approver's identity onto that one gated call instead.
 mode = "webhook"
 url = "https://approvals.example.com/hook"
 headers_from_request = { "authorization" = "authorization" }   # PR #490, unrelated
-# outbound MCP header name -> webhook response header name
+# keys: outbound MCP tool header names; values: webhook response header names
 tool_headers_from_response = { "authorization" = "x-approver-token" }
 ```
 
@@ -486,7 +486,16 @@ When `tool_headers_from_response` is non-empty:
   case-insensitively and taking the first value on a repeat. One missing name
   fails the whole capture.
 - A capture failure resolves the approval to an error: the gated call fails
-  with a message naming every missing header, never a value.
+  with a message naming both sides of every missing mapping, the webhook
+  response header as the one absent, never a value, e.g. `approver identity
+  capture failed: webhook response missing header "x-approver-token" (mapped
+  to tool header "authorization")`. The approval request sent to the webhook
+  does not advertise which response headers will be read; the mapping in
+  config is the contract the webhook author must meet.
+- Unlike `headers_from_request`, whose static `headers` entries silently
+  serve as fallback when a mapped inbound header is absent, capture here
+  fails closed: forwarding nothing would run the call under the wrong
+  identity.
 - A denied, timed-out, or cancelled decision captures nothing, because there
   is no decision to capture from.
 
@@ -499,13 +508,19 @@ Capture does not require `https://`. A webhook route with
 `tool_headers_from_response` configured over plain `http://` is usable and
 unsigned. A deployment that terminates TLS ahead of the process is a
 legitimate topology, but the route is never silent: each binary's startup logs
-one warning per `[hitl]` config naming the exposure, alongside the boot-time
-HMAC-signing check (`warn_on_cleartext_capture`). In the CLI the warning also
-reaches stderr, since its default tracing subscriber is a no-op without
-`log_file`. The webhook client itself never logs this warning; only the
-boot-time call does, and the log line carries the webhook's scheme and host
-only. The one rule `https://` still enforces is unchanged: an HMAC secret
-configured over `http://` is a misconfiguration and fails closed at boot.
+the cleartext-capture warning per `[hitl]` config naming the exposure, plus
+one boot line per mapping stating the forwarding direction (`approver
+forwarding summary`), alongside the boot-time signing validation
+(`validate_webhook_signing_config`) and the cleartext warning's emitter
+(`warn_on_cleartext_capture`). In the CLI both lines also reach stderr, since
+its default tracing subscriber is a no-op without `log_file`. The webhook
+client itself never logs these lines; only the boot-time call does, and every
+log line carries the webhook's scheme and host only. The one rule `https://`
+still enforces is unchanged: an HMAC secret configured over `http://` is a
+misconfiguration and fails closed at boot. Note the boundary of that
+signature: HMAC verification covers the webhook body only. The mapped
+response headers are read from the response as delivered, outside that
+signature.
 
 ### Transport support
 
@@ -532,7 +547,10 @@ re-enters `pre_call` and the gate mints a fresh `DecisionId` per call.
 `execute_mcp_tool` stamps the outbound header NAMES an override applied
 (sorted, comma-joined, never the values) on the `mcp.tool_call` span as
 `applied_headers`. Event-level audit uses the capture failure's error text,
-which names every missing header. No missing-header failure reaches the wire.
+which names both sides of every missing mapping. A capture failure also logs
+one `aura::hitl` warn quoting that text with the decision id, so the failure
+is visible under the default console filter. No missing-header failure
+reaches the wire.
 No `aura-events` wire type changes: under fail-closed semantics a capture
 success stamp would be degenerate, so the existing `Errored` outcome already
 carries the full audit signal.

--- a/examples/complete/hitl-webhook.toml
+++ b/examples/complete/hitl-webhook.toml
@@ -47,6 +47,11 @@ headers = { "x-aura-tenant" = "sre-prod" }
 # service can see who asked. Keys are webhook header names, values are inbound
 # request header names (matched case-insensitively).
 headers_from_request = { "authorization" = "authorization" }
+# Forward the approver's identity onto the gated tool call. Keys are outbound
+# MCP tool header names, values are webhook response header names (matched
+# case-insensitively). Every value-side header must be present on an approved
+# response or the gated call fails closed.
+tool_headers_from_response = { "authorization" = "x-approver-token" }
 
 [mcp]
 sanitize_schemas = true


### PR DESCRIPTION
## What

`tool_headers_from_response` maps a webhook response header onto the MCP tool call. When the approved response was missing that header, the error named only the TOML key side, so with `x-source-header = "x-dest-header"` aura complained about `x-source-header` - the header the webhook had actually returned. This PR names both sides, logs the direction at boot, and makes the failure visible under the default console filter. The example config, field rustdoc, and design doc state the key/value direction; the hosted docs page follows in a PR against mezmo/documentation.

## Operator-visible changes

- Capture failures now read: `approver identity capture failed: webhook response missing header "x-dest-header" (mapped to tool header "x-source-header")`. Names only; the same text reaches the chat error and the `aura.approval_completed` event.
- Each binary logs one boot line per mapping: `HITL approver identity forwarding on http://127.0.0.1:8477: tool header "x-source-header" <- webhook response header "x-dest-header"` (origin redacted to scheme://host).
- A capture failure logs `WARN aura::hitl: HITL approver header forwarding blocked: ... decision_id=...`, visible with no RUST_LOG set.
- The cleartext-capture warning now says what an observer can read (the captured header values, not the configured names) and that the route remains enabled.
- Webhook origin redaction goes through the URL parser, so a token hidden behind a backslash in the URL cannot reach a log line.

Fixes: #633
