### PR TITLE
feat(workflow): add durable configured workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +87,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -245,7 +265,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "sse-stream",
- "strum",
+ "strum 0.26.3",
  "tempfile",
  "thiserror 2.0.18",
  "tiktoken-rs",
@@ -308,6 +328,7 @@ dependencies = [
  "dotenvy",
  "globset",
  "http 1.4.0",
+ "jsonschema",
  "regex",
  "serde",
  "serde_json",
@@ -1083,7 +1104,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -1091,6 +1121,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -1117,6 +1153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1174,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -1564,6 +1612,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,6 +1826,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,7 +1911,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
+dependencies = [
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -1893,6 +1967,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,12 +1990,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e246562084dde8ebbcc943b261c406ce4f68e5032ec28029a251a47d6a295500"
+dependencies = [
+ "num",
+ "num-bigint",
 ]
 
 [[package]]
@@ -2144,7 +2245,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2152,6 +2253,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -2646,6 +2752,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68339c3d874e48151d74ffe256d93a58cffa240983cb0967d3cbaea083a44fe"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.19.1",
+ "fraction",
+ "getrandom 0.3.4",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6307b5b51216ec9b941b52244c74043fa0b1d6b657b56199f57cb1416d3641c5"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0230ac05e09c6111e96c147b75c390579f5cbd45654b980c68ac60fe17b3f129"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "getrandom 0.3.4",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+ "zmij",
+]
+
+[[package]]
 name = "lazy-regex"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2773,6 +2932,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,12 +3049,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -2916,6 +3110,27 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3686,6 +3901,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a196a5b4a8a12f46b6353174df865a05d41a6055aff212ec30877492788618b6"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3699,9 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4449,7 +4681,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -4462,6 +4703,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -4636,7 +4889,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bstr",
- "fancy-regex",
+ "fancy-regex 0.13.0",
  "lazy_static",
  "regex",
  "rustc-hash 1.1.0",
@@ -5170,6 +5423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5252,6 +5511,16 @@ dependencies = [
  "serde_core",
  "sha1_smol",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]
@@ -6011,6 +6280,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/crates/aura-cli/src/main.rs
+++ b/crates/aura-cli/src/main.rs
@@ -14,7 +14,7 @@ use aura_cli::ui::prompt::AgentHost;
 /// template resolution has overrides.
 ///
 /// Returns whether the process is running standalone or not.
-fn resolve_env_config(args: &Args) -> bool {
+fn resolve_env_config(_args: &Args) -> bool {
     // Loads .env so a config's {{ env.* }} references resolve without manual
     // exporting. CWD first, then the config file's directory (init writes
     // .env next to the config). dotenvy never overwrites — shell exports and
@@ -24,7 +24,7 @@ fn resolve_env_config(args: &Args) -> bool {
     // `resolve_standalone` reads AURA_API_URL from the process environment, so
     // it must run after the CWD `.env` is loaded.
     #[cfg(feature = "standalone-cli")]
-    let is_standalone = aura_cli::cli::resolve_standalone(args);
+    let is_standalone = aura_cli::cli::resolve_standalone(_args);
     #[cfg(not(feature = "standalone-cli"))]
     let is_standalone = false;
 
@@ -33,7 +33,7 @@ fn resolve_env_config(args: &Args) -> bool {
     // is ignored here — the backend reports it.
     #[cfg(feature = "standalone-cli")]
     if is_standalone
-        && let Ok(path) = aura_cli::agent_config::resolve(args.agent_config.as_deref())
+        && let Ok(path) = aura_cli::agent_config::resolve(_args.agent_config.as_deref())
         && let Some(dir) = aura_cli::agent_config::env_dir(&path)
     {
         dotenvy::from_path(dir.join(".env")).ok();

--- a/crates/aura-config/Cargo.toml
+++ b/crates/aura-config/Cargo.toml
@@ -30,3 +30,5 @@ globset = "0.4"
 
 # Directory perms validation
 tempfile = "3"
+
+jsonschema = { version = "0.55.1", default-features = false }

--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -432,6 +432,12 @@ impl Config {
 
         if let Some(orch) = &self.orchestration {
             orch.validate_worker_names()?;
+            orch.validate_stages()?;
+            if !orch.stages.is_empty() && self.effective_memory_dir().is_none() {
+                return Err(crate::ConfigError::Validation(
+                    "configured workflow stages require memory_dir".into(),
+                ));
+            }
         }
 
         Ok(())

--- a/crates/aura-config/src/lib.rs
+++ b/crates/aura-config/src/lib.rs
@@ -8,6 +8,7 @@ pub mod orchestration;
 pub mod scratchpad;
 pub mod session_store;
 pub mod skills;
+pub mod workflow;
 pub mod writer;
 
 #[cfg(test)]

--- a/crates/aura-config/src/orchestration.rs
+++ b/crates/aura-config/src/orchestration.rs
@@ -311,6 +311,8 @@ impl Default for ArtifactsConfig {
 /// `artifacts.memory_dir`).
 #[derive(Debug, Clone, Serialize)]
 pub struct OrchestrationConfig {
+    /// Ordered stages; empty retains model-directed orchestration.
+    pub stages: Vec<crate::workflow::WorkflowStage>,
     // --- Mode ---
     /// Whether orchestration mode is enabled.
     /// When false (default), standard single-agent streaming is used.
@@ -371,6 +373,7 @@ impl Default for OrchestrationConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            stages: Vec::new(),
             max_planning_cycles: default_max_planning_cycles(),
             max_plan_parse_retries: default_max_plan_parse_retries(),
             worker_system_prompt: None,
@@ -540,6 +543,8 @@ impl OrchestrationConfig {
 #[derive(Deserialize)]
 struct RawOrchestrationConfig {
     #[serde(default)]
+    stages: Vec<crate::workflow::WorkflowStage>,
+    #[serde(default)]
     enabled: bool,
     #[serde(default = "default_max_planning_cycles")]
     max_planning_cycles: usize,
@@ -623,6 +628,7 @@ impl<'de> Deserialize<'de> for OrchestrationConfig {
 
         Ok(OrchestrationConfig {
             enabled: raw.enabled,
+            stages: raw.stages,
             max_planning_cycles: raw.max_planning_cycles,
             max_plan_parse_retries: raw.max_plan_parse_retries,
             worker_system_prompt: raw.worker_system_prompt,

--- a/crates/aura-config/src/orchestration.rs
+++ b/crates/aura-config/src/orchestration.rs
@@ -312,6 +312,7 @@ impl Default for ArtifactsConfig {
 #[derive(Debug, Clone, Serialize)]
 pub struct OrchestrationConfig {
     /// Ordered stages; empty retains model-directed orchestration.
+    #[serde(flatten, serialize_with = "crate::workflow::serialize_stages")]
     pub stages: Vec<crate::workflow::WorkflowStage>,
     // --- Mode ---
     /// Whether orchestration mode is enabled.
@@ -542,8 +543,8 @@ impl OrchestrationConfig {
 /// Flat fields take precedence over sub-table values when both are present.
 #[derive(Deserialize)]
 struct RawOrchestrationConfig {
-    #[serde(default)]
-    stages: Vec<crate::workflow::WorkflowStage>,
+    #[serde(flatten)]
+    workflow: crate::workflow::NamedStages,
     #[serde(default)]
     enabled: bool,
     #[serde(default = "default_max_planning_cycles")]
@@ -552,7 +553,7 @@ struct RawOrchestrationConfig {
     max_plan_parse_retries: usize,
     #[serde(default)]
     worker_system_prompt: Option<String>,
-    #[serde(default, rename = "worker")]
+    #[serde(default, rename = "worker", alias = "workers")]
     workers: HashMap<String, WorkerConfig>,
     #[serde(default)]
     coordinator_vector_stores: Vec<String>,
@@ -628,7 +629,10 @@ impl<'de> Deserialize<'de> for OrchestrationConfig {
 
         Ok(OrchestrationConfig {
             enabled: raw.enabled,
-            stages: raw.stages,
+            stages: raw
+                .workflow
+                .into_ordered()
+                .map_err(serde::de::Error::custom)?,
             max_planning_cycles: raw.max_planning_cycles,
             max_plan_parse_retries: raw.max_plan_parse_retries,
             worker_system_prompt: raw.worker_system_prompt,

--- a/crates/aura-config/src/workflow.rs
+++ b/crates/aura-config/src/workflow.rs
@@ -1,0 +1,219 @@
+//! Ordered workflows reuse named workers and their MCP permissions.
+
+use std::collections::{BTreeMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{ConfigError, OrchestrationConfig};
+
+/// An explicitly configured stage. Inputs are JSON pointers into
+/// `{ "input": ..., "stages": { "stage_id": result } }`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowStage {
+    pub id: String,
+    pub worker: String,
+    #[serde(default)]
+    pub inputs: BTreeMap<String, String>,
+    pub operation: StageOperation,
+    /// Validate the complete result before making it available downstream.
+    pub output_schema: Value,
+    /// MCP notifications dispatched at offsets from the approval request.
+    #[serde(default)]
+    pub on_approval_wait: Vec<WaitNotification>,
+}
+
+/// Uses the named worker's MCP permissions; recipient routing stays in that MCP.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WaitNotification {
+    #[serde(default)]
+    pub inputs: BTreeMap<String, String>,
+    pub after_secs: u64,
+    pub worker: String,
+    pub tool: String,
+    pub arguments: Value,
+}
+
+/// Execution semantics are configuration, never a model-generated plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum StageOperation {
+    Worker {
+        prompt: String,
+    },
+    Tool {
+        tool: String,
+        arguments: Value,
+    },
+    Verify {
+        /// Explicit declaration that repeated probes cannot mutate the target.
+        read_only: bool,
+        tool: String,
+        arguments: Value,
+        success_schema: Value,
+        failure_schema: Option<Value>,
+        interval_secs: u64,
+        timeout_secs: u64,
+    },
+    Wait {
+        seconds: u64,
+    },
+}
+
+/// Compile schemas without permitting remote or local-file references.
+pub fn compile_schema(schema: &Value) -> Result<jsonschema::Validator, ConfigError> {
+    fn reject_external(value: &Value) -> bool {
+        match value {
+            Value::Object(map) => map.iter().any(|(key, value)| {
+                ((key == "$ref" || key == "$dynamicRef")
+                    && value.as_str().is_some_and(|r| !r.starts_with('#')))
+                    || reject_external(value)
+            }),
+            Value::Array(values) => values.iter().any(reject_external),
+            _ => false,
+        }
+    }
+    if reject_external(schema) {
+        return Err(ConfigError::Validation(
+            "workflow schemas require local fragment references".into(),
+        ));
+    }
+    jsonschema::validator_for(schema)
+        .map_err(|error| ConfigError::Validation(format!("invalid workflow schema: {error}")))
+}
+
+impl OrchestrationConfig {
+    pub fn validate_stages(&self) -> Result<(), ConfigError> {
+        let mut ids = HashSet::new();
+        for stage in &self.stages {
+            if stage.id.is_empty()
+                || !stage
+                    .id
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+            {
+                return Err(ConfigError::Validation(
+                    "workflow stage ids must contain only letters, digits and underscores".into(),
+                ));
+            }
+            if !self.workers.contains_key(&stage.worker) {
+                return Err(ConfigError::Validation(format!(
+                    "stage {} references unknown worker {}",
+                    stage.id, stage.worker
+                )));
+            }
+            for pointer in stage.inputs.values() {
+                let parts: Vec<_> = pointer.split('/').collect();
+                let valid = pointer.starts_with('/')
+                    && valid_pointer(pointer)
+                    && (parts.get(1) == Some(&"input")
+                        || parts.get(1) == Some(&"run")
+                        || (parts.get(1) == Some(&"stages")
+                            && parts.get(2).is_some_and(|id| ids.contains(*id))));
+                if !valid {
+                    return Err(ConfigError::Validation(format!(
+                        "stage {} input must reference input or an earlier stage: {pointer}",
+                        stage.id
+                    )));
+                }
+            }
+            if !ids.insert(stage.id.as_str()) {
+                return Err(ConfigError::Validation(format!(
+                    "duplicate workflow stage {}",
+                    stage.id
+                )));
+            }
+            compile_schema(&stage.output_schema)?;
+            match &stage.operation {
+                StageOperation::Tool { tool, arguments }
+                | StageOperation::Verify {
+                    tool, arguments, ..
+                } if tool.is_empty()
+                    || !arguments.is_object()
+                    || stage.inputs.keys().any(|key| arguments.get(key).is_some()) =>
+                {
+                    return Err(ConfigError::Validation(
+                        "tool stages need a name, object arguments and non-overlapping inputs"
+                            .into(),
+                    ));
+                }
+                StageOperation::Wait { seconds } if *seconds > MAX_WAIT_SECS => {
+                    return Err(ConfigError::Validation("wait exceeds one year".into()));
+                }
+                _ => {}
+            }
+            for notification in &stage.on_approval_wait {
+                if notification.after_secs > MAX_WAIT_SECS
+                    || !notification.arguments.is_object()
+                    || notification.tool.is_empty()
+                    || !self.workers.contains_key(&notification.worker)
+                {
+                    return Err(ConfigError::Validation(
+                        "invalid approval notification".into(),
+                    ));
+                }
+            }
+
+            if let StageOperation::Verify {
+                success_schema,
+                failure_schema,
+                interval_secs,
+                timeout_secs,
+                read_only,
+                ..
+            } = &stage.operation
+            {
+                if !read_only
+                    || *interval_secs == 0
+                    || *timeout_secs == 0
+                    || *timeout_secs > MAX_WAIT_SECS
+                    || interval_secs > timeout_secs
+                {
+                    return Err(ConfigError::Validation(
+                        "verification requires a positive interval within its timeout".into(),
+                    ));
+                }
+                compile_schema(success_schema)?;
+                if let Some(schema) = failure_schema {
+                    compile_schema(schema)?;
+                }
+            }
+        }
+        if !self.stages.is_empty() && !self.enabled {
+            return Err(ConfigError::Validation(
+                "configured stages require orchestration.enabled".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Maximum persisted wait horizon: one year.
+const MAX_WAIT_SECS: u64 = 31_536_000;
+
+fn valid_pointer(pointer: &str) -> bool {
+    let mut chars = pointer.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '~' && !matches!(chars.next(), Some('0' | '1')) {
+            return false;
+        }
+    }
+    true
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn rejects_external_references_and_invalid_schemas() {
+        assert!(compile_schema(&json!({"$ref":"file:///etc/passwd"})).is_err());
+        assert!(compile_schema(&json!({"$ref":"https://example.org/schema"})).is_err());
+        assert!(compile_schema(&json!({"type":"not-a-type"})).is_err());
+        let schema = compile_schema(&json!({"type":"object", "required":["approved"], "properties":{"approved":{"type":"boolean"}}})).unwrap();
+        assert!(!schema.is_valid(&json!({"approved":"yes"})));
+        assert!(schema.is_valid(&json!({"approved":true})));
+    }
+}

--- a/crates/aura-config/src/workflow.rs
+++ b/crates/aura-config/src/workflow.rs
@@ -12,6 +12,8 @@ use crate::{ConfigError, OrchestrationConfig};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowStage {
+    /// Derived from the named stage table, never a second configuration field.
+    #[serde(skip)]
     pub id: String,
     pub worker: String,
     #[serde(default)]
@@ -22,6 +24,58 @@ pub struct WorkflowStage {
     /// MCP notifications dispatched at offsets from the approval request.
     #[serde(default)]
     pub on_approval_wait: Vec<WaitNotification>,
+}
+
+/// Wire representation keeps execution order independent of map ordering.
+#[derive(Default, Deserialize)]
+pub(crate) struct NamedStages {
+    #[serde(default)]
+    stage_order: Vec<String>,
+    #[serde(default)]
+    stages: BTreeMap<String, WorkflowStage>,
+}
+
+impl NamedStages {
+    pub(crate) fn into_ordered(mut self) -> Result<Vec<WorkflowStage>, ConfigError> {
+        let mut ordered = Vec::with_capacity(self.stage_order.len());
+        for id in self.stage_order {
+            let mut stage = self.stages.remove(&id).ok_or_else(|| {
+                ConfigError::Validation(format!(
+                    "stage_order references unknown or repeated stage {id}"
+                ))
+            })?;
+            stage.id = id;
+            ordered.push(stage);
+        }
+        if !self.stages.is_empty() {
+            return Err(ConfigError::Validation(
+                "stage_order must list every configured stage exactly once".into(),
+            ));
+        }
+        Ok(ordered)
+    }
+}
+
+pub(crate) fn serialize_stages<S>(
+    stages: &[WorkflowStage],
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    #[derive(Serialize)]
+    struct NamedStagesRef<'a> {
+        stage_order: Vec<&'a str>,
+        stages: BTreeMap<&'a str, &'a WorkflowStage>,
+    }
+    NamedStagesRef {
+        stage_order: stages.iter().map(|stage| stage.id.as_str()).collect(),
+        stages: stages
+            .iter()
+            .map(|stage| (stage.id.as_str(), stage))
+            .collect(),
+    }
+    .serialize(serializer)
 }
 
 /// Uses the named worker's MCP permissions; recipient routing stays in that MCP.
@@ -206,6 +260,63 @@ fn valid_pointer(pointer: &str) -> bool {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    const NAMED: &str = r#"
+enabled = true
+stage_order = ["verify", "act"]
+[worker.operator]
+description = "test"
+preamble = "test"
+[stages.act]
+worker = "operator"
+inputs = { evidence = "/stages/verify" }
+output_schema = { type = "object" }
+operation = { kind = "wait", seconds = 0 }
+[stages.verify]
+worker = "operator"
+output_schema = { type = "object" }
+operation = { kind = "wait", seconds = 0 }
+"#;
+
+    #[test]
+    fn named_stages_follow_explicit_order_and_round_trip() {
+        let config: OrchestrationConfig = toml::from_str(NAMED).unwrap();
+        config.validate_stages().unwrap();
+        assert_eq!(config.stages[0].id, "verify");
+        assert_eq!(config.stages[1].id, "act");
+        let serialized = serde_json::to_value(&config).unwrap();
+        assert_eq!(serialized["stage_order"], json!(["verify", "act"]));
+        assert!(serialized["stages"]["act"].get("id").is_none());
+        for round_trip in [
+            serde_json::from_value::<OrchestrationConfig>(serialized.clone()).unwrap(),
+            toml::from_str(&toml::to_string(&config).unwrap()).unwrap(),
+        ] {
+            round_trip.validate_stages().unwrap();
+            assert_eq!(serde_json::to_value(round_trip).unwrap(), serialized);
+        }
+    }
+
+    #[test]
+    fn rejects_missing_repeated_unknown_and_unordered_stages() {
+        for order in [
+            "[]",
+            "[\"verify\"]",
+            "[\"act\", \"act\"]",
+            "[\"unknown\", \"act\"]",
+        ] {
+            let invalid = NAMED.replace("[\"verify\", \"act\"]", order);
+            assert!(
+                toml::from_str::<OrchestrationConfig>(&invalid).is_err(),
+                "{order}"
+            );
+        }
+        let omitted = NAMED.replace("stage_order = [\"verify\", \"act\"]", "");
+        assert!(toml::from_str::<OrchestrationConfig>(&omitted).is_err());
+        let redundant_id = NAMED.replace("[stages.act]", "[stages.act]\nid = \"other\"");
+        assert!(toml::from_str::<OrchestrationConfig>(&redundant_id).is_err());
+        let array = NAMED.replace("[stages.act]", "[[stages.act]]");
+        assert!(toml::from_str::<OrchestrationConfig>(&array).is_err());
+    }
 
     #[test]
     fn rejects_external_references_and_invalid_schemas() {

--- a/crates/aura-events/src/orchestration.rs
+++ b/crates/aura-events/src/orchestration.rs
@@ -91,6 +91,12 @@ pub mod event_names {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum OrchestrationStreamEvent {
+    /// Durable workflow snapshot; sequence numbers support replay through A2A.
+    WorkflowUpdated {
+        run: serde_json::Value,
+        #[serde(flatten)]
+        context: EventContext,
+    },
     /// Emitted when orchestrator creates a plan from user query.
     PlanCreated {
         goal: String,
@@ -253,6 +259,7 @@ impl OrchestrationStreamEvent {
     /// Get the SSE event name for this event type.
     pub fn event_name(&self) -> &'static str {
         match self {
+            Self::WorkflowUpdated { .. } => "aura.orchestrator.workflow_updated",
             Self::PlanCreated { .. } => event_names::PLAN_CREATED,
             Self::DirectAnswer { .. } => event_names::DIRECT_ANSWER,
             Self::ClarificationNeeded { .. } => event_names::CLARIFICATION_NEEDED,

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -125,6 +125,10 @@ impl AuraAgentExecutor {
             }
         };
 
+        let workflow = config
+            .as_ref()
+            .and_then(|c| c.orchestration.as_ref())
+            .is_some_and(|o| !o.stages.is_empty());
         AgentCard {
             name,
             description,
@@ -135,7 +139,7 @@ impl AuraAgentExecutor {
             capabilities: AgentCapabilities {
                 streaming: Some(true),
                 push_notifications: Some(false),
-                extensions: None,
+                extensions: workflow.then(|| vec![a2a::AgentExtension { uri: "urn:aura:workflow:v1".into(), description: Some("Configured workflow controls in aura.workflow data parts; durable snapshots in workflow artifacts".into()), required: Some(false), params: None }]),
                 extended_agent_card: None,
             },
             supported_interfaces: vec![
@@ -203,9 +207,12 @@ impl AgentExecutor for AuraAgentExecutor {
             let task_id = ctx.task_id.clone();
             let context_id = ctx.context_id.clone();
 
-            let text = ctx.message
-                .ok_or_else(|| A2AError::invalid_params("Message has no parts to use as a command."))
-                .and_then(|msg| extract_text(msg.parts))?;
+            let message = ctx.message.ok_or_else(|| A2AError::invalid_params("Message has no parts to use as a command."))?;
+            let configured_workflow = config.orchestration.as_ref().is_some_and(|o| !o.stages.is_empty());
+            let workflow_request = extract_workflow_request(&message, configured_workflow)?;
+            let text = if workflow_request.as_ref().is_some_and(|r| r.command != aura::orchestration::workflow::WorkflowCommand::Start) {
+                String::new()
+            } else { extract_text(message.parts.into_iter().filter(|part| !matches!(&part.content, PartContent::Data(data) if data.get("aura.workflow").is_some())).collect())? };
 
             let req_headers: HashMap<String, String> = ctx
                 .service_params
@@ -227,7 +234,8 @@ impl AgentExecutor for AuraAgentExecutor {
 
             let request_id = format!("a2a_{}", task_id);
             let session_id = Some(context_id.clone());
-            let builder = RigBuilder::new(config, pending_approvals).with_hitl_hmac(hitl_hmac);
+            let builder = RigBuilder::new(config, pending_approvals).with_hitl_hmac(hitl_hmac)
+                .with_workflow_request(workflow_request);
             let agent = match builder
                 .build_streaming_agent_with_headers(
                     Some(&req_headers),
@@ -278,6 +286,7 @@ impl AgentExecutor for AuraAgentExecutor {
             let _request_guard = ActiveRequestGuard::new(active_request_tracker);
 
             let mut success = true; // assume everything is successful
+            let mut final_state = TaskState::Completed;
 
             let mut reasoning_num = 0;
             loop {
@@ -404,7 +413,15 @@ impl AgentExecutor for AuraAgentExecutor {
                     Ok(StreamItem::ContextUsage { .. }) => {
                         event!(Level::DEBUG, request_id, "context usage");
                     }
+                    Ok(StreamItem::OrchestratorEvent(aura::orchestration::OrchestratorEvent::WorkflowUpdated { run })) => {
+                        yield Ok(StreamResponse::ArtifactUpdate(TaskArtifactUpdateEvent {
+                            task_id: task_id.clone(), context_id: context_id.clone(),
+                            artifact: Artifact { artifact_id: "workflow".into(), name: Some("Workflow run".into()), description: None, parts: vec![Part::data(run)], metadata: Some(HashMap::from([("type".into(), Value::String("workflow".into()))])), extensions: None },
+                            append: Some(false), last_chunk: Some(false), metadata: None,
+                        }));
+                    }
                     Ok(StreamItem::OrchestratorEvent(_)) => {
+
                         event!(Level::DEBUG, request_id, "orchestration event");
                     }
                     Ok(StreamItem::McpStatus(_)) => {
@@ -419,7 +436,19 @@ impl AgentExecutor for AuraAgentExecutor {
                     Ok(StreamItem::StreamAssistantItem(StreamedAssistantContent::ReasoningDelta { .. })) => {
                         event!(Level::DEBUG, request_id, "reasoning delta");
                     }
-                    Ok(StreamItem::Final(final_info)) => {
+                                        Ok(StreamItem::Final(final_info)) => {
+                        let final_parts;
+                        if configured_workflow {
+                            let record: Value = serde_json::from_str(&final_info.content).map_err(|e| A2AError::internal(format!("invalid workflow record: {e}")))?;
+                            final_state = match record.pointer("/state/state").and_then(Value::as_str) {
+                                Some("completed") => TaskState::Completed,
+                                Some("cancelled") => TaskState::Canceled,
+                                Some("failed" | "inconclusive") => TaskState::Failed,
+                                _ => TaskState::InputRequired,
+                            };
+                            final_parts = vec![Part::data(record)];
+                        } else { final_parts = vec![Part::text(final_info.content)]; }
+
                         let append = append_tracker.entry((task_id.clone(), context_id.clone(), FINAL_ARTIFACT_ID.to_owned()))
                             .and_modify(|e| *e = true)
                             .or_insert(false);
@@ -428,7 +457,7 @@ impl AgentExecutor for AuraAgentExecutor {
                             artifact_id: FINAL_ARTIFACT_ID.to_owned(),
                             name: Some("Final Info".into()),
                             description: None,
-                            parts: vec![Part::text(final_info.content)],
+                            parts: final_parts,
                             metadata: Some(HashMap::from([
                                 ("input_tokens".into(), Value::Number(final_info.usage.input_tokens.into())),
                                 ("output_tokens".into(), Value::Number(final_info.usage.output_tokens.into())),
@@ -495,7 +524,7 @@ impl AgentExecutor for AuraAgentExecutor {
                     task_id,
                     context_id,
                     status: TaskStatus {
-                        state: TaskState::Completed,
+                        state: final_state,
                         message: None,
                         timestamp: Some(chrono::Utc::now()),
                     },
@@ -509,8 +538,11 @@ impl AgentExecutor for AuraAgentExecutor {
         let task_id = ctx.task_id.clone();
         let context_id = ctx.context_id.clone();
         let task_cancel_state = self.task_cancel_state.clone();
+        let task_store = self.task_store.clone();
+        let configs = self.app_state.configs.clone();
+        let approvals = self.app_state.pending_approvals.clone();
 
-        Box::pin(futures_util::stream::once(async move {
+        Box::pin(async_stream::try_stream! {
             let entry = lock_cancel_state(&task_cancel_state).remove(&task_id);
 
             // Token-cancel wakes execute()'s select! → loop breaks → generator drops
@@ -528,7 +560,53 @@ impl AgentExecutor for AuraAgentExecutor {
                 RequestCancellation::unregister(&entry.request_id);
             }
 
-            Ok(StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+            let workflow = task_store.get(&task_id).await?
+                .and_then(|task| task.artifacts)
+                .and_then(|artifacts| artifacts.into_iter().find(|a| a.artifact_id == "workflow"))
+                .and_then(|artifact| match artifact.parts.first() {
+                    Some(Part { content: PartContent::Data(record), .. }) => Some((artifact.clone(), record.clone())),
+                    _ => None,
+                });
+            if let Some((mut artifact, record)) = workflow {
+                let run_id = record
+                    .get("run_id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| A2AError::internal("workflow run id missing"))?
+                    .parse()
+                    .map_err(|_| A2AError::internal("invalid persisted run id"))?;
+                let agent_name = record
+                    .get("agent")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| A2AError::internal("workflow agent missing"))?;
+                let config = configs
+                    .iter()
+                    .find(|config| config.agent.name == agent_name)
+                    .ok_or_else(|| A2AError::internal("workflow configuration unavailable"))?;
+                let mut runtime = RigBuilder::new(config.clone(), approvals).get_agent_config();
+                runtime.session_id = Some(context_id.clone());
+                runtime.workflow_request = Some(aura::orchestration::workflow::WorkflowRequest {
+                    run_id,
+                    command: aura::orchestration::workflow::WorkflowCommand::Cancel,
+                    message_id: format!("cancel-task:{task_id}"),
+                });
+                let orchestrator = aura::orchestration::Orchestrator::new(runtime)
+                    .await
+                    .map_err(|e| A2AError::internal(e.to_string()))?;
+                let record = orchestrator
+                    .control_workflow()
+                    .await
+                    .map_err(|e| A2AError::internal(e.to_string()))?;
+                artifact.parts = vec![Part::data(record)];
+                yield StreamResponse::ArtifactUpdate(TaskArtifactUpdateEvent {
+                    task_id: task_id.clone(),
+                    context_id: context_id.clone(),
+                    artifact,
+                    metadata: None,
+                    append: Some(false),
+                    last_chunk: Some(true),
+                });
+            }
+            yield StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
                 task_id,
                 context_id,
                 status: TaskStatus {
@@ -537,9 +615,46 @@ impl AgentExecutor for AuraAgentExecutor {
                     timestamp: Some(chrono::Utc::now()),
                 },
                 metadata: None,
-            }))
-        }))
+            });
+        })
     }
+}
+
+/// Controls are transport data, never inferred from natural language.
+fn extract_workflow_request(
+    message: &Message,
+    configured: bool,
+) -> Result<Option<aura::orchestration::workflow::WorkflowRequest>, A2AError> {
+    use aura::orchestration::workflow::{WorkflowCommand, WorkflowRequest};
+    let mut request = None;
+    for part in &message.parts {
+        if let PartContent::Data(data) = &part.content
+            && let Some(control) = data.get("aura.workflow")
+        {
+            if !configured || request.is_some() {
+                return Err(A2AError::invalid_params(
+                    "workflow control requires configured stages and exactly one control part",
+                ));
+            }
+            #[derive(serde::Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct Control {
+                run_id: uuid::Uuid,
+                command: WorkflowCommand,
+            }
+            let control: Control = serde_json::from_value(control.clone())
+                .map_err(|e| A2AError::invalid_params(format!("invalid workflow control: {e}")))?;
+            request = Some(WorkflowRequest {
+                run_id: control.run_id,
+                command: control.command,
+                message_id: message.message_id.clone(),
+            });
+        }
+    }
+    if configured && request.is_none() {
+        request = Some(WorkflowRequest::start(&message.message_id));
+    }
+    Ok(request)
 }
 
 fn extract_text(parts: Vec<Part>) -> Result<String, A2AError> {
@@ -763,6 +878,35 @@ mod tests {
                 ..aura_config::AgentConfig::default()
             },
         }
+    }
+
+    #[test]
+    fn workflow_controls_are_typed_data_and_require_configured_stages() {
+        use aura::orchestration::workflow::WorkflowCommand;
+        let id = uuid::Uuid::new_v4();
+        let message = Message::new(
+            Role::User,
+            vec![Part::data(
+                serde_json::json!({"aura.workflow":{"run_id":id,"command":"takeover"}}),
+            )],
+        );
+        assert!(extract_workflow_request(&message, false).is_err());
+        let request = extract_workflow_request(&message, true).unwrap().unwrap();
+        assert_eq!(request.command, WorkflowCommand::Takeover);
+        assert_eq!(request.message_id, message.message_id);
+        let text = Message::new(Role::User, vec![Part::text("takeover this run")]);
+        assert_eq!(
+            extract_workflow_request(&text, true)
+                .unwrap()
+                .unwrap()
+                .command,
+            WorkflowCommand::Start
+        );
+        let duplicate = Message::new(
+            Role::User,
+            vec![message.parts[0].clone(), message.parts[0].clone()],
+        );
+        assert!(extract_workflow_request(&duplicate, true).is_err());
     }
 
     #[test]

--- a/crates/aura-web-server/src/a2a/shared_task_store.rs
+++ b/crates/aura-web-server/src/a2a/shared_task_store.rs
@@ -40,7 +40,17 @@ fn merge_artifacts(mut task: Task) -> Task {
             .iter_mut()
             .find(|a| a.artifact_id == artifact.artifact_id)
         {
-            existing.parts.extend(artifact.parts);
+            if artifact
+                .metadata
+                .as_ref()
+                .and_then(|m| m.get("type"))
+                .and_then(serde_json::Value::as_str)
+                == Some("workflow")
+            {
+                *existing = artifact;
+            } else {
+                existing.parts.extend(artifact.parts);
+            }
         } else {
             merged.push(artifact);
         }

--- a/crates/aura-web-server/src/session_store.rs
+++ b/crates/aura-web-server/src/session_store.rs
@@ -8,6 +8,8 @@
 #[cfg(feature = "session-store-redis")]
 mod redis;
 
+mod file_tasks;
+
 use std::sync::Arc;
 
 use a2a_server::{InMemoryTaskStore, TaskStore};
@@ -50,7 +52,7 @@ pub async fn build_session_store(
     match config {
         SessionStoreConfig::Memory => Ok(Arc::new(InMemorySessionStore::new())),
         SessionStoreConfig::File(file_config) => {
-            // File-backed approvals; tasks and bus stay in memory.
+            // File-backed approvals and tasks; the event bus stays in memory.
             Ok(Arc::new(FileSessionStore::new(file_config)?))
         }
         #[cfg(feature = "session-store-redis")]
@@ -115,7 +117,7 @@ impl SessionStore for InMemorySessionStore {
 /// The file-backed backend.
 pub struct FileSessionStore {
     approvals: Arc<FileApprovalStore>,
-    tasks: Arc<InMemoryTaskStore>,
+    tasks: Arc<file_tasks::FileTaskStore>,
     bus: Arc<InMemoryEventBus>,
 }
 
@@ -125,7 +127,11 @@ impl FileSessionStore {
     pub fn new(config: &FileSessionStoreConfig) -> Result<Self, SessionStoreError> {
         Ok(Self {
             approvals: Arc::new(FileApprovalStore::open(&config.path)?),
-            tasks: Arc::new(InMemoryTaskStore::new()),
+            tasks: Arc::new(file_tasks::FileTaskStore::open(&config.path).map_err(|e| {
+                SessionStoreError::Connect {
+                    reason: e.to_string(),
+                }
+            })?),
             bus: Arc::new(InMemoryEventBus::new()),
         })
     }

--- a/crates/aura-web-server/src/session_store/file_tasks.rs
+++ b/crates/aura-web-server/src/session_store/file_tasks.rs
@@ -1,0 +1,186 @@
+//! Single-instance A2A task persistence for the existing file session backend.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use a2a::{A2AError, ListTasksRequest, ListTasksResponse, Task, TaskState};
+use a2a_server::{InMemoryTaskStore, TaskStore, task_store::TaskVersion};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Serialize, Deserialize)]
+struct Entry {
+    task: Task,
+    version: TaskVersion,
+}
+
+pub(super) struct FileTaskStore {
+    directory: PathBuf,
+    entries: Arc<Mutex<BTreeMap<String, Entry>>>,
+    _claim: Arc<File>,
+}
+
+impl FileTaskStore {
+    pub(super) fn open(root: &str) -> io::Result<Self> {
+        let directory = Path::new(root).join("tasks");
+        std::fs::create_dir_all(&directory)?;
+        let claim = File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(directory.join("writer.lock"))?;
+        claim.try_lock().map_err(io::Error::other)?;
+        let mut entries = BTreeMap::new();
+        for file in std::fs::read_dir(&directory)? {
+            let path = file?.path();
+            if path.extension().and_then(|v| v.to_str()) != Some("json") {
+                continue;
+            }
+            let mut entry: Entry =
+                serde_json::from_slice(&std::fs::read(path)?).map_err(io::Error::other)?;
+            // A transport stream cannot survive a server restart. The workflow
+            // record remains authoritative and resume reattaches fresh credentials.
+            if matches!(
+                entry.task.status.state,
+                TaskState::Working | TaskState::Submitted
+            ) {
+                entry.task.status.state = TaskState::InputRequired;
+            }
+            if entries.insert(entry.task.id.clone(), entry).is_some() {
+                return Err(io::Error::other("duplicate persisted A2A task"));
+            }
+        }
+        Ok(Self {
+            directory,
+            entries: Arc::new(Mutex::new(entries)),
+            _claim: Arc::new(claim),
+        })
+    }
+
+    async fn write(&self, task: Task, create: bool) -> Result<TaskVersion, A2AError> {
+        let entries = Arc::clone(&self.entries);
+        let claim = Arc::clone(&self._claim);
+        let directory = self.directory.clone();
+        tokio::task::spawn_blocking(move || {
+            let _claim = claim;
+            let mut entries = entries
+                .lock()
+                .map_err(|_| A2AError::internal("task writer poisoned"))?;
+            let version = match (entries.get(&task.id), create) {
+                (None, true) => 1,
+                (Some(_), true) => return Err(A2AError::invalid_params("task already exists")),
+                (None, false) => return Err(A2AError::task_not_found(&task.id)),
+                (Some(entry), false) => entry
+                    .version
+                    .checked_add(1)
+                    .ok_or_else(|| A2AError::internal("task version exhausted"))?,
+            };
+            let entry = Entry { task, version };
+            let publish = || -> io::Result<()> {
+                let bytes = serde_json::to_vec(&entry).map_err(io::Error::other)?;
+                let id =
+                    aura::orchestration::workflow::WorkflowRequest::start(&entry.task.id).run_id;
+                let path = directory.join(format!("{id}.json"));
+                let tmp = path.with_extension("tmp");
+                let mut file = File::create(&tmp)?;
+                file.write_all(&bytes)?;
+                file.sync_all()?;
+                std::fs::rename(tmp, &path)?;
+                File::open(&directory)?.sync_all()
+            };
+            publish().map_err(|e| A2AError::internal(e.to_string()))?;
+            entries.insert(entry.task.id.clone(), entry);
+            Ok(version)
+        })
+        .await
+        .map_err(|e| A2AError::internal(e.to_string()))?
+    }
+}
+
+#[async_trait]
+impl TaskStore for FileTaskStore {
+    async fn create(&self, task: Task) -> Result<TaskVersion, A2AError> {
+        self.write(task, true).await
+    }
+    async fn update(&self, task: Task) -> Result<TaskVersion, A2AError> {
+        self.write(task, false).await
+    }
+    async fn get(&self, id: &str) -> Result<Option<Task>, A2AError> {
+        Ok(self
+            .entries
+            .lock()
+            .map_err(|_| A2AError::internal("task store poisoned"))?
+            .get(id)
+            .map(|e| e.task.clone()))
+    }
+    async fn list(&self, request: &ListTasksRequest) -> Result<ListTasksResponse, A2AError> {
+        // Reuse upstream filtering/history rules. Clamp pagination before the
+        // upstream slice operation, which assumes a token inside the result set.
+        let snapshot = InMemoryTaskStore::new();
+        let tasks: Vec<_> = self
+            .entries
+            .lock()
+            .map_err(|_| A2AError::internal("task store poisoned"))?
+            .values()
+            .map(|e| e.task.clone())
+            .collect();
+        for task in tasks {
+            snapshot.create(task).await?;
+        }
+        let mut query = request.clone();
+        query.page_token = None;
+        query.page_size = Some(i32::MAX);
+        let mut result = snapshot.list(&query).await?;
+        let start = request
+            .page_token
+            .as_deref()
+            .unwrap_or("0")
+            .parse::<usize>()
+            .map_err(|_| A2AError::invalid_params("invalid page token"))?
+            .min(result.tasks.len());
+        let size = request.page_size.filter(|n| *n > 0).unwrap_or(50) as usize;
+        let end = start.saturating_add(size).min(result.tasks.len());
+        result.next_page_token = if end < result.tasks.len() {
+            end.to_string()
+        } else {
+            String::new()
+        };
+        result.tasks = result.tasks[start..end].to_vec();
+        result.page_size = size as i32;
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[tokio::test]
+    async fn restart_preserves_task_and_requires_reattachment() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().to_str().unwrap();
+        let store = FileTaskStore::open(path).unwrap();
+        assert!(FileTaskStore::open(path).is_err());
+        let task = Task {
+            id: "../opaque-id".into(),
+            context_id: "session".into(),
+            status: a2a::TaskStatus {
+                state: TaskState::Working,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        };
+        assert_eq!(store.create(task).await.unwrap(), 1);
+        drop(store);
+        let reopened = FileTaskStore::open(path).unwrap();
+        let task = reopened.get("../opaque-id").await.unwrap().unwrap();
+        assert_eq!(task.status.state, TaskState::InputRequired);
+        assert_eq!(reopened.update(task).await.unwrap(), 2);
+    }
+}

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -1183,6 +1183,10 @@ fn handle_orchestrator_event(
     let event_context = EventContext::new(ctx.agent_context.clone(), ctx.correlation.clone());
 
     let sse_event: OrchestrationStreamEvent = match event {
+        OrchestratorEvent::WorkflowUpdated { run } => OrchestrationStreamEvent::WorkflowUpdated {
+            run: run.clone(),
+            context: event_context,
+        },
         OrchestratorEvent::PlanCreated {
             goal,
             tasks,

--- a/crates/aura-web-server/tests/native_workflow_restart.rs
+++ b/crates/aura-web-server/tests/native_workflow_restart.rs
@@ -109,12 +109,12 @@ api_key = "unused-test-key"
 model = "unused-test-model"
 [orchestration]
 enabled = true
+stage_order = ["wait"]
 [orchestration.worker.worker]
 description = "test"
 preamble = "test"
 mcp_filter = []
-[[orchestration.stages]]
-id = "wait"
+[orchestration.stages.wait]
 worker = "worker"
 output_schema = {{ type = "object", required = ["waited"] }}
 operation = {{ kind = "wait", seconds = 5 }}
@@ -277,18 +277,17 @@ timeout_secs = 30
 enabled = true
 [orchestration]
 enabled = true
+stage_order = ["act", "verify"]
 [orchestration.worker.action]
 description = "test"
 preamble = "test"
 mcp_filter = ["mutate", "probe", "notify"]
-[[orchestration.stages]]
-id = "act"
+[orchestration.stages.act]
 worker = "action"
 output_schema = {{ type = "object", required = ["applied"] }}
 operation = {{ kind = "tool", tool = "mutate", arguments = {{}} }}
 on_approval_wait = [{{after_secs=0, worker="action", tool="notify", arguments={{}}, inputs={{payload="/run"}}}}]
-[[orchestration.stages]]
-id = "verify"
+[orchestration.stages.verify]
 worker = "action"
 output_schema = {{ type = "object", required = ["healthy"] }}
 operation = {{ kind = "verify", tool = "probe", arguments = {{}}, read_only = true, success_schema = {{ required = ["healthy"], properties = {{ healthy = {{ const = true }} }} }}, interval_secs = 1, timeout_secs = 10 }}

--- a/crates/aura-web-server/tests/native_workflow_restart.rs
+++ b/crates/aura-web-server/tests/native_workflow_restart.rs
@@ -1,0 +1,366 @@
+//! A real server process and A2A file backend; no model or external MCP needed.
+use serde_json::{Value, json};
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+struct Server(Child);
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+async fn start(root: &std::path::Path, port: u16) -> Server {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_aura-web-server"));
+    command.env_clear();
+    for name in [
+        "PATH",
+        "HOME",
+        "TMPDIR",
+        "DYLD_LIBRARY_PATH",
+        "LD_LIBRARY_PATH",
+    ] {
+        if let Some(value) = std::env::var_os(name) {
+            command.env(name, value);
+        }
+    }
+    let child = command
+        .args(["--enable-a2a", "--port", &port.to_string(), "--config"])
+        .arg(root.join("config.toml"))
+        .env("AURA_SESSION_STORE", "file")
+        .env("AURA_SESSION_STORE_PATH", root.join("sessions"))
+        .env("OTEL_SDK_DISABLED", "true")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let server = Server(child);
+    let client = reqwest::Client::new();
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            if client
+                .get(format!(
+                    "http://127.0.0.1:{port}/.well-known/agent-card.json"
+                ))
+                .send()
+                .await
+                .is_ok_and(|r| r.status().is_success())
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("server did not start");
+    server
+}
+
+async fn send(client: &reqwest::Client, base: &str, message: Value) -> Value {
+    let response = client
+        .post(format!("{base}/a2a/v1/message:send"))
+        .header("A2A-Version", "1.0")
+        .json(&json!({"message": message}))
+        .send()
+        .await
+        .unwrap();
+    let status = response.status();
+    let body: Value = response.json().await.unwrap();
+    assert!(status.is_success(), "{body}");
+    body["task"].clone()
+}
+
+async fn task(client: &reqwest::Client, base: &str, id: &str) -> Value {
+    client
+        .get(format!("{base}/a2a/v1/tasks/{id}"))
+        .header("A2A-Version", "1.0")
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn a2a_wait_survives_process_kill_and_resumes_with_its_original_deadline() {
+    exercise_restart(false).await;
+}
+
+#[tokio::test]
+async fn a2a_cancel_after_restart_persists_workflow_cancellation() {
+    exercise_restart(true).await;
+}
+
+async fn exercise_restart(cancel: bool) {
+    let root = tempfile::tempdir().unwrap();
+    let config = format!(
+        r#"
+memory_dir = "{}"
+[agent]
+name = "restart-test"
+system_prompt = "unused in configured wait"
+[agent.llm]
+provider = "openai"
+api_key = "unused-test-key"
+model = "unused-test-model"
+[orchestration]
+enabled = true
+[orchestration.worker.worker]
+description = "test"
+preamble = "test"
+mcp_filter = []
+[[orchestration.stages]]
+id = "wait"
+worker = "worker"
+output_schema = {{ type = "object", required = ["waited"] }}
+operation = {{ kind = "wait", seconds = 5 }}
+"#,
+        root.path().join("runs").display()
+    );
+    std::fs::write(root.path().join("config.toml"), config).unwrap();
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let base = format!("http://127.0.0.1:{port}");
+    let server = start(root.path(), port).await;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+    let started = send(
+        &client,
+        &base,
+        json!({"messageId":"start", "role":"ROLE_USER", "parts":[{"text":"input"}]}),
+    )
+    .await;
+    let id = started["id"].as_str().expect("start returned task");
+    let context = started["contextId"].as_str().unwrap();
+    let snapshot = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let current = task(&client, &base, id).await;
+            if let Some(run) = current["artifacts"]
+                .as_array()
+                .and_then(|artifacts| artifacts.iter().find(|a| a["artifactId"] == "workflow"))
+                .and_then(|a| a.pointer("/parts/0/data"))
+                && run.pointer("/state/state") == Some(&json!("waiting"))
+            {
+                break run.clone();
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("no durable waiting snapshot");
+    drop(server); // SIGKILL: no graceful shutdown checkpoint.
+    let _restarted = start(root.path(), port).await;
+    let restored = task(&client, &base, id).await;
+    assert_eq!(
+        restored.pointer("/status/state"),
+        Some(&json!("TASK_STATE_INPUT_REQUIRED"))
+    );
+    if cancel {
+        let response = client
+            .post(format!("{base}/a2a/v1/tasks/{id}/cancel"))
+            .header("A2A-Version", "1.0")
+            .json(&json!({}))
+            .send()
+            .await
+            .unwrap();
+        let status = response.status();
+        let body: Value = response.json().await.unwrap();
+        assert!(status.is_success(), "{body}");
+        let current = task(&client, &base, id).await;
+        assert_eq!(
+            current.pointer("/status/state"),
+            Some(&json!("TASK_STATE_CANCELED")),
+            "{current}"
+        );
+        let run = current["artifacts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|a| a["artifactId"] == "workflow")
+            .unwrap();
+        assert_eq!(
+            run.pointer("/parts/0/data/state/state"),
+            Some(&json!("cancelled")),
+            "{run}"
+        );
+        return;
+    }
+    let resumed = send(&client, &base, json!({"messageId":"resume", "contextId":context, "role":"ROLE_USER", "parts":[{"data":{"aura.workflow":{"command":"resume", "run_id":snapshot["run_id"]}}}]})).await;
+    let resumed_id = resumed["id"].as_str().unwrap();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let current = task(&client, &base, resumed_id).await;
+            if current.pointer("/status/state") == Some(&json!("TASK_STATE_COMPLETED")) {
+                break;
+            }
+            assert_ne!(
+                current.pointer("/status/state"),
+                Some(&json!("TASK_STATE_FAILED")),
+                "{current}"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("resumed wait did not finish");
+}
+
+#[tokio::test]
+async fn exact_mcp_action_waits_for_approval_and_verifies_without_a_model() {
+    use axum::{Json, Router, http::StatusCode, response::IntoResponse, routing::post};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    let mutations = Arc::new(AtomicUsize::new(0));
+    let notifications = Arc::new(AtomicUsize::new(0));
+    let count = Arc::clone(&mutations);
+    let notices = Arc::clone(&notifications);
+    let router = Router::new().route("/mcp", post(move |Json(request): Json<Value>| {
+        let count = Arc::clone(&count);
+        let notices = Arc::clone(&notices);
+        async move {
+            let result = match request["method"].as_str().unwrap_or("") {
+                "initialize" => json!({"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"workflow-test","version":"1"}}),
+                "notifications/initialized" => return StatusCode::ACCEPTED.into_response(),
+                "tools/list" => json!({"tools":[
+                    {"name":"mutate","inputSchema":{"type":"object"}},
+                    {"name":"probe","inputSchema":{"type":"object"}},
+                    {"name":"notify","inputSchema":{"type":"object"}}
+                ]}),
+                "tools/call" => {
+                    let value = match request.pointer("/params/name").and_then(Value::as_str).unwrap() {
+                        "mutate" => { count.fetch_add(1, Ordering::SeqCst); json!({"applied":true}) },
+                        "notify" => { notices.fetch_add(1, Ordering::SeqCst); json!({"delivered":true}) },
+                        "probe" => json!({"healthy":count.load(Ordering::SeqCst) == 1}),
+                        name => panic!("unexpected tool {name}"),
+                    };
+                    json!({"content":[{"type":"text","text":value.to_string()}],"structuredContent":value,"isError":false})
+                }
+                _ => json!({}),
+            };
+            Json(json!({"jsonrpc":"2.0","id":request["id"],"result":result})).into_response()
+        }
+    }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let mcp_port = listener.local_addr().unwrap().port();
+    let mcp = tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    let root = tempfile::tempdir().unwrap();
+    let config = format!(
+        r#"
+memory_dir = "{}"
+[agent]
+name = "approval-test"
+system_prompt = "unused"
+[agent.llm]
+provider = "openai"
+api_key = "unused-test-key"
+model = "unused-test-model"
+[mcp.servers.test]
+transport = "http_streamable"
+url = "http://127.0.0.1:{mcp_port}/mcp"
+[hitl]
+require_approval = ["mutate"]
+[hitl.route]
+mode = "conversational"
+timeout_secs = 30
+[hitl.park]
+enabled = true
+[orchestration]
+enabled = true
+[orchestration.worker.action]
+description = "test"
+preamble = "test"
+mcp_filter = ["mutate", "probe", "notify"]
+[[orchestration.stages]]
+id = "act"
+worker = "action"
+output_schema = {{ type = "object", required = ["applied"] }}
+operation = {{ kind = "tool", tool = "mutate", arguments = {{}} }}
+on_approval_wait = [{{after_secs=0, worker="action", tool="notify", arguments={{}}, inputs={{payload="/run"}}}}]
+[[orchestration.stages]]
+id = "verify"
+worker = "action"
+output_schema = {{ type = "object", required = ["healthy"] }}
+operation = {{ kind = "verify", tool = "probe", arguments = {{}}, read_only = true, success_schema = {{ required = ["healthy"], properties = {{ healthy = {{ const = true }} }} }}, interval_secs = 1, timeout_secs = 10 }}
+"#,
+        root.path().join("runs").display()
+    );
+    std::fs::write(root.path().join("config.toml"), config).unwrap();
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let _server = start(root.path(), port).await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+    let started = send(
+        &client,
+        &base,
+        json!({"messageId":"approval-start", "role":"ROLE_USER", "parts":[{"text":"input"}]}),
+    )
+    .await;
+    let id = started["id"].as_str().unwrap();
+    let decision = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let current = task(&client, &base, id).await;
+            assert_ne!(
+                current.pointer("/status/state"),
+                Some(&json!("TASK_STATE_FAILED")),
+                "{current}"
+            );
+            if let Some(run) = current["artifacts"]
+                .as_array()
+                .and_then(|a| a.iter().find(|a| a["artifactId"] == "workflow"))
+                .and_then(|a| a.pointer("/parts/0/data"))
+                && let Some(decision) = run
+                    .pointer("/state/checkpoint/plan/tasks/0/pending/0/decision_id")
+                    .and_then(Value::as_str)
+            {
+                break decision.to_string();
+            }
+            tokio::time::sleep(Duration::from_millis(30)).await;
+        }
+    })
+    .await
+    .expect("action did not park");
+    assert_eq!(mutations.load(Ordering::SeqCst), 0);
+    client
+        .post(format!("{base}/v1/approvals/{decision}"))
+        .json(&json!({"approved":true}))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let current = task(&client, &base, id).await;
+            assert_ne!(
+                current.pointer("/status/state"),
+                Some(&json!("TASK_STATE_FAILED")),
+                "{current}"
+            );
+            if current.pointer("/status/state") == Some(&json!("TASK_STATE_COMPLETED")) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("approved action did not finish");
+    assert_eq!(mutations.load(Ordering::SeqCst), 1);
+    assert_eq!(notifications.load(Ordering::SeqCst), 1);
+    mcp.abort();
+}

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -1109,7 +1109,8 @@ impl Agent {
 
         // Add submit_result tool when orchestration submit decision is available
         if let Some(ref decision) = config.orchestration_submit_result {
-            let submit_tool = crate::orchestration::SubmitResultTool::new(decision.clone());
+            let submit_tool = crate::orchestration::SubmitResultTool::new(decision.clone())
+                .with_schema(config.orchestration_output_schema.clone())?;
             builder_state = builder_state.add_tool(submit_tool);
         }
 

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -83,6 +83,9 @@ pub struct AgentRuntimeConfig {
     pub memory_dir: Option<String>,
     /// Orchestration mode configuration (multi-agent workflows)
     pub orchestration: Option<OrchestrationConfig>,
+    /// Authenticated transport-level workflow operation.
+    pub workflow_target_fingerprint: Option<String>,
+    pub workflow_request: Option<crate::orchestration::workflow::WorkflowRequest>,
 
     /// Discovered per-worker skill overrides keyed by worker name. Populated
     /// by `RigBuilder` at build time because skill discovery does filesystem
@@ -129,6 +132,8 @@ pub struct AgentRuntimeConfig {
 
     /// Shared decision state for worker `submit_result` tool.
     /// When set, workers get the `submit_result` tool for structured output.
+    /// JSON Schema for a configured stage's submit_result payload.
+    pub orchestration_output_schema: Option<serde_json::Value>,
     pub orchestration_submit_result: Option<crate::orchestration::SubmitResultDecision>,
 
     /// Resolved HITL approval runtime (compiled globs + decision route), built
@@ -166,6 +171,8 @@ impl Clone for AgentRuntimeConfig {
             tools: self.tools.clone(),
             memory_dir: self.memory_dir.clone(),
             orchestration: self.orchestration.clone(),
+            workflow_request: self.workflow_request.clone(),
+            workflow_target_fingerprint: self.workflow_target_fingerprint.clone(),
             worker_skills: self.worker_skills.clone(),
             // Arc fields clone the Arc (shared reference)
             tool_wrapper: self.tool_wrapper.clone(),
@@ -177,6 +184,7 @@ impl Clone for AgentRuntimeConfig {
             scratchpad_tools_config: self.scratchpad_tools_config.clone(),
             turn_nudge: self.turn_nudge.clone(),
             orchestration_submit_result: self.orchestration_submit_result.clone(),
+            orchestration_output_schema: self.orchestration_output_schema.clone(),
             hitl: self.hitl.clone(),
             request_id: self.request_id.clone(),
             instance_id: self.instance_id.clone(),

--- a/crates/aura/src/orchestration/events.rs
+++ b/crates/aura/src/orchestration/events.rs
@@ -45,6 +45,8 @@ impl RoutingMode {
 /// to SSE events (`OrchestrationStreamEvent`) by the web server handlers.
 #[derive(Debug, Clone)]
 pub enum OrchestratorEvent {
+    /// Snapshot published only after the workflow record reaches durable storage.
+    WorkflowUpdated { run: serde_json::Value },
     /// A plan has been created from the user's query.
     PlanCreated {
         /// The goal being addressed

--- a/crates/aura/src/orchestration/factory.rs
+++ b/crates/aura/src/orchestration/factory.rs
@@ -73,6 +73,8 @@ impl OrchestratorFactory {
                 // are visible to the streaming handler (UsageState is Arc-backed).
                 orchestrator.usage_state = usage_state;
                 orchestrator.outer_budget = outer_budget;
+                orchestrator.workflow_cancel = cancel_token_clone.clone();
+                let configured_workflow = orchestrator.has_configured_workflow();
 
                 // Set MCP request ID for progress notification routing, and
                 // surface per-server connection status so degraded/unavailable
@@ -117,7 +119,7 @@ impl OrchestratorFactory {
                             }
                         }
                     }
-                    _ = cancel_token_clone.cancelled() => {
+                    _ = cancel_token_clone.cancelled(), if !configured_workflow => {
                         tracing::info!("Orchestration cancelled");
                         if let Some(ref mcp_manager) = orchestrator.mcp_manager {
                             let cancelled = mcp_manager

--- a/crates/aura/src/orchestration/mod.rs
+++ b/crates/aura/src/orchestration/mod.rs
@@ -59,6 +59,7 @@ mod templates;
 mod test_rig;
 pub mod tools;
 mod types;
+pub mod workflow;
 
 pub use config::{
     ArtifactsConfig, OrchestrationConfig, TimeoutsConfig, ToolVisibility, WorkerConfig,

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -41,6 +41,9 @@
 //! - `IterationComplete` - when the post-execute coordinator decision completes
 //! - `Synthesizing` - when task results are being consolidated for the coordinator
 
+#[path = "workflow_driver.rs"]
+mod workflow_driver;
+
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -388,6 +391,7 @@ pub(super) fn spawn_tool_event_forwarder(
 /// Created lazily by `OrchestratorFactory::stream()` to coordinate multiple
 /// agents through a plan-execute-continue loop.
 pub struct Orchestrator {
+    pub(super) workflow_cancel: CancellationToken,
     /// ID for the orchestrator
     orchestrator_id: String,
 
@@ -528,6 +532,10 @@ enum LoopStep {
 }
 
 impl Orchestrator {
+    pub(super) fn has_configured_workflow(&self) -> bool {
+        !self.config.stages.is_empty()
+    }
+
     /// Create a new orchestrator from configuration.
     pub async fn new(
         agent_config: AgentRuntimeConfig,
@@ -535,7 +543,20 @@ impl Orchestrator {
         let orchestration_config = agent_config.orchestration.clone().unwrap_or_default();
 
         // Initialize MCP manager (shared across coordinator and all workers via Arc)
-        let mcp_manager = if let Some(ref mcp_config) = agent_config.mcp {
+        let controls_only = agent_config
+            .workflow_request
+            .as_ref()
+            .is_some_and(|request| {
+                matches!(
+                    request.command,
+                    super::workflow::WorkflowCommand::Inspect
+                        | super::workflow::WorkflowCommand::Takeover
+                        | super::workflow::WorkflowCommand::Cancel
+                )
+            });
+        let mcp_manager = if let Some(ref mcp_config) = agent_config.mcp
+            && !controls_only
+        {
             tracing::info!("Orchestrator: initializing MCP connections");
             Some(Arc::new(
                 McpManager::initialize_from_config(mcp_config).await?,
@@ -555,11 +576,22 @@ impl Orchestrator {
                 "Orchestrator: Initializing execution persistence at: {}",
                 memory_dir
             );
-            let p = ExecutionPersistence::new(memory_dir, agent_config.session_id.clone())
-                .await
-                .map_err(|e| format!("Failed to initialize persistence: {}", e))?;
-            p.prune_session_runs(orchestration_config.max_session_runs())
-                .await;
+            let run_id = agent_config
+                .workflow_request
+                .as_ref()
+                .map(|r| r.run_id)
+                .unwrap_or_else(uuid::Uuid::now_v7);
+            let p = ExecutionPersistence::with_run_id(
+                memory_dir,
+                agent_config.session_id.clone(),
+                run_id,
+            )
+            .await
+            .map_err(|e| format!("Failed to initialize persistence: {}", e))?;
+            if orchestration_config.stages.is_empty() {
+                p.prune_session_runs(orchestration_config.max_session_runs())
+                    .await;
+            }
             Arc::new(Mutex::new(p))
         } else {
             tracing::info!("Orchestrator: Persistence disabled (no memory_dir configured)");
@@ -599,6 +631,7 @@ impl Orchestrator {
         );
 
         Ok(Self {
+            workflow_cancel: CancellationToken::new(),
             orchestrator_id,
             config: orchestration_config,
             agent_config,
@@ -632,6 +665,7 @@ impl Orchestrator {
         worker_name: Option<&str>,
         park_cell: Option<&Arc<BlockedCell>>,
         recorded: Option<&Arc<RecordedDecisions>>,
+        exact_call: bool,
     ) -> Result<AgentWithPreamble, Box<dyn std::error::Error + Send + Sync>> {
         use super::duplicate_call_guard::DuplicateCallGuard;
         use super::observer_wrapper::ObserverWrapper;
@@ -694,9 +728,17 @@ impl Orchestrator {
         // Per-worker scratchpad override falls back to [agent.scratchpad].
         // Each worker gets a FRESH ContextBudget scoped to its effective LLM —
         // workers never share a budget.
+        let deterministic_stage = exact_call
+            || self.config.stages.get(task_id).is_some_and(|stage| {
+                !matches!(
+                    stage.operation,
+                    aura_config::workflow::StageOperation::Worker { .. }
+                )
+            });
         let effective_scratchpad = worker_cfg
             .and_then(|w| w.scratchpad.as_ref())
             .or(self.agent_config.agent.scratchpad.as_ref())
+            .filter(|_| !deterministic_stage)
             .cloned();
 
         let mut scratchpad_tools = Vec::<Arc<dyn ToolWrapper>>::new();
@@ -816,11 +858,15 @@ impl Orchestrator {
             tracing::info!("Worker {} turn_depth={}", task_id, resolved_depth);
         }
 
-        let turn_nudge = crate::turn_nudge::TurnNudgeState::new_with_submit_tool(
-            worker_config.agent.nudge_last_turn,
-            worker_config.agent.nudge_turns_remaining,
-            resolved_depth,
-        );
+        let turn_nudge = if deterministic_stage {
+            None
+        } else {
+            crate::turn_nudge::TurnNudgeState::new_with_submit_tool(
+                worker_config.agent.nudge_last_turn,
+                worker_config.agent.nudge_turns_remaining,
+                resolved_depth,
+            )
+        };
 
         // ComposedWrapper applies transform_output in reverse-list order, so
         // the LAST entry runs FIRST on the raw tool output. Persistence must
@@ -981,6 +1027,11 @@ impl Orchestrator {
         // Give workers the submit_result tool for structured output
         let submit_result_decision: super::tools::SubmitResultDecision = Arc::new(Mutex::new(None));
         worker_config.orchestration_submit_result = Some(submit_result_decision.clone());
+        worker_config.orchestration_output_schema = self
+            .config
+            .stages
+            .get(task_id)
+            .map(|stage| stage.output_schema.clone());
 
         // Disable orchestration in worker config to avoid nested orchestration
         worker_config.orchestration = None;
@@ -2909,6 +2960,11 @@ Assign tasks to the worker whose tools best match the required operations."#,
 
         // Box<dyn ToolDyn> is not Clone, so each provider arm constructs its own instance.
         let wait_for_tools = || -> Vec<Box<dyn rig::tool::ToolDyn>> {
+            // Configured workflows poll through validated verification stages.
+            // The legacy wait_for dispatcher does not apply worker wrappers.
+            if !self.config.stages.is_empty() {
+                return Vec::new();
+            }
             shared_mcp
                 .as_ref()
                 .map(|mcp| {
@@ -3647,6 +3703,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     *worker_name,
                     park.as_ref().map(|p| &p.cell),
                     None,
+                    false,
                 )
                 .await?;
 
@@ -3951,6 +4008,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                 worker_name,
                 Some(&park.cell),
                 Some(&resume.recorded),
+                false,
             )
             .await?;
 
@@ -4376,6 +4434,9 @@ Assign tasks to the worker whose tools best match the required operations."#,
         chat_history: Vec<rig::completion::Message>,
         event_tx: tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>,
     ) -> Result<String, StreamError> {
+        if !self.config.stages.is_empty() {
+            return self.run_workflow(query, &event_tx).await;
+        }
         let span = tracing::Span::current();
         let (goal_preview, _) = safe_truncate(query, 200);
         span.record("orchestration.goal", goal_preview);
@@ -8072,7 +8133,8 @@ mod tests {
     /// Serializes the override-using tests: the override queue is
     /// process-global, and two parallel installs could cross-consume each
     /// other's scripted workers. Async-aware so the guard may cross awaits.
-    static WORKER_OVERRIDE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    pub(super) static WORKER_OVERRIDE_LOCK: tokio::sync::Mutex<()> =
+        tokio::sync::Mutex::const_new(());
 
     /// A park-mode orchestrator whose `operations` worker is built through
     /// the override seam: the gate glob matches the stub tool, and the

--- a/crates/aura/src/orchestration/park/continuation.rs
+++ b/crates/aura/src/orchestration/park/continuation.rs
@@ -118,6 +118,13 @@ pub(crate) struct ResumingDocumentHandle {
 }
 
 impl ResumingDocumentHandle {
+    pub(crate) fn from_document(document: ParkedRun, publish_path: PathBuf) -> Self {
+        Self {
+            document: tokio::sync::Mutex::new(document),
+            publish_path,
+        }
+    }
+
     /// Load the parked document at `path` and arm the handle. Appends publish
     /// to the sibling `{run_id}.resuming.json`; the parked document itself is
     /// left untouched.

--- a/crates/aura/src/orchestration/park/mod.rs
+++ b/crates/aura/src/orchestration/park/mod.rs
@@ -7,7 +7,9 @@ mod document;
 mod guard;
 mod recorded_decisions;
 
-pub(crate) use commit::{ParkCommitInputs, cancel_run_approvals, commit_from_run_state};
+pub(crate) use commit::{
+    ParkCommitInputs, cancel_run_approvals, commit_from_run_state, config_fingerprint,
+};
 // The rehydrate entry points: consumed by commit 3's tests; the P45 resume
 // endpoint consumes them in production.
 #[allow(unused_imports)]
@@ -17,7 +19,8 @@ pub(crate) use continuation::{
 };
 #[allow(unused_imports)]
 pub(crate) use document::{
-    PARKED_DOCUMENT_SUFFIX, ParkedRun, RESUMING_DOCUMENT_SUFFIX, RunStateForPark, load_parked_run,
+    PARKED_DOCUMENT_SUFFIX, ParkedPlan, ParkedRun, ParkedTaskNode, RESUMING_DOCUMENT_SUFFIX,
+    RunStateForPark, load_parked_run,
 };
 pub(crate) use guard::ParkGuard;
 pub(crate) use recorded_decisions::{CallKey, RecordedDecisions};

--- a/crates/aura/src/orchestration/persistence.rs
+++ b/crates/aura/src/orchestration/persistence.rs
@@ -286,6 +286,14 @@ impl ExecutionPersistence {
     /// `{base_path}/{session_id}/{run_id}/...`, grouping runs by session.
     /// Without a session_id, the flat `{base_path}/{run_id}/...` layout is used.
     pub async fn new<P: AsRef<Path>>(base_path: P, session_id: Option<String>) -> io::Result<Self> {
+        Self::with_run_id(base_path, session_id, uuid::Uuid::now_v7()).await
+    }
+
+    pub(crate) async fn with_run_id<P: AsRef<Path>>(
+        base_path: P,
+        session_id: Option<String>,
+        run_id: uuid::Uuid,
+    ) -> io::Result<Self> {
         let base_path = base_path.as_ref().to_path_buf();
 
         // Validate session_id to prevent path traversal
@@ -306,7 +314,7 @@ impl ExecutionPersistence {
         };
 
         // Generate unique run ID
-        let run_id = uuid::Uuid::now_v7().to_string();
+        let run_id = run_id.to_string();
         let run_path = effective_base.join(&run_id);
 
         fs::create_dir_all(&run_path).await?;

--- a/crates/aura/src/orchestration/stream_events.rs
+++ b/crates/aura/src/orchestration/stream_events.rs
@@ -88,6 +88,12 @@ pub mod event_names {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum OrchestrationStreamEvent {
+    /// Durable workflow snapshot; sequence numbers support replay through A2A.
+    WorkflowUpdated {
+        run: serde_json::Value,
+        #[serde(flatten)]
+        context: EventContext,
+    },
     /// Emitted when orchestrator creates a plan from user query.
     PlanCreated {
         goal: String,
@@ -220,6 +226,7 @@ impl OrchestrationStreamEvent {
     /// Get the SSE event name for this event type.
     pub fn event_name(&self) -> &'static str {
         match self {
+            Self::WorkflowUpdated { .. } => "aura.orchestrator.workflow_updated",
             Self::PlanCreated { .. } => event_names::PLAN_CREATED,
             Self::DirectAnswer { .. } => event_names::DIRECT_ANSWER,
             Self::ClarificationNeeded { .. } => event_names::CLARIFICATION_NEEDED,

--- a/crates/aura/src/orchestration/tools/submit_result.rs
+++ b/crates/aura/src/orchestration/tools/submit_result.rs
@@ -45,11 +45,26 @@ pub type SubmitResultDecision = Arc<Mutex<Option<SubmitResultOutput>>>;
 #[derive(Clone)]
 pub struct SubmitResultTool {
     decision: SubmitResultDecision,
+    schema: Option<serde_json::Value>,
 }
 
 impl SubmitResultTool {
+    pub fn with_schema(
+        mut self,
+        schema: Option<serde_json::Value>,
+    ) -> Result<Self, aura_config::ConfigError> {
+        if let Some(schema) = &schema {
+            aura_config::workflow::compile_schema(schema)?;
+        }
+        self.schema = schema;
+        Ok(self)
+    }
+
     pub fn new(decision: SubmitResultDecision) -> Self {
-        Self { decision }
+        Self {
+            decision,
+            schema: None,
+        }
     }
 }
 
@@ -58,8 +73,8 @@ pub struct SubmitResultArgs {
     /// Concise summary of findings (1-3 sentences). Shown to the coordinator
     /// and stored in session history.
     pub summary: String,
-    /// Complete findings and analysis.
-    pub result: String,
+    /// Complete findings; configured workflows submit a native JSON value.
+    pub result: serde_json::Value,
     /// Confidence in the result: "high", "medium", or "low".
     pub confidence: String,
 }
@@ -96,10 +111,10 @@ impl Tool for SubmitResultTool {
                         "type": "string",
                         "description": "Concise summary of findings (1-3 sentences). This becomes the preview shown to the coordinator and stored in session history."
                     },
-                    "result": {
+                    "result": self.schema.clone().unwrap_or_else(|| serde_json::json!({
                         "type": "string",
                         "description": "Complete findings and analysis."
-                    },
+                    })),
                     "confidence": {
                         "type": "string",
                         "enum": ["high", "medium", "low"],
@@ -112,7 +127,24 @@ impl Tool for SubmitResultTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        if let Some(schema) = &self.schema {
+            let validator = aura_config::workflow::compile_schema(schema)
+                .expect("schema checked during construction");
+            if let Err(error) = validator.validate(&args.result) {
+                return Ok(SubmitResultToolOutput {
+                    status: format!(
+                        "Invalid result at {}: {error}. Correct the result and submit again.",
+                        error.instance_path()
+                    ),
+                });
+            }
+        } else if !args.result.is_string() {
+            return Ok(SubmitResultToolOutput {
+                status: "Result must be a string.".into(),
+            });
+        }
         let mut guard = self.decision.lock().await;
+
         if guard.is_some() {
             tracing::warn!(
                 summary = %args.summary,
@@ -126,7 +158,7 @@ impl Tool for SubmitResultTool {
         tracing::info!(
             summary = %args.summary,
             confidence = %args.confidence,
-            result_len = args.result.len(),
+            result_len = args.result.to_string().len(),
             "submit_result called (first submission accepted)"
         );
 
@@ -139,7 +171,14 @@ impl Tool for SubmitResultTool {
 
         *guard = Some(SubmitResultOutput {
             summary: args.summary,
-            result: args.result,
+            result: if self.schema.is_some() {
+                args.result.to_string()
+            } else {
+                args.result
+                    .as_str()
+                    .expect("string checked above")
+                    .to_owned()
+            },
             confidence,
         });
 
@@ -162,7 +201,7 @@ mod tests {
         let result = tool
             .call(SubmitResultArgs {
                 summary: "Found 42 errors".to_string(),
-                result: "Full analysis...".to_string(),
+                result: "Full analysis...".into(),
                 confidence: "high".to_string(),
             })
             .await
@@ -184,7 +223,7 @@ mod tests {
 
         tool.call(SubmitResultArgs {
             summary: "First".to_string(),
-            result: "First result".to_string(),
+            result: "First result".into(),
             confidence: "high".to_string(),
         })
         .await
@@ -193,7 +232,7 @@ mod tests {
         let result = tool
             .call(SubmitResultArgs {
                 summary: "Second".to_string(),
-                result: "Second result".to_string(),
+                result: "Second result".into(),
                 confidence: "low".to_string(),
             })
             .await

--- a/crates/aura/src/orchestration/workflow.rs
+++ b/crates/aura/src/orchestration/workflow.rs
@@ -1,0 +1,291 @@
+//! Durable configured-run records and typed controls shared with A2A.
+//!
+//! Files contain workflow data and approval references, never credentials.
+//! An OS-held lock excludes concurrent writers; it is released after a crash.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use super::park::ParkedRun;
+
+/// Parsed from an A2A data part before any text reaches a model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowRequest {
+    pub run_id: uuid::Uuid,
+    pub command: WorkflowCommand,
+    pub message_id: String,
+}
+
+impl WorkflowRequest {
+    /// Stable start identity for retries of an A2A message in the same scope.
+    pub fn start(message_id: &str) -> Self {
+        let digest = Sha256::digest(message_id.as_bytes());
+        let mut bytes = [0; 16];
+        bytes.copy_from_slice(&digest[..16]);
+        Self {
+            run_id: uuid::Uuid::from_bytes(bytes),
+            command: WorkflowCommand::Start,
+            message_id: message_id.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowCommand {
+    Start,
+    Resume,
+    Inspect,
+    Takeover,
+    Cancel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub(crate) enum RunState {
+    Ready,
+    Running,
+    Received {
+        output: String,
+    },
+    AwaitingApproval {
+        checkpoint: Box<ParkedRun>,
+    },
+    Waiting {
+        wake_at: DateTime<Utc>,
+        deadline: Option<DateTime<Utc>>,
+    },
+    HumanOwned {
+        suspended: Box<RunState>,
+    },
+    Cancelled {
+        execution_uncertain: bool,
+    },
+    Failed {
+        reason: String,
+    },
+    Inconclusive,
+    Uncertain,
+    Completed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct RunEvent {
+    pub sequence: usize,
+    pub at: DateTime<Utc>,
+    pub stage: usize,
+    pub event: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct PendingNotification {
+    pub key: String,
+    pub suspended: Box<RunState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct RunRecord {
+    pub version: u32,
+    pub run_id: uuid::Uuid,
+    pub agent: String,
+    pub fingerprint: String,
+    pub input: Value,
+    pub stage: usize,
+    pub results: BTreeMap<String, Value>,
+    pub receipts: Vec<Value>,
+    pub notifications: Vec<String>,
+    pub pending_notification: Option<PendingNotification>,
+    pub state: RunState,
+    pub events: Vec<RunEvent>,
+    pub messages: BTreeMap<String, String>,
+    /// The verification deadline survives polling, approval and process restarts.
+    pub verification_deadline: Option<DateTime<Utc>>,
+}
+
+impl RunRecord {
+    pub(crate) fn transition(&mut self, state: RunState, event: &str) {
+        self.state = state;
+        self.events.push(RunEvent {
+            sequence: self.events.len() + 1,
+            at: Utc::now(),
+            stage: self.stage,
+            event: event.into(),
+        });
+    }
+}
+
+/// A run claim held for the lifetime of execution, including durable waits.
+/// Separate runs can proceed concurrently; the same run cannot execute twice.
+pub(crate) struct RunStore {
+    path: PathBuf,
+    _claim: Option<Arc<File>>,
+    writes: Arc<Mutex<u64>>,
+    next_write: AtomicU64,
+}
+
+impl RunStore {
+    pub(crate) fn reader(root: &str, scope: &str, run_id: uuid::Uuid) -> Self {
+        let scope = hex::encode(Sha256::digest(scope.as_bytes()));
+        Self {
+            path: Path::new(root)
+                .join("workflows")
+                .join(scope)
+                .join(format!("{run_id}.json")),
+            _claim: None,
+            writes: Arc::new(Mutex::new(0)),
+            next_write: AtomicU64::new(1),
+        }
+    }
+
+    pub(crate) async fn open(root: &str, scope: &str, run_id: uuid::Uuid) -> io::Result<Self> {
+        let scope = hex::encode(Sha256::digest(scope.as_bytes()));
+        let directory = Path::new(root).join("workflows").join(scope);
+        tokio::task::spawn_blocking(move || {
+            std::fs::create_dir_all(&directory)?;
+            let claim = File::options()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(directory.join(format!("{run_id}.lock")))?;
+            claim.try_lock().map_err(|error| match error {
+                std::fs::TryLockError::WouldBlock => io::Error::from(io::ErrorKind::WouldBlock),
+                std::fs::TryLockError::Error(error) => error,
+            })?;
+            Ok(Self {
+                path: directory.join(format!("{run_id}.json")),
+                _claim: Some(Arc::new(claim)),
+                writes: Arc::new(Mutex::new(0)),
+                next_write: AtomicU64::new(1),
+            })
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+
+    pub(crate) async fn load(&self) -> io::Result<Option<RunRecord>> {
+        match tokio::fs::read(&self.path).await {
+            Ok(bytes) => {
+                let record: RunRecord = serde_json::from_slice(&bytes).map_err(io::Error::other)?;
+                if record.version != 1 {
+                    return Err(io::Error::other("unsupported workflow record version"));
+                }
+                Ok(Some(record))
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(crate) async fn save(&self, record: &RunRecord) -> io::Result<()> {
+        if self._claim.is_none() {
+            return Err(io::Error::other("workflow write requires a claim"));
+        }
+        let bytes = serde_json::to_vec(record).map_err(io::Error::other)?;
+        let path = self.path.clone();
+        let claim = self._claim.clone();
+        let writes = Arc::clone(&self.writes);
+        let ticket = self.next_write.fetch_add(1, Ordering::Relaxed);
+        tokio::task::spawn_blocking(move || {
+            let _claim = claim;
+            let mut published = writes
+                .lock()
+                .map_err(|_| io::Error::other("workflow writer poisoned"))?;
+            if ticket < *published {
+                return Ok(());
+            }
+            *published = ticket;
+            let tmp = path.with_extension("tmp");
+            let mut file = File::create(&tmp)?;
+            file.write_all(&bytes)?;
+            file.sync_all()?;
+            std::fs::rename(tmp, &path)?;
+            File::open(
+                path.parent()
+                    .ok_or_else(|| io::Error::other("missing workflow directory"))?,
+            )?
+            .sync_all()
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+
+    pub(crate) fn resume_path(&self) -> PathBuf {
+        self.path.with_extension("resuming.json")
+    }
+}
+
+pub(crate) fn target_fingerprint(mcp: &Option<aura_config::McpConfig>) -> String {
+    hex::encode(Sha256::digest(
+        serde_json::to_value(mcp)
+            .expect("MCP config is serializable")
+            .to_string(),
+    ))
+}
+
+pub(crate) struct RunCancellation(pub(crate) crate::request_cancellation::RequestCancellation);
+impl Drop for RunCancellation {
+    fn drop(&mut self) {
+        crate::request_cancellation::RequestCancellation::unregister(&self.0.request_id);
+    }
+}
+
+impl RunState {
+    pub(crate) fn execution_uncertain(&self) -> bool {
+        match self {
+            Self::Running | Self::Uncertain => true,
+            Self::HumanOwned { suspended } => suspended.execution_uncertain(),
+            Self::Cancelled {
+                execution_uncertain,
+            } => *execution_uncertain,
+            _ => false,
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn claim_survives_reopen_and_excludes_a_second_writer() {
+        let root = tempfile::tempdir().unwrap();
+        let root = root.path().to_str().unwrap();
+        let id = uuid::Uuid::new_v4();
+        let store = RunStore::open(root, "session", id).await.unwrap();
+        assert!(RunStore::open(root, "session", id).await.is_err());
+        assert!(RunStore::open(root, "another session", id).await.is_ok());
+        let record = RunRecord {
+            version: 1,
+            run_id: id,
+            agent: "test".into(),
+            fingerprint: "config".into(),
+            input: Value::Null,
+            stage: 0,
+            results: BTreeMap::new(),
+            receipts: Vec::new(),
+            notifications: Vec::new(),
+            pending_notification: None,
+            state: RunState::Running,
+            events: Vec::new(),
+            messages: BTreeMap::new(),
+            verification_deadline: None,
+        };
+        store.save(&record).await.unwrap();
+        drop(store);
+        let reopened = RunStore::open(root, "session", id).await.unwrap();
+        assert!(matches!(
+            reopened.load().await.unwrap().unwrap().state,
+            RunState::Running
+        ));
+    }
+}

--- a/crates/aura/src/orchestration/workflow_driver.rs
+++ b/crates/aura/src/orchestration/workflow_driver.rs
@@ -1,0 +1,412 @@
+//! Configured execution uses the same worker registry and approval continuation
+//! as model-planned orchestration. No coordinator plans or rewrites these stages.
+
+use std::collections::BTreeMap;
+
+use aura_config::workflow::compile_schema;
+use chrono::Utc;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use super::Orchestrator;
+
+use crate::orchestration::park::{ParkedRun, config_fingerprint};
+
+use crate::orchestration::workflow::{RunRecord, RunState, RunStore, WorkflowCommand};
+use crate::provider_agent::{StreamError, StreamItem};
+
+#[path = "workflow_stages.rs"]
+mod stages;
+
+type Events = tokio::sync::mpsc::Sender<Result<StreamItem, StreamError>>;
+
+enum StageResult {
+    Complete(Value),
+    Parked(Box<ParkedRun>),
+    Inconclusive,
+}
+
+impl Orchestrator {
+    /// Apply a transport-level control without asking a model to interpret it.
+    pub async fn control_workflow(&self) -> Result<Value, StreamError> {
+        if self
+            .agent_config
+            .workflow_request
+            .as_ref()
+            .is_none_or(|r| r.command == WorkflowCommand::Start)
+        {
+            return Err("workflow control requires an explicit non-start command".into());
+        }
+        let (events, _receiver) = tokio::sync::mpsc::channel(1);
+        serde_json::from_str(&self.run_workflow("", &events).await?).map_err(Into::into)
+    }
+
+    pub(super) async fn run_workflow(
+        &self,
+        query: &str,
+        events: &Events,
+    ) -> Result<String, StreamError> {
+        self.config.validate_stages()?;
+        let root = self
+            .agent_config
+            .effective_memory_dir()
+            .ok_or("configured workflows require memory_dir")?;
+        let id = self.persistence.lock().await.run_id().parse()?;
+        let scope = json!([self.agent_config.agent.name, self.agent_config.session_id]).to_string();
+        let request = self.agent_config.workflow_request.as_ref();
+        let command = request.map(|r| r.command).unwrap_or(WorkflowCommand::Start);
+        let fingerprint = hex::encode(Sha256::digest(format!(
+            "{}:{}",
+            config_fingerprint(&self.agent_config),
+            serde_json::to_string(&json!([
+                self.config.stages,
+                self.agent_config
+                    .workflow_target_fingerprint
+                    .clone()
+                    .unwrap_or_else(|| crate::orchestration::workflow::target_fingerprint(
+                        &self.agent_config.mcp
+                    ))
+            ]))?
+        )));
+
+        if command == WorkflowCommand::Inspect {
+            let record = RunStore::reader(root, &scope, id)
+                .load()
+                .await?
+                .ok_or("workflow run not found")?;
+            return Ok(serde_json::to_string(&record)?);
+        }
+        let cancel_id = format!(
+            "workflow:{}:{id}",
+            hex::encode(Sha256::digest(format!("{root}:{scope}")))
+        );
+        if matches!(command, WorkflowCommand::Takeover | WorkflowCommand::Cancel) {
+            let existing = RunStore::reader(root, &scope, id)
+                .load()
+                .await?
+                .ok_or("workflow run not found")?;
+            if let Some(request) = request
+                && let Some(previous) = existing.messages.get(&request.message_id)
+            {
+                let digest = hex::encode(Sha256::digest(format!(
+                    "{}:{query}",
+                    serde_json::to_string(request)?
+                )));
+                if previous != &digest {
+                    return Err("message id reused with different workflow content".into());
+                }
+                return Ok(serde_json::to_string(&existing)?);
+            }
+            if command != WorkflowCommand::Cancel && existing.fingerprint != fingerprint {
+                return Err("workflow configuration changed".into());
+            }
+
+            crate::request_cancellation::RequestCancellation::cancel(
+                &cancel_id,
+                "workflow human control",
+            );
+        }
+        let store = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                match RunStore::open(root, &scope, id).await {
+                    Ok(store) => break Ok::<_, StreamError>(store),
+                    Err(error)
+                        if matches!(
+                            command,
+                            WorkflowCommand::Takeover | WorkflowCommand::Cancel
+                        ) && error.kind() == std::io::ErrorKind::WouldBlock =>
+                    {
+                        tokio::time::sleep(std::time::Duration::from_millis(20)).await
+                    }
+                    Err(error) => break Err(error.into()),
+                }
+            }
+        })
+        .await
+        .map_err(|_| "workflow is busy; control did not acquire execution ownership")??;
+        let cancellation = crate::orchestration::workflow::RunCancellation(
+            crate::request_cancellation::RequestCancellation::register(cancel_id),
+        );
+
+        let mut record = match store.load().await? {
+            Some(record) => record,
+            None if command == WorkflowCommand::Start => RunRecord {
+                version: 1,
+                run_id: id,
+                agent: self.agent_config.agent.name.clone(),
+                fingerprint: fingerprint.clone(),
+                input: serde_json::from_str(query).unwrap_or_else(|_| Value::String(query.into())),
+                stage: 0,
+                results: BTreeMap::new(),
+                receipts: Vec::new(),
+                notifications: Vec::new(),
+                pending_notification: None,
+                state: RunState::Ready,
+                events: Vec::new(),
+                messages: BTreeMap::new(),
+                verification_deadline: None,
+            },
+            None => return Err("workflow run not found in this agent/session".into()),
+        };
+        if command == WorkflowCommand::Inspect {
+            return Ok(serde_json::to_string(&record)?);
+        }
+        if let Some(request) = request {
+            let digest = hex::encode(Sha256::digest(format!(
+                "{}:{query}",
+                serde_json::to_string(request)?
+            )));
+            if let Some(previous) = record.messages.get(&request.message_id) {
+                if previous != &digest {
+                    return Err("message id reused with different workflow content".into());
+                }
+                return Ok(serde_json::to_string(&record)?);
+            }
+            record.messages.insert(request.message_id.clone(), digest);
+        }
+        if matches!(record.state, RunState::Running) {
+            record.transition(
+                RunState::Uncertain,
+                "execution interrupted; reconcile externally before starting a replacement run",
+            );
+            save_workflow(&record, &store, events).await?;
+        }
+        match command {
+            WorkflowCommand::Cancel => record.transition(
+                RunState::Cancelled {
+                    execution_uncertain: record.state.execution_uncertain(),
+                },
+                "cancelled by human",
+            ),
+            WorkflowCommand::Takeover if !matches!(record.state, RunState::HumanOwned { .. }) => {
+                record.transition(
+                    RunState::HumanOwned {
+                        suspended: Box::new(record.state.clone()),
+                    },
+                    "human takeover",
+                )
+            }
+            WorkflowCommand::Resume => {
+                if let RunState::HumanOwned { suspended } = &record.state {
+                    record.transition((**suspended).clone(), "human returned execution control");
+                }
+            }
+
+            _ => {}
+        }
+        if let Some(notification) = record.pending_notification.clone() {
+            match &record.state {
+                RunState::Received { output } => {
+                    if let Err(error) = decode_receipt(output) {
+                        record.pending_notification = None;
+                        record.transition(
+                            RunState::Failed {
+                                reason: error.to_string(),
+                            },
+                            "notification receipt failed",
+                        );
+                    } else {
+                        record.notifications.push(notification.key);
+                        record.pending_notification = None;
+                        record
+                            .transition(*notification.suspended, "notification receipt recovered");
+                    }
+                    save_workflow(&record, &store, events).await?;
+                }
+                RunState::AwaitingApproval { .. } => record.pending_notification = None,
+                _ => {}
+            }
+        }
+        if record.fingerprint != fingerprint && !matches!(command, WorkflowCommand::Cancel) {
+            return Err("workflow configuration changed; refusing to resume".into());
+        }
+        if matches!(
+            record.state,
+            RunState::Cancelled { .. }
+                | RunState::HumanOwned { .. }
+                | RunState::Uncertain
+                | RunState::Completed
+                | RunState::Failed { .. }
+                | RunState::Inconclusive
+        ) {
+            save_workflow(&record, &store, events).await?;
+            if matches!(record.state, RunState::Cancelled { .. })
+                && let Ok(registry) = self.workflow_registry()
+            {
+                registry
+                    .cancel_request(&format!("run:{}", record.run_id))
+                    .await;
+            }
+            return Ok(serde_json::to_string(&record)?);
+        }
+        if command == WorkflowCommand::Start && record.stage != 0 {
+            return Err("existing workflow requires resume".into());
+        }
+        self.validate_workflow_tools()?;
+        save_workflow(&record, &store, events).await?;
+        while let Some(stage) = self.config.stages.get(record.stage) {
+            let result = tokio::select! {
+                result = self.run_stage(stage, &mut record, &store, events) => result,
+                _ = self.workflow_cancel.cancelled() => {
+                    record.transition(RunState::Cancelled { execution_uncertain: record.state.execution_uncertain() }, "request cancelled");
+                    save_workflow(&record, &store, events).await?;
+                    return Ok(serde_json::to_string(&record)?);
+                }
+                _ = cancellation.0.token.cancelled() => {
+
+                    if matches!(record.state, RunState::Running) {
+                        record.transition(RunState::Uncertain, "interrupted invocation may have executed");
+                    }
+                    save_workflow(&record, &store, events).await?;
+                    return Ok(serde_json::to_string(&record)?);
+                }
+            };
+
+            match result {
+                Ok(StageResult::Complete(value)) => {
+                    if let Err(error) = compile_schema(&stage.output_schema)?.validate(&value) {
+                        record.transition(
+                            RunState::Failed {
+                                reason: format!("invalid stage handoff: {error}"),
+                            },
+                            "handoff rejected",
+                        );
+                        save_workflow(&record, &store, events).await?;
+                        break;
+                    }
+                    record.results.insert(stage.id.clone(), value);
+                    record.stage += 1;
+                    record.verification_deadline = None;
+                    record.transition(RunState::Ready, "stage completed");
+                }
+                Ok(StageResult::Parked(checkpoint)) => {
+                    if !matches!(record.state, RunState::AwaitingApproval { .. }) {
+                        record.transition(
+                            RunState::AwaitingApproval { checkpoint },
+                            "awaiting approval",
+                        );
+                        save_workflow(&record, &store, events).await?;
+                        if let Some(guard) = &self.park_guard {
+                            guard.mark_published();
+                        }
+                    }
+                    tokio::select! {
+                            result = self.workflow_notifications(stage, &mut record, &store) => result?,
+                            _ = self.workflow_cancel.cancelled() => {
+                        record.transition(RunState::Cancelled { execution_uncertain: record.state.execution_uncertain() }, "request cancelled");
+                        save_workflow(&record, &store, events).await?;
+                        return Ok(serde_json::to_string(&record)?);
+                    }
+                    _ = cancellation.0.token.cancelled() => {
+
+                                if matches!(record.state, RunState::Running) { record.transition(RunState::Uncertain, "notification interrupted"); }
+                                save_workflow(&record, &store, events).await?;
+                                return Ok(serde_json::to_string(&record)?);
+                            }
+                        }
+                    tokio::select! {
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {},
+                        _ = self.workflow_cancel.cancelled() => {
+                            record.transition(RunState::Cancelled { execution_uncertain: record.state.execution_uncertain() }, "request cancelled");
+                            save_workflow(&record, &store, events).await?;
+                            return Ok(serde_json::to_string(&record)?);
+                        },
+                        _ = cancellation.0.token.cancelled() => return Ok(serde_json::to_string(&record)?),
+                    }
+                    continue;
+                }
+                Ok(StageResult::Inconclusive) => {
+                    record.transition(
+                        RunState::Inconclusive,
+                        "verification deadline reached without recovery evidence",
+                    );
+                    save_workflow(&record, &store, events).await?;
+                    break;
+                }
+                Err(error) => {
+                    if matches!(record.state, RunState::Running) {
+                        record.transition(
+                            RunState::Uncertain,
+                            &format!("execution outcome uncertain: {error}"),
+                        );
+                    } else {
+                        record.transition(
+                            RunState::Failed {
+                                reason: error.to_string(),
+                            },
+                            "stage failed",
+                        );
+                    }
+
+                    save_workflow(&record, &store, events).await?;
+                    break;
+                }
+            }
+            save_workflow(&record, &store, events).await?;
+        }
+        if record.stage == self.config.stages.len() {
+            record.transition(RunState::Completed, "workflow completed");
+            save_workflow(&record, &store, events).await?;
+        }
+        Ok(serde_json::to_string(&record)?)
+    }
+}
+
+fn deadline(seconds: u64) -> Result<chrono::DateTime<Utc>, StreamError> {
+    let duration = chrono::Duration::seconds(i64::try_from(seconds)?);
+    Utc::now()
+        .checked_add_signed(duration)
+        .ok_or_else(|| "workflow deadline out of range".into())
+}
+
+fn merge_arguments(
+    arguments: &Value,
+    inputs: serde_json::Map<String, Value>,
+) -> Result<Value, StreamError> {
+    let mut arguments = arguments
+        .as_object()
+        .ok_or("tool arguments must be an object")?
+        .clone();
+    for (key, value) in inputs {
+        if arguments.insert(key.clone(), value).is_some() {
+            return Err(format!("input {key} overwrites a configured argument").into());
+        }
+    }
+    Ok(Value::Object(arguments))
+}
+
+fn decode_receipt(output: &str) -> Result<Value, StreamError> {
+    let value: Value = serde_json::from_str(output)?;
+    let value = if let Value::String(text) = value {
+        serde_json::from_str(&text).unwrap_or(Value::String(text))
+    } else {
+        value
+    };
+    if !matches!(
+        crate::tool_error_detection::detect_tool_error(
+            value.as_str().unwrap_or(&value.to_string())
+        ),
+        crate::tool_error_detection::ToolResultStatus::Success
+    ) {
+        return Err("MCP execution returned an error".into());
+    }
+    Ok(value)
+}
+
+async fn save_workflow(
+    record: &RunRecord,
+    store: &RunStore,
+    events: &Events,
+) -> Result<(), StreamError> {
+    store.save(record).await?;
+    let event = crate::orchestration::OrchestratorEvent::WorkflowUpdated {
+        run: serde_json::to_value(record)?,
+    };
+    // Durable state must never depend on an attached consumer draining a stream.
+    let _ = events.try_send(Ok(StreamItem::OrchestratorEvent(event)));
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "workflow_driver_tests.rs"]
+mod tests;

--- a/crates/aura/src/orchestration/workflow_driver.rs
+++ b/crates/aura/src/orchestration/workflow_driver.rs
@@ -59,7 +59,11 @@ impl Orchestrator {
             "{}:{}",
             config_fingerprint(&self.agent_config),
             serde_json::to_string(&json!([
-                self.config.stages,
+                self.config
+                    .stages
+                    .iter()
+                    .map(|stage| (&stage.id, stage))
+                    .collect::<Vec<_>>(),
                 self.agent_config
                     .workflow_target_fingerprint
                     .clone()

--- a/crates/aura/src/orchestration/workflow_driver_tests.rs
+++ b/crates/aura/src/orchestration/workflow_driver_tests.rs
@@ -1,0 +1,312 @@
+use super::*;
+use crate::config::AgentRuntimeConfig;
+use crate::orchestration::workflow::{WorkflowCommand, WorkflowRequest};
+use aura_config::workflow::WorkflowStage;
+
+fn config(root: &str, request: WorkflowRequest, stages: Value) -> AgentRuntimeConfig {
+    AgentRuntimeConfig {
+        memory_dir: Some(root.into()),
+        session_id: Some("test-session".into()),
+        workflow_request: Some(request),
+        orchestration: Some(serde_json::from_value(json!({
+            "enabled":true,
+            "worker":{"worker":{"description":"test", "preamble":"Submit the requested result", "mcp_filter":[], "turn_depth":8}},
+            "stages":stages
+        })).unwrap()),
+        ..Default::default()
+    }
+}
+
+fn wait_stages(seconds: u64) -> Value {
+    json!([{"id":"wait", "worker":"worker", "output_schema":{"type":"object", "required":["waited"]}, "operation":{"kind":"wait", "seconds":seconds}}])
+}
+
+async fn run(config: AgentRuntimeConfig, query: &str) -> RunRecord {
+    let orchestrator = Orchestrator::new(config).await.unwrap();
+    let (events, _rx) = tokio::sync::mpsc::channel(1024);
+    let result = orchestrator.run_workflow(query, &events).await.unwrap();
+    serde_json::from_str(&result).unwrap()
+}
+
+#[tokio::test]
+async fn completed_run_deduplicates_and_conflicting_message_is_rejected() {
+    let root = tempfile::tempdir().unwrap();
+    let request = WorkflowRequest::start("start");
+    let cfg = config(
+        root.path().to_str().unwrap(),
+        request.clone(),
+        wait_stages(0),
+    );
+    let first = run(cfg.clone(), "original").await;
+    assert!(matches!(first.state, RunState::Completed));
+    let replay = run(cfg.clone(), "original").await;
+    assert_eq!(first.events.len(), replay.events.len());
+    let orchestrator = Orchestrator::new(cfg).await.unwrap();
+    let (events, _rx) = tokio::sync::mpsc::channel(16);
+    assert!(
+        orchestrator
+            .run_workflow("changed", &events)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("reused")
+    );
+}
+
+#[tokio::test]
+async fn inspection_and_takeover_work_during_a_durable_wait() {
+    let root = tempfile::tempdir().unwrap();
+    let request = WorkflowRequest::start("start");
+    let cfg = config(
+        root.path().to_str().unwrap(),
+        request.clone(),
+        wait_stages(60),
+    );
+    let active = tokio::spawn(run(cfg.clone(), "input"));
+    let scope = json!([cfg.agent.name, cfg.session_id]).to_string();
+    let reader = RunStore::reader(root.path().to_str().unwrap(), &scope, request.run_id);
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if reader
+                .load()
+                .await
+                .unwrap()
+                .is_some_and(|r| matches!(r.state, RunState::Waiting { .. }))
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+    let mut inspect = cfg.clone();
+    inspect.workflow_request = Some(WorkflowRequest {
+        command: WorkflowCommand::Inspect,
+        message_id: "inspect".into(),
+        ..request.clone()
+    });
+    assert!(matches!(
+        run(inspect, "").await.state,
+        RunState::Waiting { .. }
+    ));
+    let mut takeover = cfg;
+    takeover.workflow_request = Some(WorkflowRequest {
+        command: WorkflowCommand::Takeover,
+        message_id: "takeover".into(),
+        ..request
+    });
+    let result = tokio::time::timeout(std::time::Duration::from_secs(5), run(takeover, ""))
+        .await
+        .unwrap();
+    assert!(
+        matches!(result.state, RunState::HumanOwned { suspended } if matches!(*suspended, RunState::Waiting { .. }))
+    );
+    active.await.unwrap();
+}
+
+#[tokio::test]
+async fn restart_does_not_replay_an_interrupted_invocation() {
+    let root = tempfile::tempdir().unwrap();
+    let request = WorkflowRequest::start("start");
+    let cfg = config(
+        root.path().to_str().unwrap(),
+        request.clone(),
+        wait_stages(0),
+    );
+    let mut record = run(cfg.clone(), "input").await;
+    record.stage = 0;
+    record.transition(RunState::Running, "simulated crash after dispatch");
+    let scope = json!([cfg.agent.name, cfg.session_id]).to_string();
+    let store = RunStore::open(root.path().to_str().unwrap(), &scope, request.run_id)
+        .await
+        .unwrap();
+    store.save(&record).await.unwrap();
+    drop(store);
+    let mut resume = cfg;
+    resume.workflow_request = Some(WorkflowRequest {
+        command: WorkflowCommand::Resume,
+        message_id: "resume".into(),
+        ..request
+    });
+    let recovered = run(resume, "").await;
+    assert!(matches!(recovered.state, RunState::Uncertain));
+    assert_eq!(recovered.stage, 0);
+}
+
+#[tokio::test]
+async fn schema_corrected_worker_handoff_drives_the_next_configured_stage() {
+    use crate::orchestration::test_rig::{
+        self, ScriptedCompletionModel, ScriptedToolCall, ScriptedTurn, WorkerOverride,
+    };
+    let _guard = super::super::tests::WORKER_OVERRIDE_LOCK.lock().await;
+    let root = tempfile::tempdir().unwrap();
+    let cfg = config(
+        root.path().to_str().unwrap(),
+        WorkflowRequest::start("workers"),
+        json!([
+            {"id":"investigate", "worker":"worker", "output_schema":{"type":"object", "required":["count"],"properties":{"count":{"type":"integer"}}}, "operation":{"kind":"worker", "prompt":"Find count"}},
+            {"id":"decide", "worker":"worker", "inputs":{"evidence":"/stages/investigate"}, "output_schema":{"type":"object", "required":["action"]}, "operation":{"kind":"worker", "prompt":"Choose action"}}
+        ]),
+    );
+    let submission = |id: &str, result: Value| {
+        ScriptedTurn::tool_calls(vec![ScriptedToolCall::new(
+            id,
+            "submit_result",
+            json!({"summary":"test", "result":result, "confidence":"high"}),
+        )])
+    };
+    test_rig::install_worker_overrides(vec![
+        WorkerOverride {
+            model: ScriptedCompletionModel::new(vec![
+                submission("bad", json!({"count":"wrong"})),
+                submission("good", json!({"count":2})),
+                ScriptedTurn::text("done"),
+            ]),
+            extra_tools: vec![],
+        },
+        WorkerOverride {
+            model: ScriptedCompletionModel::new(vec![
+                submission("decision", json!({"action":"inspect"})),
+                ScriptedTurn::text("done"),
+            ]),
+            extra_tools: vec![],
+        },
+    ]);
+    let result = run(cfg, "input").await;
+    assert!(matches!(result.state, RunState::Completed));
+    assert_eq!(result.results["investigate"]["count"], 2);
+    assert_eq!(result.results["decide"]["action"], "inspect");
+}
+
+#[test]
+fn decoded_errors_and_uncertainty_are_preserved() {
+    assert!(
+        decode_receipt(&serde_json::to_string("Tool returned an error: unavailable").unwrap())
+            .is_err()
+    );
+    let state = RunState::HumanOwned {
+        suspended: Box::new(RunState::Cancelled {
+            execution_uncertain: true,
+        }),
+    };
+    assert!(state.execution_uncertain());
+}
+
+#[tokio::test]
+async fn worker_receipt_recovery_preserves_json_looking_strings() {
+    let root = tempfile::tempdir().unwrap();
+    let cfg = config(
+        root.path().to_str().unwrap(),
+        WorkflowRequest::start("strings"),
+        wait_stages(0),
+    );
+    let mut record = run(cfg.clone(), "input").await;
+    record.stage = 0;
+    let orchestrator = Orchestrator::new(cfg.clone()).await.unwrap();
+    let scope = json!([cfg.agent.name, cfg.session_id]).to_string();
+    let store = RunStore::open(root.path().to_str().unwrap(), &scope, record.run_id)
+        .await
+        .unwrap();
+    let (events, _rx) = tokio::sync::mpsc::channel(16);
+    let stage: WorkflowStage = serde_json::from_value(json!({"id":"worker", "worker":"worker", "output_schema":{"type":"string"}, "operation":{"kind":"worker", "prompt":"unused"}})).unwrap();
+    for text in ["42", "{}", "null"] {
+        record.state = RunState::Received {
+            output: serde_json::to_string(text).unwrap(),
+        };
+        let StageResult::Complete(value) = orchestrator
+            .run_stage(&stage, &mut record, &store, &events)
+            .await
+            .unwrap()
+        else {
+            panic!("receipt did not complete");
+        };
+        assert_eq!(value, Value::String(text.into()));
+    }
+}
+
+#[tokio::test]
+async fn notification_receipt_restores_suspended_wait_without_resending() {
+    let root = tempfile::tempdir().unwrap();
+    let request = WorkflowRequest::start("notification");
+    let cfg = config(
+        root.path().to_str().unwrap(),
+        request.clone(),
+        wait_stages(0),
+    );
+    let mut record = run(cfg.clone(), "input").await;
+    record.stage = 0;
+    record.pending_notification = Some(crate::orchestration::workflow::PendingNotification {
+        key: "0:0".into(),
+        suspended: Box::new(RunState::Waiting {
+            wake_at: Utc::now(),
+            deadline: None,
+        }),
+    });
+    record.state = RunState::Received {
+        output: json!({"delivered":true}).to_string(),
+    };
+    let scope = json!([cfg.agent.name, cfg.session_id]).to_string();
+    let store = RunStore::open(root.path().to_str().unwrap(), &scope, record.run_id)
+        .await
+        .unwrap();
+    store.save(&record).await.unwrap();
+    drop(store);
+    let mut resume = cfg;
+    resume.workflow_request = Some(WorkflowRequest {
+        command: WorkflowCommand::Resume,
+        message_id: "recover".into(),
+        ..request
+    });
+    for (index, state, command, expected) in [
+        (
+            0,
+            record.state.clone(),
+            WorkflowCommand::Resume,
+            "completed",
+        ),
+        (
+            1,
+            RunState::HumanOwned {
+                suspended: Box::new(record.state.clone()),
+            },
+            WorkflowCommand::Resume,
+            "completed",
+        ),
+        (
+            2,
+            RunState::Received {
+                output: json!("Tool returned an error: delivery failed").to_string(),
+            },
+            WorkflowCommand::Cancel,
+            "cancelled",
+        ),
+        (
+            3,
+            RunState::Received {
+                output: json!("Tool returned an error: delivery failed").to_string(),
+            },
+            WorkflowCommand::Resume,
+            "failed",
+        ),
+    ] {
+        record.state = state;
+        let store = RunStore::open(root.path().to_str().unwrap(), &scope, record.run_id)
+            .await
+            .unwrap();
+        store.save(&record).await.unwrap();
+        drop(store);
+        let mut cfg = resume.clone();
+        cfg.workflow_request.as_mut().unwrap().command = command;
+        cfg.workflow_request.as_mut().unwrap().message_id = format!("recover-{index}");
+        let recovered = run(cfg, "").await;
+        assert_eq!(
+            serde_json::to_value(&recovered.state).unwrap()["state"],
+            expected
+        );
+        if expected == "completed" {
+            assert_eq!(recovered.notifications, ["0:0"]);
+            assert!(recovered.pending_notification.is_none());
+        }
+    }
+}

--- a/crates/aura/src/orchestration/workflow_driver_tests.rs
+++ b/crates/aura/src/orchestration/workflow_driver_tests.rs
@@ -4,6 +4,18 @@ use crate::orchestration::workflow::{WorkflowCommand, WorkflowRequest};
 use aura_config::workflow::WorkflowStage;
 
 fn config(root: &str, request: WorkflowRequest, stages: Value) -> AgentRuntimeConfig {
+    let mut order = Vec::new();
+    let stages: serde_json::Map<String, Value> = stages
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|stage| {
+            let mut stage = stage.as_object().unwrap().clone();
+            let id = stage.remove("id").unwrap().as_str().unwrap().to_owned();
+            order.push(id.clone());
+            (id, Value::Object(stage))
+        })
+        .collect();
     AgentRuntimeConfig {
         memory_dir: Some(root.into()),
         session_id: Some("test-session".into()),
@@ -11,7 +23,7 @@ fn config(root: &str, request: WorkflowRequest, stages: Value) -> AgentRuntimeCo
         orchestration: Some(serde_json::from_value(json!({
             "enabled":true,
             "worker":{"worker":{"description":"test", "preamble":"Submit the requested result", "mcp_filter":[], "turn_depth":8}},
-            "stages":stages
+            "stage_order":order, "stages":stages
         })).unwrap()),
         ..Default::default()
     }
@@ -209,7 +221,8 @@ async fn worker_receipt_recovery_preserves_json_looking_strings() {
         .await
         .unwrap();
     let (events, _rx) = tokio::sync::mpsc::channel(16);
-    let stage: WorkflowStage = serde_json::from_value(json!({"id":"worker", "worker":"worker", "output_schema":{"type":"string"}, "operation":{"kind":"worker", "prompt":"unused"}})).unwrap();
+    let mut stage: WorkflowStage = serde_json::from_value(json!({ "worker":"worker", "output_schema":{"type":"string"}, "operation":{"kind":"worker", "prompt":"unused"}})).unwrap();
+    stage.id = "worker".into();
     for text in ["42", "{}", "null"] {
         record.state = RunState::Received {
             output: serde_json::to_string(text).unwrap(),

--- a/crates/aura/src/orchestration/workflow_stages.rs
+++ b/crates/aura/src/orchestration/workflow_stages.rs
@@ -1,0 +1,511 @@
+//! Stage dispatch, approval continuations, and verification through existing workers.
+
+use std::sync::Arc;
+
+use aura_config::workflow::{StageOperation, WorkflowStage, compile_schema};
+use chrono::Utc;
+use serde_json::{Value, json};
+
+use super::super::{Orchestrator, TaskExecutionParams, TaskOutcome};
+use crate::hitl::{ApprovalDecision, DecisionRoute, PendingApprovals};
+use crate::orchestration::park::{
+    ParkedPlan, ParkedRun, ParkedTaskNode, ResumeContext, ResumingDocumentHandle, TaskContinuation,
+    load_recorded_decisions,
+};
+use crate::orchestration::types::{BlockedCell, CellOutcome, PendingCall, TaskStatus};
+use crate::orchestration::workflow::{RunRecord, RunState, RunStore};
+use crate::provider_agent::StreamError;
+
+use super::{Events, StageResult, deadline, decode_receipt, merge_arguments, save_workflow};
+
+impl Orchestrator {
+    pub(super) fn validate_workflow_tools(&self) -> Result<(), StreamError> {
+        for stage in &self.config.stages {
+            match &stage.operation {
+                StageOperation::Tool { tool, .. } | StageOperation::Verify { tool, .. } => {
+                    self.check_workflow_tool(&stage.worker, tool)?
+                }
+                _ => {}
+            }
+            for notification in &stage.on_approval_wait {
+                self.check_workflow_tool(&notification.worker, &notification.tool)?;
+                if self.agent_config.hitl.as_ref().is_some_and(|hitl| {
+                    hitl.patterns
+                        .iter()
+                        .any(|pattern| pattern.matches(&notification.tool))
+                }) {
+                    return Err("approval notifications cannot themselves require approval".into());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn check_workflow_tool(&self, worker: &str, name: &str) -> Result<(), StreamError> {
+        let manager = self
+            .mcp_manager
+            .as_ref()
+            .ok_or("configured tool requires MCP")?;
+        if manager
+            .tool_definitions_iter()
+            .filter(|tool| tool.name == name)
+            .count()
+            != 1
+        {
+            return Err(format!("workflow tool must identify exactly one MCP tool: {name}").into());
+        }
+        let mut config = self.agent_config.clone();
+        if let Some(filter) = self
+            .config
+            .workers
+            .get(worker)
+            .and_then(|w| w.mcp_filter.clone())
+        {
+            config.mcp_filter = Some(filter);
+        }
+        if !config.tool_matches_filter(name) {
+            return Err(format!("worker {worker} cannot call {name}").into());
+        }
+        Ok(())
+    }
+
+    pub(super) async fn run_stage(
+        &self,
+        stage: &WorkflowStage,
+        record: &mut RunRecord,
+        store: &RunStore,
+        events: &Events,
+    ) -> Result<StageResult, StreamError> {
+        if let RunState::Received { output } = &record.state
+            && !matches!(stage.operation, StageOperation::Verify { .. })
+        {
+            return Ok(StageResult::Complete(
+                if matches!(stage.operation, StageOperation::Worker { .. }) {
+                    serde_json::from_str(output)?
+                } else {
+                    decode_receipt(output)?
+                },
+            ));
+        }
+        let source = json!({"input": record.input, "stages": record.results, "run": record});
+
+        let mut inputs = serde_json::Map::new();
+        for (key, pointer) in &stage.inputs {
+            inputs.insert(
+                key.clone(),
+                source
+                    .pointer(pointer)
+                    .ok_or_else(|| format!("missing input {pointer} for stage {}", stage.id))?
+                    .clone(),
+            );
+        }
+        let checkpoint = match &record.state {
+            RunState::AwaitingApproval { checkpoint } => Some(checkpoint.clone()),
+            _ => None,
+        };
+        let resume = if let Some(checkpoint) = &checkpoint {
+            let registry = self.workflow_registry()?;
+            let (recorded, _) = match load_recorded_decisions(registry, checkpoint).await {
+                Ok(value) => value,
+                Err(crate::orchestration::park::RehydrateError::Parked { .. }) => {
+                    return Ok(StageResult::Parked(checkpoint.clone()));
+                }
+                Err(error) => return Err(error.to_string().into()),
+            };
+            for node in &checkpoint.plan.tasks {
+                for call in node.pending.iter().flatten() {
+                    if matches!(
+                        registry.recorded_decision(&call.decision_id).await,
+                        Some(ApprovalDecision::Denied { .. })
+                    ) {
+                        return Err("human denied the proposed action".into());
+                    }
+                }
+            }
+            Some(ResumeContext {
+                recorded,
+                document: Arc::new(ResumingDocumentHandle::from_document(
+                    (**checkpoint).clone(),
+                    store.resume_path(),
+                )),
+            })
+        } else {
+            None
+        };
+        if let RunState::Waiting { wake_at, .. } = &record.state
+            && let Ok(delay) = (*wake_at - Utc::now()).to_std()
+        {
+            tokio::time::sleep(delay).await;
+        }
+        match &stage.operation {
+            StageOperation::Wait { seconds } => {
+                if !matches!(record.state, RunState::Waiting { .. }) {
+                    let wake_at = deadline(*seconds)?;
+                    record.transition(
+                        RunState::Waiting {
+                            wake_at,
+                            deadline: None,
+                        },
+                        "durable wait started",
+                    );
+                    save_workflow(record, store, events).await?;
+                    tokio::time::sleep(std::time::Duration::from_secs(*seconds)).await;
+                }
+                Ok(StageResult::Complete(json!({"waited": true})))
+            }
+            StageOperation::Worker { prompt } => {
+                let continuation = checkpoint
+                    .as_ref()
+                    .and_then(|doc| doc.plan.tasks.first())
+                    .map(|node| {
+                        Ok::<_, StreamError>(TaskContinuation {
+                            attempt: node.attempt.ok_or("missing worker attempt")?,
+                            history: node.history.clone().ok_or("missing worker history")?,
+                            current_prompt: node
+                                .current_prompt
+                                .clone()
+                                .ok_or("missing worker prompt")?,
+                            pending: node.pending.clone().ok_or("missing pending calls")?,
+                        })
+                    })
+                    .transpose()?;
+                record.transition(RunState::Running, "worker started");
+                save_workflow(record, store, events).await?;
+                let context = Some(Value::Object(inputs).to_string());
+                let params = TaskExecutionParams {
+                    task_description: prompt,
+                    task_context: &context,
+                    worker_name: Some(&stage.worker),
+                };
+                match self
+                    .execute_task(
+                        record.stage,
+                        &params,
+                        Some(events),
+                        continuation.as_ref(),
+                        resume.as_ref(),
+                    )
+                    .await?
+                {
+                    TaskOutcome::Completed(result) => {
+                        if result.structured_output.is_none() {
+                            return Err(
+                                "worker exhausted corrections without a validated submit_result"
+                                    .into(),
+                            );
+                        }
+                        let value = serde_json::from_str(&result.result)?;
+                        record.transition(
+                            RunState::Received {
+                                output: result.result,
+                            },
+                            "worker result recorded",
+                        );
+                        save_workflow(record, store, events).await?;
+                        Ok(StageResult::Complete(value))
+                    }
+                    TaskOutcome::Blocked {
+                        pending,
+                        attempt,
+                        snapshot,
+                    } => Ok(StageResult::Parked(Box::new(
+                        self.workflow_checkpoint(record, stage, pending, attempt, Some(snapshot))
+                            .await?,
+                    ))),
+                }
+            }
+            StageOperation::Tool { tool, arguments } => {
+                let arguments = merge_arguments(arguments, inputs)?;
+                self.workflow_call(record, store, stage, tool, &arguments, resume.as_ref())
+                    .await
+            }
+            StageOperation::Verify {
+                tool,
+                arguments,
+                success_schema,
+                failure_schema,
+                interval_secs,
+                timeout_secs,
+                ..
+            } => {
+                let arguments = merge_arguments(arguments, inputs)?;
+                let deadline_at = *record
+                    .verification_deadline
+                    .get_or_insert(deadline(*timeout_secs)?);
+                let success = compile_schema(success_schema)?;
+                let failure = failure_schema.as_ref().map(compile_schema).transpose()?;
+                let mut resume = resume;
+                loop {
+                    if Utc::now() >= deadline_at {
+                        return Ok(StageResult::Inconclusive);
+                    }
+                    let remaining = (deadline_at - Utc::now()).to_std()?;
+                    let sample = match tokio::time::timeout(
+                        remaining,
+                        self.workflow_call(record, store, stage, tool, &arguments, resume.as_ref()),
+                    )
+                    .await
+                    {
+                        Ok(result) => result?,
+                        Err(_) => return Ok(StageResult::Inconclusive),
+                    };
+                    resume = None;
+                    let StageResult::Complete(value) = sample else {
+                        return Ok(sample);
+                    };
+                    if success.is_valid(&value) {
+                        return Ok(StageResult::Complete(value));
+                    }
+                    if failure
+                        .as_ref()
+                        .is_some_and(|schema| schema.is_valid(&value))
+                    {
+                        return Err("verification observed the configured failure condition".into());
+                    }
+                    let wake_at = deadline(*interval_secs)?.min(deadline_at);
+                    record.transition(
+                        RunState::Waiting {
+                            wake_at,
+                            deadline: Some(deadline_at),
+                        },
+                        "verification pending",
+                    );
+                    save_workflow(record, store, events).await?;
+                    if let Ok(delay) = (wake_at - Utc::now()).to_std() {
+                        tokio::time::sleep(delay).await;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn workflow_call(
+        &self,
+        record: &mut RunRecord,
+        store: &RunStore,
+        stage: &WorkflowStage,
+        tool: &str,
+        arguments: &Value,
+        resume: Option<&ResumeContext>,
+    ) -> Result<StageResult, StreamError> {
+        if let RunState::Received { output } = &record.state {
+            return Ok(StageResult::Complete(decode_receipt(output)?));
+        }
+        // Only registered MCP names are accepted, not internal tools such as
+        // submit_result, wait_for, or request_approval.
+        let manager = self
+            .mcp_manager
+            .as_ref()
+            .ok_or("MCP tool stage requires MCP configuration")?;
+        if !manager
+            .get_available_tool_names()
+            .iter()
+            .any(|name| name == tool)
+        {
+            return Err(format!("unknown MCP tool {tool}").into());
+        }
+        let cell = Arc::new(BlockedCell::default());
+        cell.set_current_call_id(Some(format!("{}:{}", record.run_id, record.stage)));
+        let worker = self
+            .create_worker(
+                record.stage,
+                1,
+                Some(&stage.worker),
+                Some(&cell),
+                resume.map(|r| &r.recorded),
+                true,
+            )
+            .await?;
+        let _strict = resume.map(|r| r.recorded.strict_guard(record.stage));
+        record.transition(
+            RunState::Running,
+            "tool invocation started; missing receipt requires reconciliation",
+        );
+        store.save(record).await?;
+        let output = worker
+            .agent
+            .inner
+            .call_tool(tool, &arguments.to_string())
+            .await?;
+        match cell.outcome() {
+            CellOutcome::Blocked { pending } | CellOutcome::Orphaned { pending } => {
+                return Ok(StageResult::Parked(Box::new(
+                    self.workflow_checkpoint(record, stage, pending, 1, None)
+                        .await?,
+                )));
+            }
+            CellOutcome::Normal => {}
+        }
+        record.receipts.push(json!({"stage": record.stage, "tool": tool, "arguments": arguments, "output": output, "at": Utc::now()}));
+        record.transition(
+            RunState::Received {
+                output: output.clone(),
+            },
+            "tool receipt recorded",
+        );
+        store.save(record).await?;
+        let value: Value = serde_json::from_str(&output)?;
+
+        let value = if let Value::String(text) = value {
+            serde_json::from_str(&text).unwrap_or(Value::String(text))
+        } else {
+            value
+        };
+        if !matches!(
+            crate::tool_error_detection::detect_tool_error(
+                value.as_str().unwrap_or(&value.to_string())
+            ),
+            crate::tool_error_detection::ToolResultStatus::Success
+        ) {
+            return Err("MCP execution returned an error".into());
+        }
+        Ok(StageResult::Complete(value))
+    }
+
+    pub(super) async fn workflow_notifications(
+        &self,
+        stage: &WorkflowStage,
+        record: &mut RunRecord,
+        store: &RunStore,
+    ) -> Result<(), StreamError> {
+        let RunState::AwaitingApproval { checkpoint } = &record.state else {
+            return Ok(());
+        };
+        let parked_at =
+            chrono::DateTime::parse_from_rfc3339(&checkpoint.parked_at)?.with_timezone(&Utc);
+        for (index, notification) in stage.on_approval_wait.iter().enumerate() {
+            let key = format!("{}:{index}", record.stage);
+            if record.notifications.contains(&key)
+                || (Utc::now() - parked_at).num_seconds() < i64::try_from(notification.after_secs)?
+            {
+                continue;
+            }
+            if self.agent_config.hitl.as_ref().is_some_and(|hitl| {
+                hitl.patterns
+                    .iter()
+                    .any(|pattern| pattern.matches(&notification.tool))
+            }) {
+                return Err("approval notifications cannot themselves require approval".into());
+            }
+            let mut notification_stage = stage.clone();
+            notification_stage.worker = notification.worker.clone();
+            notification_stage.operation = StageOperation::Tool {
+                tool: notification.tool.clone(),
+                arguments: notification.arguments.clone(),
+            };
+            let suspended = record.state.clone();
+            let mut arguments = notification
+                .arguments
+                .as_object()
+                .ok_or("notification arguments must be an object")?
+                .clone();
+            let source = json!({"input": record.input, "stages": record.results, "run": record});
+            for (name, pointer) in &notification.inputs {
+                if arguments
+                    .insert(
+                        name.clone(),
+                        source
+                            .pointer(pointer)
+                            .ok_or("notification input missing")?
+                            .clone(),
+                    )
+                    .is_some()
+                {
+                    return Err("notification input overwrites an argument".into());
+                }
+            }
+            record.pending_notification =
+                Some(crate::orchestration::workflow::PendingNotification {
+                    key: key.clone(),
+                    suspended: Box::new(suspended.clone()),
+                });
+            store.save(record).await?;
+
+            match self
+                .workflow_call(
+                    record,
+                    store,
+                    &notification_stage,
+                    &notification.tool,
+                    &Value::Object(arguments),
+                    None,
+                )
+                .await?
+            {
+                StageResult::Complete(_) => {
+                    record.notifications.push(key);
+                    record.pending_notification = None;
+                    record.transition(suspended, "approval notification delivered");
+                    store.save(record).await?;
+                }
+                _ => return Err("approval notification did not complete".into()),
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn workflow_registry(&self) -> Result<&PendingApprovals, StreamError> {
+        match self.agent_config.hitl.as_ref().map(|h| &*h.route) {
+            Some(DecisionRoute::Conversational { registry, .. }) => Ok(registry),
+            _ => Err("durable workflow approvals require the conversational approval store".into()),
+        }
+    }
+
+    async fn workflow_checkpoint(
+        &self,
+        record: &RunRecord,
+        stage: &WorkflowStage,
+        pending: Vec<PendingCall>,
+        attempt: usize,
+        snapshot: Option<crate::orchestration::ParkSnapshot>,
+    ) -> Result<ParkedRun, StreamError> {
+        let registry = self.workflow_registry()?;
+        let mut expires = None;
+        for call in &pending {
+            let approval = registry
+                .try_parked(&call.decision_id)
+                .await?
+                .ok_or("parked approval missing from store")?;
+            expires = Some(
+                expires.map_or(approval.expires_at, |at: chrono::DateTime<Utc>| {
+                    at.min(approval.expires_at)
+                }),
+            );
+        }
+        Ok(ParkedRun {
+            schema_version: 1,
+            session_id: self.agent_config.session_id.clone(),
+            run_id: record.run_id.to_string(),
+            parked_at: Utc::now().to_rfc3339(),
+            expires_at: expires.ok_or("empty parked approval set")?.to_rfc3339(),
+            query: record.input.to_string(),
+            chat_history: Vec::new(),
+            coordinator_conversation: Vec::new(),
+            routing_decision: None,
+            iteration: 1,
+            planning_ms: 0,
+            failure_history: Vec::new(),
+            executed: Vec::new(),
+            config_fingerprint: record.fingerprint.clone(),
+            plan: ParkedPlan {
+                goal: record.input.to_string(),
+                steps: None,
+                tasks: vec![ParkedTaskNode {
+                    task_id: record.stage,
+                    description: stage.id.clone(),
+                    dependencies: Vec::new(),
+                    worker: Some(stage.worker.clone()),
+                    rationale: String::new(),
+                    status: TaskStatus::AwaitingApproval,
+                    result: None,
+                    error: None,
+                    failure_category: None,
+                    attempt: Some(attempt),
+                    pending: Some(pending),
+                    history: snapshot.as_ref().map(|s| s.history.clone()),
+                    current_prompt: snapshot.map(|s| s.current_prompt),
+                }],
+            },
+        })
+    }
+}

--- a/crates/aura/src/rig_builder.rs
+++ b/crates/aura/src/rig_builder.rs
@@ -18,14 +18,25 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 pub struct RigBuilder {
+    workflow_request: Option<crate::orchestration::workflow::WorkflowRequest>,
     config: Config,
     pending_approvals: PendingApprovals,
     hitl_hmac: Option<crate::hitl::WebhookHmac>,
 }
 
 impl RigBuilder {
+    /// Attach a parsed workflow control; it never enters the model prompt.
+    pub fn with_workflow_request(
+        mut self,
+        request: Option<crate::orchestration::workflow::WorkflowRequest>,
+    ) -> Self {
+        self.workflow_request = request;
+        self
+    }
+
     pub fn new(config: Config, pending_approvals: PendingApprovals) -> Self {
         Self {
+            workflow_request: None,
             config,
             pending_approvals,
             hitl_hmac: None,
@@ -83,6 +94,10 @@ impl RigBuilder {
             tools: self.config.tools.clone(),
             memory_dir: self.config.memory_dir.clone(),
             orchestration: self.config.orchestration.clone(),
+            workflow_request: self.workflow_request.clone(),
+            workflow_target_fingerprint: Some(crate::orchestration::workflow::target_fingerprint(
+                &self.config.mcp,
+            )),
             hitl: self.config.hitl.as_ref().map(|cfg| {
                 crate::hitl::HitlRuntime::from_config(
                     cfg,

--- a/docs/design/native-workflow-lifecycle.md
+++ b/docs/design/native-workflow-lifecycle.md
@@ -8,8 +8,12 @@ for this single-instance implementation.
 
 ## Configuration and handoffs
 
-See the [complete example](../../examples/complete/native-workflow.toml). Each stage specifies a unique ID,
-worker, operation, input bindings and output JSON Schema. JSON pointers resolve
+See the [complete example](../../examples/complete/native-workflow.toml). Each
+stage uses a named table such as `[orchestration.stages.act]` and specifies its
+worker, operation, input bindings and output JSON Schema. The table name is the
+stage ID; there is no separate `id` field. Set `orchestration.stage_order` to list
+every stage ID exactly once in execution order. Table placement and alphabetical
+key ordering never determine execution order. JSON pointers resolve
 against `/input`, `/stages/<earlier_id>` and `/run`. Missing bindings fail before
 that stage executes. Tool arguments and bindings cannot overwrite one another.
 Schemas accept local fragment references only; schema loading does not fetch

--- a/docs/design/native-workflow-lifecycle.md
+++ b/docs/design/native-workflow-lifecycle.md
@@ -1,0 +1,120 @@
+# Native configured workflow lifecycle
+
+Configured `orchestration.stages` replace coordinator planning for that agent.
+Existing agents with no stages retain model-directed orchestration. Stages run
+in order, using named workers, the shared MCP manager, existing tool wrappers,
+and the existing HITL decision store. No external workflow engine is required
+for this single-instance implementation.
+
+## Configuration and handoffs
+
+See the [complete example](../../examples/complete/native-workflow.toml). Each stage specifies a unique ID,
+worker, operation, input bindings and output JSON Schema. JSON pointers resolve
+against `/input`, `/stages/<earlier_id>` and `/run`. Missing bindings fail before
+that stage executes. Tool arguments and bindings cannot overwrite one another.
+Schemas accept local fragment references only; schema loading does not fetch
+files or remote resources.
+
+Worker stages expose the configured result schema in `submit_result`. Invalid
+submissions return correction feedback and do not occupy the result slot.
+Unstructured fallback text cannot advance a configured workflow. Existing
+unconfigured workers retain their string result contract.
+
+Tool stages dispatch exact arguments through the registered worker tool server,
+including its MCP filter, approval, observation and persistence wrappers.
+Scratchpad substitution and turn-nudge prose are disabled for exact calls so
+handoff validation receives the complete result. Configured workers do not get
+the legacy `wait_for` tool, whose probe dispatcher bypasses worker wrappers.
+Use verification stages for polling.
+
+Verification requires an explicit `read_only = true` declaration. Its success
+schema, optional failure schema, polling interval and wall-clock deadline are
+configuration. A successful mutation is not evidence of recovery. A timeout
+without matching evidence is `inconclusive`; it never becomes success. Polling
+and waits have a maximum configured horizon of one year.
+
+## Persistence and recovery
+
+Set `memory_dir` on persistent storage. Workflow records live in
+`memory_dir/workflows/<agent-and-session-digest>/<run-id>.json`. Run ownership is
+an OS file lock. Writes use same-directory rename with file and directory sync.
+Blocking writes retain their ownership lock through cancellation, and stale
+queued writes cannot overwrite a newer state. Configured workflows skip legacy
+artifact pruning so pending continuations keep their evidence. Operators must
+retain or remove completed run directories according to their retention policy.
+
+The record owns stage position, full handoffs, raw tool receipts, notification
+progress, absolute deadlines, message digests and a sequenced event history.
+Approval decisions remain authoritative in the existing approval store. Parked
+worker conversations embed the existing park/reify checkpoint shape. Resume
+uses its exact-call/scope checks and existing worker continuation.
+
+Before dispatch, the record becomes `running`. Receipt persistence precedes
+parsing and handoff validation. Restart after a recorded receipt consumes that
+receipt; restart with no receipt becomes `uncertain` and cannot automatically
+repeat the invocation. An interrupted notification is also uncertain. This is
+not an exactly-once guarantee for a remote system. Reconcile uncertain remote
+outcomes externally before starting any replacement run.
+
+An active run checks parked decisions once per second without model calls.
+Notifications/reminders use `on_approval_wait` offsets and ordinary MCP calls;
+recipient lookup and channel delivery belong to those tools. Notification tools
+cannot themselves require approval. Verification and timer deadlines survive
+restarts.
+
+Use `AURA_SESSION_STORE=file` and `AURA_SESSION_STORE_PATH` for durable A2A tasks
+and approvals. The file backend permits one server writer. After process
+restart, interrupted A2A tasks become `input-required`. Send a resume control in
+the same agent/session with fresh request credentials. Resume continues safe
+waits and recorded receipts, and rejects uncertain calls or changed execution
+configuration. Credentials are not copied into workflow records. This version
+does not automatically reconstruct authenticated clients at server startup,
+or coordinate execution across multiple instances.
+
+## A2A control contract
+
+Start with a normal A2A text message; its message ID determines the run ID within
+the agent/session. The first durable workflow snapshot exposes the run ID.
+Alternatively, include a data part with an explicit run ID:
+
+```json
+{"data":{"aura.workflow":{"run_id":"59fe2bc4-9967-49ae-80a3-fcd562532b14","command":"start"}}}
+```
+
+Commands are `start`, `inspect`, `resume`, `takeover`, and `cancel`. Supply a new
+A2A message ID for each operation. Repeating the same operation/message returns
+the recorded state; reusing its ID with different content is rejected. Controls
+are parsed before model input and never interpreted from natural language.
+
+`takeover` pauses automatic execution and retains its suspended state, including
+any approval checkpoint. `resume` explicitly returns control to Aura and checks
+the approval store again. Takeover does not revoke an already recorded human
+decision. If takeover interrupted an invocation, uncertainty prevents execution
+from resuming. Cancellation preserves uncertainty even across repeated controls
+and revokes pending approvals. A2A task cancellation applies this durable control
+even after a server restart.
+
+Controls use the same access boundary as existing A2A task operations. Agent and
+session names scope records; they are not an authentication system. Deploy behind
+the existing authenticated trusted-client boundary. Approval answers continue
+through `/v1/approvals/{decision_id}`; an `approvalOutcome` in model output grants
+no permission.
+
+Durable snapshots stream as `aura.orchestrator.workflow_updated` and as replacing
+A2A `workflow` artifacts. The A2A file backend retains the latest artifact and
+history through restart. Snapshot event sequences allow clients to reconcile
+missed updates; `inspect` returns the full record. Completed, failed and
+inconclusive outcomes are distinct from input-required human/uncertain states.
+
+A final configured MCP tool can export `/run` to a memory service. It receives
+all preceding results, receipts and events; its own eventual receipt remains in
+the local authoritative record. Memory retrieval and learned precedents remain
+ordinary worker MCP/RAG capabilities, not execution authorization.
+
+## Local verification
+
+Run `cargo test --workspace` for schema, handoff, persistence and control tests.
+`cargo test -p aura-web-server --test native_workflow_restart` launches real Aura
+processes with a local MCP fixture. It checks approval-gated execution,
+notification delivery, recovery verification, restart/resume and cancellation
+after restart without provider credentials.

--- a/docs/design/native-workflow-lifecycle.md
+++ b/docs/design/native-workflow-lifecycle.md
@@ -1,124 +1,149 @@
 # Native configured workflow lifecycle
 
-Configured `orchestration.stages` replace coordinator planning for that agent.
-Existing agents with no stages retain model-directed orchestration. Stages run
-in order, using named workers, the shared MCP manager, existing tool wrappers,
-and the existing HITL decision store. No external workflow engine is required
-for this single-instance implementation.
+Use a configured workflow when you know which steps Aura should run and in what
+order. An incident workflow might start with an investigation and a proposed
+remediation. Aura can wait for approval before applying the change, then check
+whether it worked.
+Aura saves progress so a caller can resume the run after a restart.
 
-## Configuration and handoffs
+The workflow uses Aura's existing workers, MCP tools, approval store, and
+park/reify support for saving and resuming worker conversations. It runs on one
+Aura instance and does not require an external workflow engine. Agents without
+configured stages continue to use coordinator planning.
 
-See the [complete example](../../examples/complete/native-workflow.toml). Each
-stage uses a named table such as `[orchestration.stages.act]` and specifies its
-worker, operation, input bindings and output JSON Schema. The table name is the
-stage ID; there is no separate `id` field. Set `orchestration.stage_order` to list
-every stage ID exactly once in execution order. Table placement and alphabetical
-key ordering never determine execution order. JSON pointers resolve
-against `/input`, `/stages/<earlier_id>` and `/run`. Missing bindings fail before
-that stage executes. Tool arguments and bindings cannot overwrite one another.
-Schemas accept local fragment references only; schema loading does not fetch
-files or remote resources.
+## Define the stages
 
-Worker stages expose the configured result schema in `submit_result`. Invalid
-submissions return correction feedback and do not occupy the result slot.
-Unstructured fallback text cannot advance a configured workflow. Existing
-unconfigured workers retain their string result contract.
+The [complete example](../../examples/complete/native-workflow.toml) shows an
+incident workflow. Define each stage in a named table such as
+`[orchestration.stages.act]`. The table name is the stage ID. Set
+`orchestration.stage_order` to list every stage ID exactly once in execution
+order. Moving tables around in the file does not change that order.
 
-Tool stages dispatch exact arguments through the registered worker tool server,
-including its MCP filter, approval, observation and persistence wrappers.
-Scratchpad substitution and turn-nudge prose are disabled for exact calls so
-handoff validation receives the complete result. Configured workers do not get
-the legacy `wait_for` tool, whose probe dispatcher bypasses worker wrappers.
-Use verification stages for polling.
+Each stage specifies a worker, an operation, input bindings, and an output JSON
+Schema. The operation determines what Aura does:
 
-Verification requires an explicit `read_only = true` declaration. Its success
-schema, optional failure schema, polling interval and wall-clock deadline are
-configuration. A successful mutation is not evidence of recovery. A timeout
-without matching evidence is `inconclusive`; it never becomes success. Polling
-and waits have a maximum configured horizon of one year.
+- `worker` asks a worker to perform the task and submit a result.
+- `tool` calls an MCP tool with the configured arguments.
+- `wait` pauses for the configured number of seconds.
+- `verify` polls a tool until its response matches a success or failure schema,
+  or the deadline expires.
 
-## Persistence and recovery
+Input bindings use JSON pointers. `/input` refers to the original input.
+`/stages/<earlier_id>` refers to an earlier stage's result, and `/run` refers to
+the run record.
+A missing input stops the stage before it executes. A binding cannot overwrite
+an argument already set in the configuration.
 
-Set `memory_dir` on persistent storage. Workflow records live in
-`memory_dir/workflows/<agent-and-session-digest>/<run-id>.json`. Run ownership is
-an OS file lock. Writes use same-directory rename with file and directory sync.
-Blocking writes retain their ownership lock through cancellation, and stale
-queued writes cannot overwrite a newer state. Configured workflows skip legacy
-artifact pruning so pending continuations keep their evidence. Operators must
-retain or remove completed run directories according to their retention policy.
+Aura validates each result before passing it to the next stage. For worker
+stages, `submit_result` exposes the configured schema. If a worker submits an
+invalid result, it gets feedback and can try again. Free-form text cannot
+advance the workflow. Workers outside configured workflows keep their existing
+string result format. Schemas can use local fragment references; Aura does not
+load schema references from files or remote services.
 
-The record owns stage position, full handoffs, raw tool receipts, notification
-progress, absolute deadlines, message digests and a sequenced event history.
-Approval decisions remain authoritative in the existing approval store. Parked
-worker conversations embed the existing park/reify checkpoint shape. Resume
-uses its exact-call/scope checks and existing worker continuation.
+Tool stages use the worker's MCP permissions and existing approval, observation,
+and persistence wrappers. For exact tool calls, Aura disables scratchpad
+substitution and turn-nudge text so validation receives the full tool response.
+Configured workers use verification stages instead of the legacy `wait_for`
+tool, which bypasses those wrappers.
 
-Before dispatch, the record becomes `running`. Receipt persistence precedes
-parsing and handoff validation. Restart after a recorded receipt consumes that
-receipt; restart with no receipt becomes `uncertain` and cannot automatically
-repeat the invocation. An interrupted notification is also uncertain. This is
-not an exactly-once guarantee for a remote system. Reconcile uncertain remote
-outcomes externally before starting any replacement run.
+## Wait for approval and check the result
 
-An active run checks parked decisions once per second without model calls.
-Notifications/reminders use `on_approval_wait` offsets and ordinary MCP calls;
-recipient lookup and channel delivery belong to those tools. Notification tools
-cannot themselves require approval. Verification and timer deadlines survive
-restarts.
+Approval decisions come from the existing approval store. An active run checks
+for a decision once per second without calling a model. Once approved, Aura
+uses the existing park/reify checks to resume the approved call in its original
+scope. A model returning `approvalOutcome` does not grant permission.
 
-Use `AURA_SESSION_STORE=file` and `AURA_SESSION_STORE_PATH` for durable A2A tasks
-and approvals. The file backend permits one server writer. After process
-restart, interrupted A2A tasks become `input-required`. Send a resume control in
-the same agent/session with fresh request credentials. Resume continues safe
-waits and recorded receipts, and rejects uncertain calls or changed execution
-configuration. Credentials are not copied into workflow records. This version
-does not automatically reconstruct authenticated clients at server startup,
-or coordinate execution across multiple instances.
+Use `on_approval_wait` to send notifications or reminders at configured offsets
+while approval is pending. These are ordinary MCP calls. The MCP tool handles
+recipient lookup and delivery, and must not require approval itself.
 
-## A2A control contract
+An action completing successfully does not prove that the problem is fixed.
+A `verify` stage checks the response against a success schema and, optionally,
+a failure schema. Set its polling interval and deadline, and declare
+`read_only = true` for the probe. If the deadline expires without matching
+evidence, the result is `inconclusive`. Waits and polling have a maximum
+configured horizon of one year. Their deadlines survive a restart.
 
-Start with a normal A2A text message; its message ID determines the run ID within
-the agent/session. The first durable workflow snapshot exposes the run ID.
-Alternatively, include a data part with an explicit run ID:
+## Save progress and recover after a restart
+
+Put `memory_dir` on persistent storage. Aura saves each run at
+`memory_dir/workflows/<agent-and-session-digest>/<run-id>.json`. The record
+contains the current stage, complete stage results, saved tool responses
+(receipts), notification progress, deadlines, message digests, and event history.
+Approval decisions stay in the approval store.
+
+Aura marks an invocation `running` before dispatch and saves its receipt before
+parsing or validating it. If Aura restarts after saving the receipt, resume uses
+that receipt. If an invocation was in progress and no receipt was saved, the run
+becomes `uncertain`. Aura will not automatically repeat that invocation. This
+also applies to interrupted notification calls. Check the remote system's
+outcome before starting a replacement run; Aura cannot guarantee exactly-once
+execution in that system.
+
+Set `AURA_SESSION_STORE=file` and `AURA_SESSION_STORE_PATH` to persist A2A tasks
+and approvals. After a restart, interrupted A2A tasks become `input-required`.
+Send a `resume` control in the same agent/session with fresh request credentials.
+Aura continues saved waits and receipts, but refuses to execute uncertain calls
+or resume with changed execution configuration. It does not automatically
+rebuild authenticated clients at startup or coordinate multiple Aura instances.
+
+An OS file lock gives one writer ownership of a run. Aura saves files with a
+same-directory rename and syncs the file and directory. Blocking writes retain
+the lock through cancellation; an older queued write cannot overwrite newer
+state. The file session backend also permits only one server writer.
+
+Configured workflows skip legacy artifact pruning so a paused worker keeps its
+evidence. Apply your retention policy to completed run directories.
+
+## Control a run through A2A
+
+Start with a normal A2A text message. Its message ID determines the run ID within
+the agent/session, and the first saved workflow snapshot exposes that ID. You
+can also supply an explicit run ID in a data part:
 
 ```json
 {"data":{"aura.workflow":{"run_id":"59fe2bc4-9967-49ae-80a3-fcd562532b14","command":"start"}}}
 ```
 
-Commands are `start`, `inspect`, `resume`, `takeover`, and `cancel`. Supply a new
-A2A message ID for each operation. Repeating the same operation/message returns
-the recorded state; reusing its ID with different content is rejected. Controls
-are parsed before model input and never interpreted from natural language.
+The commands are `start`, `inspect`, `resume`, `takeover`, and `cancel`. Use a new
+A2A message ID for each operation. Repeating the same operation and message
+returns the saved state. Reusing its message ID with different content is an
+error. Aura reads controls before model input; natural-language requests do not
+act as controls.
 
-`takeover` pauses automatic execution and retains its suspended state, including
-any approval checkpoint. `resume` explicitly returns control to Aura and checks
-the approval store again. Takeover does not revoke an already recorded human
-decision. If takeover interrupted an invocation, uncertainty prevents execution
-from resuming. Cancellation preserves uncertainty even across repeated controls
-and revokes pending approvals. A2A task cancellation applies this durable control
-even after a server restart.
+`takeover` pauses automatic execution and keeps the saved state, including any
+approval checkpoint. It does not revoke an approval already recorded by a
+human. `resume` returns control to Aura and checks the approval store again. If
+takeover interrupted an invocation, Aura will not resume it. Check its outcome
+externally before starting a replacement run.
 
-Controls use the same access boundary as existing A2A task operations. Agent and
-session names scope records; they are not an authentication system. Deploy behind
-the existing authenticated trusted-client boundary. Approval answers continue
-through `/v1/approvals/{decision_id}`; an `approvalOutcome` in model output grants
-no permission.
+`cancel` revokes pending approvals and preserves any uncertainty about calls
+already dispatched. A2A task cancellation applies this control even after a
+server restart.
 
-Durable snapshots stream as `aura.orchestrator.workflow_updated` and as replacing
-A2A `workflow` artifacts. The A2A file backend retains the latest artifact and
-history through restart. Snapshot event sequences allow clients to reconcile
-missed updates; `inspect` returns the full record. Completed, failed and
-inconclusive outcomes are distinct from input-required human/uncertain states.
+Use the same authenticated, trusted-client boundary as other A2A task operations.
+Agent and session names separate records; they do not authenticate the caller.
+Submit approval answers through `/v1/approvals/{decision_id}`.
 
-A final configured MCP tool can export `/run` to a memory service. It receives
-all preceding results, receipts and events; its own eventual receipt remains in
-the local authoritative record. Memory retrieval and learned precedents remain
-ordinary worker MCP/RAG capabilities, not execution authorization.
+## Read or export the run record
+
+Aura streams snapshots as `aura.orchestrator.workflow_updated` events and A2A
+`workflow` artifacts. Each artifact replaces the previous snapshot. The file
+backend keeps the latest artifact and task history through restart. Event
+sequence numbers help clients detect missed updates; `inspect` returns the full
+record. Completed, failed, and inconclusive runs have distinct outcomes. Runs
+that need human input or have uncertain execution remain input-required.
+
+A final MCP tool stage can export `/run` to a memory service. It receives all
+preceding results, receipts, and events. The export call's own receipt stays in
+the local run record. Workers can still retrieve prior knowledge through MCP
+or RAG; that knowledge does not authorize execution.
 
 ## Local verification
 
-Run `cargo test --workspace` for schema, handoff, persistence and control tests.
+Run `cargo test --workspace` for schema, handoff, persistence, and control tests.
 `cargo test -p aura-web-server --test native_workflow_restart` launches real Aura
-processes with a local MCP fixture. It checks approval-gated execution,
-notification delivery, recovery verification, restart/resume and cancellation
+processes with a local MCP fixture. It checks execution after approval,
+notification delivery, recovery verification, restart/resume, and cancellation
 after restart without provider credentials.

--- a/examples/complete/native-workflow.toml
+++ b/examples/complete/native-workflow.toml
@@ -1,0 +1,86 @@
+# A configured incident lifecycle using existing MCP tools and A2A controls.
+# Replace the illustrative MCP endpoint/tools/schemas with your service's contract.
+# Server prerequisites: AURA_SESSION_STORE=file,
+# AURA_SESSION_STORE_PATH=/var/lib/aura/session-store, AURA_CUSTOM_EVENTS=true.
+# Persist both directories below on the single Aura instance.
+# Use a persistent volume path in production.
+memory_dir = "/tmp/aura-workflow-runs"
+
+[agent]
+name = "Incident lifecycle"
+system_prompt = "Follow the configured incident workflow."
+turn_depth = 12
+
+[agent.llm]
+provider = "openai"
+api_key = "{{ env.OPENAI_API_KEY }}"
+model = "gpt-5.2"
+
+[mcp.servers.operations]
+transport = "http_streamable"
+url = "http://localhost:8081/mcp"
+
+[hitl]
+require_approval = ["run_workflow"]
+[hitl.route]
+mode = "conversational"
+timeout_secs = 3600
+[hitl.park]
+enabled = true
+
+[orchestration]
+enabled = true
+
+[orchestration.worker.investigator]
+description = "Read incident evidence"
+preamble = "Read the incident evidence. Submit a JSON object with evidence and incident_id using submit_result."
+mcp_filter = ["read_incident"]
+
+[orchestration.worker.decision]
+description = "Choose an allowed SOP"
+preamble = "Use the evidence to choose restart_service or no_action. Submit workflow and incident_id using submit_result."
+mcp_filter = []
+
+[orchestration.worker.action]
+description = "Execute and verify exact configured calls"
+preamble = "Configured tool execution"
+mcp_filter = ["run_workflow", "check_recovery", "notify", "store_run"]
+
+[[orchestration.stages]]
+id = "investigate"
+worker = "investigator"
+inputs = { incident = "/input" }
+output_schema = { type = "object", required = ["evidence", "incident_id"], properties = { evidence = { type = "string" }, incident_id = { type = "string" } } }
+operation = { kind = "worker", prompt = "Investigate this incident using the available read tool." }
+
+[[orchestration.stages]]
+id = "decide"
+worker = "decision"
+inputs = { evidence = "/stages/investigate" }
+output_schema = { type = "object", required = ["workflow", "incident_id"], properties = { workflow = { enum = ["restart_service", "no_action"] }, incident_id = { type = "string" } }, additionalProperties = false }
+operation = { kind = "worker", prompt = "Select the SOP justified by this evidence. Use no_action if no mutation is justified." }
+
+[[orchestration.stages]]
+id = "act"
+worker = "action"
+inputs = { workflow = "/stages/decide/workflow", incident_id = "/stages/decide/incident_id" }
+output_schema = { type = "object", required = ["status"], properties = { status = { const = "succeeded" } } }
+operation = { kind = "tool", tool = "run_workflow", arguments = {} }
+on_approval_wait = [
+  { after_secs = 0, worker = "action", tool = "notify", arguments = { channel = "oncall" }, inputs = { payload = "/run" } },
+  { after_secs = 900, worker = "action", tool = "notify", arguments = { channel = "escalation" }, inputs = { payload = "/run" } }
+]
+
+[[orchestration.stages]]
+id = "verify"
+worker = "action"
+inputs = { incident_id = "/stages/investigate/incident_id" }
+output_schema = { type = "object", required = ["healthy"], properties = { healthy = { const = true } } }
+operation = { kind = "verify", tool = "check_recovery", arguments = {}, read_only = true, success_schema = { required = ["healthy"], properties = { healthy = { const = true } } }, interval_secs = 5, timeout_secs = 300 }
+
+[[orchestration.stages]]
+id = "export"
+worker = "action"
+inputs = { record = "/run" }
+output_schema = { type = "object", required = ["stored"], properties = { stored = { const = true } } }
+operation = { kind = "tool", tool = "store_run", arguments = {} }

--- a/examples/complete/native-workflow.toml
+++ b/examples/complete/native-workflow.toml
@@ -30,6 +30,7 @@ enabled = true
 
 [orchestration]
 enabled = true
+stage_order = ["investigate", "decide", "act", "verify", "export"]
 
 [orchestration.worker.investigator]
 description = "Read incident evidence"
@@ -46,22 +47,19 @@ description = "Execute and verify exact configured calls"
 preamble = "Configured tool execution"
 mcp_filter = ["run_workflow", "check_recovery", "notify", "store_run"]
 
-[[orchestration.stages]]
-id = "investigate"
+[orchestration.stages.investigate]
 worker = "investigator"
 inputs = { incident = "/input" }
 output_schema = { type = "object", required = ["evidence", "incident_id"], properties = { evidence = { type = "string" }, incident_id = { type = "string" } } }
 operation = { kind = "worker", prompt = "Investigate this incident using the available read tool." }
 
-[[orchestration.stages]]
-id = "decide"
+[orchestration.stages.decide]
 worker = "decision"
 inputs = { evidence = "/stages/investigate" }
 output_schema = { type = "object", required = ["workflow", "incident_id"], properties = { workflow = { enum = ["restart_service", "no_action"] }, incident_id = { type = "string" } }, additionalProperties = false }
 operation = { kind = "worker", prompt = "Select the SOP justified by this evidence. Use no_action if no mutation is justified." }
 
-[[orchestration.stages]]
-id = "act"
+[orchestration.stages.act]
 worker = "action"
 inputs = { workflow = "/stages/decide/workflow", incident_id = "/stages/decide/incident_id" }
 output_schema = { type = "object", required = ["status"], properties = { status = { const = "succeeded" } } }
@@ -71,15 +69,13 @@ on_approval_wait = [
   { after_secs = 900, worker = "action", tool = "notify", arguments = { channel = "escalation" }, inputs = { payload = "/run" } }
 ]
 
-[[orchestration.stages]]
-id = "verify"
+[orchestration.stages.verify]
 worker = "action"
 inputs = { incident_id = "/stages/investigate/incident_id" }
 output_schema = { type = "object", required = ["healthy"], properties = { healthy = { const = true } } }
 operation = { kind = "verify", tool = "check_recovery", arguments = {}, read_only = true, success_schema = { required = ["healthy"], properties = { healthy = { const = true } } }, interval_secs = 5, timeout_secs = 300 }
 
-[[orchestration.stages]]
-id = "export"
+[orchestration.stages.export]
 worker = "action"
 inputs = { record = "/run" }
 output_schema = { type = "object", required = ["stored"], properties = { stored = { const = true } } }

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -267,8 +267,9 @@ model = "gpt-5.2"
 # Native ordered workflow (optional; empty stages retain coordinator planning).
 # See examples/complete/native-workflow.toml for investigate → act → verify.
 # Requires durable memory_dir; parked approvals also require the file session backend.
-# [[orchestration.stages]]
-# id = "investigate"
+# [orchestration]
+# stage_order = ["investigate"]
+# [orchestration.stages.investigate]
 # worker = "operations"
 # inputs = { incident = "/input" }
 # output_schema = { type = "object", required = ["evidence"] }

--- a/examples/reference.toml
+++ b/examples/reference.toml
@@ -263,3 +263,17 @@ model = "gpt-5.2"
 # model = "anthropic/claude-sonnet-4"
 # base_url = "https://custom-endpoint/v1"  # optional: OpenRouter-compatible proxies only
 
+
+# Native ordered workflow (optional; empty stages retain coordinator planning).
+# See examples/complete/native-workflow.toml for investigate → act → verify.
+# Requires durable memory_dir; parked approvals also require the file session backend.
+# [[orchestration.stages]]
+# id = "investigate"
+# worker = "operations"
+# inputs = { incident = "/input" }
+# output_schema = { type = "object", required = ["evidence"] }
+# operation = { kind = "worker", prompt = "Investigate and submit evidence." }
+# Operations: worker, tool (exact MCP arguments), wait (seconds), verify
+# (explicit read_only=true, success_schema, optional failure_schema, interval_secs,
+# timeout_secs). Inputs use JSON pointers into /input, /stages/<earlier_id>, /run.
+# on_approval_wait entries configure timed MCP notifications without adapters.


### PR DESCRIPTION
Incident workflows need to keep their place while waiting for approval and
verify recovery after a change. This adds a configured sequence of stages to
Aura. Each worker's result must pass validation before the next stage runs,
and saved progress lets the caller resume after a restart.

Stages use named tables such as `[orchestration.stages.act]` and an explicit
`stage_order`. Execution uses Aura's existing workers and MCP permissions.
Approval and restart handling build on the existing approval store and
park/reify support. Agents without stages keep coordinator planning.

The run record tracks stage results, tool receipts, approval waits,
notifications, and verification deadlines. A2A exposes inspect, takeover,
resume, and cancel controls, plus the latest run snapshot. The file session
backend persists tasks alongside approvals, including cancellation after a
restart. If a dispatched call has no saved receipt, Aura marks its outcome
uncertain and refuses to repeat it automatically.

This targets one Aura instance. Restart recovery requires an explicit resume
with fresh credentials. It does not promise exactly-once remote execution.

## Validation

- 2,304 workspace tests passed.
- Real-process tests cover approval, notification delivery, verification,
  restart/resume, and cancellation after restart using a local MCP fixture.
- Formatting, strict Clippy, HTTP-only checks, and commit lint passed. The
  HTTP-only lane includes a small fix for an existing unused-argument warning.
- STDIO MCP integration passed. Provider-backed Docker suites were not run
  because no API key was configured.

See `docs/design/native-workflow-lifecycle.md` and
`examples/complete/native-workflow.toml` for setup and behavior.
