### PR TITLE
build: drop lto and codegen-units from the release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,8 @@ license = "Apache-2.0"
 repository = "https://github.com/mezmo/aura"
 
 [profile.release]
-# prefer thin lto until runtime performance warrants optimizations
-lto = "thin"
-codegen-units = 1
+# Stripping is the only size optimization worth its build cost; see #668 for
+# the lto / codegen-units measurements.
 strip = "symbols"
 
 [workspace.dependencies]


### PR DESCRIPTION
Removes `lto = "thin"` and `codegen-units = 1` from `[profile.release]`, keeping `strip = "symbols"`.

These two settings came in with #563 (fat LTO, later downgraded to thin in #570) purely to shrink the release binaries. They serialize codegen for every workspace crate and add an LTO pass to every link, which is what pushed the release pipeline past its old 60 minute Jenkins timeout. #570 states that runtime performance is neither benchmarked nor a concern, so there is no performance reason to keep them.

Measured on a 32-core machine against nightly at ff32249e:

| Release build | With lto + codegen-units=1 | Without |
|---|---|---|
| Incremental after touching `crates/aura/src/lib.rs` | 3m 27s | 53s |
| Full cold rebuild, all 574 units, fresh target dir | 4m 12s | 1m 54s |
| Longest single unit | 118s (`aura-web-server` bin) | 35s (`aura` lib) |

Stripping alone gives most of the size win at zero build cost. `aura` on linux-amd64:

| Profile | Size |
|---|---|
| No strip, no LTO | 81.8 MiB |
| Strip only (this PR) | 65.0 MiB |
| Strip + thin LTO + codegen-units=1 (nightly today) | 56.6 MiB |

Side effect: release artifacts grow by roughly 8 MiB per binary and a few MiB per deb/rpm. xz compression of the packages is unchanged.

Fixes #668
