### PR TITLE
fix(init): exit prompts on terminal interrupts

### DIFF
--- a/crates/aura-cli/src/init.rs
+++ b/crates/aura-cli/src/init.rs
@@ -112,10 +112,17 @@ pub struct InitArgs {
 pub fn run_init(args: &InitArgs) -> Result<()> {
     let is_tty = std::io::stdin().is_terminal();
     let interactive = !args.non_interactive && is_tty;
+    let stdin: Box<dyn std::io::BufRead> = if is_tty {
+        // The terminal editor opens stdin directly. Keeping another Stdin
+        // handle here can hold its global input lock while readline starts.
+        Box::new(std::io::empty())
+    } else {
+        Box::new(std::io::BufReader::new(std::io::stdin()))
+    };
     let mut prompter = Prompter {
         interactive,
         is_tty,
-        stdin: std::io::stdin().lock(),
+        stdin,
     };
     if prompter.interactive {
         println!(

--- a/crates/aura-cli/src/init/prompt.rs
+++ b/crates/aura-cli/src/init/prompt.rs
@@ -2,9 +2,357 @@
 //! logic stays testable without a terminal — tests construct a `Prompter` over
 //! scripted stdin.
 
-use std::io::{BufRead, Write as _};
+use std::io::{BufRead, Write};
+use std::sync::{
+    Arc, LazyLock,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+use std::time::Duration;
 
 use anyhow::{Result, bail};
+use crossterm::{
+    cursor::{MoveLeft, MoveRight},
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    queue,
+    terminal::{Clear, ClearType},
+};
+use signal_hook::{
+    SigId,
+    consts::signal::{SIGINT, SIGTERM},
+};
+use unicode_width::UnicodeWidthChar;
+
+fn is_prompt_interrupt(key: &KeyEvent) -> bool {
+    key.modifiers.contains(KeyModifiers::CONTROL)
+        && matches!(key.code, KeyCode::Char('c' | 'C' | 'z' | 'Z'))
+}
+
+struct PromptSignals {
+    outside_prompt: Arc<AtomicBool>,
+    pending_signal: Arc<AtomicUsize>,
+    _signal_ids: Vec<SigId>,
+}
+
+impl PromptSignals {
+    fn install() -> std::io::Result<Self> {
+        let outside_prompt = Arc::new(AtomicBool::new(true));
+        let pending_signal = Arc::new(AtomicUsize::new(0));
+        let mut signal_ids = Vec::new();
+        for signal in [SIGINT, SIGTERM] {
+            // Keep the signal-hook actions for the process lifetime. Removing
+            // the final action would leave the signal ignored rather than
+            // restoring its default disposition.
+            signal_ids.push(signal_hook::flag::register_conditional_default(
+                signal,
+                Arc::clone(&outside_prompt),
+            )?);
+            signal_ids.push(signal_hook::flag::register_usize(
+                signal,
+                Arc::clone(&pending_signal),
+                signal as usize,
+            )?);
+        }
+        Ok(Self {
+            outside_prompt,
+            pending_signal,
+            _signal_ids: signal_ids,
+        })
+    }
+}
+
+static PROMPT_SIGNALS: LazyLock<std::io::Result<PromptSignals>> =
+    LazyLock::new(PromptSignals::install);
+
+struct RawModeGuard {
+    signals: &'static PromptSignals,
+}
+
+impl RawModeGuard {
+    fn enter() -> std::io::Result<Self> {
+        let signals = PROMPT_SIGNALS
+            .as_ref()
+            .map_err(|error| std::io::Error::new(error.kind(), error.to_string()))?;
+        signals.pending_signal.store(0, Ordering::SeqCst);
+        signals.outside_prompt.store(false, Ordering::SeqCst);
+        if let Err(error) = crossterm::terminal::enable_raw_mode() {
+            signals.outside_prompt.store(true, Ordering::SeqCst);
+            return Err(error);
+        }
+        Ok(Self { signals })
+    }
+
+    fn pending_signal(&self) -> usize {
+        self.signals.pending_signal.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = crossterm::terminal::disable_raw_mode();
+        self.signals.outside_prompt.store(true, Ordering::SeqCst);
+    }
+}
+
+#[derive(Default)]
+struct LineEditor {
+    chars: Vec<char>,
+    cursor: usize,
+}
+
+impl LineEditor {
+    fn text(&self) -> String {
+        self.chars.iter().collect()
+    }
+
+    fn cursor_width(&self) -> usize {
+        display_width(&self.chars[..self.cursor])
+    }
+
+    fn insert(&mut self, value: char) {
+        self.chars.insert(self.cursor, value);
+        self.cursor += 1;
+    }
+
+    fn backspace(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+        self.cursor -= 1;
+        self.chars.remove(self.cursor);
+        true
+    }
+
+    fn delete(&mut self) -> bool {
+        if self.cursor == self.chars.len() {
+            return false;
+        }
+        self.chars.remove(self.cursor);
+        true
+    }
+
+    fn clear_to_start(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+        self.chars.drain(..self.cursor);
+        self.cursor = 0;
+        true
+    }
+
+    fn erase_word(&mut self) -> bool {
+        let initial = self.cursor;
+        while self.cursor > 0 && self.chars[self.cursor - 1].is_whitespace() {
+            self.cursor -= 1;
+        }
+        while self.cursor > 0 && !self.chars[self.cursor - 1].is_whitespace() {
+            self.cursor -= 1;
+        }
+        if self.cursor == initial {
+            return false;
+        }
+        self.chars.drain(self.cursor..initial);
+        true
+    }
+
+    fn redraw(&self, old_cursor_width: usize, echo: bool) -> std::io::Result<()> {
+        if !echo {
+            return Ok(());
+        }
+        let mut stdout = std::io::stdout();
+        queue_move_left(&mut stdout, old_cursor_width)?;
+        queue!(stdout, Clear(ClearType::UntilNewLine))?;
+        let text = self.text();
+        write!(stdout, "{text}")?;
+        queue_move_left(
+            &mut stdout,
+            display_width(&self.chars).saturating_sub(self.cursor_width()),
+        )?;
+        stdout.flush()
+    }
+}
+
+fn display_width(chars: &[char]) -> usize {
+    chars
+        .iter()
+        .map(|character| character.width().unwrap_or(0))
+        .sum()
+}
+
+fn queue_move_left(output: &mut impl Write, mut columns: usize) -> std::io::Result<()> {
+    while columns > 0 {
+        let step = columns.min(u16::MAX as usize) as u16;
+        queue!(output, MoveLeft(step))?;
+        columns -= usize::from(step);
+    }
+    Ok(())
+}
+
+fn queue_move_right(output: &mut impl Write, mut columns: usize) -> std::io::Result<()> {
+    while columns > 0 {
+        let step = columns.min(u16::MAX as usize) as u16;
+        queue!(output, MoveRight(step))?;
+        columns -= usize::from(step);
+    }
+    Ok(())
+}
+
+fn read_tty_answer(echo: bool) -> Result<Option<String>> {
+    let raw_mode = RawModeGuard::enter()?;
+    let mut editor = LineEditor::default();
+
+    loop {
+        let signal = raw_mode.pending_signal();
+        if signal != 0 {
+            bail!("init interrupted by signal {signal}");
+        }
+        if !event::poll(Duration::from_millis(50))? {
+            continue;
+        }
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            continue;
+        }
+        if is_prompt_interrupt(&key) {
+            print!(
+                "^{}\r\n",
+                match key.code {
+                    KeyCode::Char(c) => c.to_ascii_uppercase(),
+                    _ => unreachable!(),
+                }
+            );
+            std::io::stdout().flush()?;
+            bail!("init interrupted");
+        }
+
+        match key.code {
+            KeyCode::Enter => {
+                print!("\r\n");
+                std::io::stdout().flush()?;
+                return Ok(Some(editor.text()));
+            }
+            KeyCode::Char('d')
+                if key.modifiers.contains(KeyModifiers::CONTROL) && editor.chars.is_empty() =>
+            {
+                print!("\r\n");
+                std::io::stdout().flush()?;
+                return Ok(None);
+            }
+            KeyCode::Char('a') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                let columns = editor.cursor_width();
+                editor.cursor = 0;
+                if echo {
+                    let mut stdout = std::io::stdout();
+                    queue_move_left(&mut stdout, columns)?;
+                    stdout.flush()?;
+                }
+            }
+            KeyCode::Char('e') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                let columns = display_width(&editor.chars[editor.cursor..]);
+                editor.cursor = editor.chars.len();
+                if echo {
+                    let mut stdout = std::io::stdout();
+                    queue_move_right(&mut stdout, columns)?;
+                    stdout.flush()?;
+                }
+            }
+            KeyCode::Char('b')
+                if key.modifiers.contains(KeyModifiers::CONTROL) && editor.cursor > 0 =>
+            {
+                let columns = editor.chars[editor.cursor - 1].width().unwrap_or(0);
+                editor.cursor -= 1;
+                if echo {
+                    let mut stdout = std::io::stdout();
+                    queue_move_left(&mut stdout, columns)?;
+                    stdout.flush()?;
+                }
+            }
+            KeyCode::Char('f')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && editor.cursor < editor.chars.len() =>
+            {
+                let columns = editor.chars[editor.cursor].width().unwrap_or(0);
+                editor.cursor += 1;
+                if echo {
+                    let mut stdout = std::io::stdout();
+                    queue_move_right(&mut stdout, columns)?;
+                    stdout.flush()?;
+                }
+            }
+            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                let old_cursor_width = editor.cursor_width();
+                if editor.clear_to_start() {
+                    editor.redraw(old_cursor_width, echo)?;
+                }
+            }
+            KeyCode::Char('w') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                let old_cursor_width = editor.cursor_width();
+                if editor.erase_word() {
+                    editor.redraw(old_cursor_width, echo)?;
+                }
+            }
+            KeyCode::Char(c)
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                let old_cursor_width = editor.cursor_width();
+                editor.insert(c);
+                editor.redraw(old_cursor_width, echo)?;
+            }
+            KeyCode::Backspace => {
+                let old_cursor_width = editor.cursor_width();
+                if editor.backspace() {
+                    editor.redraw(old_cursor_width, echo)?;
+                }
+            }
+            KeyCode::Delete => {
+                let old_cursor_width = editor.cursor_width();
+                if editor.delete() {
+                    editor.redraw(old_cursor_width, echo)?;
+                }
+            }
+            KeyCode::Left if editor.cursor > 0 => {
+                let columns = editor.chars[editor.cursor - 1].width().unwrap_or(0);
+                editor.cursor -= 1;
+                if echo {
+                    let mut stdout = std::io::stdout();
+                    queue_move_left(&mut stdout, columns)?;
+                    stdout.flush()?;
+                }
+            }
+            KeyCode::Right if editor.cursor < editor.chars.len() => {
+                let columns = editor.chars[editor.cursor].width().unwrap_or(0);
+                editor.cursor += 1;
+                if echo {
+                    let mut stdout = std::io::stdout();
+                    queue_move_right(&mut stdout, columns)?;
+                    stdout.flush()?;
+                }
+            }
+            KeyCode::Home => {
+                let columns = editor.cursor_width();
+                editor.cursor = 0;
+                if echo {
+                    let mut stdout = std::io::stdout();
+                    queue_move_left(&mut stdout, columns)?;
+                    stdout.flush()?;
+                }
+            }
+            KeyCode::End => {
+                let columns = display_width(&editor.chars[editor.cursor..]);
+                editor.cursor = editor.chars.len();
+                if echo {
+                    let mut stdout = std::io::stdout();
+                    queue_move_right(&mut stdout, columns)?;
+                    stdout.flush()?;
+                }
+            }
+            _ => {}
+        }
+    }
+}
 
 /// Interactive prompt helper. Fields are `pub(crate)` so tests in sibling
 /// modules can build one over scripted input.
@@ -18,6 +366,24 @@ pub(crate) struct Prompter<R: BufRead> {
 }
 
 impl<R: BufRead> Prompter<R> {
+    /// Read one answer while preserving terminal interrupt semantics.
+    ///
+    /// `BufRead::read_line` cannot distinguish Ctrl-C or Ctrl-Z from text when
+    /// the terminal does not generate signals. The TTY reader handles those
+    /// keys directly so setup exits without waiting for Enter.
+    fn read_answer(&mut self) -> Result<Option<String>> {
+        if self.is_tty {
+            return read_tty_answer(true);
+        }
+
+        let mut line = String::new();
+        if self.stdin.read_line(&mut line)? == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(line))
+        }
+    }
+
     /// Ask a question with an optional default. Returns `None` when
     /// non-interactive (the caller decides whether that's fatal).
     pub(crate) fn ask(&mut self, question: &str, default: Option<&str>) -> Result<Option<String>> {
@@ -29,8 +395,7 @@ impl<R: BufRead> Prompter<R> {
             None => print!("{question}: "),
         }
         std::io::stdout().flush()?;
-        let mut line = String::new();
-        self.stdin.read_line(&mut line)?;
+        let line = self.read_answer()?.unwrap_or_default();
         let answer = line.trim();
         if answer.is_empty() {
             Ok(default.map(String::from))
@@ -69,10 +434,9 @@ impl<R: BufRead> Prompter<R> {
                 None => print!("{question}: "),
             }
             std::io::stdout().flush()?;
-            let mut line = String::new();
-            if self.stdin.read_line(&mut line)? == 0 {
+            let Some(line) = self.read_answer()? else {
                 return Ok(default);
-            }
+            };
             let answer = line.trim();
             if answer.is_empty() {
                 if default.is_some() {
@@ -95,8 +459,7 @@ impl<R: BufRead> Prompter<R> {
         let hint = if default { "Y/n" } else { "y/N" };
         print!("{question} [{hint}]: ");
         std::io::stdout().flush()?;
-        let mut line = String::new();
-        self.stdin.read_line(&mut line)?;
+        let line = self.read_answer()?.unwrap_or_default();
         let answer = line.trim().to_lowercase();
         if answer.is_empty() {
             Ok(default)
@@ -105,10 +468,10 @@ impl<R: BufRead> Prompter<R> {
         }
     }
 
-    /// Prompt for an API key with masked input. On a real terminal the input
-    /// is read with echo suppressed via `rpassword`. In test contexts
-    /// (`is_tty = false`), falls back to `read_line` on the injected stdin.
-    /// Returns `None` on empty input or EOF.
+    /// Prompt for an API key with masked input. On a real terminal the shared
+    /// interrupt-aware reader suppresses echo. In test contexts (`is_tty =
+    /// false`), input comes from the injected reader. Returns `None` on empty
+    /// input or EOF.
     pub(crate) fn ask_secret_masked(&mut self, prompt: &str) -> Result<Option<String>> {
         if !self.interactive {
             return Ok(None);
@@ -116,9 +479,7 @@ impl<R: BufRead> Prompter<R> {
         print!("{prompt}: ");
         std::io::stdout().flush()?;
         let raw = if self.is_tty {
-            let secret = rpassword::read_password()?;
-            println!();
-            secret
+            read_tty_answer(false)?.unwrap_or_default()
         } else {
             let mut line = String::new();
             self.stdin.read_line(&mut line)?;
@@ -152,10 +513,9 @@ impl<R: BufRead> Prompter<R> {
                 None => print!("Which model should AURA use?: "),
             }
             std::io::stdout().flush()?;
-            let mut line = String::new();
-            if self.stdin.read_line(&mut line)? == 0 {
+            let Some(line) = self.read_answer()? else {
                 return Ok(suggested);
-            }
+            };
             let answer = line.trim();
             if answer.is_empty() {
                 return Ok(suggested);
@@ -179,7 +539,11 @@ impl<R: BufRead> Prompter<R> {
 
 #[cfg(test)]
 mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
     use crate::init::test_support::{non_interactive, scripted};
+
+    use super::{LineEditor, is_prompt_interrupt};
 
     fn sample_shortlist() -> Vec<String> {
         vec![
@@ -187,6 +551,47 @@ mod tests {
             "gpt-4.1".to_string(),
             "gpt-4o".to_string(),
         ]
+    }
+
+    #[test]
+    fn tty_interrupt_keys_exit_init() {
+        for key in ['c', 'C', 'z', 'Z'] {
+            assert!(is_prompt_interrupt(&KeyEvent::new(
+                KeyCode::Char(key),
+                KeyModifiers::CONTROL,
+            )));
+        }
+        assert!(!is_prompt_interrupt(&KeyEvent::new(
+            KeyCode::Char('c'),
+            KeyModifiers::NONE,
+        )));
+    }
+
+    #[test]
+    fn tty_line_editor_preserves_clear_and_word_erase() {
+        let mut editor = LineEditor::default();
+        for character in "first second  ".chars() {
+            editor.insert(character);
+        }
+        assert!(editor.erase_word());
+        assert_eq!(editor.text(), "first ");
+        assert!(editor.clear_to_start());
+        assert_eq!(editor.text(), "");
+    }
+
+    #[test]
+    fn tty_line_editor_supports_cursor_insert_and_delete() {
+        let mut editor = LineEditor::default();
+        for character in "ac".chars() {
+            editor.insert(character);
+        }
+        editor.cursor = 1;
+        editor.insert('b');
+        assert_eq!(editor.text(), "abc");
+        assert!(editor.backspace());
+        assert_eq!(editor.text(), "ac");
+        assert!(editor.delete());
+        assert_eq!(editor.text(), "a");
     }
 
     #[test]

--- a/crates/aura-cli/src/init/prompt.rs
+++ b/crates/aura-cli/src/init/prompt.rs
@@ -5,7 +5,7 @@
 use std::io::{BufRead, Write};
 use std::sync::{
     Arc, LazyLock,
-    atomic::{AtomicBool, AtomicUsize, Ordering},
+    atomic::{AtomicUsize, Ordering},
 };
 use std::time::Duration;
 
@@ -19,8 +19,33 @@ use crossterm::{
 use signal_hook::{
     SigId,
     consts::signal::{SIGINT, SIGTERM},
+    low_level,
 };
 use unicode_width::UnicodeWidthChar;
+
+const OUTSIDE_PROMPT: usize = 0;
+const ACTIVE_PROMPT: usize = 1;
+
+fn signal_state(signal: i32) -> usize {
+    signal as usize + 1
+}
+
+fn state_signal(state: usize) -> Option<usize> {
+    (state > ACTIVE_PROMPT).then_some(state - 1)
+}
+
+/// Record a signal while a prompt owns the terminal. A `true` return means
+/// teardown already won the atomic transition and the default action must run.
+fn record_prompt_signal(state: &AtomicUsize, signal: i32) -> bool {
+    state
+        .compare_exchange(
+            ACTIVE_PROMPT,
+            signal_state(signal),
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        )
+        .is_err_and(|current| current == OUTSIDE_PROMPT)
+}
 
 fn is_prompt_interrupt(key: &KeyEvent) -> bool {
     key.modifiers.contains(KeyModifiers::CONTROL)
@@ -28,35 +53,40 @@ fn is_prompt_interrupt(key: &KeyEvent) -> bool {
 }
 
 struct PromptSignals {
-    outside_prompt: Arc<AtomicBool>,
-    pending_signal: Arc<AtomicUsize>,
+    state: Arc<AtomicUsize>,
     _signal_ids: Vec<SigId>,
 }
 
 impl PromptSignals {
     fn install() -> std::io::Result<Self> {
-        let outside_prompt = Arc::new(AtomicBool::new(true));
-        let pending_signal = Arc::new(AtomicUsize::new(0));
+        let state = Arc::new(AtomicUsize::new(OUTSIDE_PROMPT));
         let mut signal_ids = Vec::new();
         for signal in [SIGINT, SIGTERM] {
             // Keep the signal-hook actions for the process lifetime. Removing
             // the final action would leave the signal ignored rather than
             // restoring its default disposition.
-            signal_ids.push(signal_hook::flag::register_conditional_default(
-                signal,
-                Arc::clone(&outside_prompt),
-            )?);
-            signal_ids.push(signal_hook::flag::register_usize(
-                signal,
-                Arc::clone(&pending_signal),
-                signal as usize,
-            )?);
+            let state = Arc::clone(&state);
+            signal_ids.push(unsafe {
+                // SAFETY: the handler performs only atomic operations and
+                // signal-hook's signal-safe default-action emulation.
+                low_level::register(signal, move || {
+                    if record_prompt_signal(&state, signal) {
+                        let _ = low_level::emulate_default_handler(signal);
+                    }
+                })?
+            });
         }
         Ok(Self {
-            outside_prompt,
-            pending_signal,
+            state,
             _signal_ids: signal_ids,
         })
+    }
+
+    fn finish_prompt(&self) -> Option<usize> {
+        // The swap linearizes teardown with the signal handler's compare-and-
+        // exchange. A signal is therefore either returned here or observes the
+        // outside state and takes its default action; it cannot be swallowed.
+        state_signal(self.state.swap(OUTSIDE_PROMPT, Ordering::SeqCst))
     }
 }
 
@@ -65,6 +95,7 @@ static PROMPT_SIGNALS: LazyLock<std::io::Result<PromptSignals>> =
 
 struct RawModeGuard {
     signals: &'static PromptSignals,
+    active: bool,
 }
 
 impl RawModeGuard {
@@ -72,24 +103,41 @@ impl RawModeGuard {
         let signals = PROMPT_SIGNALS
             .as_ref()
             .map_err(|error| std::io::Error::new(error.kind(), error.to_string()))?;
-        signals.pending_signal.store(0, Ordering::SeqCst);
-        signals.outside_prompt.store(false, Ordering::SeqCst);
+        signals.state.store(ACTIVE_PROMPT, Ordering::SeqCst);
         if let Err(error) = crossterm::terminal::enable_raw_mode() {
-            signals.outside_prompt.store(true, Ordering::SeqCst);
+            signals.finish_prompt();
             return Err(error);
         }
-        Ok(Self { signals })
+        Ok(Self {
+            signals,
+            active: true,
+        })
     }
 
-    fn pending_signal(&self) -> usize {
-        self.signals.pending_signal.load(Ordering::SeqCst)
+    fn pending_signal(&self) -> Option<usize> {
+        state_signal(self.signals.state.load(Ordering::SeqCst))
+    }
+
+    fn restore(&mut self) -> Option<usize> {
+        if !self.active {
+            return None;
+        }
+        let _ = crossterm::terminal::disable_raw_mode();
+        self.active = false;
+        self.signals.finish_prompt()
+    }
+
+    fn finish<T>(mut self, value: T) -> Result<T> {
+        if let Some(signal) = self.restore() {
+            bail!("init interrupted by signal {signal}");
+        }
+        Ok(value)
     }
 }
 
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
-        let _ = crossterm::terminal::disable_raw_mode();
-        self.signals.outside_prompt.store(true, Ordering::SeqCst);
+        self.restore();
     }
 }
 
@@ -201,8 +249,7 @@ fn read_tty_answer(echo: bool) -> Result<Option<String>> {
     let mut editor = LineEditor::default();
 
     loop {
-        let signal = raw_mode.pending_signal();
-        if signal != 0 {
+        if let Some(signal) = raw_mode.pending_signal() {
             bail!("init interrupted by signal {signal}");
         }
         if !event::poll(Duration::from_millis(50))? {
@@ -230,14 +277,14 @@ fn read_tty_answer(echo: bool) -> Result<Option<String>> {
             KeyCode::Enter => {
                 print!("\r\n");
                 std::io::stdout().flush()?;
-                return Ok(Some(editor.text()));
+                return raw_mode.finish(Some(editor.text()));
             }
             KeyCode::Char('d')
                 if key.modifiers.contains(KeyModifiers::CONTROL) && editor.chars.is_empty() =>
             {
                 print!("\r\n");
                 std::io::stdout().flush()?;
-                return Ok(None);
+                return raw_mode.finish(None);
             }
             KeyCode::Char('a') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 let columns = editor.cursor_width();
@@ -539,11 +586,20 @@ impl<R: BufRead> Prompter<R> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use signal_hook::consts::signal::SIGTERM;
 
     use crate::init::test_support::{non_interactive, scripted};
 
-    use super::{LineEditor, is_prompt_interrupt};
+    use super::{
+        ACTIVE_PROMPT, LineEditor, OUTSIDE_PROMPT, PromptSignals, is_prompt_interrupt,
+        record_prompt_signal,
+    };
 
     fn sample_shortlist() -> Vec<String> {
         vec![
@@ -565,6 +621,25 @@ mod tests {
             KeyCode::Char('c'),
             KeyModifiers::NONE,
         )));
+    }
+
+    #[test]
+    fn prompt_signal_and_teardown_have_no_unhandled_order() {
+        let signals = PromptSignals {
+            state: Arc::new(AtomicUsize::new(ACTIVE_PROMPT)),
+            _signal_ids: Vec::new(),
+        };
+
+        // If the handler wins, teardown consumes the pending signal.
+        assert!(!record_prompt_signal(&signals.state, SIGTERM));
+        assert_eq!(signals.finish_prompt(), Some(SIGTERM as usize));
+
+        // If teardown wins, the handler observes that it must run the signal's
+        // default action instead of leaving an unconsumed pending value.
+        signals.state.store(ACTIVE_PROMPT, Ordering::SeqCst);
+        assert_eq!(signals.finish_prompt(), None);
+        assert!(record_prompt_signal(&signals.state, SIGTERM));
+        assert_eq!(signals.state.load(Ordering::SeqCst), OUTSIDE_PROMPT);
     }
 
     #[test]

--- a/crates/aura-cli/tests/init_interrupts.rs
+++ b/crates/aura-cli/tests/init_interrupts.rs
@@ -1,0 +1,242 @@
+#![cfg(unix)]
+
+use std::fs::File;
+use std::io::{ErrorKind, Read, Write};
+use std::mem::MaybeUninit;
+use std::net::TcpListener;
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::process::ExitStatusExt;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+struct PtyChild {
+    child: Child,
+    master: File,
+    monitor: File,
+    output: Vec<u8>,
+    _home: tempfile::TempDir,
+}
+
+impl PtyChild {
+    fn spawn(args: &[&str]) -> Self {
+        let home = tempfile::TempDir::new().unwrap();
+        let output_path = home.path().join("agent.toml");
+        let (master, slave) = open_pty();
+        let monitor = duplicate(slave);
+        let stdout = duplicate(slave);
+        let stderr = duplicate(slave);
+        let stdin = unsafe { File::from_raw_fd(slave) };
+
+        set_nonblocking(master.as_raw_fd());
+        let child = Command::new(env!("CARGO_BIN_EXE_aura"))
+            .args(args)
+            .arg("--output")
+            .arg(output_path)
+            .env("HOME", home.path())
+            .env("TERM", "xterm-256color")
+            .env_remove("OPENAI_API_KEY")
+            .env_remove("ANTHROPIC_API_KEY")
+            .current_dir(home.path())
+            .stdin(Stdio::from(stdin))
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .spawn()
+            .unwrap();
+
+        Self {
+            child,
+            master,
+            monitor,
+            output: Vec::new(),
+            _home: home,
+        }
+    }
+
+    fn wait_for(&mut self, needle: &str) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            self.read_available();
+            if self.output_text().contains(needle) {
+                return;
+            }
+            assert!(
+                self.child.try_wait().unwrap().is_none(),
+                "{}",
+                self.output_text()
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!("did not see {needle:?}: {}", self.output_text());
+    }
+
+    fn wait_for_raw_mode(&self) {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < deadline {
+            if terminal_flags(self.monitor.as_raw_fd()) & libc::ICANON == 0 {
+                return;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!("prompt never entered raw mode");
+    }
+
+    fn send(&mut self, bytes: &[u8]) {
+        self.master.write_all(bytes).unwrap();
+        self.master.flush().unwrap();
+    }
+
+    fn terminate(&self, signal: libc::c_int) {
+        let result = unsafe { libc::kill(self.child.id() as libc::pid_t, signal) };
+        assert_eq!(result, 0, "failed to send signal {signal}");
+    }
+
+    fn wait_for_exit(&mut self) -> ExitStatus {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < deadline {
+            self.read_available();
+            if let Some(status) = self.child.try_wait().unwrap() {
+                self.read_available();
+                return status;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        self.child.kill().unwrap();
+        let _ = self.child.wait();
+        panic!("process did not exit: {}", self.output_text());
+    }
+
+    fn assert_terminal_restored(&self) {
+        let flags = terminal_flags(self.monitor.as_raw_fd());
+        assert_ne!(flags & libc::ICANON, 0, "canonical mode was not restored");
+        assert_ne!(flags & libc::ISIG, 0, "signal handling was not restored");
+        assert_ne!(flags & libc::ECHO, 0, "echo was not restored");
+    }
+
+    fn output_text(&self) -> String {
+        String::from_utf8_lossy(&self.output).into_owned()
+    }
+
+    fn read_available(&mut self) {
+        let mut buffer = [0_u8; 4096];
+        loop {
+            match self.master.read(&mut buffer) {
+                Ok(0) => return,
+                Ok(length) => self.output.extend_from_slice(&buffer[..length]),
+                Err(error) if error.kind() == ErrorKind::WouldBlock => return,
+                Err(error) => panic!("failed to read pseudo-terminal: {error}"),
+            }
+        }
+    }
+}
+
+impl Drop for PtyChild {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn open_pty() -> (File, RawFd) {
+    let mut master = -1;
+    let mut slave = -1;
+    let result = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(result, 0, "openpty failed");
+    let master = unsafe { File::from_raw_fd(master) };
+    (master, slave)
+}
+
+fn duplicate(fd: RawFd) -> File {
+    let duplicate = unsafe { libc::dup(fd) };
+    assert_ne!(duplicate, -1, "dup failed");
+    unsafe { File::from_raw_fd(duplicate) }
+}
+
+fn set_nonblocking(fd: RawFd) {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    assert_ne!(flags, -1, "F_GETFL failed");
+    let result = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    assert_ne!(result, -1, "F_SETFL failed");
+}
+
+fn terminal_flags(fd: RawFd) -> libc::tcflag_t {
+    let mut attributes = MaybeUninit::<libc::termios>::uninit();
+    let result = unsafe { libc::tcgetattr(fd, attributes.as_mut_ptr()) };
+    assert_eq!(result, 0, "tcgetattr failed");
+    unsafe { attributes.assume_init() }.c_lflag
+}
+
+#[test]
+fn ctrl_z_exits_the_masked_api_key_prompt_and_restores_terminal() {
+    let mut process = PtyChild::spawn(&["init", "--provider", "openai", "--offline"]);
+    process.wait_for("Enter your API key: ");
+    process.wait_for_raw_mode();
+    process.send(b"\x1a");
+    let status = process.wait_for_exit();
+    assert!(!status.success(), "interruption returned success");
+    assert!(process.output_text().contains("init interrupted"));
+    process.assert_terminal_restored();
+}
+
+#[test]
+fn ctrl_u_clears_the_current_answer_before_provider_selection() {
+    let mut process = PtyChild::spawn(&["init", "--offline"]);
+    process.wait_for("Provider: ");
+    process.wait_for_raw_mode();
+    process.send(b"12\x152\r");
+    process.wait_for("Enter your API key: ");
+    assert!(!process.output_text().contains("Please enter a number"));
+    process.send(b"\x03");
+    let status = process.wait_for_exit();
+    assert!(!status.success(), "interruption returned success");
+    process.assert_terminal_restored();
+}
+
+#[test]
+fn sigterm_exits_an_active_prompt_and_restores_terminal() {
+    let mut process = PtyChild::spawn(&["init", "--offline"]);
+    process.wait_for("Provider: ");
+    process.wait_for_raw_mode();
+    process.terminate(libc::SIGTERM);
+    let status = process.wait_for_exit();
+    assert!(!status.success(), "termination returned success");
+    process.assert_terminal_restored();
+}
+
+#[test]
+fn sigterm_keeps_its_default_action_after_a_prompt_completes() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let (accepted_tx, accepted_rx) = mpsc::sync_channel(0);
+    let (release_tx, release_rx) = mpsc::sync_channel(0);
+    let server = thread::spawn(move || {
+        let (_connection, _) = listener.accept().unwrap();
+        accepted_tx.send(()).unwrap();
+        let _ = release_rx.recv();
+    });
+
+    let mut process = PtyChild::spawn(&["init", "--provider", "ollama"]);
+    process.wait_for("Ollama base URL");
+    process.wait_for_raw_mode();
+    process.send(format!("http://{address}\r").as_bytes());
+    accepted_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+
+    process.terminate(libc::SIGTERM);
+    let status = process.wait_for_exit();
+    assert_eq!(status.signal(), Some(libc::SIGTERM));
+    process.assert_terminal_restored();
+
+    release_tx.send(()).unwrap();
+    server.join().unwrap();
+}


### PR DESCRIPTION
## What

Make every interactive `aura init` prompt exit immediately on Ctrl-C or
Ctrl-Z, including the masked API-key prompt. The shared terminal reader keeps
line editing controls and restores terminal settings before handling SIGINT or
SIGTERM.

## Why

`aura init` currently reads prompts through cooked stdin and can print or
buffer interrupt keys instead of exiting. This fixes #629 without changing the
scripted and non-interactive input path.

## Testing

- `cargo test --workspace` — 2,295 passed, 15 ignored, 0 failed
- `make fmt-check`
- `make lint`
- `make lint-commits`
- `cargo test -p aura-cli --test init_interrupts -- --nocapture` — 4 passed

The pseudo-terminal tests cover Ctrl-Z at the masked API-key prompt, Ctrl-U
editing, terminal restoration on SIGTERM during a prompt, and default SIGTERM
termination after a prompt returns.

Fixes: #629
