### PR TITLE
feat(mcp): add linear to the blessed mcp catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Through compatible [MCP](https://modelcontextprotocol.io) servers and built-in i
 | Jira | Search and update issues, projects, and workflows |
 | Kafka | Inspect clusters, topics, consumer groups, and message flows |
 | [Kubernetes](https://www.youtube.com/watch?v=IDkH4-FfGXo) | Inspect clusters, workloads, events, and logs |
+| Linear | Search and update issues, projects, and cycles |
 | [Mezmo](https://www.youtube.com/watch?v=sjb3D5tZiOg) | Analyze logs, exports, and telemetry pipelines |
 | New Relic | Query metrics, logs, traces, alerts, and dashboards |
 | [Notion](https://www.youtube.com/watch?v=jXa1jDvpF34) | Search and maintain operational runbooks |

--- a/crates/aura-cli/src/repl/mcp/catalog.rs
+++ b/crates/aura-cli/src/repl/mcp/catalog.rs
@@ -98,6 +98,23 @@ pub(crate) const CATALOG: &[CatalogEntry] = &[
         starter_prompt: "Which Datadog monitors are currently alerting?",
     },
     CatalogEntry {
+        key: "linear",
+        description: "Linear issue tracking, projects, and cycles",
+        prerequisites: "Requires a Linear personal API key (Settings > Security & access > \
+                        API keys).\n\
+                        AURA will be able to read and write issues, projects, and cycles.",
+        template: Template::Http {
+            url: "https://mcp.linear.app/mcp",
+            headers: &[HeaderTemplate {
+                header: "Authorization",
+                value_template: "Bearer {{ env.LINEAR_API_KEY }}",
+                env_var: "LINEAR_API_KEY",
+                secret_prompt: "Linear API key",
+            }],
+        },
+        starter_prompt: "What issues are assigned to me right now?",
+    },
+    CatalogEntry {
         key: "kubernetes",
         description: "Kubernetes cluster inspection via kubernetes-mcp-server",
         prerequisites: "Requires Node.js (npx) and a working kubeconfig context.\n\


### PR DESCRIPTION
## What

Adds Linear to the curated MCP server catalog (`/mcp add`), alongside the existing Mezmo, PagerDuty, and Datadog entries, and lists it in the README integrations table.

## Why

Linear is a common part of an SRE/on-call workflow (tracking incident follow-ups, linking alerts to issues) but wasn't in the blessed catalog, even though the other issue trackers already listed in the README (Jira) are supported generically via MCP.

Linear's hosted MCP server (`https://mcp.linear.app/mcp`) supports passing a personal API key directly as `Authorization: Bearer <token>`, in addition to its interactive OAuth flow (see [Linear's MCP docs](https://linear.app/docs/mcp)). That's the same static-header auth shape the `Http` template already uses for Mezmo, PagerDuty, and Datadog, so no changes to the wizard or template types were needed — just a new `CatalogEntry`.

## Changes

- `crates/aura-cli/src/repl/mcp/catalog.rs` — new `linear` `CatalogEntry` (Http template, `LINEAR_API_KEY` env var, starter prompt).
- `README.md` — add Linear to the integrations table.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace` (includes `catalog_templates_render_and_reload`, which iterates every `CATALOG` entry generically and covers the new one without further changes)
- `npm run commitlint` (`commitlint-mzm`) against this branch