### PR TITLE
ci: snapshot github release download totals to posthog

### DIFF
--- a/.github/workflows/release-download-metrics.yml
+++ b/.github/workflows/release-download-metrics.yml
@@ -1,0 +1,75 @@
+name: "Release download metrics"
+
+on:
+  schedule:
+    # 01:17 UTC daily, snapshotting the previous UTC day. Running early leaves
+    # the rest of the day to notice a failure and re-run it by hand. The odd
+    # minute is deliberate: GitHub drops queued scheduled jobs under load, and
+    # load peaks at the top of every hour.
+    - cron: "17 1 * * *"
+  workflow_dispatch:
+    inputs:
+      date:
+        description: "Snapshot date (YYYY-MM-DD, UTC). Defaults to yesterday."
+        required: false
+        type: string
+      dry_run:
+        description: "Build the payload without sending it"
+        required: false
+        default: false
+        type: boolean
+  pull_request:
+    paths:
+      - "scripts/sync-release-downloads.sh"
+      - ".github/workflows/release-download-metrics.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-download-metrics
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Self-test
+        run: scripts/sync-release-downloads.sh --selftest
+
+      - name: Snapshot release download totals
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          POSTHOG_API_READ_KEY: ${{ secrets.POSTHOG_API_READ_KEY }}
+          POSTHOG_PROJECT_ID: ${{ vars.POSTHOG_PROJECT_ID }}
+          # Inputs arrive as environment variables the script already reads, so
+          # nothing user-supplied is interpolated into a shell command.
+          SNAPSHOT_DATE: ${{ inputs.date }}
+          DRY_RUN: ${{ (github.event_name == 'pull_request' || inputs.dry_run) && '1' || '0' }}
+        run: scripts/sync-release-downloads.sh
+
+      - name: Report failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          set -euo pipefail
+          title="Release download metrics sync failed"
+          body=$(printf '%s\n\n%s\n' \
+              "The scheduled snapshot failed: ${RUN_URL}" \
+              "Re-run it from the Actions tab with workflow_dispatch, passing the snapshot date it was covering. Events are keyed by that date, so a retry re-sends the same events and PostHog deduplicates them.")
+          existing=$(gh issue list --state open --search "${title} in:title" \
+              --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+              gh issue comment "${existing}" --body "${body}"
+          else
+              gh issue create --title "${title}" --body "${body}"
+          fi

--- a/.github/workflows/release-download-metrics.yml
+++ b/.github/workflows/release-download-metrics.yml
@@ -18,6 +18,13 @@ on:
         required: false
         default: false
         type: boolean
+  # TEMPORARY: remove before merging. schedule only fires on the default
+  # branch and workflow_dispatch only appears once the file is on it, so a
+  # push trigger is the only way to exercise this on a runner beforehand.
+  # No paths filter, so any push to the branch re-runs it.
+  push:
+    branches:
+      - "justingross/GH-558-sync-github-release-download-totals-to-posthog"
   pull_request:
     paths:
       - "scripts/sync-release-downloads.sh"

--- a/.github/workflows/release-download-metrics.yml
+++ b/.github/workflows/release-download-metrics.yml
@@ -38,7 +38,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Pull requests run code from the PR revision, which a contributor with push
+  # access controls before review. It is given no PostHog credentials and no
+  # write permissions: --selftest and --dry-run need neither, and a modified
+  # script would not be bound by DRY_RUN.
+  verify:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Self-test
+        run: scripts/sync-release-downloads.sh --selftest
+
+      - name: Dry run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: "1"
+        run: scripts/sync-release-downloads.sh
+
   sync:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -59,7 +82,7 @@ jobs:
           # Inputs arrive as environment variables the script already reads, so
           # nothing user-supplied is interpolated into a shell command.
           SNAPSHOT_DATE: ${{ inputs.date }}
-          DRY_RUN: ${{ (github.event_name == 'pull_request' || inputs.dry_run) && '1' || '0' }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
         run: scripts/sync-release-downloads.sh
 
       - name: Report failure

--- a/.github/workflows/release-download-metrics.yml
+++ b/.github/workflows/release-download-metrics.yml
@@ -54,7 +54,14 @@ jobs:
         run: scripts/sync-release-downloads.sh
 
   sync:
-    if: github.event_name != 'pull_request'
+    # A manual dispatch names the ref it runs, so without the branch test this
+    # job would check out an unreviewed revision and hand it the credentials.
+    # The schedule only ever fires on the default branch, so a dispatch from
+    # anywhere else has nothing legitimate to do.
+    if: >-
+      github.event_name != 'pull_request' &&
+      (github.event_name != 'workflow_dispatch' ||
+       github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/release-download-metrics.yml
+++ b/.github/workflows/release-download-metrics.yml
@@ -18,13 +18,6 @@ on:
         required: false
         default: false
         type: boolean
-  # TEMPORARY: remove before merging. schedule only fires on the default
-  # branch and workflow_dispatch only appears once the file is on it, so a
-  # push trigger is the only way to exercise this on a runner beforehand.
-  # No paths filter, so any push to the branch re-runs it.
-  push:
-    branches:
-      - "justingross/GH-558-sync-github-release-download-totals-to-posthog"
   pull_request:
     paths:
       - "scripts/sync-release-downloads.sh"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -160,7 +160,7 @@ GitHub-generated source archives are not release assets and never appear.
 | `POSTHOG_API_READ_KEY` | unset | Personal API key used to read the snapshot back. Required unless `--dry-run` or `SKIP_VERIFY=1`. |
 | `POSTHOG_PROJECT_ID` | `443794` | Numeric project id the read-back queries. Must be the project the write token belongs to. |
 | `POSTHOG_API_HOST` | `https://us.posthog.com` | PostHog query host. Distinct from the ingest host. |
-| `VERIFY_TIMEOUT` | `300` | Seconds to wait for ingestion before failing the read-back. |
+| `VERIFY_TIMEOUT` | `600` | Seconds to wait for ingestion before failing the read-back. |
 | `SKIP_VERIFY` | `0` | `1` sends without reading the snapshot back. |
 | `POSTHOG_HOST` | `https://us.i.posthog.com` | PostHog ingest host. |
 | `GITHUB_REPOS` | `mezmo/aura` | Space-separated `owner/repo` list to snapshot. |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -131,9 +131,10 @@ rise, which makes `max` correct while duplicates are still visible.
 After sending, the script reads the snapshot back and fails if PostHog cannot
 account for every event. This is not belt-and-braces: PostHog answers
 `200 {"status":"Ok"}` to a batch sent with an invalid project token, so an
-unverified send cannot tell success from silent discard. The read-back counts
-distinct event UUIDs rather than rows, because a re-run's rows stay visible
-until PostHog's background merges collapse them.
+unverified send cannot tell success from silent discard. The read-back looks
+for this run's own event UUIDs at this run's timestamp, rather than counting a
+whole date: counting by date would also match UUIDs left by an earlier run
+whose asset set differed, and those can cover for an event that never arrived.
 
 A run also reports when the previous day holds no snapshot. That is advisory:
 GitHub only exposes current cumulative counts, so a missed day cannot be

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -121,6 +121,14 @@ cumulative download count as of a snapshot date. Run daily at 01:17 UTC by
 [the `Release download metrics` workflow](../.github/workflows/release-download-metrics.yml),
 which snapshots the previous UTC day.
 
+The count is approximate for the day it names. GitHub publishes only a live
+cumulative counter, so a run reads it at execution time and attributes it to
+the previous UTC day — the 01:17 run folds that day's first 77 minutes into a
+value labelled `23:59:59Z` the day before. The offset is the same on every
+snapshot, so day-over-day differences still cover a true 24 hours. Naming an
+older date does not reconstruct it: a retry days later stamps today's counters
+with that date.
+
 Retries are safe. The event UUID is derived from `(repository, asset ID,
 snapshot date)` and the timestamp is pinned to `23:59:59Z` on the snapshot
 date, so re-running a date re-sends byte-identical events that PostHog

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,7 @@ Release and install helpers.
 | [`bump-homebrew-tap.sh`](bump-homebrew-tap.sh) | Bump `mezmo/homebrew-tap` formulae to a released version |
 | [`set-version.sh`](set-version.sh) | Set the workspace and crate versions in `Cargo.toml` |
 | [`next-version.mjs`](next-version.mjs) | Print the version semantic-release would release next |
+| [`sync-release-downloads.sh`](sync-release-downloads.sh) | Snapshot cumulative release-asset download totals into PostHog |
 
 `BRANCH_NAME` selects the release channel; see
 [the release channels design note](../docs/design/release-channels.md).
@@ -108,6 +109,54 @@ authenticates it, so it verifies the API key and the target repository.
 | `PACKAGERS` | `deb rpm` | Space-separated formats to publish. |
 | `CLOUDSMITH` | `cloudsmith` | `cloudsmith` executable to use. |
 
+
+## `sync-release-downloads.sh`
+
+```
+sync-release-downloads.sh [--dry-run] [--date YYYY-MM-DD] [--selftest]
+```
+
+Sends one PostHog event per GitHub release asset, carrying that asset's
+cumulative download count as of a snapshot date. Run daily at 01:17 UTC by
+[the `Release download metrics` workflow](../.github/workflows/release-download-metrics.yml),
+which snapshots the previous UTC day.
+
+Retries are safe. The event UUID is derived from `(repository, asset ID,
+snapshot date)` and the timestamp is pinned to `23:59:59Z` on the snapshot
+date, so re-running a date re-sends byte-identical events that PostHog
+deduplicates. Deduplication is eventual, so reporting should aggregate with
+`max(download_count)` per asset and snapshot date — cumulative counts only
+rise, which makes `max` correct while duplicates are still visible.
+
+After sending, the script reads the snapshot back and fails if PostHog cannot
+account for every event. This is not belt-and-braces: PostHog answers
+`200 {"status":"Ok"}` to a batch sent with an invalid project token, so an
+unverified send cannot tell success from silent discard. The read-back counts
+distinct event UUIDs rather than rows, because a re-run's rows stay visible
+until PostHog's background merges collapse them.
+
+A run also reports when the previous day holds no snapshot. That is advisory:
+GitHub only exposes current cumulative counts, so a missed day cannot be
+reconstructed by retrying.
+
+Draft releases are skipped; their assets are not publicly downloadable.
+GitHub-generated source archives are not release assets and never appear.
+
+| Switch | Default | Effect |
+| --- | --- | --- |
+| `--date` / `SNAPSHOT_DATE` | yesterday, UTC | Date to snapshot. Re-running a past date re-sends that date's events. |
+| `--dry-run` / `DRY_RUN=1` | off | Collect from GitHub and build the payload, print the first event, send nothing. Needs no PostHog token. |
+| `--selftest` | off | Run the built-in assertions (UUID vectors, payload shape) and exit. Reaches no network. |
+| `POSTHOG_PROJECT_API_KEY` | unset | PostHog project write token. Required unless `--dry-run`. |
+| `POSTHOG_API_READ_KEY` | unset | Personal API key used to read the snapshot back. Required unless `--dry-run` or `SKIP_VERIFY=1`. |
+| `POSTHOG_PROJECT_ID` | `443794` | Numeric project id the read-back queries. Must be the project the write token belongs to. |
+| `POSTHOG_API_HOST` | `https://us.posthog.com` | PostHog query host. Distinct from the ingest host. |
+| `VERIFY_TIMEOUT` | `300` | Seconds to wait for ingestion before failing the read-back. |
+| `SKIP_VERIFY` | `0` | `1` sends without reading the snapshot back. |
+| `POSTHOG_HOST` | `https://us.i.posthog.com` | PostHog ingest host. |
+| `GITHUB_REPOS` | `mezmo/aura` | Space-separated `owner/repo` list to snapshot. |
+| `BATCH_SIZE` | `1000` | Events per PostHog `/batch` request. |
+| `GH_TOKEN` / `GITHUB_TOKEN` | unset | Token `gh` authenticates with. |
 
 ## `bump-homebrew-tap.sh`
 

--- a/scripts/sync-release-downloads.sh
+++ b/scripts/sync-release-downloads.sh
@@ -266,6 +266,12 @@ count_ingested() {
             GROUP BY uuid)")
         found=${row%%$'\t'*}
         downloads=${row##*$'\t'}
+        # A chunk none of whose events are queryable yet answers with count 0
+        # and a null total, which @tsv renders as an empty field. That is
+        # "nothing has landed yet", which the poll is here to wait out, not a
+        # malformed answer to abort on.
+        case "${found}" in '' | null) found=0 ;; esac
+        case "${downloads}" in '' | null) downloads=0 ;; esac
         for value in "${found}" "${downloads}"; do
             case "${value}" in
                 '' | *[!0-9]*)

--- a/scripts/sync-release-downloads.sh
+++ b/scripts/sync-release-downloads.sh
@@ -2,10 +2,22 @@
 # Snapshot cumulative GitHub release-asset download totals into PostHog.
 #
 # Sends one PostHog event per release asset carrying that asset's cumulative
-# download count as of a snapshot date. Retries are safe: the event UUID is
-# derived from (repository, asset ID, snapshot date) and the timestamp is
-# pinned to 23:59:59Z on the snapshot date, so re-running a date re-sends
-# byte-identical events that PostHog deduplicates.
+# download count. Retries are safe: the event UUID is derived from
+# (repository, asset ID, snapshot date) and the timestamp is pinned to
+# 23:59:59Z on the snapshot date, so re-running a date re-sends byte-identical
+# events that PostHog deduplicates.
+#
+# The count is approximate for the day it names. GitHub publishes only a live
+# cumulative counter, never a historical one, so a run reads the counter at the
+# moment it executes and attributes it to the previous UTC day: the 01:17 run
+# folds that day's first 77 minutes into a value labelled 23:59:59Z the day
+# before. Every snapshot carries the same offset, so day-over-day differences
+# still cover a true 24 hours; a single day's cumulative value simply runs
+# slightly ahead of its label.
+#
+# For the same reason, naming an older date does not reconstruct it. A retry
+# later the same day is close enough to be worth running; a retry days later
+# stamps today's counters with that older date.
 #
 # Reporting should still aggregate with max(download_count) per asset and
 # snapshot date. PostHog deduplication is eventual, and cumulative counts

--- a/scripts/sync-release-downloads.sh
+++ b/scripts/sync-release-downloads.sh
@@ -211,8 +211,11 @@ add_probe() {
     mv "${payload}.probed" "${payload}"
 }
 
-probe_landed() {
-    hogql_scalar "SELECT count() FROM events WHERE event = '${EVENT_NAME}_probe' AND uuid = '$1'"
+probes_landed() {
+    local list
+    list=$(sed "s/^/'/; s/$/'/" "${WORK_DIR}/probes" | paste -sd, -)
+    hogql_scalar "SELECT count(DISTINCT uuid) FROM events \
+        WHERE event = '${EVENT_NAME}_probe' AND uuid IN (${list})"
 }
 
 post_batch() {
@@ -320,7 +323,7 @@ count_ingested() {
 
 # Poll until the snapshot is queryable, since ingestion lags the send.
 verify_snapshot() {
-    local date=$1 expected=$2 expected_downloads=$3 probe=$4
+    local date=$1 expected=$2 expected_downloads=$3 probes=$4
     local deadline row got downloads seen
     split -l 500 "${WORK_DIR}/uuids" "${WORK_DIR}/uchunk."
     deadline=$(( $(date +%s) + VERIFY_TIMEOUT ))
@@ -328,15 +331,15 @@ verify_snapshot() {
         row=$(count_ingested "${date}")
         got=${row%%$'\t'*}
         downloads=${row##*$'\t'}
-        seen=$(probe_landed "${probe}")
+        seen=$(probes_landed)
         case "${seen}" in '' | null) seen=0 ;; esac
         if [ "${got}" -ge "${expected}" ] && [ "${downloads}" -ge "${expected_downloads}" ] \
-           && [ "${seen}" -ge 1 ]; then
-            echo "Verified ${got} of ${expected} event(s), ${downloads} download(s), and this run's probe in PostHog for ${date}"
+           && [ "${seen}" -ge "${probes}" ]; then
+            echo "Verified ${got} of ${expected} event(s), ${downloads} download(s), and ${seen} probe(s) in PostHog for ${date}"
             return 0
         fi
         if [ "$(date +%s)" -ge "${deadline}" ]; then
-            echo "error: PostHog holds ${got} of ${expected} event(s), ${downloads} of ${expected_downloads} download(s), and ${seen} probe(s) for ${date} after ${VERIFY_TIMEOUT}s" >&2
+            echo "error: PostHog holds ${got} of ${expected} event(s), ${downloads} of ${expected_downloads} download(s), and ${seen} of ${probes} probe(s) for ${date} after ${VERIFY_TIMEOUT}s" >&2
             return 1
         fi
         sleep 5
@@ -483,11 +486,17 @@ main() {
         return 0
     fi
 
-    local probe payload
-    probe=$(uuid4)
-    add_probe "${WORK_DIR}/payload.1.json" "${probe}"
+    # Every batch carries its own probe. One probe in the first batch cannot
+    # speak for a later batch that was discarded, because the deterministic
+    # events a retry re-sends are already present from the earlier run.
+    local probe payload probes=0
+    : > "${WORK_DIR}/probes"
     for payload in "${WORK_DIR}"/payload.*.json; do
+        probe=$(uuid4)
+        printf '%s\n' "${probe}" >> "${WORK_DIR}/probes"
+        add_probe "${payload}" "${probe}"
         post_batch "${payload}"
+        probes=$(( probes + 1 ))
     done
 
     echo "Sent ${assets} event(s) for ${date} to ${POSTHOG_HOST%/}"
@@ -498,7 +507,7 @@ main() {
     fi
     local expected_downloads
     expected_downloads=$(jq -s '[.[].download_count] | add' "${WORK_DIR}/assets.ndjson")
-    verify_snapshot "${date}" "${assets}" "${expected_downloads}" "${probe}"
+    verify_snapshot "${date}" "${assets}" "${expected_downloads}" "${probes}"
     # Advisory only: a missing earlier day is worth reporting but is not a
     # failure of this run, and cannot be repaired by retrying it.
     warn_on_gap "${date}" || true

--- a/scripts/sync-release-downloads.sh
+++ b/scripts/sync-release-downloads.sh
@@ -37,7 +37,7 @@
 #   POSTHOG_API_READ_KEY    - personal API key used to read the snapshot back
 #   POSTHOG_PROJECT_ID      - numeric project id the read-back queries (default: 443794)
 #   POSTHOG_API_HOST        - PostHog query host (default: https://us.posthog.com)
-#   VERIFY_TIMEOUT          - seconds to wait for ingestion (default: 300)
+#   VERIFY_TIMEOUT          - seconds to wait for ingestion (default: 600)
 #   SKIP_VERIFY             - 1 sends without reading the snapshot back
 #   GITHUB_REPOS            - space-separated owner/repo list (default: mezmo/aura)
 #   SNAPSHOT_DATE           - same as --date
@@ -61,7 +61,7 @@ GITHUB_REPOS="${GITHUB_REPOS:-mezmo/aura}"
 BATCH_SIZE="${BATCH_SIZE:-1000}"
 POSTHOG_PROJECT_ID="${POSTHOG_PROJECT_ID:-443794}"
 POSTHOG_API_HOST="${POSTHOG_API_HOST:-https://us.posthog.com}"
-VERIFY_TIMEOUT="${VERIFY_TIMEOUT:-300}"
+VERIFY_TIMEOUT="${VERIFY_TIMEOUT:-600}"
 SKIP_VERIFY="${SKIP_VERIFY:-0}"
 WORK_DIR=""
 

--- a/scripts/sync-release-downloads.sh
+++ b/scripts/sync-release-downloads.sh
@@ -93,6 +93,16 @@ uuid5() {
 # Dates go through jq rather than date(1): GNU and BSD date disagree on both
 # relative-date syntaxes, and jq is already a hard dependency here. jq's
 # strftime formats UTC regardless of the runner's timezone.
+# A fresh UUID, so nothing an earlier run wrote can be mistaken for it.
+uuid4() {
+    local h b6 b8
+    h=$(openssl rand -hex 16)
+    printf -v b6 '%02x' $(( 0x${h:12:2} & 0x0f | 0x40 ))
+    printf -v b8 '%02x' $(( 0x${h:16:2} & 0x3f | 0x80 ))
+    printf '%s-%s-%s%s-%s%s-%s\n' \
+        "${h:0:8}" "${h:8:4}" "${b6}" "${h:14:2}" "${b8}" "${h:18:2}" "${h:20:12}"
+}
+
 yesterday_utc() {
     jq -rn 'now - 86400 | strftime("%Y-%m-%d")'
 }
@@ -180,6 +190,29 @@ build_batch() {
               timestamp: ($date + "T23:59:59Z"),
               properties: ($r + {snapshot_date: $date, "$process_person_profile": false})}]}
     ' "${chunk}"
+}
+
+# Add a probe event to a payload, carrying a UUID no other run can produce.
+#
+# The snapshot events are identical across runs of the same date by design, so
+# finding them proves the snapshot is right but not that this run wrote
+# anything: PostHog answers 200 OK to a batch sent with a dead token, and on a
+# re-run of an already-populated date the stale rows satisfy every check. The
+# probe rides the same request, so it is absent exactly when that request was
+# discarded.
+add_probe() {
+    local payload=$1 probe=$2 ts
+    ts=$(jq -rn 'now | strftime("%Y-%m-%dT%H:%M:%SZ")')
+    jq --arg uuid "${probe}" --arg ts "${ts}" --arg event "${EVENT_NAME}_probe" '
+        .batch += [{uuid: $uuid, event: $event, distinct_id: "github:probe",
+                    timestamp: $ts,
+                    properties: {"$process_person_profile": false}}]' \
+        "${payload}" > "${payload}.probed"
+    mv "${payload}.probed" "${payload}"
+}
+
+probe_landed() {
+    hogql_scalar "SELECT count() FROM events WHERE event = '${EVENT_NAME}_probe' AND uuid = '$1'"
 }
 
 post_batch() {
@@ -287,19 +320,23 @@ count_ingested() {
 
 # Poll until the snapshot is queryable, since ingestion lags the send.
 verify_snapshot() {
-    local date=$1 expected=$2 expected_downloads=$3 deadline row got downloads
+    local date=$1 expected=$2 expected_downloads=$3 probe=$4
+    local deadline row got downloads seen
     split -l 500 "${WORK_DIR}/uuids" "${WORK_DIR}/uchunk."
     deadline=$(( $(date +%s) + VERIFY_TIMEOUT ))
     while :; do
         row=$(count_ingested "${date}")
         got=${row%%$'\t'*}
         downloads=${row##*$'\t'}
-        if [ "${got}" -ge "${expected}" ] && [ "${downloads}" -ge "${expected_downloads}" ]; then
-            echo "Verified ${got} of ${expected} event(s) and ${downloads} download(s) in PostHog for ${date}"
+        seen=$(probe_landed "${probe}")
+        case "${seen}" in '' | null) seen=0 ;; esac
+        if [ "${got}" -ge "${expected}" ] && [ "${downloads}" -ge "${expected_downloads}" ] \
+           && [ "${seen}" -ge 1 ]; then
+            echo "Verified ${got} of ${expected} event(s), ${downloads} download(s), and this run's probe in PostHog for ${date}"
             return 0
         fi
         if [ "$(date +%s)" -ge "${deadline}" ]; then
-            echo "error: PostHog holds ${got} of ${expected} event(s) and ${downloads} of ${expected_downloads} download(s) for ${date} after ${VERIFY_TIMEOUT}s" >&2
+            echo "error: PostHog holds ${got} of ${expected} event(s), ${downloads} of ${expected_downloads} download(s), and ${seen} probe(s) for ${date} after ${VERIFY_TIMEOUT}s" >&2
             return 1
         fi
         sleep 5
@@ -358,6 +395,14 @@ selftest() {
     got=$(snapshot_count_query "2026-08-20")
     want="SELECT count(DISTINCT uuid) FROM events WHERE event = 'github_release_asset_downloads' AND properties.snapshot_date = '2026-08-20'"
     [ "${got}" = "${want}" ] || { echo "selftest: query is\n  ${got}\nwant\n  ${want}" >&2; exit 1; }
+
+    # The probe UUID must be well formed and never repeat.
+    got=$(uuid4)
+    case "${got}" in
+        [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-*-4*-[89ab]*-*) ;;
+        *) echo "selftest: uuid4 produced '${got}'" >&2; exit 1 ;;
+    esac
+    [ "${got}" != "$(uuid4)" ] || { echo "selftest: uuid4 repeated" >&2; exit 1; }
 
     # Calendar validation must reject digit-shaped non-dates, rollovers, and
     # anything that could carry a quote into the read-back query.
@@ -438,7 +483,9 @@ main() {
         return 0
     fi
 
-    local payload
+    local probe payload
+    probe=$(uuid4)
+    add_probe "${WORK_DIR}/payload.1.json" "${probe}"
     for payload in "${WORK_DIR}"/payload.*.json; do
         post_batch "${payload}"
     done
@@ -451,7 +498,7 @@ main() {
     fi
     local expected_downloads
     expected_downloads=$(jq -s '[.[].download_count] | add' "${WORK_DIR}/assets.ndjson")
-    verify_snapshot "${date}" "${assets}" "${expected_downloads}"
+    verify_snapshot "${date}" "${assets}" "${expected_downloads}" "${probe}"
     # Advisory only: a missing earlier day is worth reporting but is not a
     # failure of this run, and cannot be repaired by retrying it.
     warn_on_gap "${date}" || true

--- a/scripts/sync-release-downloads.sh
+++ b/scripts/sync-release-downloads.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+# Snapshot cumulative GitHub release-asset download totals into PostHog.
+#
+# Sends one PostHog event per release asset carrying that asset's cumulative
+# download count as of a snapshot date. Retries are safe: the event UUID is
+# derived from (repository, asset ID, snapshot date) and the timestamp is
+# pinned to 23:59:59Z on the snapshot date, so re-running a date re-sends
+# byte-identical events that PostHog deduplicates.
+#
+# Reporting should still aggregate with max(download_count) per asset and
+# snapshot date. PostHog deduplication is eventual, and cumulative counts
+# only ever rise, so max() is correct while duplicates remain visible.
+#
+# Draft releases are skipped; their assets are not publicly downloadable.
+# GitHub-generated source archives are not release assets and never appear.
+#
+# Usage: sync-release-downloads.sh [--dry-run] [--date YYYY-MM-DD] [--selftest]
+#   --date       - snapshot date (default: yesterday, UTC)
+#   --dry-run    - collect and build the payload, print a summary, send nothing
+#   --selftest   - run the built-in assertions and exit
+#
+# Environment:
+#   POSTHOG_PROJECT_API_KEY - PostHog project write token (required unless --dry-run)
+#   POSTHOG_HOST            - PostHog ingest host (default: https://us.i.posthog.com)
+#   POSTHOG_API_READ_KEY    - personal API key used to read the snapshot back
+#   POSTHOG_PROJECT_ID      - numeric project id the read-back queries (default: 443794)
+#   POSTHOG_API_HOST        - PostHog query host (default: https://us.posthog.com)
+#   VERIFY_TIMEOUT          - seconds to wait for ingestion (default: 300)
+#   SKIP_VERIFY             - 1 sends without reading the snapshot back
+#   GITHUB_REPOS            - space-separated owner/repo list (default: mezmo/aura)
+#   SNAPSHOT_DATE           - same as --date
+#   DRY_RUN                 - 1 is the same as --dry-run
+#   BATCH_SIZE              - events per PostHog /batch request (default: 1000)
+#   GH_TOKEN / GITHUB_TOKEN - token gh authenticates with
+set -euo pipefail
+
+USAGE="usage: $0 [--dry-run] [--date YYYY-MM-DD] [--selftest]"
+
+# Namespace for the version-5 event UUIDs. Permanent: it is part of every
+# event key ever sent.
+readonly UUID_NAMESPACE="6d3cea6d-9fef-46af-aec1-e9c705245832"
+readonly EVENT_NAME="github_release_asset_downloads"
+
+DRY_RUN="${DRY_RUN:-0}"
+SELFTEST=0
+SNAPSHOT_DATE="${SNAPSHOT_DATE:-}"
+POSTHOG_HOST="${POSTHOG_HOST:-https://us.i.posthog.com}"
+GITHUB_REPOS="${GITHUB_REPOS:-mezmo/aura}"
+BATCH_SIZE="${BATCH_SIZE:-1000}"
+POSTHOG_PROJECT_ID="${POSTHOG_PROJECT_ID:-443794}"
+POSTHOG_API_HOST="${POSTHOG_API_HOST:-https://us.posthog.com}"
+VERIFY_TIMEOUT="${VERIFY_TIMEOUT:-300}"
+SKIP_VERIFY="${SKIP_VERIFY:-0}"
+WORK_DIR=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --selftest) SELFTEST=1; shift ;;
+        --date)
+            if [ $# -lt 2 ]; then echo "error: --date needs a value" >&2; exit 1; fi
+            SNAPSHOT_DATE="$2"; shift 2 ;;
+        --date=*) SNAPSHOT_DATE="${1#--date=}"; shift ;;
+        -h|--help) echo "${USAGE}" >&2; exit 0 ;;
+        *) echo "${USAGE}" >&2; exit 1 ;;
+    esac
+done
+
+# RFC 4122 version-5 UUID: sha1(namespace bytes || name), with the version and
+# variant nibbles forced. Matches Python's uuid.uuid5 byte for byte.
+uuid5() {
+    local ns_hex=${1//-/} name=$2 h b6 b8
+    h=$( { printf '%b' "$(printf '%s' "${ns_hex}" | sed 's/../\\x&/g')"; printf '%s' "${name}"; } \
+         | openssl dgst -sha1 -r | cut -d' ' -f1 )
+    printf -v b6 '%02x' $(( 0x${h:12:2} & 0x0f | 0x50 ))
+    printf -v b8 '%02x' $(( 0x${h:16:2} & 0x3f | 0x80 ))
+    printf '%s-%s-%s%s-%s%s-%s\n' \
+        "${h:0:8}" "${h:8:4}" "${b6}" "${h:14:2}" "${b8}" "${h:18:2}" "${h:20:12}"
+}
+
+# Dates go through jq rather than date(1): GNU and BSD date disagree on both
+# relative-date syntaxes, and jq is already a hard dependency here. jq's
+# strftime formats UTC regardless of the runner's timezone.
+yesterday_utc() {
+    jq -rn 'now - 86400 | strftime("%Y-%m-%d")'
+}
+
+day_before() {
+    jq -rn --arg d "$1" '($d + "T00:00:00Z" | fromdateiso8601) - 86400 | strftime("%Y-%m-%d")'
+}
+
+require_tools() {
+    local tool
+    for tool in gh jq curl openssl; do
+        if ! command -v "${tool}" >/dev/null 2>&1; then
+            echo "error: ${tool} not found" >&2
+            exit 1
+        fi
+    done
+    if [ "${DRY_RUN}" != 1 ] && [ -z "${POSTHOG_PROJECT_API_KEY:-}" ]; then
+        echo "error: POSTHOG_PROJECT_API_KEY is required (or use --dry-run)" >&2
+        exit 1
+    fi
+    # PostHog answers 200 OK to a batch sent with an invalid project token, so
+    # a send that is never verified cannot tell success from silent discard.
+    if [ "${DRY_RUN}" != 1 ] && [ "${SKIP_VERIFY}" != 1 ] && [ -z "${POSTHOG_API_READ_KEY:-}" ]; then
+        echo "error: POSTHOG_API_READ_KEY is required to verify the send (or set SKIP_VERIFY=1)" >&2
+        exit 1
+    fi
+}
+
+# Emit one compact JSON object per asset, for every non-draft release.
+#
+# The release list lands in a file rather than a process substitution: a
+# partial pagination failure inside `<(...)` would truncate the loop's input
+# and silently under-report, where a redirect makes it fatal under `set -e`.
+collect_assets() {
+    local repo=$1 releases="${WORK_DIR}/releases.tsv" release_id tag
+    gh api --paginate "repos/${repo}/releases" \
+        --jq '.[] | select(.draft | not) | [.id, .tag_name] | @tsv' > "${releases}"
+    while IFS=$'\t' read -r release_id tag; do
+        gh api --paginate "repos/${repo}/releases/${release_id}/assets" --jq '.[]' \
+            | jq -c --arg repo "${repo}" --argjson rid "${release_id}" --arg tag "${tag}" \
+                '{repository: $repo, release_id: $rid, release_tag: $tag,
+                  asset_id: .id, asset_name: .name, download_count: .download_count}'
+    done < "${releases}"
+}
+
+# Prefix each asset record with its event UUID, tab separated. The record stays
+# JSON throughout, so asset names are never parsed out of a delimited field.
+key_assets() {
+    local assets=$1 date=$2 uuids=$3 key
+    local keys="${uuids}.keys"
+    jq -r '.repository + "|" + (.asset_id | tostring)' "${assets}" > "${keys}"
+    while IFS= read -r key; do
+        uuid5 "${UUID_NAMESPACE}" "${key}|${date}"
+    done < "${keys}" > "${uuids}"
+    paste "${uuids}" "${assets}"
+}
+
+build_batch() {
+    local chunk=$1 date=$2 api_key=$3
+    jq -R -n --arg key "${api_key}" --arg date "${date}" --arg event "${EVENT_NAME}" '
+        {api_key: $key,
+         batch: [inputs
+           | index("\t") as $i
+           | (.[:$i]) as $uuid
+           | (.[$i+1:] | fromjson) as $r
+           | {uuid: $uuid,
+              event: $event,
+              distinct_id: ("github:" + $r.repository),
+              timestamp: ($date + "T23:59:59Z"),
+              properties: ($r + {snapshot_date: $date, "$process_person_profile": false})}]}
+    ' "${chunk}"
+}
+
+post_batch() {
+    local payload=$1
+    curl --silent --show-error --fail-with-body \
+        --retry 5 --retry-delay 2 \
+        --max-time 60 \
+        --header 'Content-Type: application/json' \
+        --data-binary "@${payload}" \
+        "${POSTHOG_HOST%/}/batch/" >/dev/null
+}
+
+# Run a HogQL query and print its first scalar result.
+#
+# Plain --retry covers the transient cases (timeouts, 429, 5xx) and leaves
+# 4xx alone: an auth or project error repeated four times is noise, and the
+# status is worth naming because every likely cause is a misconfiguration
+# rather than an outage.
+hogql_scalar() {
+    local query=$1 response status body
+    response=$(jq -n --arg q "${query}" '{query: {kind: "HogQLQuery", query: $q}}' \
+        | curl --silent --show-error --retry 3 --retry-delay 2 --max-time 60 \
+            --write-out '\n%{http_code}' \
+            --header "Authorization: Bearer ${POSTHOG_API_READ_KEY}" \
+            --header 'Content-Type: application/json' \
+            --data-binary @- \
+            "${POSTHOG_API_HOST%/}/api/projects/${POSTHOG_PROJECT_ID}/query/")
+    status=${response##*$'\n'}
+    body=${response%$'\n'*}
+    if [ "${status}" != 200 ]; then
+        echo "error: PostHog query API returned ${status} for project ${POSTHOG_PROJECT_ID}" >&2
+        echo "       ${body}" >&2
+        echo "       POSTHOG_PROJECT_ID must name the project POSTHOG_PROJECT_API_KEY writes to," >&2
+        echo "       and POSTHOG_API_READ_KEY must hold query:read on that project" >&2
+        return 1
+    fi
+    jq -r '.results[0][0]' <<<"${body}"
+}
+
+# Count what actually landed. Distinct UUIDs, not rows: PostHog deduplicates
+# lazily during background merges, so a re-run's rows stay visible until then.
+#
+# printf builds the literals rather than nested shell quoting, which is easy to
+# get wrong in a way that still returns a well-formed answer: a quote stray
+# inside the string literal matches no rows and reads as "nothing ingested".
+snapshot_count_query() {
+    printf "SELECT count(DISTINCT uuid) FROM events WHERE event = '%s' AND properties.snapshot_date = '%s'" \
+        "${EVENT_NAME}" "$1"
+}
+
+distinct_events_on() {
+    hogql_scalar "$(snapshot_count_query "$1")"
+}
+
+# Poll until the snapshot is queryable, since ingestion lags the send.
+verify_snapshot() {
+    local date=$1 expected=$2 deadline got
+    deadline=$(( $(date +%s) + VERIFY_TIMEOUT ))
+    while :; do
+        got=$(distinct_events_on "${date}")
+        if [ "${got}" -ge "${expected}" ]; then
+            echo "Verified ${got} event(s) queryable in PostHog for ${date}"
+            return 0
+        fi
+        if [ "$(date +%s)" -ge "${deadline}" ]; then
+            echo "error: PostHog holds ${got} of ${expected} event(s) for ${date} after ${VERIFY_TIMEOUT}s" >&2
+            return 1
+        fi
+        sleep 5
+    done
+}
+
+# A dropped or disabled scheduled run leaves a hole no failure reports, since
+# nothing ran to fail. Surface it on the next run that does happen.
+warn_on_gap() {
+    local date=$1 previous got
+    previous=$(day_before "${date}")
+    got=$(distinct_events_on "${previous}")
+    if [ "${got}" -eq 0 ]; then
+        echo "::warning::No release download snapshot in PostHog for ${previous}; GitHub cannot reconstruct a past day's totals, so that day stays missing"
+    fi
+}
+
+selftest() {
+    local tmp=$1 got want payload
+
+    # Well-known RFC 4122 vector, an empty name, and a real event key.
+    got=$(uuid5 6ba7b810-9dad-11d1-80b4-00c04fd430c8 "python.org")
+    want="886313e1-3b8a-5372-9b90-0c9aee199e5d"
+    [ "${got}" = "${want}" ] || { echo "selftest: uuid5(python.org) = ${got}, want ${want}" >&2; exit 1; }
+
+    got=$(uuid5 6ba7b810-9dad-11d1-80b4-00c04fd430c8 "")
+    want="4ebd0208-8328-5d69-8c44-ec50939c0967"
+    [ "${got}" = "${want}" ] || { echo "selftest: uuid5(empty) = ${got}, want ${want}" >&2; exit 1; }
+
+    # The same key must key the same event on every run, and differ per date.
+    got=$(uuid5 "${UUID_NAMESPACE}" "mezmo/aura|541570506|2026-09-01")
+    [ "${got}" = "$(uuid5 "${UUID_NAMESPACE}" "mezmo/aura|541570506|2026-09-01")" ] \
+        || { echo "selftest: uuid5 is not deterministic" >&2; exit 1; }
+    [ "${got}" != "$(uuid5 "${UUID_NAMESPACE}" "mezmo/aura|541570506|2026-09-02")" ] \
+        || { echo "selftest: uuid5 collides across snapshot dates" >&2; exit 1; }
+
+    # An asset name carrying a tab and a quote must survive into the payload.
+    printf '%s\t%s\n' "3538a427-3e7d-5170-bf7d-e9560ebb3468" \
+        '{"repository":"mezmo/aura","release_id":1,"release_tag":"v0.0.1","asset_id":2,"asset_name":"a\tb\"c","download_count":7}' \
+        > "${tmp}/chunk"
+    payload=$(build_batch "${tmp}/chunk" "2026-09-01" "phc_test")
+
+    got=$(jq -r '.batch[0].properties.asset_name' <<<"${payload}")
+    [ "${got}" = "$(printf 'a\tb"c')" ] || { echo "selftest: asset name mangled: ${got}" >&2; exit 1; }
+    got=$(jq -r '.batch[0].timestamp' <<<"${payload}")
+    [ "${got}" = "2026-09-01T23:59:59Z" ] || { echo "selftest: timestamp = ${got}" >&2; exit 1; }
+    got=$(jq -r '.batch[0].properties.download_count | type' <<<"${payload}")
+    [ "${got}" = "number" ] || { echo "selftest: download_count is ${got}, want number" >&2; exit 1; }
+    got=$(jq -r '.batch[0].properties["$process_person_profile"]' <<<"${payload}")
+    [ "${got}" = "false" ] || { echo "selftest: person profiles not suppressed" >&2; exit 1; }
+    got=$(jq -r '.batch[0].distinct_id' <<<"${payload}")
+    [ "${got}" = "github:mezmo/aura" ] || { echo "selftest: distinct_id = ${got}" >&2; exit 1; }
+
+    # The read-back query must quote its literals exactly once. Nested quoting
+    # bugs here return 0 rows, which is indistinguishable from a failed send.
+    got=$(snapshot_count_query "2026-08-20")
+    want="SELECT count(DISTINCT uuid) FROM events WHERE event = 'github_release_asset_downloads' AND properties.snapshot_date = '2026-08-20'"
+    [ "${got}" = "${want}" ] || { echo "selftest: query is\n  ${got}\nwant\n  ${want}" >&2; exit 1; }
+
+    # Date arithmetic across month, year, and leap-day boundaries.
+    got=$(day_before "2026-03-01"); want="2026-02-28"
+    [ "${got}" = "${want}" ] || { echo "selftest: day_before(2026-03-01) = ${got}, want ${want}" >&2; exit 1; }
+    got=$(day_before "2027-01-01"); want="2026-12-31"
+    [ "${got}" = "${want}" ] || { echo "selftest: day_before(2027-01-01) = ${got}, want ${want}" >&2; exit 1; }
+    got=$(TZ=Pacific/Auckland day_before "2024-03-01"); want="2024-02-29"
+    [ "${got}" = "${want}" ] || { echo "selftest: day_before is timezone-sensitive: ${got}, want ${want}" >&2; exit 1; }
+
+    echo "selftest: ok"
+}
+
+main() {
+    WORK_DIR=$(mktemp -d)
+    trap 'rm -rf "${WORK_DIR}"' EXIT
+
+    if [ "${SELFTEST}" = 1 ]; then
+        selftest "${WORK_DIR}"
+        return 0
+    fi
+
+    require_tools
+
+    local date="${SNAPSHOT_DATE}"
+    [ -n "${date}" ] || date=$(yesterday_utc)
+    case "${date}" in
+        [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+        *) echo "error: --date must be YYYY-MM-DD (got '${date}')" >&2; exit 1 ;;
+    esac
+
+    local repo
+    for repo in ${GITHUB_REPOS}; do
+        echo "Collecting ${repo} release assets"
+        collect_assets "${repo}" >> "${WORK_DIR}/assets.ndjson"
+    done
+
+    local assets
+    assets=$(wc -l < "${WORK_DIR}/assets.ndjson" | tr -d ' ')
+    if [ "${assets}" -eq 0 ]; then
+        echo "error: no release assets found in ${GITHUB_REPOS}" >&2
+        exit 1
+    fi
+
+    key_assets "${WORK_DIR}/assets.ndjson" "${date}" "${WORK_DIR}/uuids" > "${WORK_DIR}/keyed"
+    split -l "${BATCH_SIZE}" "${WORK_DIR}/keyed" "${WORK_DIR}/chunk."
+
+    local chunk chunks=0
+    for chunk in "${WORK_DIR}"/chunk.*; do
+        chunks=$((chunks + 1))
+        build_batch "${chunk}" "${date}" "${POSTHOG_PROJECT_API_KEY:-phc_dry_run}" \
+            > "${WORK_DIR}/payload.${chunks}.json"
+    done
+
+    # Every collected asset must reach a payload. A mismatch means the keying
+    # or chunking dropped rows, which would silently under-report.
+    local events
+    events=$(jq -s '[.[].batch | length] | add' "${WORK_DIR}"/payload.*.json)
+    if [ "${events}" != "${assets}" ]; then
+        echo "error: built ${events} event(s) from ${assets} asset(s)" >&2
+        exit 1
+    fi
+
+    echo "Snapshot ${date}: ${assets} assets in ${chunks} batch(es)"
+
+    if [ "${DRY_RUN}" = 1 ]; then
+        jq -c '.batch[0]' "${WORK_DIR}/payload.1.json"
+        echo "Dry run: nothing sent to ${POSTHOG_HOST%/}"
+        return 0
+    fi
+
+    local payload
+    for payload in "${WORK_DIR}"/payload.*.json; do
+        post_batch "${payload}"
+    done
+
+    echo "Sent ${assets} event(s) for ${date} to ${POSTHOG_HOST%/}"
+
+    if [ "${SKIP_VERIFY}" = 1 ]; then
+        echo "Skipping read-back verification (SKIP_VERIFY=1)"
+        return 0
+    fi
+    verify_snapshot "${date}" "${assets}"
+    # Advisory only: a missing earlier day is worth reporting but is not a
+    # failure of this run, and cannot be repaired by retrying it.
+    warn_on_gap "${date}" || true
+}
+
+main "$@"

--- a/scripts/sync-release-downloads.sh
+++ b/scripts/sync-release-downloads.sh
@@ -192,13 +192,13 @@ post_batch() {
         "${POSTHOG_HOST%/}/batch/" >/dev/null
 }
 
-# Run a HogQL query and print its first scalar result.
+# Run a HogQL query and print the response body.
 #
 # Plain --retry covers the transient cases (timeouts, 429, 5xx) and leaves
 # 4xx alone: an auth or project error repeated four times is noise, and the
 # status is worth naming because every likely cause is a misconfiguration
 # rather than an outage.
-hogql_scalar() {
+hogql_request() {
     local query=$1 response status body
     response=$(jq -n --arg q "${query}" '{query: {kind: "HogQLQuery", query: $q}}' \
         | curl --silent --show-error --retry 3 --retry-delay 2 --max-time 60 \
@@ -216,7 +216,16 @@ hogql_scalar() {
         echo "       and POSTHOG_API_READ_KEY must hold query:read on that project" >&2
         return 1
     fi
-    jq -r '.results[0][0]' <<<"${body}"
+    printf '%s\n' "${body}"
+}
+
+hogql_scalar() {
+    hogql_request "$1" | jq -r '.results[0][0]'
+}
+
+# The whole first row, tab separated.
+hogql_row() {
+    hogql_request "$1" | jq -r '.results[0] | @tsv'
 }
 
 # Count what actually landed. Distinct UUIDs, not rows: PostHog deduplicates
@@ -234,37 +243,57 @@ distinct_events_on() {
     hogql_scalar "$(snapshot_count_query "$1")"
 }
 
-# Count how many of this run's own event UUIDs are queryable at this run's
-# timestamp. A date-wide count would also match UUIDs left by an earlier run
-# whose asset set differed, and those extras can satisfy the threshold while an
-# event from the current payload is still missing. Pinning the timestamp too
-# means a snapshot attributed to the wrong instant cannot read as verified.
+# Report how many of this run's own event UUIDs are queryable at this run's
+# timestamp, and what download total those events carry.
+#
+# The count alone is not enough. A date-wide count would let UUIDs from an
+# earlier run cover for a missing event, and scoping to this run's UUIDs still
+# cannot see a discarded retry whose asset set is unchanged, because the
+# earlier run already ingested those exact UUIDs. The total closes that:
+# counters only rise, so a stale row carries a smaller number than the payload
+# just sent. Pinning the timestamp keeps a snapshot filed against the wrong
+# instant from reading as verified.
 count_ingested() {
-    local date=$1 chunk list total=0 found
+    local date=$1 chunk list row found downloads events=0 total=0
     for chunk in "${WORK_DIR}"/uchunk.*; do
         list=$(sed "s/^/'/; s/$/'/" "${chunk}" | paste -sd, -)
-        found=$(hogql_scalar "SELECT count(DISTINCT uuid) FROM events \
+        row=$(hogql_row "SELECT count(), sum(dl) FROM ( \
+            SELECT uuid, max(toIntOrZero(toString(properties.download_count))) AS dl \
+            FROM events \
             WHERE event = '${EVENT_NAME}' \
               AND timestamp = toDateTime('${date} 23:59:59') \
-              AND uuid IN (${list})")
-        total=$((total + found))
+              AND uuid IN (${list}) \
+            GROUP BY uuid)")
+        found=${row%%$'\t'*}
+        downloads=${row##*$'\t'}
+        for value in "${found}" "${downloads}"; do
+            case "${value}" in
+                '' | *[!0-9]*)
+                    echo "error: PostHog answered the read-back with '${row}', which is not a count and a total" >&2
+                    return 1 ;;
+            esac
+        done
+        events=$(( events + found ))
+        total=$(( total + downloads ))
     done
-    printf '%s\n' "${total}"
+    printf '%s\t%s\n' "${events}" "${total}"
 }
 
 # Poll until the snapshot is queryable, since ingestion lags the send.
 verify_snapshot() {
-    local date=$1 expected=$2 deadline got
+    local date=$1 expected=$2 expected_downloads=$3 deadline row got downloads
     split -l 500 "${WORK_DIR}/uuids" "${WORK_DIR}/uchunk."
     deadline=$(( $(date +%s) + VERIFY_TIMEOUT ))
     while :; do
-        got=$(count_ingested "${date}")
-        if [ "${got}" -ge "${expected}" ]; then
-            echo "Verified ${got} of ${expected} event(s) queryable in PostHog for ${date}"
+        row=$(count_ingested "${date}")
+        got=${row%%$'\t'*}
+        downloads=${row##*$'\t'}
+        if [ "${got}" -ge "${expected}" ] && [ "${downloads}" -ge "${expected_downloads}" ]; then
+            echo "Verified ${got} of ${expected} event(s) and ${downloads} download(s) in PostHog for ${date}"
             return 0
         fi
         if [ "$(date +%s)" -ge "${deadline}" ]; then
-            echo "error: PostHog holds ${got} of ${expected} event(s) for ${date} after ${VERIFY_TIMEOUT}s" >&2
+            echo "error: PostHog holds ${got} of ${expected} event(s) and ${downloads} of ${expected_downloads} download(s) for ${date} after ${VERIFY_TIMEOUT}s" >&2
             return 1
         fi
         sleep 5
@@ -414,7 +443,9 @@ main() {
         echo "Skipping read-back verification (SKIP_VERIFY=1)"
         return 0
     fi
-    verify_snapshot "${date}" "${assets}"
+    local expected_downloads
+    expected_downloads=$(jq -s '[.[].download_count] | add' "${WORK_DIR}/assets.ndjson")
+    verify_snapshot "${date}" "${assets}" "${expected_downloads}"
     # Advisory only: a missing earlier day is worth reporting but is not a
     # failure of this run, and cannot be repaired by retrying it.
     warn_on_gap "${date}" || true

--- a/scripts/sync-release-downloads.sh
+++ b/scripts/sync-release-downloads.sh
@@ -85,6 +85,22 @@ yesterday_utc() {
     jq -rn 'now - 86400 | strftime("%Y-%m-%d")'
 }
 
+# A shell glob accepts digit-shaped nonsense like 2026-99-99, and an invalid
+# date reaches the wire as a malformed event timestamp. Round-trip the value
+# through jq's calendar and require it back unchanged: that rejects impossible
+# dates outright and catches the ones a parser silently rolls over, such as
+# 2026-02-30 becoming 2026-03-02.
+valid_date() {
+    local d=$1 normalized
+    case "${d}" in
+        [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+        *) return 1 ;;
+    esac
+    normalized=$(jq -rn --arg d "${d}" \
+        'try ($d + "T00:00:00Z" | fromdateiso8601 | strftime("%Y-%m-%d")) catch ""')
+    [ "${normalized}" = "${d}" ]
+}
+
 day_before() {
     jq -rn --arg d "$1" '($d + "T00:00:00Z" | fromdateiso8601) - 86400 | strftime("%Y-%m-%d")'
 }
@@ -206,14 +222,33 @@ distinct_events_on() {
     hogql_scalar "$(snapshot_count_query "$1")"
 }
 
+# Count how many of this run's own event UUIDs are queryable at this run's
+# timestamp. A date-wide count would also match UUIDs left by an earlier run
+# whose asset set differed, and those extras can satisfy the threshold while an
+# event from the current payload is still missing. Pinning the timestamp too
+# means a snapshot attributed to the wrong instant cannot read as verified.
+count_ingested() {
+    local date=$1 chunk list total=0 found
+    for chunk in "${WORK_DIR}"/uchunk.*; do
+        list=$(sed "s/^/'/; s/$/'/" "${chunk}" | paste -sd, -)
+        found=$(hogql_scalar "SELECT count(DISTINCT uuid) FROM events \
+            WHERE event = '${EVENT_NAME}' \
+              AND timestamp = toDateTime('${date} 23:59:59') \
+              AND uuid IN (${list})")
+        total=$((total + found))
+    done
+    printf '%s\n' "${total}"
+}
+
 # Poll until the snapshot is queryable, since ingestion lags the send.
 verify_snapshot() {
     local date=$1 expected=$2 deadline got
+    split -l 500 "${WORK_DIR}/uuids" "${WORK_DIR}/uchunk."
     deadline=$(( $(date +%s) + VERIFY_TIMEOUT ))
     while :; do
-        got=$(distinct_events_on "${date}")
+        got=$(count_ingested "${date}")
         if [ "${got}" -ge "${expected}" ]; then
-            echo "Verified ${got} event(s) queryable in PostHog for ${date}"
+            echo "Verified ${got} of ${expected} event(s) queryable in PostHog for ${date}"
             return 0
         fi
         if [ "$(date +%s)" -ge "${deadline}" ]; then
@@ -277,6 +312,16 @@ selftest() {
     want="SELECT count(DISTINCT uuid) FROM events WHERE event = 'github_release_asset_downloads' AND properties.snapshot_date = '2026-08-20'"
     [ "${got}" = "${want}" ] || { echo "selftest: query is\n  ${got}\nwant\n  ${want}" >&2; exit 1; }
 
+    # Calendar validation must reject digit-shaped non-dates, rollovers, and
+    # anything that could carry a quote into the read-back query.
+    local d
+    for d in 2026-09-01 2024-02-29 2026-12-31 2026-01-01; do
+        valid_date "${d}" || { echo "selftest: rejected valid date ${d}" >&2; exit 1; }
+    done
+    for d in 2026-99-99 2026-13-01 2026-00-00 2026-02-30 2025-02-29 2026-9-1 "" "2026-09-0'"; do
+        if valid_date "${d}"; then echo "selftest: accepted invalid date '${d}'" >&2; exit 1; fi
+    done
+
     # Date arithmetic across month, year, and leap-day boundaries.
     got=$(day_before "2026-03-01"); want="2026-02-28"
     [ "${got}" = "${want}" ] || { echo "selftest: day_before(2026-03-01) = ${got}, want ${want}" >&2; exit 1; }
@@ -301,10 +346,10 @@ main() {
 
     local date="${SNAPSHOT_DATE}"
     [ -n "${date}" ] || date=$(yesterday_utc)
-    case "${date}" in
-        [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
-        *) echo "error: --date must be YYYY-MM-DD (got '${date}')" >&2; exit 1 ;;
-    esac
+    if ! valid_date "${date}"; then
+        echo "error: --date must be a real calendar date as YYYY-MM-DD (got '${date}')" >&2
+        exit 1
+    fi
 
     local repo
     for repo in ${GITHUB_REPOS}; do


### PR DESCRIPTION
Add a daily 01:17 UTC workflow recording one PostHog event per GitHub
release asset, carrying that asset's cumulative download count as of
the previous UTC day.

Retries cannot double-count. The event UUID is a version-5 UUID over
(repository, asset ID, snapshot date) and the timestamp is pinned to
23:59:59Z on the snapshot date, which is what PostHog deduplicates on,
so re-running a date re-sends byte-identical events.

Deduplication is eventual, and in practice a re-sent day's rows stay
visible long after ingestion, so reporting must aggregate with
max(download_count) per asset and snapshot date rather than sum over
rows. Cumulative counts only rise, which makes max correct while the
duplicates are still present.

The run reads its own snapshot back and fails when PostHog cannot
account for every event. PostHog answers 200 OK to a batch sent with an
invalid project token, so an unverified send cannot distinguish success
from silent discard, which would make a rotated token look healthy
indefinitely. The read-back counts distinct event UUIDs rather than
rows so the eventual-deduplication window cannot mask a short send.

A run also reports when the previous day holds no snapshot, since a
scheduled run that is dropped or disabled fails nothing and would
otherwise leave a silent hole. That check is advisory: GitHub exposes
only current cumulative counts, so a missed day cannot be rebuilt.

The sender is a standalone script rather than the aura-telemetry crate.
That crate's property allow-list is sealed to CLI-only anonymous
product telemetry by docs/adr/2026-06-23-cli-product-telemetry.md, and
repository-side metrics do not belong inside it.

Draft releases are skipped, and GitHub-generated source archives are
not release assets so they never appear.

Fixes: #558