### PR TITLE
refactor: brand the request id

### DIFF
--- a/crates/aura-cli/src/repl/mcp/wizard.rs
+++ b/crates/aura-cli/src/repl/mcp/wizard.rs
@@ -401,7 +401,10 @@ fn verify_server(
             })
             .ok_or_else(|| format!("`{name}` missing from the connection status snapshot"));
         manager
-            .cancel_and_close_all("mcp-add-verify", "verification complete")
+            .cancel_and_close_all(
+                &aura::RequestId::new("mcp-add-verify"),
+                "verification complete",
+            )
             .await;
         result
     })

--- a/crates/aura-events/src/agent.rs
+++ b/crates/aura-events/src/agent.rs
@@ -1,0 +1,269 @@
+//! The agent-produced event vocabulary.
+//!
+//! [`AgentEvent`] is what a running agent emits. Observers — an SSE producer, an
+//! A2A status bridge, an OTel exporter — consume this stream and project it into
+//! whatever shape they serve. Contrast [`crate::AuraStreamEvent`], which is the
+//! HTTP *wire* form of one such projection.
+//!
+//! Two properties distinguish this schema from the wire schema:
+//!
+//! - **Internally tagged.** [`crate::AuraStreamEvent`] is `#[serde(untagged)]`,
+//!   so its variant order is load-bearing during deserialization. This enum
+//!   carries a `type` discriminator instead, making variant order irrelevant.
+//! - **No correlation context.** The wire events flatten a
+//!   [`CorrelationContext`](crate::CorrelationContext) (session id, trace id)
+//!   into every payload. That is ambient request state, not something an agent
+//!   knows, so it is applied by the observer rather than carried here.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AgentContext, ApprovalCompleted, ApprovalPending, ApprovalRequested, McpServerStatus, Progress,
+    ProgressToken, TokenCount, TokenUsage, ToolCallId, ToolName, WorkerPhase,
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AgentEvent {
+    pub agent: AgentContext,
+    pub payload: AgentEventPayload,
+}
+
+impl AgentEvent {
+    pub fn new(agent: AgentContext, payload: AgentEventPayload) -> Self {
+        Self { agent, payload }
+    }
+
+    /// Attributes the payload to `agent_id: "main"`.
+    pub fn single_agent(payload: AgentEventPayload) -> Self {
+        Self::new(AgentContext::single_agent(), payload)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ToolOutcome {
+    Success { result: String },
+    Failure { error: String },
+}
+
+/// What an agent has to say about its own execution.
+///
+/// `#[non_exhaustive]` because the vocabulary grows as producers move onto this
+/// schema — orchestration events in particular are not yet modelled here.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AgentEventPayload {
+    SessionInfo {
+        model: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model_context_limit: Option<TokenCount>,
+    },
+
+    McpStatus {
+        servers: Vec<McpServerStatus>,
+    },
+
+    TextDelta {
+        content: String,
+    },
+
+    Reasoning {
+        content: String,
+    },
+
+    /// The model's decision to call a tool, ahead of any execution.
+    ToolRequested {
+        tool_call_id: ToolCallId,
+        tool_name: ToolName,
+        arguments: serde_json::Value,
+    },
+
+    ToolStart {
+        tool_call_id: ToolCallId,
+        tool_name: ToolName,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        progress_token: Option<ProgressToken>,
+    },
+
+    ToolComplete {
+        tool_call_id: ToolCallId,
+        tool_name: ToolName,
+        duration_ms: u64,
+        #[serde(flatten)]
+        outcome: ToolOutcome,
+    },
+
+    ToolProgress {
+        progress_token: ProgressToken,
+        progress: Progress,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+
+    WorkerPhase {
+        phase: WorkerPhase,
+        /// Plan-relative: unique within its iteration, not across a run.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        task_id: Option<usize>,
+    },
+
+    /// One turn's tokens, attributed to the tool calls that turn covered.
+    ToolUsage {
+        tool_call_ids: Vec<ToolCallId>,
+        #[serde(flatten)]
+        usage: TokenUsage,
+    },
+
+    /// Cumulative across every turn.
+    Usage {
+        #[serde(flatten)]
+        usage: TokenUsage,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_read_input_tokens: Option<TokenCount>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_creation_input_tokens: Option<TokenCount>,
+    },
+
+    /// Context-window occupancy, not billing.
+    ContextUsage {
+        context_tokens: TokenCount,
+        response_tokens: TokenCount,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context_window: Option<TokenCount>,
+    },
+
+    ScratchpadUsage {
+        tokens_intercepted: TokenCount,
+        tokens_extracted: TokenCount,
+    },
+
+    ApprovalRequested(ApprovalRequested),
+
+    ApprovalPending(ApprovalPending),
+
+    ApprovalCompleted(ApprovalCompleted),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn roundtrip(payload: AgentEventPayload) -> AgentEventPayload {
+        let json = serde_json::to_string(&payload).expect("payload should serialize");
+        serde_json::from_str(&json).expect("payload should deserialize")
+    }
+
+    #[test]
+    fn the_tag_names_the_variant() {
+        let json = serde_json::to_value(AgentEventPayload::TextDelta {
+            content: "hi".to_string(),
+        })
+        .expect("should serialize");
+
+        assert_eq!(json["type"], "text_delta");
+        assert_eq!(json["content"], "hi");
+    }
+
+    /// The wire enum needs `ToolComplete` declared before `ToolStart` and
+    /// `ToolUsage` before `Usage` to deserialize correctly. The tag makes the
+    /// same shapes unambiguous here regardless of declaration order.
+    #[test]
+    fn variants_the_wire_enum_must_order_are_unambiguous_here() {
+        let start = roundtrip(AgentEventPayload::ToolStart {
+            tool_call_id: ToolCallId::new("call_1"),
+            tool_name: ToolName::new("list_files"),
+            progress_token: None,
+        });
+        assert!(matches!(start, AgentEventPayload::ToolStart { .. }));
+
+        let usage = roundtrip(AgentEventPayload::Usage {
+            usage: TokenUsage {
+                prompt_tokens: TokenCount::new(1),
+                completion_tokens: TokenCount::new(2),
+                total_tokens: TokenCount::new(3),
+            },
+            cache_read_input_tokens: Some(TokenCount::new(80)),
+            cache_creation_input_tokens: Some(TokenCount::new(4)),
+        });
+        assert!(matches!(
+            usage,
+            AgentEventPayload::Usage {
+                cache_read_input_tokens: Some(_),
+                cache_creation_input_tokens: Some(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn tool_outcome_flattens_onto_tool_complete() {
+        let json = serde_json::to_value(AgentEventPayload::ToolComplete {
+            tool_call_id: ToolCallId::new("call_1"),
+            tool_name: ToolName::new("list_files"),
+            duration_ms: 12,
+            outcome: ToolOutcome::Failure {
+                error: "boom".to_string(),
+            },
+        })
+        .expect("should serialize");
+
+        assert_eq!(json["type"], "tool_complete");
+        assert_eq!(json["outcome"], "failure");
+        assert_eq!(json["error"], "boom");
+    }
+
+    #[test]
+    fn an_event_carries_its_emitting_agent() {
+        let event = AgentEvent::new(
+            AgentContext::worker("log_worker", None, "orchestrator"),
+            AgentEventPayload::TextDelta {
+                content: "scanning".to_string(),
+            },
+        );
+        let json = serde_json::to_value(&event).expect("should serialize");
+
+        assert_eq!(json["agent"]["agent_id"], "log_worker");
+        assert_eq!(json["agent"]["parent_agent_id"], "orchestrator");
+        assert_eq!(json["payload"]["type"], "text_delta");
+    }
+
+    /// `ToolUsage` is the one variant that mixes a flattened struct with a
+    /// field of its own, so it exercises `flatten` under the `type` tag.
+    #[test]
+    fn a_flattened_usage_survives_a_roundtrip_beside_its_tool_ids() {
+        let payload = roundtrip(AgentEventPayload::ToolUsage {
+            tool_call_ids: vec![ToolCallId::new("call_1")],
+            usage: TokenUsage {
+                prompt_tokens: TokenCount::new(10),
+                completion_tokens: TokenCount::new(5),
+                total_tokens: TokenCount::new(15),
+            },
+        });
+
+        let AgentEventPayload::ToolUsage {
+            tool_call_ids,
+            usage,
+        } = payload
+        else {
+            panic!("expected ToolUsage");
+        };
+        assert_eq!(tool_call_ids, vec![ToolCallId::new("call_1")]);
+        assert_eq!(usage.total_tokens.get(), 15);
+    }
+
+    #[test]
+    fn arguments_survive_a_roundtrip() {
+        let payload = roundtrip(AgentEventPayload::ToolRequested {
+            tool_call_id: ToolCallId::new("call_1"),
+            tool_name: ToolName::new("list_files"),
+            arguments: json!({ "path": "/mock", "depth": 2 }),
+        });
+
+        let AgentEventPayload::ToolRequested { arguments, .. } = payload else {
+            panic!("expected ToolRequested");
+        };
+        assert_eq!(arguments, json!({ "path": "/mock", "depth": 2 }));
+    }
+}

--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -14,6 +14,7 @@
 //! Both enums derive `Serialize + Deserialize` so they can be used for
 //! producing SSE (server) and parsing SSE (client) with the same types.
 
+pub mod agent;
 pub mod event_names;
 pub mod orchestration;
 
@@ -61,6 +62,176 @@ pub fn format_named_sse(event_name: &str, data: &impl Serialize) -> String {
     format!("event: {event_name}\ndata: {json}\n\n")
 }
 
+// --- Domain value types -----------------------------------------------------
+//
+// The building blocks shared by the agent schema ([`agent::AgentEventPayload`])
+// and the wire schema below. Opaque newtypes reached through canonical
+// conversion traits; each serializes as its inner value.
+
+/// Generates the shared surface of a string newtype: construction, borrowing,
+/// display, and comparison against the string types.
+macro_rules! string_newtype {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Self {
+                Self(value.into())
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            pub fn into_string(self) -> String {
+                self.0
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(value: String) -> Self {
+                Self(value)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(value: &str) -> Self {
+                Self(value.to_owned())
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl PartialEq<str> for $name {
+            fn eq(&self, other: &str) -> bool {
+                self.0 == other
+            }
+        }
+
+        impl PartialEq<&str> for $name {
+            fn eq(&self, other: &&str) -> bool {
+                self.0 == *other
+            }
+        }
+
+        impl PartialEq<String> for $name {
+            fn eq(&self, other: &String) -> bool {
+                &self.0 == other
+            }
+        }
+    };
+}
+
+string_newtype! {
+    /// The id a model assigns to one tool call.
+    ToolCallId
+}
+
+string_newtype! {
+    ToolName
+}
+
+/// Tokens as reported by a model provider, never counted locally.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct TokenCount(u64);
+
+impl TokenCount {
+    pub fn new(tokens: u64) -> Self {
+        Self(tokens)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for TokenCount {
+    fn from(tokens: u64) -> Self {
+        Self(tokens)
+    }
+}
+
+impl From<TokenCount> for u64 {
+    fn from(count: TokenCount) -> Self {
+        count.0
+    }
+}
+
+impl std::fmt::Display for TokenCount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// One provider-billed token measurement.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenUsage {
+    pub prompt_tokens: TokenCount,
+    pub completion_tokens: TokenCount,
+    /// Total as the provider reported it, not a sum of the other two fields.
+    pub total_tokens: TokenCount,
+}
+
+/// How far along an operation is, in whatever unit the reporter chose.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Progress {
+    pub current: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total: Option<f64>,
+}
+
+impl Progress {
+    pub fn ratio(current: f64, total: f64) -> Self {
+        Self {
+            current,
+            total: Some(total),
+        }
+    }
+
+    pub fn indeterminate(current: f64) -> Self {
+        Self {
+            current,
+            total: None,
+        }
+    }
+
+    /// A zero total counts as complete.
+    pub fn percent(&self) -> Option<u8> {
+        self.total.map(|total| {
+            if total == 0.0 {
+                100
+            } else {
+                ((self.current / total) * 100.0).min(100.0) as u8
+            }
+        })
+    }
+}
+
+impl std::fmt::Display for Progress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.total {
+            Some(total) => write!(f, "{}/{total}", self.current),
+            None => write!(f, "{}", self.current),
+        }
+    }
+}
+
 /// Context identifying which agent emitted an event.
 ///
 /// For single-agent deployments, use `AgentContext::single_agent()` which sets
@@ -69,7 +240,7 @@ pub fn format_named_sse(event_name: &str, data: &impl Serialize) -> String {
 ///
 /// Note: `AgentContext::default()` gives an empty `agent_id` - use `single_agent()`
 /// for the standard single-agent context.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct AgentContext {
     /// Unique identifier for this agent (e.g., "main", "log_worker", "rca_worker")
     pub agent_id: String,
@@ -713,6 +884,63 @@ impl AuraStreamEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn percent_needs_a_total() {
+        assert_eq!(Progress::ratio(50.0, 100.0).percent(), Some(50));
+        assert_eq!(Progress::indeterminate(50.0).percent(), None);
+    }
+
+    /// A server reporting `0/0` has nothing left to do, so it reads as done
+    /// rather than as a division by zero.
+    #[test]
+    fn a_zero_total_is_complete() {
+        assert_eq!(Progress::ratio(0.0, 0.0).percent(), Some(100));
+    }
+
+    #[test]
+    fn percent_is_capped_at_a_hundred() {
+        assert_eq!(Progress::ratio(150.0, 100.0).percent(), Some(100));
+    }
+
+    #[test]
+    fn a_string_newtype_serializes_as_its_bare_string() {
+        let json = serde_json::to_value(ToolCallId::new("call_abc")).unwrap();
+        assert_eq!(json, serde_json::json!("call_abc"));
+        assert_eq!(
+            serde_json::from_value::<ToolCallId>(json).unwrap(),
+            "call_abc"
+        );
+    }
+
+    /// `TokenUsage` flattens into the event variants that carry it, so the
+    /// grouping stays invisible on the wire.
+    #[test]
+    fn token_usage_flattens_to_bare_counts() {
+        #[derive(Serialize)]
+        struct Carrier {
+            #[serde(flatten)]
+            usage: TokenUsage,
+        }
+
+        let json = serde_json::to_value(Carrier {
+            usage: TokenUsage {
+                prompt_tokens: TokenCount::new(10),
+                completion_tokens: TokenCount::new(5),
+                total_tokens: TokenCount::new(15),
+            },
+        })
+        .unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15
+            })
+        );
+    }
 
     #[test]
     fn agent_info_mcp_servers_backward_compatible() {

--- a/crates/aura-events/src/lib.rs
+++ b/crates/aura-events/src/lib.rs
@@ -68,12 +68,28 @@ pub fn format_named_sse(event_name: &str, data: &impl Serialize) -> String {
 // and the wire schema below. Opaque newtypes reached through canonical
 // conversion traits; each serializes as its inner value.
 
-/// Generates the shared surface of a string newtype: construction, borrowing,
+/// Generates the shared surface of a string newtype — construction, borrowing,
 /// display, and comparison against the string types.
+///
+/// The expansion derives `serde::Serialize`/`Deserialize` through a plain
+/// `::serde` path, so an invoking crate needs `serde` as a direct dependency
+/// or the derive fails to resolve at the call site.
+#[doc(hidden)]
+#[macro_export]
 macro_rules! string_newtype {
     ($(#[$meta:meta])* $name:ident) => {
         $(#[$meta])*
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+        #[derive(
+            Debug,
+            Clone,
+            PartialEq,
+            Eq,
+            Hash,
+            PartialOrd,
+            Ord,
+            ::serde::Serialize,
+            ::serde::Deserialize,
+        )]
         #[serde(transparent)]
         pub struct $name(String);
 

--- a/crates/aura-test-utils/src/mock_agent.rs
+++ b/crates/aura-test-utils/src/mock_agent.rs
@@ -1,5 +1,6 @@
 //! A [`StreamingAgent`] for tests that need an agent without a provider.
 
+use aura::RequestId;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -12,8 +13,8 @@ use futures::stream::{self, BoxStream, StreamExt};
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
-type StartHook = Arc<dyn Fn(String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
-type EffectHook = Arc<dyn Fn(String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+type StartHook = Arc<dyn Fn(RequestId) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+type EffectHook = Arc<dyn Fn(RequestId) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
 
 /// Pause inserted after each scripted step.
 ///
@@ -41,7 +42,7 @@ impl Step {
     /// be published to from inside the script.
     pub fn effect<F, Fut>(effect: F) -> Self
     where
-        F: Fn(String) -> Fut + Send + Sync + 'static,
+        F: Fn(RequestId) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = ()> + Send + 'static,
     {
         Self::Effect(Arc::new(move |request_id| Box::pin(effect(request_id))))
@@ -120,16 +121,19 @@ impl MockAgent {
     /// call's `request_id`.
     pub fn on_stream_start<F, Fut>(mut self, hook: F) -> Self
     where
-        F: Fn(String) -> Fut + Send + Sync + 'static,
+        F: Fn(RequestId) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = ()> + Send + 'static,
     {
         self.on_stream_start = Some(Arc::new(move |request_id| Box::pin(hook(request_id))));
         self
     }
 
-    async fn start(&self, request_id: &str) -> BoxStream<'static, Result<StreamItem, StreamError>> {
+    async fn start(
+        &self,
+        request_id: &RequestId,
+    ) -> BoxStream<'static, Result<StreamItem, StreamError>> {
         if let Some(hook) = &self.on_stream_start {
-            hook(request_id.to_string()).await;
+            hook(request_id.clone()).await;
         }
 
         let stream: BoxStream<'static, Result<StreamItem, StreamError>> = match &self.script {
@@ -140,7 +144,7 @@ impl MockAgent {
                     .expect("script lock")
                     .take()
                     .unwrap_or_default();
-                let request_id = request_id.to_string();
+                let request_id = request_id.clone();
                 Box::pin(
                     stream::iter(steps)
                         .then(move |step| {
@@ -176,7 +180,7 @@ impl StreamingAgent for MockAgent {
         _query: &str,
         _chat_history: Vec<Message>,
         _cancel_token: CancellationToken,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> Result<BoxStream<'static, Result<StreamItem, StreamError>>, StreamError> {
         Ok(self.start(request_id).await)
     }
@@ -186,7 +190,7 @@ impl StreamingAgent for MockAgent {
         _query: &str,
         _chat_history: Vec<Message>,
         _timeout: Duration,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> (
         BoxStream<'static, Result<StreamItem, StreamError>>,
         watch::Sender<bool>,
@@ -197,7 +201,7 @@ impl StreamingAgent for MockAgent {
         (stream, cancel_tx, UsageState::new())
     }
 
-    async fn cancel_and_close_mcp(&self, _request_id: &str, _reason: &str) -> usize {
+    async fn cancel_and_close_mcp(&self, _request_id: &RequestId, _reason: &str) -> usize {
         0
     }
 }
@@ -211,7 +215,12 @@ mod tests {
     async fn a_pending_agent_never_yields() {
         let agent = MockAgent::pending();
         let mut stream = agent
-            .stream("q", vec![], CancellationToken::new(), "req_1")
+            .stream(
+                "q",
+                vec![],
+                CancellationToken::new(),
+                &RequestId::new("req_1"),
+            )
             .await
             .expect("mock stream should start");
         assert!(
@@ -236,12 +245,22 @@ mod tests {
 
             if entry_point == "stream" {
                 let _ = agent
-                    .stream("q", vec![], CancellationToken::new(), "req_1")
+                    .stream(
+                        "q",
+                        vec![],
+                        CancellationToken::new(),
+                        &RequestId::new("req_1"),
+                    )
                     .await
                     .expect("mock stream should start");
             } else {
                 let _ = agent
-                    .stream_with_timeout("q", vec![], Duration::from_secs(1), "req_1")
+                    .stream_with_timeout(
+                        "q",
+                        vec![],
+                        Duration::from_secs(1),
+                        &RequestId::new("req_1"),
+                    )
                     .await;
             }
 
@@ -256,7 +275,12 @@ mod tests {
     async fn a_yielding_agent_produces_its_items_then_ends() {
         let agent = MockAgent::yielding([items::text("hello "), items::text("world")]);
         let stream = agent
-            .stream("q", vec![], CancellationToken::new(), "req_1")
+            .stream(
+                "q",
+                vec![],
+                CancellationToken::new(),
+                &RequestId::new("req_1"),
+            )
             .await
             .expect("mock stream should start");
 
@@ -290,7 +314,12 @@ mod tests {
         ]);
 
         let stream = agent
-            .stream("q", vec![], CancellationToken::new(), "req_42")
+            .stream(
+                "q",
+                vec![],
+                CancellationToken::new(),
+                &RequestId::new("req_42"),
+            )
             .await
             .expect("mock stream should start");
         let items: Vec<_> = stream.collect().await;
@@ -304,13 +333,23 @@ mod tests {
         let agent = MockAgent::yielding([items::text("once")]);
 
         let first: Vec<_> = agent
-            .stream("q", vec![], CancellationToken::new(), "req_1")
+            .stream(
+                "q",
+                vec![],
+                CancellationToken::new(),
+                &RequestId::new("req_1"),
+            )
             .await
             .expect("mock stream should start")
             .collect()
             .await;
         let second: Vec<_> = agent
-            .stream("q", vec![], CancellationToken::new(), "req_1")
+            .stream(
+                "q",
+                vec![],
+                CancellationToken::new(),
+                &RequestId::new("req_1"),
+            )
             .await
             .expect("mock stream should start")
             .collect()
@@ -337,7 +376,12 @@ mod tests {
         ]);
 
         let mut stream = agent
-            .stream("q", vec![], CancellationToken::new(), "req_1")
+            .stream(
+                "q",
+                vec![],
+                CancellationToken::new(),
+                &RequestId::new("req_1"),
+            )
             .await
             .expect("mock stream should start");
         while stream.next().await.is_some() {

--- a/crates/aura-web-server/src/a2a/agent_executor.rs
+++ b/crates/aura-web-server/src/a2a/agent_executor.rs
@@ -1,3 +1,4 @@
+use aura::RequestId;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -38,7 +39,7 @@ pub struct AuraAgentExecutor {
 struct TaskCancelEntry {
     token: CancellationToken,
     agent: Arc<dyn StreamingAgent>,
-    request_id: String,
+    request_id: RequestId,
 }
 
 /// The live executions' cancel handles, keyed by task id.
@@ -59,7 +60,7 @@ fn lock_cancel_state(state: &TaskCancelState) -> MutexGuard<'_, HashMap<String, 
 struct TaskCancelGuard {
     state: Arc<TaskCancelState>,
     task_id: String,
-    request_id: String,
+    request_id: RequestId,
 }
 
 impl Drop for TaskCancelGuard {
@@ -225,7 +226,7 @@ impl AgentExecutor for AuraAgentExecutor {
                 metadata: None,
             }));
 
-            let request_id = format!("a2a_{}", task_id);
+            let request_id = RequestId::new(format!("a2a_{}", task_id));
             let session_id = Some(context_id.clone());
             let builder = RigBuilder::new(config, pending_approvals).with_hitl_hmac(hitl_hmac);
             let agent = match builder
@@ -250,7 +251,7 @@ impl AgentExecutor for AuraAgentExecutor {
             let cancel_token = stream_shutdown_token.child_token();
             // Register with the global cancellation registry for parity with the OpenAI handler
             // and to let any future code address this request by id.
-            RequestCancellation::register(request_id.clone());
+            RequestCancellation::register(&request_id);
             let _cancel_guard = TaskCancelGuard {
                 state: task_cancel_state.clone(),
                 task_id: task_id.clone(),
@@ -289,13 +290,13 @@ impl AgentExecutor for AuraAgentExecutor {
                 let Some(item) = next else { break };
                 match item {
                     Ok(StreamItem::StreamAssistantItem(StreamedAssistantContent::Text(t))) => {
-                        event!(Level::DEBUG, request_id, t, "stream content received");
+                        event!(Level::DEBUG, %request_id, t, "stream content received");
 
                         let append = append_tracker.entry((task_id.clone(), context_id.clone(), RESPONSE_ARTIFACT_ID.to_owned()))
                             .and_modify(|e| *e = true)
                             .or_insert(false);
 
-                        event!(Level::DEBUG, request_id, "response returned and should be appended: {}", *append);
+                        event!(Level::DEBUG, %request_id, "response returned and should be appended: {}", *append);
 
                         let artifact = Artifact {
                             artifact_id: RESPONSE_ARTIFACT_ID.to_owned(),
@@ -315,7 +316,7 @@ impl AgentExecutor for AuraAgentExecutor {
                         }));
                     }
                     Ok(StreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCall(tc))) => {
-                        event!(Level::DEBUG, request_id, tool_name = tc.name.as_str(), "tool call received");
+                        event!(Level::DEBUG, %request_id, tool_name = tc.name.as_str(), "tool call received");
 
                         let artifact_id: String = format!("tool_call_{}", tc.id);
                         let append = append_tracker.entry((task_id.clone(), context_id.clone(), artifact_id.to_owned()))
@@ -345,7 +346,7 @@ impl AgentExecutor for AuraAgentExecutor {
                         }));
                     }
                     Ok(StreamItem::StreamAssistantItem(StreamedAssistantContent::Reasoning(r))) => {
-                        event!(Level::DEBUG, request_id, reasoning = r, "reasoning received");
+                        event!(Level::DEBUG, %request_id, reasoning = r, "reasoning received");
                         reasoning_num += 1;
 
                         let artifact_id: String = format!("reasoning_{}", reasoning_num);
@@ -371,7 +372,7 @@ impl AgentExecutor for AuraAgentExecutor {
                         }));
                     }
                     Ok(StreamItem::ScratchpadUsage { agent_id, tokens_intercepted, tokens_extracted }) => {
-                        event!(Level::DEBUG, request_id, "scratchpad usage");
+                        event!(Level::DEBUG, %request_id, "scratchpad usage");
 
                         let artifact_id: String = format!("scratchpad_{}", agent_id);
                         let append = append_tracker.entry((task_id.clone(), context_id.clone(), artifact_id.to_owned()))
@@ -399,25 +400,25 @@ impl AgentExecutor for AuraAgentExecutor {
                         }));
                     }
                     Ok(StreamItem::TurnUsage(..)) => {
-                        event!(Level::DEBUG, request_id, "turn usage");
+                        event!(Level::DEBUG, %request_id, "turn usage");
                     }
                     Ok(StreamItem::ContextUsage { .. }) => {
-                        event!(Level::DEBUG, request_id, "context usage");
+                        event!(Level::DEBUG, %request_id, "context usage");
                     }
                     Ok(StreamItem::OrchestratorEvent(_)) => {
-                        event!(Level::DEBUG, request_id, "orchestration event");
+                        event!(Level::DEBUG, %request_id, "orchestration event");
                     }
                     Ok(StreamItem::McpStatus(_)) => {
-                        event!(Level::DEBUG, request_id, "mcp status");
+                        event!(Level::DEBUG, %request_id, "mcp status");
                     }
                     Ok(StreamItem::StreamUserItem(_)) => {
-                        event!(Level::DEBUG, request_id, "stream user item");
+                        event!(Level::DEBUG, %request_id, "stream user item");
                     }
                     Ok(StreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCallDelta { .. })) => {
-                        event!(Level::DEBUG, request_id, "stream assistant item");
+                        event!(Level::DEBUG, %request_id, "stream assistant item");
                     }
                     Ok(StreamItem::StreamAssistantItem(StreamedAssistantContent::ReasoningDelta { .. })) => {
-                        event!(Level::DEBUG, request_id, "reasoning delta");
+                        event!(Level::DEBUG, %request_id, "reasoning delta");
                     }
                     Ok(StreamItem::Final(final_info)) => {
                         let append = append_tracker.entry((task_id.clone(), context_id.clone(), FINAL_ARTIFACT_ID.to_owned()))
@@ -447,11 +448,11 @@ impl AgentExecutor for AuraAgentExecutor {
                         break; // done processing
                     }
                     Ok(StreamItem::FinalMarker) => {
-                        event!(Level::DEBUG, request_id, "stream final marker");
+                        event!(Level::DEBUG, %request_id, "stream final marker");
                         break; // done processing
                     }
                     Err(e) => {
-                        event!(Level::ERROR, request_id, task_id, error = e.to_string(), "stream error");
+                        event!(Level::ERROR, %request_id, task_id, error = e.to_string(), "stream error");
                         yield Ok(fail_status(&task_id, &context_id, &e.to_string()));
                         success = false;
                         break; // done processing
@@ -585,7 +586,7 @@ pub(super) fn fail_status(task_id: &str, context_id: &str, error_msg: &str) -> S
 
 async fn get_history_for_context(
     task_store: SharedTaskStore,
-    request_id: &str,
+    request_id: &RequestId,
     context_id: &str,
     task_id: &str,
 ) -> Result<Vec<aura::Message>, A2AError> {
@@ -595,7 +596,7 @@ async fn get_history_for_context(
     loop {
         event!(
             Level::DEBUG,
-            request_id,
+            %request_id,
             context_id,
             "processing history for context"
         );
@@ -616,7 +617,7 @@ async fn get_history_for_context(
 
         event!(
             Level::DEBUG,
-            request_id,
+            %request_id,
             context_id,
             "found {} tasks, continue token '{}'",
             page.tasks.len(),
@@ -638,7 +639,7 @@ async fn get_history_for_context(
 
     let chat_history: Vec<aura::Message> = tasks.iter().flat_map(task_turns).collect();
 
-    event!(Level::DEBUG, request_id, context_id, chat_history = ?chat_history, "determined this following history to use");
+    event!(Level::DEBUG, %request_id, context_id, chat_history = ?chat_history, "determined this following history to use");
     Ok(chat_history)
 }
 
@@ -852,10 +853,10 @@ mod tests {
     #[test]
     fn dropping_the_cancel_guard_releases_the_entry_and_registration() {
         let task_id = format!("t_{}", uuid::Uuid::new_v4());
-        let request_id = format!("a2a_{task_id}");
+        let request_id = RequestId::new(format!("a2a_{task_id}"));
         let state: Arc<TaskCancelState> = Arc::new(Mutex::new(HashMap::new()));
 
-        RequestCancellation::register(request_id.clone());
+        RequestCancellation::register(&request_id);
         let guard = TaskCancelGuard {
             state: state.clone(),
             task_id: task_id.clone(),
@@ -882,10 +883,10 @@ mod tests {
     #[test]
     fn dropping_the_cancel_guard_after_an_explicit_cleanup_is_a_noop() {
         let task_id = format!("t_{}", uuid::Uuid::new_v4());
-        let request_id = format!("a2a_{task_id}");
+        let request_id = RequestId::new(format!("a2a_{task_id}"));
         let state: Arc<TaskCancelState> = Arc::new(Mutex::new(HashMap::new()));
 
-        RequestCancellation::register(request_id.clone());
+        RequestCancellation::register(&request_id);
         let guard = TaskCancelGuard {
             state: state.clone(),
             task_id: task_id.clone(),
@@ -967,7 +968,7 @@ mod tests {
         for task in tasks {
             store.create(task).await.expect("task created");
         }
-        get_history_for_context(store, "req", "ctx", executing)
+        get_history_for_context(store, &RequestId::new("req"), "ctx", executing)
             .await
             .expect("history built")
     }

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1,4 +1,5 @@
 use a2a::VERSION;
+use aura::RequestId;
 use aura::RigBuilder;
 use aura::{
     RequestCancellation, ResponseContent, StreamingAgent, UsageState, approval_event_subscribe,
@@ -28,12 +29,12 @@ use crate::types::*;
 
 /// RAII guard for request-scoped subscriptions. Ensures cleanup even on panic.
 struct RequestResourceGuard {
-    request_id: String,
+    request_id: RequestId,
     pending_approvals: aura::hitl::PendingApprovals,
 }
 
 impl RequestResourceGuard {
-    fn new(request_id: String, pending_approvals: aura::hitl::PendingApprovals) -> Self {
+    fn new(request_id: RequestId, pending_approvals: aura::hitl::PendingApprovals) -> Self {
         Self {
             request_id,
             pending_approvals,
@@ -121,7 +122,7 @@ impl std::fmt::Display for PrepareError {
 /// Both streaming and non-streaming handlers delegate to the same core logic with different
 /// delivery modes but the same observability instrumentation and stream processing.
 pub struct CompletionConfig {
-    pub request_id: String,
+    pub request_id: RequestId,
     pub timeout_duration: std::time::Duration,
     pub first_chunk_timeout: Option<std::time::Duration>,
     pub inactivity_timeout: Option<std::time::Duration>,
@@ -189,7 +190,7 @@ async fn build_agent_for_request(
     req_headers: &HashMap<String, String>,
     additional_tools: Vec<Box<dyn aura::ToolDyn>>,
     client_tools: Option<&[ClientToolDefinition]>,
-    request_id: String,
+    request_id: RequestId,
     session_id: String,
     data: &AppState,
 ) -> Result<Arc<aura::Agent>, PrepareError> {
@@ -230,7 +231,7 @@ pub struct RequestSetup {
     /// invokes a passthrough tool.
     pub has_client_tools: bool,
     /// Request id (`req_…`) shared by the agent build and the completion stream.
-    pub request_id: String,
+    pub request_id: RequestId,
     /// OpenAI-compatible `user` field, for the `user.id` span attribute.
     pub user_id: Option<String>,
     /// Request `metadata` serialized as a JSON object string, for the
@@ -261,7 +262,7 @@ pub async fn prepare_request(
     // orchestration) shares one value with the completion stream. The HITL gate
     // and approval events stamp this id; previously it was minted later in
     // `build_completion_config`, after the agent was already built.
-    let request_id = format!("req_{}", Uuid::new_v4().simple());
+    let request_id = RequestId::new(format!("req_{}", Uuid::new_v4().simple()));
 
     // Single pass: pull the user query out of `messages` and convert the rest
     // into Aura/Rig history, with optional client-tool support (preserves
@@ -519,7 +520,7 @@ pub async fn execute_completion(
     delivery: DeliveryMode,
 ) {
     let _active_guard = ActiveRequestGuard::new(config.active_requests.clone());
-    let _cancellation = RequestCancellation::register(config.request_id.clone());
+    let _cancellation = RequestCancellation::register(&config.request_id);
 
     let _resource_guard =
         RequestResourceGuard::new(config.request_id.clone(), config.pending_approvals.clone());
@@ -731,7 +732,7 @@ async fn handle_non_streaming_completion(
 
     {
         let span = tracing::Span::current();
-        aura::logging::set_span_attribute(&span, "http.request_id", config.request_id.clone());
+        aura::logging::set_span_attribute(&span, "http.request_id", config.request_id.to_string());
     }
 
     let response_ctx = ResponseContext {
@@ -778,7 +779,7 @@ async fn handle_streaming_completion(
 
     {
         let span = tracing::Span::current();
-        aura::logging::set_span_attribute(&span, "http.request_id", config.request_id.clone());
+        aura::logging::set_span_attribute(&span, "http.request_id", config.request_id.to_string());
     }
 
     let chat_session_id = setup.chat_session_id.clone();
@@ -1342,6 +1343,7 @@ fn error_response(
 mod tests {
     use super::*;
     use crate::types::{ChatMessage, ChatMessageFunctionCall, ChatMessageToolCall, Role};
+    use aura::RequestId;
     use aura_test_utils::mock_agent::MockAgent;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -1439,7 +1441,7 @@ mod tests {
 
     #[tokio::test]
     async fn sse_approval_subscription_exists_before_stream_startup() {
-        let request_id = format!("req_test_{}", Uuid::new_v4().simple());
+        let request_id = RequestId::new(format!("req_test_{}", Uuid::new_v4().simple()));
         let published = Arc::new(AtomicBool::new(false));
         let agent: Arc<dyn StreamingAgent> = Arc::new(MockAgent::pending().on_stream_start({
             let published = Arc::clone(&published);
@@ -2325,6 +2327,8 @@ url = "http://127.0.0.1:9"
     }
 
     mod approval_ingress {
+        use aura::RequestId;
+
         use std::sync::Arc;
         use std::time::Duration;
 
@@ -2384,7 +2388,7 @@ url = "http://127.0.0.1:9"
                 version: aura::hitl::PROTOCOL_VERSION,
                 instance_id: "test-instance".to_string(),
                 decision_id: aura::hitl::DecisionId::generate(),
-                request_id: "req-smoke".into(),
+                request_id: RequestId::new("req-smoke"),
                 scope: aura::hitl::AgentScope::Single { session_id: None },
                 origin: aura::hitl::ApprovalOrigin::ConfigGate {
                     matched_pattern: "test_*".into(),
@@ -2593,7 +2597,7 @@ url = "http://127.0.0.1:9"
                 version: aura::hitl::PROTOCOL_VERSION,
                 instance_id: "test-instance".to_string(),
                 decision_id: aura::hitl::DecisionId::generate(),
-                request_id: "req-hmac".into(),
+                request_id: RequestId::new("req-hmac"),
                 scope: aura::hitl::AgentScope::Single { session_id: None },
                 origin: aura::hitl::ApprovalOrigin::ConfigGate {
                     matched_pattern: "test_*".into(),

--- a/crates/aura-web-server/src/session_store/redis/approval_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/approval_store.rs
@@ -19,6 +19,7 @@
 //! prunes per id, never the whole index key; `SWEEP_TAKE_SCRIPT` states what
 //! each id yields.
 
+use aura::RequestId;
 use std::sync::LazyLock;
 
 use async_trait::async_trait;
@@ -94,7 +95,7 @@ impl RedisApprovalStore {
         format!("{}:approval:decision:{decision_id}", self.key_prefix)
     }
 
-    fn req_key(&self, request_id: &str) -> String {
+    fn req_key(&self, request_id: &RequestId) -> String {
         format!("{}:approval:req:{request_id}", self.key_prefix)
     }
 
@@ -204,7 +205,7 @@ impl ApprovalStore for RedisApprovalStore {
 
     async fn cancel_request(
         &self,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> Result<Vec<ParkedApproval>, SessionStoreError> {
         let req_key = self.req_key(request_id);
         let mut conn = self.conn.clone();

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -26,12 +26,12 @@ use super::types::{
     FunctionCallChunk, MessageRole, StreamConfig, ToolCallChunk, ToolResultMode, ToolResultStatus,
     TurnContext, TurnState, detect_tool_error, format_sse_chunk, truncate_result,
 };
-use aura::stream_events::AuraStreamEvent;
+use aura::stream_events::{AuraStreamEvent, CorrelationContext};
 use aura::{
     ApprovalLifecycleEvent, EventContext, OrchestrationStreamEvent, OrchestratorEvent,
     PASSTHROUGH_MARKER, ProgressNotification, RequestCancellation, ResponseContent, StreamError,
     StreamItem, StreamedAssistantContent, StreamedUserContent, StreamingAgent, ToolCall,
-    ToolLifecycleEvent, ToolResult, ToolUsageEvent, UsageState,
+    ToolCallId, ToolLifecycleEvent, ToolResult, ToolUsageEvent, UsageState,
 };
 use bytes::Bytes;
 use futures_util::{Stream, StreamExt};
@@ -240,19 +240,18 @@ where
                     inactivity.touch();
                     let event = AuraStreamEvent::progress(
                         notification.message.clone().unwrap_or_else(|| {
-                            format!("Progress: {}/{:?}", notification.progress, notification.total)
+                            format!("Progress: {}", notification.progress)
                         }),
                         "mcp_progress",
                         notification.percent(),
                         Some(notification.progress_token.clone()),
-                        ctx.agent_context.clone(),
+                        notification.agent.clone().unwrap_or_else(|| ctx.agent_context.clone()),
                         ctx.correlation.clone(),
                     );
                     tracing::debug!(
-                        "Emitting aura.progress event: token={:?}, progress={}/{:?}",
+                        "Emitting aura.progress event: token={:?}, progress={}",
                         notification.progress_token,
-                        notification.progress,
-                        notification.total
+                        notification.progress
                     );
                     if tx.send(Ok(Bytes::from(event.format_sse()))).await.is_err() {
                         tracing::info!("Client disconnected during progress notification");
@@ -266,29 +265,29 @@ where
                 if let Some(tool_event) = tool_event {
                     inactivity.touch();
                     let sse_event = match tool_event {
-                        ToolLifecycleEvent::Requested { tool_id, tool_name, arguments } => {
+                        ToolLifecycleEvent::Requested { tool_id, tool_name, arguments, agent } => {
                             tracing::debug!(
                                 "Emitting aura.tool_requested event: tool_id={}, tool_name={}",
                                 tool_id, tool_name
                             );
                             AuraStreamEvent::tool_requested(
-                                &tool_id,
-                                &tool_name,
+                                tool_id.as_str(),
+                                tool_name.as_str(),
                                 arguments,
-                                ctx.agent_context.clone(),
+                                agent.unwrap_or_else(|| ctx.agent_context.clone()),
                                 ctx.correlation.clone(),
                             )
                         }
-                        ToolLifecycleEvent::Start { tool_id, tool_name, progress_token } => {
+                        ToolLifecycleEvent::Start { tool_id, tool_name, progress_token, agent } => {
                             tracing::debug!(
                                 "Emitting aura.tool_start event: tool_id={}, tool_name={}, progress_token={:?}",
                                 tool_id, tool_name, progress_token
                             );
                             AuraStreamEvent::tool_start(
-                                &tool_id,
-                                &tool_name,
+                                tool_id.as_str(),
+                                tool_name.as_str(),
                                 progress_token,
-                                ctx.agent_context.clone(),
+                                agent.unwrap_or_else(|| ctx.agent_context.clone()),
                                 ctx.correlation.clone(),
                             )
                         }
@@ -328,15 +327,9 @@ where
                     inactivity.touch();
                     tracing::debug!(
                         "Emitting aura.tool_usage event: tool_ids={:?}, prompt_tokens={}",
-                        usage_event.tool_ids, usage_event.prompt_tokens
+                        usage_event.tool_ids, usage_event.usage.prompt_tokens
                     );
-                    let sse_event = AuraStreamEvent::tool_usage(
-                        usage_event.tool_ids,
-                        usage_event.prompt_tokens,
-                        usage_event.completion_tokens,
-                        usage_event.total_tokens,
-                        ctx.correlation.clone(),
-                    );
+                    let sse_event = tool_usage_sse(usage_event, ctx.correlation.clone());
                     if tx.send(Ok(Bytes::from(sse_event.format_sse()))).await.is_err() {
                         tracing::info!("Client disconnected during tool_usage event");
                         break StreamTermination::Disconnected;
@@ -478,6 +471,20 @@ fn resolve_billed_usage(
     }
 }
 
+fn tool_usage_sse(event: ToolUsageEvent, correlation: CorrelationContext) -> AuraStreamEvent {
+    AuraStreamEvent::tool_usage(
+        event
+            .tool_ids
+            .into_iter()
+            .map(ToolCallId::into_string)
+            .collect(),
+        event.usage.prompt_tokens.get(),
+        event.usage.completion_tokens.get(),
+        event.usage.total_tokens.get(),
+        correlation,
+    )
+}
+
 /// Send final usage events, finish chunk, and [DONE] marker to the client.
 async fn send_final_events(
     emit_custom_events: bool,
@@ -489,13 +496,7 @@ async fn send_final_events(
     // Drain any pending tool_usage events before emitting final aura.usage
     if emit_custom_events {
         while let Ok(usage_event) = callbacks.tool_usage_rx.try_recv() {
-            let sse_event = AuraStreamEvent::tool_usage(
-                usage_event.tool_ids,
-                usage_event.prompt_tokens,
-                usage_event.completion_tokens,
-                usage_event.total_tokens,
-                ctx.correlation.clone(),
-            );
+            let sse_event = tool_usage_sse(usage_event, ctx.correlation.clone());
             if tx
                 .send(Ok(Bytes::from(sse_event.format_sse())))
                 .await
@@ -1555,6 +1556,7 @@ fn build_final_chunk(ctx: &TurnContext, state: &TurnState) -> Vec<Bytes> {
 mod tests {
     use super::*;
     use aura::stream_events::{AgentContext, CorrelationContext};
+    use aura::{Progress, ToolName};
     use aura_events::event_names;
 
     /// Verify handle_tool_call does NOT emit aura.tool_requested events directly.
@@ -2415,9 +2417,9 @@ mod tests {
                                 progress_token: aura::ProgressToken(aura::NumberOrString::Number(
                                     n,
                                 )),
-                                progress: n as f64,
-                                total: Some(3.0),
+                                progress: Progress::ratio(n as f64, 3.0),
                                 message: Some("working".into()),
+                                agent: None,
                             })
                             .await;
                     }
@@ -2625,9 +2627,10 @@ mod tests {
                 let tx = tx.clone();
                 async move {
                     tx.send(ToolLifecycleEvent::Requested {
-                        tool_id: TOOL_ID.to_string(),
-                        tool_name: TOOL_NAME.to_string(),
+                        tool_id: ToolCallId::new(TOOL_ID),
+                        tool_name: ToolName::new(TOOL_NAME),
                         arguments: json!({ "path": "/mock" }),
+                        agent: None,
                     })
                     .await
                     .expect("tool event channel open");
@@ -2641,9 +2644,10 @@ mod tests {
                 let tx = tx.clone();
                 async move {
                     tx.send(ToolLifecycleEvent::Start {
-                        tool_id: TOOL_ID.to_string(),
-                        tool_name: TOOL_NAME.to_string(),
+                        tool_id: ToolCallId::new(TOOL_ID),
+                        tool_name: ToolName::new(TOOL_NAME),
                         progress_token: Some(ProgressToken(NumberOrString::Number(7))),
+                        agent: None,
                     })
                     .await
                     .expect("tool event channel open");
@@ -2658,9 +2662,9 @@ mod tests {
                 async move {
                     tx.send(ProgressNotification {
                         progress_token: ProgressToken(NumberOrString::Number(7)),
-                        progress: 50.0,
-                        total: Some(100.0),
+                        progress: Progress::ratio(50.0, 100.0),
                         message: Some("halfway".to_string()),
+                        agent: None,
                     })
                     .await
                     .expect("progress channel open");

--- a/crates/aura-web-server/src/streaming/handlers.rs
+++ b/crates/aura-web-server/src/streaming/handlers.rs
@@ -19,6 +19,7 @@
 //! 3. Cancel MCP requests and close connections via `agent.cancel_and_close_mcp()`
 
 use crate::streaming::types::openai::UsageInfo;
+use aura::RequestId;
 
 use super::types::{
     CHUNK_OBJECT, ChatCompletionChunk, ChatCompletionChunkChoice, ChatCompletionChunkDelta,
@@ -42,7 +43,7 @@ use tokio::sync::{mpsc, watch};
 /// Context for cancellation and cleanup callbacks.
 pub struct StreamingCallbacks {
     /// Request ID for cancellation registry
-    pub request_id: String,
+    pub request_id: RequestId,
     /// Agent reference for MCP cleanup (cancel_and_close_mcp)
     pub agent: Arc<dyn StreamingAgent>,
     /// MCP tool event receiver (for aura.tool_requested and aura.tool_start events)
@@ -2128,7 +2129,7 @@ mod tests {
             let (approval_tx, approval_event_rx) = mpsc::channel(8);
             (
                 StreamingCallbacks {
-                    request_id: "req_inactivity_test".to_string(),
+                    request_id: RequestId::new("req_inactivity_test"),
                     agent: Arc::new(MockAgent::pending()),
                     tool_event_rx,
                     progress_rx,
@@ -2514,7 +2515,7 @@ mod tests {
                     _approval_tx: approval_tx,
                 },
                 StreamingCallbacks {
-                    request_id: "req_tool_events".to_string(),
+                    request_id: RequestId::new("req_tool_events"),
                     agent: Arc::new(MockAgent::pending()),
                     tool_event_rx,
                     progress_rx,
@@ -2567,7 +2568,12 @@ mod tests {
             );
 
             let stream = MockAgent::scripted(steps)
-                .stream("q", vec![], CancellationToken::new(), "req_tool_events")
+                .stream(
+                    "q",
+                    vec![],
+                    CancellationToken::new(),
+                    &RequestId::new("req_tool_events"),
+                )
                 .await
                 .expect("mock stream should start");
 

--- a/crates/aura-web-server/src/streaming/otel.rs
+++ b/crates/aura-web-server/src/streaming/otel.rs
@@ -7,6 +7,7 @@
 //! - [`StreamOtelContext::record_input`] — called at span start
 //! - [`StreamOtelContext::record_output`] — called after the stream ends
 
+use aura::RequestId;
 use aura::ResponseContent;
 
 use super::StreamTermination;
@@ -22,7 +23,7 @@ use super::StreamTermination;
 pub struct StreamOtelContext {
     pub provider: String,
     pub model: String,
-    pub request_id: String,
+    pub request_id: RequestId,
     pub session_id: String,
     pub query: String,
     /// OpenAI-compatible `user` field from the request.
@@ -50,7 +51,7 @@ impl StreamOtelContext {
         if let Some(system_prompt) = &self.system_prompt {
             aura::logging::set_system_prompt_attribute(&span, system_prompt);
         }
-        aura::logging::set_span_attribute(&span, "http.request_id", self.request_id.clone());
+        aura::logging::set_span_attribute(&span, "http.request_id", self.request_id.to_string());
         aura::logging::set_span_attribute(&span, "session.id", self.session_id.clone());
         aura::logging::set_span_attribute(
             &span,

--- a/crates/aura-web-server/tests/agent_event_differential.rs
+++ b/crates/aura-web-server/tests/agent_event_differential.rs
@@ -1,0 +1,396 @@
+//! Proves the agent event schema reaches consumers unchanged.
+//!
+//! Each case drives `process_sse_stream_full` twice over the same logical
+//! sequence — once publishing to the request-scoped brokers directly, once
+//! publishing [`AgentEvent`]s through [`aura::agent_events`] — and asserts the
+//! SSE frames are byte-identical. Only the producer side differs; both runs
+//! subscribe the way `handlers::stream_chat_completion` does, so the broker
+//! registry and its request-id routing are under test rather than stubbed.
+//!
+//! A variant that loses a field in translation fails here.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use aura::agent_events::{Routed, publish_to_brokers};
+use aura::tool_event_broker::publish_tool_requested;
+use aura::{
+    ApprovalLifecycleEvent, NumberOrString, Progress, ProgressNotification, ProgressToken,
+    ResponseContent, StreamError, StreamItem, StreamingAgent, TokenUsage, ToolCallId, ToolName,
+    UsageState,
+};
+use aura::{
+    approval_event_subscribe, approval_event_unsubscribe, publish_tool_start, publish_tool_usage,
+    request_progress_subscribe, request_progress_unsubscribe, tool_event_subscribe,
+    tool_event_unsubscribe, tool_usage_subscribe, tool_usage_unsubscribe,
+};
+use aura_events::TokenCount;
+use aura_events::agent::{AgentEvent, AgentEventPayload};
+use aura_test_utils::mock_agent::{MockAgent, Step, items};
+use aura_test_utils::sse::{SseEvent, parse_sse_stream};
+use aura_web_server::streaming::{
+    StreamConfig, StreamTermination, StreamingCallbacks, ToolResultMode, TurnContext,
+    process_sse_stream_full,
+};
+use bytes::Bytes;
+use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
+
+const TOOL_ID: &str = "call_abc123";
+const TOOL_NAME: &str = "list_files";
+const TOOL_ARGS: &str = r#"{"path":"/mock"}"#;
+const SESSION_ID: &str = "cs-differential";
+
+fn token() -> ProgressToken {
+    ProgressToken(NumberOrString::Number(7))
+}
+
+fn args() -> serde_json::Value {
+    serde_json::json!({ "path": "/mock" })
+}
+
+fn usage() -> TokenUsage {
+    TokenUsage {
+        prompt_tokens: TokenCount::new(10),
+        completion_tokens: TokenCount::new(5),
+        total_tokens: TokenCount::new(15),
+    }
+}
+
+/// Subscribes exactly as the production handler does, so events reach the
+/// stream through the global brokers keyed by `request_id`.
+async fn callbacks_for(request_id: &str) -> StreamingCallbacks {
+    StreamingCallbacks {
+        request_id: request_id.to_string(),
+        agent: Arc::new(MockAgent::pending()),
+        tool_event_rx: tool_event_subscribe(request_id).await,
+        progress_rx: request_progress_subscribe(request_id).await,
+        tool_usage_rx: tool_usage_subscribe(request_id).await,
+        approval_event_rx: approval_event_subscribe(request_id).await,
+        usage_state: UsageState::new(),
+        response_content: ResponseContent::new(),
+        model_name: "test/fake".to_string(),
+        stream_shutdown_token: CancellationToken::new(),
+    }
+}
+
+async fn unsubscribe_all(request_id: &str) {
+    tool_event_unsubscribe(request_id).await;
+    request_progress_unsubscribe(request_id).await;
+    tool_usage_unsubscribe(request_id).await;
+    approval_event_unsubscribe(request_id).await;
+}
+
+async fn run(request_id: &str, steps: Vec<Step>) -> Vec<SseEvent> {
+    let callbacks = callbacks_for(request_id).await;
+    let config = StreamConfig::new(true, false, ToolResultMode::Aura, 0);
+    let ctx = TurnContext::new(
+        "chatcmpl-test".to_string(),
+        "test/fake".to_string(),
+        1_700_000_000,
+        None,
+        SESSION_ID,
+    );
+
+    let stream = MockAgent::scripted(steps)
+        .stream("q", vec![], CancellationToken::new(), request_id)
+        .await
+        .expect("mock stream should start");
+
+    let (chunk_tx, mut chunk_rx) = mpsc::channel::<Result<Bytes, String>>(64);
+    let collector = tokio::spawn(async move {
+        let mut body = String::new();
+        while let Some(chunk) = chunk_rx.recv().await {
+            body.push_str(std::str::from_utf8(&chunk.expect("SSE chunk")).expect("UTF-8"));
+        }
+        body
+    });
+    let (cancel_tx, _cancel_rx) = watch::channel(false);
+
+    let termination = process_sse_stream_full(
+        &config,
+        &ctx,
+        stream,
+        chunk_tx,
+        cancel_tx,
+        Duration::from_secs(900),
+        // Far enough out that heartbeats never interleave with the script.
+        Duration::from_secs(86_400),
+        None,
+        None,
+        callbacks,
+    )
+    .await;
+    assert_eq!(termination, StreamTermination::Complete);
+
+    let body = collector.await.expect("collector should not panic");
+    unsubscribe_all(request_id).await;
+
+    let (events, done) = parse_sse_stream(&body);
+    assert!(done, "stream should terminate with [DONE]");
+    events
+}
+
+fn frames(events: &[SseEvent]) -> Vec<(Option<String>, String)> {
+    events
+        .iter()
+        .map(|e| (e.event_type.clone(), e.data.clone()))
+        .collect()
+}
+
+/// `broker` and `schema` must describe the same logical sequence. Both run with
+/// distinct request ids so their broker registrations cannot alias.
+async fn assert_paths_agree(
+    case: &str,
+    broker: impl FnOnce(&str) -> Vec<Step>,
+    schema: impl FnOnce(&str) -> Vec<Step>,
+) {
+    let broker_id = format!("req_broker_{case}");
+    let schema_id = format!("req_schema_{case}");
+
+    let via_broker = run(&broker_id, broker(&broker_id)).await;
+    let via_schema = run(&schema_id, schema(&schema_id)).await;
+
+    assert_eq!(
+        frames(&via_broker),
+        frames(&via_schema),
+        "{case}: schema path diverged from broker path"
+    );
+    assert!(
+        !via_broker.is_empty(),
+        "{case}: no frames captured, so agreement proves nothing"
+    );
+}
+
+/// Publishing through the adapter must reach a subscriber; a silent
+/// `NoSubscriber` would make both paths agree on emptiness.
+fn emit(
+    event: AgentEvent,
+) -> impl Fn(String) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send>> {
+    move |request_id: String| {
+        let event = event.clone();
+        Box::pin(async move {
+            let routed = publish_to_brokers(&request_id, event).await;
+            assert_eq!(
+                routed,
+                Routed::Delivered,
+                "adapter should reach a subscriber"
+            );
+        })
+    }
+}
+
+fn tool_result_ok() -> Result<StreamItem, StreamError> {
+    items::tool_result(TOOL_ID, "README.md\nsrc/")
+}
+
+#[tokio::test(start_paused = true)]
+async fn tool_requested_matches() {
+    assert_paths_agree(
+        "tool_requested",
+        |_| {
+            vec![
+                Step::effect(|request_id: String| async move {
+                    publish_tool_requested(
+                        &request_id,
+                        ToolCallId::new(TOOL_ID),
+                        ToolName::new(TOOL_NAME),
+                        args(),
+                    )
+                    .await;
+                }),
+                Step::item(items::text("done")),
+            ]
+        },
+        |_| {
+            vec![
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolRequested {
+                        tool_call_id: ToolCallId::new(TOOL_ID),
+                        tool_name: ToolName::new(TOOL_NAME),
+                        arguments: args(),
+                    },
+                ))),
+                Step::item(items::text("done")),
+            ]
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_full_tool_turn_matches() {
+    assert_paths_agree(
+        "full_turn",
+        |_| {
+            vec![
+                Step::effect(|request_id: String| async move {
+                    publish_tool_requested(
+                        &request_id,
+                        ToolCallId::new(TOOL_ID),
+                        ToolName::new(TOOL_NAME),
+                        args(),
+                    )
+                    .await;
+                }),
+                Step::item(items::tool_call(TOOL_ID, TOOL_NAME, TOOL_ARGS)),
+                Step::effect(|request_id: String| async move {
+                    publish_tool_start(
+                        &request_id,
+                        ToolCallId::new(TOOL_ID),
+                        ToolName::new(TOOL_NAME),
+                        Some(token()),
+                    )
+                    .await;
+                }),
+                Step::effect(|request_id: String| async move {
+                    aura::request_progress::publish(
+                        &request_id,
+                        ProgressNotification {
+                            progress_token: token(),
+                            progress: Progress::ratio(50.0, 100.0),
+                            message: Some("halfway".to_string()),
+                            agent: None,
+                        },
+                    )
+                    .await;
+                }),
+                Step::item(tool_result_ok()),
+                Step::item(items::text("Here are the files.")),
+            ]
+        },
+        |_| {
+            vec![
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolRequested {
+                        tool_call_id: ToolCallId::new(TOOL_ID),
+                        tool_name: ToolName::new(TOOL_NAME),
+                        arguments: args(),
+                    },
+                ))),
+                Step::item(items::tool_call(TOOL_ID, TOOL_NAME, TOOL_ARGS)),
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolStart {
+                        tool_call_id: ToolCallId::new(TOOL_ID),
+                        tool_name: ToolName::new(TOOL_NAME),
+                        progress_token: Some(token()),
+                    },
+                ))),
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolProgress {
+                        progress_token: token(),
+                        progress: Progress::ratio(50.0, 100.0),
+                        message: Some("halfway".to_string()),
+                    },
+                ))),
+                Step::item(tool_result_ok()),
+                Step::item(items::text("Here are the files.")),
+            ]
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn progress_without_a_message_matches() {
+    let build_broker = |_: &str| {
+        vec![
+            Step::effect(|request_id: String| async move {
+                aura::request_progress::publish(
+                    &request_id,
+                    ProgressNotification {
+                        progress_token: token(),
+                        progress: Progress::indeterminate(3.0),
+                        message: None,
+                        agent: None,
+                    },
+                )
+                .await;
+            }),
+            Step::item(items::text("done")),
+        ]
+    };
+    let build_schema = |_: &str| {
+        vec![
+            Step::effect(emit(AgentEvent::single_agent(
+                AgentEventPayload::ToolProgress {
+                    progress_token: token(),
+                    progress: Progress::indeterminate(3.0),
+                    message: None,
+                },
+            ))),
+            Step::item(items::text("done")),
+        ]
+    };
+
+    assert_paths_agree("progress_no_message", build_broker, build_schema).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn tool_usage_matches() {
+    assert_paths_agree(
+        "tool_usage",
+        |_| {
+            vec![
+                Step::effect(|request_id: String| async move {
+                    publish_tool_usage(&request_id, vec![ToolCallId::new(TOOL_ID)], usage()).await;
+                }),
+                Step::item(items::text("done")),
+            ]
+        },
+        |_| {
+            vec![
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ToolUsage {
+                        tool_call_ids: vec![ToolCallId::new(TOOL_ID)],
+                        usage: usage(),
+                    },
+                ))),
+                Step::item(items::text("done")),
+            ]
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn approval_lifecycle_matches() {
+    let requested = aura_events::ApprovalRequested {
+        decision_id: "dec_1".to_string(),
+        tool_name: TOOL_NAME.to_string(),
+        origin: aura_events::ApprovalOriginWire::ConfigGate {
+            matched_pattern: "list_*".to_string(),
+            agent_name: "main".to_string(),
+        },
+        scope: aura_events::AgentScopeWire::Single {
+            session_id: Some(SESSION_ID.to_string()),
+        },
+    };
+
+    let for_broker = requested.clone();
+    let for_schema = requested.clone();
+
+    assert_paths_agree(
+        "approval",
+        move |_| {
+            vec![
+                Step::effect(move |request_id: String| {
+                    let event = ApprovalLifecycleEvent::Requested(for_broker.clone());
+                    async move {
+                        aura::approval_event_broker::publish(&request_id, event).await;
+                    }
+                }),
+                Step::item(items::text("done")),
+            ]
+        },
+        move |_| {
+            vec![
+                Step::effect(emit(AgentEvent::single_agent(
+                    AgentEventPayload::ApprovalRequested(for_schema),
+                ))),
+                Step::item(items::text("done")),
+            ]
+        },
+    )
+    .await;
+}

--- a/crates/aura-web-server/tests/agent_event_differential.rs
+++ b/crates/aura-web-server/tests/agent_event_differential.rs
@@ -16,8 +16,8 @@ use aura::agent_events::{Routed, publish_to_brokers};
 use aura::tool_event_broker::publish_tool_requested;
 use aura::{
     ApprovalLifecycleEvent, NumberOrString, Progress, ProgressNotification, ProgressToken,
-    ResponseContent, StreamError, StreamItem, StreamingAgent, TokenUsage, ToolCallId, ToolName,
-    UsageState,
+    RequestId, ResponseContent, StreamError, StreamItem, StreamingAgent, TokenUsage, ToolCallId,
+    ToolName, UsageState,
 };
 use aura::{
     approval_event_subscribe, approval_event_unsubscribe, publish_tool_start, publish_tool_usage,
@@ -59,9 +59,9 @@ fn usage() -> TokenUsage {
 
 /// Subscribes exactly as the production handler does, so events reach the
 /// stream through the global brokers keyed by `request_id`.
-async fn callbacks_for(request_id: &str) -> StreamingCallbacks {
+async fn callbacks_for(request_id: &RequestId) -> StreamingCallbacks {
     StreamingCallbacks {
-        request_id: request_id.to_string(),
+        request_id: request_id.clone(),
         agent: Arc::new(MockAgent::pending()),
         tool_event_rx: tool_event_subscribe(request_id).await,
         progress_rx: request_progress_subscribe(request_id).await,
@@ -74,14 +74,14 @@ async fn callbacks_for(request_id: &str) -> StreamingCallbacks {
     }
 }
 
-async fn unsubscribe_all(request_id: &str) {
+async fn unsubscribe_all(request_id: &RequestId) {
     tool_event_unsubscribe(request_id).await;
     request_progress_unsubscribe(request_id).await;
     tool_usage_unsubscribe(request_id).await;
     approval_event_unsubscribe(request_id).await;
 }
 
-async fn run(request_id: &str, steps: Vec<Step>) -> Vec<SseEvent> {
+async fn run(request_id: &RequestId, steps: Vec<Step>) -> Vec<SseEvent> {
     let callbacks = callbacks_for(request_id).await;
     let config = StreamConfig::new(true, false, ToolResultMode::Aura, 0);
     let ctx = TurnContext::new(
@@ -142,11 +142,11 @@ fn frames(events: &[SseEvent]) -> Vec<(Option<String>, String)> {
 /// distinct request ids so their broker registrations cannot alias.
 async fn assert_paths_agree(
     case: &str,
-    broker: impl FnOnce(&str) -> Vec<Step>,
-    schema: impl FnOnce(&str) -> Vec<Step>,
+    broker: impl FnOnce(&RequestId) -> Vec<Step>,
+    schema: impl FnOnce(&RequestId) -> Vec<Step>,
 ) {
-    let broker_id = format!("req_broker_{case}");
-    let schema_id = format!("req_schema_{case}");
+    let broker_id = RequestId::new(format!("req_broker_{case}"));
+    let schema_id = RequestId::new(format!("req_schema_{case}"));
 
     let via_broker = run(&broker_id, broker(&broker_id)).await;
     let via_schema = run(&schema_id, schema(&schema_id)).await;
@@ -166,8 +166,8 @@ async fn assert_paths_agree(
 /// `NoSubscriber` would make both paths agree on emptiness.
 fn emit(
     event: AgentEvent,
-) -> impl Fn(String) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send>> {
-    move |request_id: String| {
+) -> impl Fn(RequestId) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send>> {
+    move |request_id: RequestId| {
         let event = event.clone();
         Box::pin(async move {
             let routed = publish_to_brokers(&request_id, event).await;
@@ -190,7 +190,7 @@ async fn tool_requested_matches() {
         "tool_requested",
         |_| {
             vec![
-                Step::effect(|request_id: String| async move {
+                Step::effect(|request_id: RequestId| async move {
                     publish_tool_requested(
                         &request_id,
                         ToolCallId::new(TOOL_ID),
@@ -224,7 +224,7 @@ async fn a_full_tool_turn_matches() {
         "full_turn",
         |_| {
             vec![
-                Step::effect(|request_id: String| async move {
+                Step::effect(|request_id: RequestId| async move {
                     publish_tool_requested(
                         &request_id,
                         ToolCallId::new(TOOL_ID),
@@ -234,7 +234,7 @@ async fn a_full_tool_turn_matches() {
                     .await;
                 }),
                 Step::item(items::tool_call(TOOL_ID, TOOL_NAME, TOOL_ARGS)),
-                Step::effect(|request_id: String| async move {
+                Step::effect(|request_id: RequestId| async move {
                     publish_tool_start(
                         &request_id,
                         ToolCallId::new(TOOL_ID),
@@ -243,7 +243,7 @@ async fn a_full_tool_turn_matches() {
                     )
                     .await;
                 }),
-                Step::effect(|request_id: String| async move {
+                Step::effect(|request_id: RequestId| async move {
                     aura::request_progress::publish(
                         &request_id,
                         ProgressNotification {
@@ -293,9 +293,9 @@ async fn a_full_tool_turn_matches() {
 
 #[tokio::test(start_paused = true)]
 async fn progress_without_a_message_matches() {
-    let build_broker = |_: &str| {
+    let build_broker = |_: &RequestId| {
         vec![
-            Step::effect(|request_id: String| async move {
+            Step::effect(|request_id: RequestId| async move {
                 aura::request_progress::publish(
                     &request_id,
                     ProgressNotification {
@@ -310,7 +310,7 @@ async fn progress_without_a_message_matches() {
             Step::item(items::text("done")),
         ]
     };
-    let build_schema = |_: &str| {
+    let build_schema = |_: &RequestId| {
         vec![
             Step::effect(emit(AgentEvent::single_agent(
                 AgentEventPayload::ToolProgress {
@@ -332,7 +332,7 @@ async fn tool_usage_matches() {
         "tool_usage",
         |_| {
             vec![
-                Step::effect(|request_id: String| async move {
+                Step::effect(|request_id: RequestId| async move {
                     publish_tool_usage(&request_id, vec![ToolCallId::new(TOOL_ID)], usage()).await;
                 }),
                 Step::item(items::text("done")),
@@ -374,7 +374,7 @@ async fn approval_lifecycle_matches() {
         "approval",
         move |_| {
             vec![
-                Step::effect(move |request_id: String| {
+                Step::effect(move |request_id: RequestId| {
                     let event = ApprovalLifecycleEvent::Requested(for_broker.clone());
                     async move {
                         aura::approval_event_broker::publish(&request_id, event).await;

--- a/crates/aura-web-server/tests/common/mod.rs
+++ b/crates/aura-web-server/tests/common/mod.rs
@@ -8,6 +8,7 @@
 //! server; for single-process backends they are two handles to the same
 //! store, which is that backend's deployment shape.
 
+use aura::RequestId;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -25,7 +26,7 @@ pub fn make_parked(request_id: &str, ttl: Duration) -> ParkedApproval {
             version: PROTOCOL_VERSION,
             instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
-            request_id: request_id.to_string(),
+            request_id: RequestId::new(request_id),
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: "kubectl_*".to_string(),
@@ -152,7 +153,10 @@ pub async fn cancel_request_removes_only_matching(instance: &Arc<dyn ApprovalSto
     instance.register(cancel).await.unwrap();
     instance.register(keep).await.unwrap();
 
-    let cleared = instance.cancel_request("req-cancel").await.unwrap();
+    let cleared = instance
+        .cancel_request(&RequestId::new("req-cancel"))
+        .await
+        .unwrap();
 
     assert_eq!(cleared.len(), 1, "exactly the matching ticket is cleared");
     assert_eq!(

--- a/crates/aura-web-server/tests/file_session_store_test.rs
+++ b/crates/aura-web-server/tests/file_session_store_test.rs
@@ -8,6 +8,7 @@
 
 mod common;
 
+use aura::RequestId;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -255,7 +256,10 @@ async fn cancel_request_removes_only_undecided_matching_approvals() {
     let other_id = other.request.decision_id;
     store.register(other).await.unwrap();
 
-    let cleared = store.cancel_request("req-owner").await.unwrap();
+    let cleared = store
+        .cancel_request(&RequestId::new("req-owner"))
+        .await
+        .unwrap();
 
     assert_eq!(cleared.len(), 1, "only the undecided ticket is cleared");
     assert_eq!(cleared[0].request.decision_id, undecided_id);
@@ -299,7 +303,10 @@ async fn cancel_request_sweeps_a_stale_decided_approval_without_returning_it() {
     )
     .unwrap();
 
-    let cleared = store.cancel_request("req-residue").await.unwrap();
+    let cleared = store
+        .cancel_request(&RequestId::new("req-residue"))
+        .await
+        .unwrap();
 
     assert_eq!(cleared.len(), 1, "only the undecided ticket is cleared");
     assert_eq!(cleared[0].request.decision_id, undecided_id);
@@ -336,7 +343,10 @@ async fn cancel_request_skips_an_undecodable_approval_file() {
     let corrupt = dir.path().join("approvals").join("corrupt.json");
     std::fs::write(&corrupt, b"not json").unwrap();
 
-    let cleared = store.cancel_request("req-corrupt").await.unwrap();
+    let cleared = store
+        .cancel_request(&RequestId::new("req-corrupt"))
+        .await
+        .unwrap();
 
     assert_eq!(cleared.len(), 1);
     assert_eq!(cleared[0].request.decision_id, id);

--- a/crates/aura-web-server/tests/mcp_progress_test.rs
+++ b/crates/aura-web-server/tests/mcp_progress_test.rs
@@ -3,6 +3,7 @@
 //! Integration tests for MCP progress notification forwarding.
 //!
 
+use aura::RequestId;
 use aura::mcp::McpClient;
 use aura::{request_progress_global, request_progress_subscribe, request_progress_unsubscribe};
 use std::collections::HashMap;
@@ -141,15 +142,15 @@ async fn test_call_tool_without_progress_still_works() {
 #[tokio::test]
 async fn test_request_progress_broker_accessible() {
     let broker = request_progress_global();
-    let test_request_id = "test_req_123";
-    let _rx = broker.subscribe(test_request_id).await;
+    let test_request_id = RequestId::new("test_req_123");
+    let _rx = broker.subscribe(&test_request_id).await;
 
     assert!(
         broker.active_subscriptions().await >= 1,
         "Should have at least 1 subscription after subscribing"
     );
 
-    broker.unsubscribe(test_request_id).await;
+    broker.unsubscribe(&test_request_id).await;
 }
 
 /// Verifies progress notifications only go to the correct request (no cross-request leakage).
@@ -158,8 +159,8 @@ async fn test_request_progress_isolation() {
     use aura::{NumberOrString, Progress, ProgressNotification, ProgressToken};
     use std::sync::Arc;
 
-    let mut rx1 = request_progress_subscribe("req_1").await;
-    let mut rx2 = request_progress_subscribe("req_2").await;
+    let mut rx1 = request_progress_subscribe(&RequestId::new("req_1")).await;
+    let mut rx2 = request_progress_subscribe(&RequestId::new("req_2")).await;
 
     let notification = ProgressNotification {
         progress_token: ProgressToken(NumberOrString::String(Arc::from("token_1"))),
@@ -169,7 +170,7 @@ async fn test_request_progress_isolation() {
     };
 
     let broker = request_progress_global();
-    let sent = broker.publish("req_1", notification).await;
+    let sent = broker.publish(&RequestId::new("req_1"), notification).await;
     assert!(sent, "Should successfully publish to req_1");
 
     let received = tokio::time::timeout(Duration::from_millis(100), rx1.recv())
@@ -185,16 +186,16 @@ async fn test_request_progress_isolation() {
         "req_2 should NOT receive progress meant for req_1"
     );
 
-    request_progress_unsubscribe("req_1").await;
-    request_progress_unsubscribe("req_2").await;
+    request_progress_unsubscribe(&RequestId::new("req_1")).await;
+    request_progress_unsubscribe(&RequestId::new("req_2")).await;
 }
 
 #[tokio::test]
 async fn test_unsubscribe_stops_progress() {
     use aura::{NumberOrString, Progress, ProgressNotification, ProgressToken};
 
-    let request_id = "req_cancel_test";
-    let mut rx = request_progress_subscribe(request_id).await;
+    let request_id = RequestId::new("req_cancel_test");
+    let mut rx = request_progress_subscribe(&request_id).await;
 
     let broker = request_progress_global();
     let notification = ProgressNotification {
@@ -203,12 +204,12 @@ async fn test_unsubscribe_stops_progress() {
         message: Some("Step 1".to_string()),
         agent: None,
     };
-    broker.publish(request_id, notification).await;
+    broker.publish(&request_id, notification).await;
 
     let received = rx.recv().await;
     assert!(received.is_some(), "Should receive first notification");
 
-    request_progress_unsubscribe(request_id).await;
+    request_progress_unsubscribe(&request_id).await;
 
     let notification2 = ProgressNotification {
         progress_token: ProgressToken(NumberOrString::Number(1)),
@@ -216,7 +217,7 @@ async fn test_unsubscribe_stops_progress() {
         message: Some("Step 2 - should not be received".to_string()),
         agent: None,
     };
-    let sent = broker.publish(request_id, notification2).await;
+    let sent = broker.publish(&request_id, notification2).await;
 
     assert!(!sent, "Should not be able to send after unsubscribe");
 }

--- a/crates/aura-web-server/tests/mcp_progress_test.rs
+++ b/crates/aura-web-server/tests/mcp_progress_test.rs
@@ -155,7 +155,7 @@ async fn test_request_progress_broker_accessible() {
 /// Verifies progress notifications only go to the correct request (no cross-request leakage).
 #[tokio::test]
 async fn test_request_progress_isolation() {
-    use aura::{NumberOrString, ProgressNotification, ProgressToken};
+    use aura::{NumberOrString, Progress, ProgressNotification, ProgressToken};
     use std::sync::Arc;
 
     let mut rx1 = request_progress_subscribe("req_1").await;
@@ -163,9 +163,9 @@ async fn test_request_progress_isolation() {
 
     let notification = ProgressNotification {
         progress_token: ProgressToken(NumberOrString::String(Arc::from("token_1"))),
-        progress: 50.0,
-        total: Some(100.0),
+        progress: Progress::ratio(50.0, 100.0),
         message: Some("Progress for request 1".to_string()),
+        agent: None,
     };
 
     let broker = request_progress_global();
@@ -191,7 +191,7 @@ async fn test_request_progress_isolation() {
 
 #[tokio::test]
 async fn test_unsubscribe_stops_progress() {
-    use aura::{NumberOrString, ProgressNotification, ProgressToken};
+    use aura::{NumberOrString, Progress, ProgressNotification, ProgressToken};
 
     let request_id = "req_cancel_test";
     let mut rx = request_progress_subscribe(request_id).await;
@@ -199,9 +199,9 @@ async fn test_unsubscribe_stops_progress() {
     let broker = request_progress_global();
     let notification = ProgressNotification {
         progress_token: ProgressToken(NumberOrString::Number(1)),
-        progress: 10.0,
-        total: Some(100.0),
+        progress: Progress::ratio(10.0, 100.0),
         message: Some("Step 1".to_string()),
+        agent: None,
     };
     broker.publish(request_id, notification).await;
 
@@ -212,9 +212,9 @@ async fn test_unsubscribe_stops_progress() {
 
     let notification2 = ProgressNotification {
         progress_token: ProgressToken(NumberOrString::Number(1)),
-        progress: 20.0,
-        total: Some(100.0),
+        progress: Progress::ratio(20.0, 100.0),
         message: Some("Step 2 - should not be received".to_string()),
+        agent: None,
     };
     let sent = broker.publish(request_id, notification2).await;
 

--- a/crates/aura/src/agent_events.rs
+++ b/crates/aura/src/agent_events.rs
@@ -1,0 +1,349 @@
+//! Projection of [`AgentEvent`]s back onto the request-scoped brokers.
+//!
+//! Producers move onto the [`aura_events::agent`] schema one at a time. This
+//! adapter lets them do that without any consumer changing, because it
+//! republishes an agent's events into the same brokers the SSE handler already
+//! subscribes to, so both paths converge on identical output.
+//!
+//! Scope: the side channels only — tool lifecycle, MCP progress, tool usage,
+//! and HITL approvals. Content-bearing events ([`AgentEventPayload::TextDelta`]
+//! and friends) reach consumers through the `StreamItem` stream rather than a
+//! broker, and gain their projection alongside the producer that emits them.
+
+use aura_events::agent::{AgentEvent, AgentEventPayload};
+
+use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
+use crate::env_flags::bool_env;
+use crate::request_progress::{self, ProgressNotification};
+use crate::tool_event_broker::{self, ToolLifecycleEvent, publish_tool_usage};
+
+pub const ENV_AGENT_EVENTS: &str = "AURA_AGENT_EVENTS";
+
+/// Defaults off until the schema reaches parity with the broker path.
+pub fn agent_events_enabled() -> bool {
+    bool_env(ENV_AGENT_EVENTS, false)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Routed {
+    Delivered,
+    NoSubscriber,
+    /// The payload has no broker.
+    NotSideChannel,
+}
+
+/// Publishing is fire-and-forget, so a request whose subscriber has gone away
+/// yields `NoSubscriber` rather than an error. Content-bearing payloads have no
+/// broker to publish to and fall through to `NotSideChannel`; they reach
+/// consumers over the `StreamItem` stream instead.
+///
+/// The event's [`AgentContext`] rides along on every broker event that carries
+/// one, so a worker's tool call stays attributed to the worker rather than to
+/// the stream's own agent.
+pub async fn publish_to_brokers(request_id: &str, event: AgentEvent) -> Routed {
+    let AgentEvent { agent, payload } = event;
+    let delivered = match payload {
+        AgentEventPayload::ToolRequested {
+            tool_call_id,
+            tool_name,
+            arguments,
+        } => {
+            tool_event_broker::publish(
+                request_id,
+                ToolLifecycleEvent::Requested {
+                    tool_id: tool_call_id,
+                    tool_name,
+                    arguments,
+                    agent: Some(agent),
+                },
+            )
+            .await
+        }
+
+        AgentEventPayload::ToolStart {
+            tool_call_id,
+            tool_name,
+            progress_token,
+        } => {
+            tool_event_broker::publish(
+                request_id,
+                ToolLifecycleEvent::Start {
+                    tool_id: tool_call_id,
+                    tool_name,
+                    progress_token,
+                    agent: Some(agent),
+                },
+            )
+            .await
+        }
+
+        AgentEventPayload::ToolProgress {
+            progress_token,
+            progress,
+            message,
+        } => {
+            request_progress::publish(
+                request_id,
+                ProgressNotification {
+                    progress_token,
+                    progress,
+                    message,
+                    agent: Some(agent),
+                },
+            )
+            .await
+        }
+
+        AgentEventPayload::ToolUsage {
+            tool_call_ids,
+            usage,
+        } => publish_tool_usage(request_id, tool_call_ids, usage).await,
+
+        AgentEventPayload::ApprovalRequested(approval) => {
+            approval_event_broker::publish(request_id, ApprovalLifecycleEvent::Requested(approval))
+                .await
+        }
+
+        AgentEventPayload::ApprovalPending(approval) => {
+            approval_event_broker::publish(request_id, ApprovalLifecycleEvent::Pending(approval))
+                .await
+        }
+
+        AgentEventPayload::ApprovalCompleted(approval) => {
+            approval_event_broker::publish(request_id, ApprovalLifecycleEvent::Completed(approval))
+                .await
+        }
+
+        // Listed rather than folded into the wildcard: `AgentEventPayload` is
+        // `#[non_exhaustive]` across the crate boundary, so the wildcard is
+        // mandatory and exhaustiveness checking cannot flag a new side-channel
+        // variant that forgets its arm here.
+        AgentEventPayload::SessionInfo { .. }
+        | AgentEventPayload::McpStatus { .. }
+        | AgentEventPayload::TextDelta { .. }
+        | AgentEventPayload::Reasoning { .. }
+        | AgentEventPayload::ToolComplete { .. }
+        | AgentEventPayload::WorkerPhase { .. }
+        | AgentEventPayload::Usage { .. }
+        | AgentEventPayload::ContextUsage { .. }
+        | AgentEventPayload::ScratchpadUsage { .. } => return Routed::NotSideChannel,
+
+        unknown => {
+            tracing::warn!(
+                payload = ?std::mem::discriminant(&unknown),
+                "agent event payload has no broker arm; the event reached no consumer"
+            );
+            return Routed::NotSideChannel;
+        }
+    };
+
+    if delivered {
+        Routed::Delivered
+    } else {
+        Routed::NoSubscriber
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aura_events::agent::ToolOutcome;
+    use aura_events::{
+        AgentContext, NumberOrString, Progress, ProgressToken, TokenCount, TokenUsage, ToolCallId,
+        ToolName,
+    };
+    use serde_json::json;
+
+    use crate::request_progress::subscribe as progress_subscribe;
+    use crate::tool_event_broker::{
+        ToolLifecycleEvent, subscribe as tool_event_subscribe, tool_usage_subscribe,
+    };
+
+    fn token(n: i64) -> ProgressToken {
+        ProgressToken(NumberOrString::Number(n))
+    }
+
+    #[tokio::test]
+    async fn tool_requested_reaches_the_tool_event_broker() {
+        let request_id = "req_adapter_requested";
+        let mut rx = tool_event_subscribe(request_id).await;
+
+        let routed = publish_to_brokers(
+            request_id,
+            AgentEvent::single_agent(AgentEventPayload::ToolRequested {
+                tool_call_id: ToolCallId::new("call_1"),
+                tool_name: ToolName::new("list_files"),
+                arguments: json!({ "path": "/mock" }),
+            }),
+        )
+        .await;
+
+        assert_eq!(routed, Routed::Delivered);
+        let event = rx.recv().await.expect("event should arrive");
+        let ToolLifecycleEvent::Requested {
+            tool_id,
+            tool_name,
+            arguments,
+            ..
+        } = event
+        else {
+            panic!("expected Requested");
+        };
+        assert_eq!(tool_id, "call_1");
+        assert_eq!(tool_name, "list_files");
+        assert_eq!(arguments, json!({ "path": "/mock" }));
+    }
+
+    #[tokio::test]
+    async fn tool_start_carries_its_progress_token() {
+        let request_id = "req_adapter_start";
+        let mut rx = tool_event_subscribe(request_id).await;
+
+        publish_to_brokers(
+            request_id,
+            AgentEvent::single_agent(AgentEventPayload::ToolStart {
+                tool_call_id: ToolCallId::new("call_1"),
+                tool_name: ToolName::new("list_files"),
+                progress_token: Some(token(7)),
+            }),
+        )
+        .await;
+
+        let ToolLifecycleEvent::Start { progress_token, .. } =
+            rx.recv().await.expect("event should arrive")
+        else {
+            panic!("expected Start");
+        };
+        assert_eq!(progress_token, Some(token(7)));
+    }
+
+    #[tokio::test]
+    async fn progress_keeps_the_raw_values_the_handler_derives_percent_from() {
+        let request_id = "req_adapter_progress";
+        let mut rx = progress_subscribe(request_id).await;
+
+        publish_to_brokers(
+            request_id,
+            AgentEvent::single_agent(AgentEventPayload::ToolProgress {
+                progress_token: token(7),
+                progress: Progress::ratio(50.0, 100.0),
+                message: Some("halfway".to_string()),
+            }),
+        )
+        .await;
+
+        let notification = rx.recv().await.expect("notification should arrive");
+        assert_eq!(notification.progress.current, 50.0);
+        assert_eq!(notification.progress.total, Some(100.0));
+        assert_eq!(notification.message.as_deref(), Some("halfway"));
+        assert_eq!(notification.percent(), Some(50));
+    }
+
+    #[tokio::test]
+    async fn tool_usage_reaches_the_usage_broker() {
+        let request_id = "req_adapter_usage";
+        let mut rx = tool_usage_subscribe(request_id).await;
+
+        publish_to_brokers(
+            request_id,
+            AgentEvent::single_agent(AgentEventPayload::ToolUsage {
+                tool_call_ids: vec![ToolCallId::new("call_1")],
+                usage: TokenUsage {
+                    prompt_tokens: TokenCount::new(10),
+                    completion_tokens: TokenCount::new(5),
+                    total_tokens: TokenCount::new(15),
+                },
+            }),
+        )
+        .await;
+
+        let usage = rx.recv().await.expect("usage should arrive");
+        assert_eq!(usage.tool_ids, vec![ToolCallId::new("call_1")]);
+        assert_eq!(usage.usage.total_tokens.get(), 15);
+    }
+
+    #[tokio::test]
+    async fn content_events_are_not_routed_to_a_broker() {
+        let routed = publish_to_brokers(
+            "req_adapter_text",
+            AgentEvent::single_agent(AgentEventPayload::TextDelta {
+                content: "hello".to_string(),
+            }),
+        )
+        .await;
+
+        assert_eq!(routed, Routed::NotSideChannel);
+    }
+
+    #[tokio::test]
+    async fn tool_complete_is_carried_by_the_stream_not_a_broker() {
+        let routed = publish_to_brokers(
+            "req_adapter_complete",
+            AgentEvent::single_agent(AgentEventPayload::ToolComplete {
+                tool_call_id: ToolCallId::new("call_1"),
+                tool_name: ToolName::new("list_files"),
+                duration_ms: 3,
+                outcome: ToolOutcome::Success {
+                    result: "ok".to_string(),
+                },
+            }),
+        )
+        .await;
+
+        assert_eq!(routed, Routed::NotSideChannel);
+    }
+
+    #[tokio::test]
+    async fn a_side_channel_event_with_nobody_listening_reports_no_subscriber() {
+        let routed = publish_to_brokers(
+            "req_adapter_unsubscribed",
+            AgentEvent::single_agent(AgentEventPayload::ToolRequested {
+                tool_call_id: ToolCallId::new("call_1"),
+                tool_name: ToolName::new("list_files"),
+                arguments: json!({}),
+            }),
+        )
+        .await;
+
+        assert_eq!(routed, Routed::NoSubscriber);
+    }
+
+    /// A worker's tool call stays the worker's. Every other adapter test uses
+    /// [`AgentEvent::single_agent`], where dropping the context and stamping
+    /// the stream's own agent are indistinguishable.
+    #[tokio::test]
+    async fn a_workers_context_survives_the_broker_hop() {
+        let request_id = "req_adapter_worker_context";
+        let mut rx = tool_event_subscribe(request_id).await;
+        let worker = AgentContext::worker("log_worker", None, "orchestrator");
+
+        publish_to_brokers(
+            request_id,
+            AgentEvent::new(
+                worker.clone(),
+                AgentEventPayload::ToolRequested {
+                    tool_call_id: ToolCallId::new("call_1"),
+                    tool_name: ToolName::new("list_files"),
+                    arguments: json!({}),
+                },
+            ),
+        )
+        .await;
+
+        let ToolLifecycleEvent::Requested { agent, .. } =
+            rx.recv().await.expect("event should arrive")
+        else {
+            panic!("expected Requested");
+        };
+        assert_eq!(agent, Some(worker));
+    }
+
+    /// Probes an unset name rather than [`ENV_AGENT_EVENTS`] itself, because
+    /// reading the real var asserts on the ambient environment and fails for
+    /// anyone who has the flag exported.
+    #[test]
+    fn the_flag_is_off_unless_set() {
+        assert_eq!(ENV_AGENT_EVENTS, "AURA_AGENT_EVENTS");
+        assert!(!bool_env("AURA_AGENT_EVENTS_UNSET_PROBE", false));
+    }
+}

--- a/crates/aura/src/agent_events.rs
+++ b/crates/aura/src/agent_events.rs
@@ -12,6 +12,7 @@
 
 use aura_events::agent::{AgentEvent, AgentEventPayload};
 
+use crate::RequestId;
 use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
 use crate::env_flags::bool_env;
 use crate::request_progress::{self, ProgressNotification};
@@ -40,7 +41,7 @@ pub enum Routed {
 /// The event's [`AgentContext`] rides along on every broker event that carries
 /// one, so a worker's tool call stays attributed to the worker rather than to
 /// the stream's own agent.
-pub async fn publish_to_brokers(request_id: &str, event: AgentEvent) -> Routed {
+pub async fn publish_to_brokers(request_id: &RequestId, event: AgentEvent) -> Routed {
     let AgentEvent { agent, payload } = event;
     let delivered = match payload {
         AgentEventPayload::ToolRequested {
@@ -155,6 +156,7 @@ mod tests {
     use serde_json::json;
 
     use crate::request_progress::subscribe as progress_subscribe;
+
     use crate::tool_event_broker::{
         ToolLifecycleEvent, subscribe as tool_event_subscribe, tool_usage_subscribe,
     };
@@ -165,11 +167,11 @@ mod tests {
 
     #[tokio::test]
     async fn tool_requested_reaches_the_tool_event_broker() {
-        let request_id = "req_adapter_requested";
-        let mut rx = tool_event_subscribe(request_id).await;
+        let request_id = RequestId::new("req_adapter_requested");
+        let mut rx = tool_event_subscribe(&request_id).await;
 
         let routed = publish_to_brokers(
-            request_id,
+            &request_id,
             AgentEvent::single_agent(AgentEventPayload::ToolRequested {
                 tool_call_id: ToolCallId::new("call_1"),
                 tool_name: ToolName::new("list_files"),
@@ -196,11 +198,11 @@ mod tests {
 
     #[tokio::test]
     async fn tool_start_carries_its_progress_token() {
-        let request_id = "req_adapter_start";
-        let mut rx = tool_event_subscribe(request_id).await;
+        let request_id = RequestId::new("req_adapter_start");
+        let mut rx = tool_event_subscribe(&request_id).await;
 
         publish_to_brokers(
-            request_id,
+            &request_id,
             AgentEvent::single_agent(AgentEventPayload::ToolStart {
                 tool_call_id: ToolCallId::new("call_1"),
                 tool_name: ToolName::new("list_files"),
@@ -219,11 +221,11 @@ mod tests {
 
     #[tokio::test]
     async fn progress_keeps_the_raw_values_the_handler_derives_percent_from() {
-        let request_id = "req_adapter_progress";
-        let mut rx = progress_subscribe(request_id).await;
+        let request_id = RequestId::new("req_adapter_progress");
+        let mut rx = progress_subscribe(&request_id).await;
 
         publish_to_brokers(
-            request_id,
+            &request_id,
             AgentEvent::single_agent(AgentEventPayload::ToolProgress {
                 progress_token: token(7),
                 progress: Progress::ratio(50.0, 100.0),
@@ -241,11 +243,11 @@ mod tests {
 
     #[tokio::test]
     async fn tool_usage_reaches_the_usage_broker() {
-        let request_id = "req_adapter_usage";
-        let mut rx = tool_usage_subscribe(request_id).await;
+        let request_id = RequestId::new("req_adapter_usage");
+        let mut rx = tool_usage_subscribe(&request_id).await;
 
         publish_to_brokers(
-            request_id,
+            &request_id,
             AgentEvent::single_agent(AgentEventPayload::ToolUsage {
                 tool_call_ids: vec![ToolCallId::new("call_1")],
                 usage: TokenUsage {
@@ -265,7 +267,7 @@ mod tests {
     #[tokio::test]
     async fn content_events_are_not_routed_to_a_broker() {
         let routed = publish_to_brokers(
-            "req_adapter_text",
+            &RequestId::new("req_adapter_text"),
             AgentEvent::single_agent(AgentEventPayload::TextDelta {
                 content: "hello".to_string(),
             }),
@@ -278,7 +280,7 @@ mod tests {
     #[tokio::test]
     async fn tool_complete_is_carried_by_the_stream_not_a_broker() {
         let routed = publish_to_brokers(
-            "req_adapter_complete",
+            &RequestId::new("req_adapter_complete"),
             AgentEvent::single_agent(AgentEventPayload::ToolComplete {
                 tool_call_id: ToolCallId::new("call_1"),
                 tool_name: ToolName::new("list_files"),
@@ -296,7 +298,7 @@ mod tests {
     #[tokio::test]
     async fn a_side_channel_event_with_nobody_listening_reports_no_subscriber() {
         let routed = publish_to_brokers(
-            "req_adapter_unsubscribed",
+            &RequestId::new("req_adapter_unsubscribed"),
             AgentEvent::single_agent(AgentEventPayload::ToolRequested {
                 tool_call_id: ToolCallId::new("call_1"),
                 tool_name: ToolName::new("list_files"),
@@ -313,12 +315,12 @@ mod tests {
     /// the stream's own agent are indistinguishable.
     #[tokio::test]
     async fn a_workers_context_survives_the_broker_hop() {
-        let request_id = "req_adapter_worker_context";
-        let mut rx = tool_event_subscribe(request_id).await;
+        let request_id = RequestId::new("req_adapter_worker_context");
+        let mut rx = tool_event_subscribe(&request_id).await;
         let worker = AgentContext::worker("log_worker", None, "orchestrator");
 
         publish_to_brokers(
-            request_id,
+            &request_id,
             AgentEvent::new(
                 worker.clone(),
                 AgentEventPayload::ToolRequested {

--- a/crates/aura/src/approval_event_broker.rs
+++ b/crates/aura/src/approval_event_broker.rs
@@ -7,6 +7,7 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
+use crate::RequestId;
 use aura_events::{ApprovalCompleted, ApprovalPending, ApprovalRequested};
 use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, warn};
@@ -23,7 +24,7 @@ pub enum ApprovalLifecycleEvent {
 
 /// Request-scoped approval event broker.
 pub struct ApprovalEventBroker {
-    senders: RwLock<HashMap<String, mpsc::Sender<ApprovalLifecycleEvent>>>,
+    senders: RwLock<HashMap<RequestId, mpsc::Sender<ApprovalLifecycleEvent>>>,
 }
 
 impl ApprovalEventBroker {
@@ -35,7 +36,10 @@ impl ApprovalEventBroker {
     }
 
     /// Subscribe to approval lifecycle events for one request.
-    pub async fn subscribe(&self, request_id: &str) -> mpsc::Receiver<ApprovalLifecycleEvent> {
+    pub async fn subscribe(
+        &self,
+        request_id: &RequestId,
+    ) -> mpsc::Receiver<ApprovalLifecycleEvent> {
         let (tx, rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
         let mut senders = self.senders.write().await;
         senders.insert(request_id.to_owned(), tx);
@@ -48,7 +52,7 @@ impl ApprovalEventBroker {
     }
 
     /// Remove a request subscription.
-    pub async fn unsubscribe(&self, request_id: &str) {
+    pub async fn unsubscribe(&self, request_id: &RequestId) {
         let mut senders = self.senders.write().await;
         if senders.remove(request_id).is_some() {
             debug!(
@@ -61,7 +65,7 @@ impl ApprovalEventBroker {
 
     /// Publish an approval lifecycle event. Returns false if no stream is active
     /// or the receiver cannot accept the event immediately.
-    pub async fn publish(&self, request_id: &str, event: ApprovalLifecycleEvent) -> bool {
+    pub async fn publish(&self, request_id: &RequestId, event: ApprovalLifecycleEvent) -> bool {
         let sender = {
             let senders = self.senders.read().await;
             senders.get(request_id).cloned()
@@ -116,15 +120,15 @@ pub fn global() -> &'static ApprovalEventBroker {
     GLOBAL_BROKER.get_or_init(ApprovalEventBroker::new)
 }
 
-pub async fn subscribe(request_id: &str) -> mpsc::Receiver<ApprovalLifecycleEvent> {
+pub async fn subscribe(request_id: &RequestId) -> mpsc::Receiver<ApprovalLifecycleEvent> {
     global().subscribe(request_id).await
 }
 
-pub async fn unsubscribe(request_id: &str) {
+pub async fn unsubscribe(request_id: &RequestId) {
     global().unsubscribe(request_id).await;
 }
 
-pub async fn publish(request_id: &str, event: ApprovalLifecycleEvent) -> bool {
+pub async fn publish(request_id: &RequestId, event: ApprovalLifecycleEvent) -> bool {
     global().publish(request_id, event).await
 }
 
@@ -149,9 +153,13 @@ mod tests {
     #[tokio::test]
     async fn subscribe_publish_recv_roundtrip() {
         let broker = ApprovalEventBroker::new();
-        let mut rx = broker.subscribe("req-1").await;
+        let mut rx = broker.subscribe(&RequestId::new("req-1")).await;
 
-        assert!(broker.publish("req-1", requested("dec-1")).await);
+        assert!(
+            broker
+                .publish(&RequestId::new("req-1"), requested("dec-1"))
+                .await
+        );
 
         match rx.recv().await.expect("event") {
             ApprovalLifecycleEvent::Requested(event) => assert_eq!(event.decision_id, "dec-1"),
@@ -163,26 +171,38 @@ mod tests {
     async fn publish_without_subscriber_returns_false() {
         let broker = ApprovalEventBroker::new();
 
-        assert!(!broker.publish("missing", requested("dec-1")).await);
+        assert!(
+            !broker
+                .publish(&RequestId::new("missing"), requested("dec-1"))
+                .await
+        );
     }
 
     #[tokio::test]
     async fn receiver_drop_cleans_stale_subscription() {
         let broker = ApprovalEventBroker::new();
-        let rx = broker.subscribe("req-1").await;
+        let rx = broker.subscribe(&RequestId::new("req-1")).await;
         drop(rx);
 
-        assert!(!broker.publish("req-1", requested("dec-1")).await);
+        assert!(
+            !broker
+                .publish(&RequestId::new("req-1"), requested("dec-1"))
+                .await
+        );
         assert_eq!(broker.active_subscriptions().await, 0);
     }
 
     #[tokio::test]
     async fn events_are_isolated_by_request() {
         let broker = ApprovalEventBroker::new();
-        let mut rx_a = broker.subscribe("req-a").await;
-        let mut rx_b = broker.subscribe("req-b").await;
+        let mut rx_a = broker.subscribe(&RequestId::new("req-a")).await;
+        let mut rx_b = broker.subscribe(&RequestId::new("req-b")).await;
 
-        assert!(broker.publish("req-b", requested("dec-b")).await);
+        assert!(
+            broker
+                .publish(&RequestId::new("req-b"), requested("dec-b"))
+                .await
+        );
 
         assert!(rx_a.try_recv().is_err());
         match rx_b.recv().await.expect("event") {

--- a/crates/aura/src/builder.rs
+++ b/crates/aura/src/builder.rs
@@ -326,7 +326,15 @@ impl Agent {
                     .clone()
                     .map(crate::config::SessionId::new),
             };
-            let request_id = config_owned.request_id.clone().unwrap_or_default();
+            // One id for the gate and the tool below, so both publish to the
+            // same topic. A build with no HTTP request behind it still gets a
+            // distinct value rather than sharing one with every other build.
+            let request_id = config_owned.request_id.clone().unwrap_or_else(|| {
+                crate::request_cancellation::RequestId::new(format!(
+                    "local:{}",
+                    uuid::Uuid::new_v4()
+                ))
+            });
             let gate: Arc<dyn crate::tool_wrapper::ToolWrapper> =
                 Arc::new(crate::hitl::HitlApprovalWrapper::new(
                     hitl.patterns.clone(),
@@ -1428,7 +1436,7 @@ impl Agent {
         &self,
         query: &str,
         timeout: Duration,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> (
         Pin<Box<dyn futures::stream::Stream<Item = Result<StreamItem, StreamError>> + Send>>,
         watch::Sender<bool>,
@@ -1473,7 +1481,7 @@ impl Agent {
         query: &str,
         chat_history: Vec<rig::completion::Message>,
         timeout: Duration,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> (
         Pin<Box<dyn futures::stream::Stream<Item = Result<StreamItem, StreamError>> + Send>>,
         watch::Sender<bool>,
@@ -1539,7 +1547,7 @@ impl Agent {
     ///
     /// # Returns
     /// Total number of cancellation notifications sent
-    pub async fn cancel_mcp_requests(&self, http_request_id: &str, reason: &str) -> usize {
+    pub async fn cancel_mcp_requests(&self, http_request_id: &RequestId, reason: &str) -> usize {
         if let Some(mcp_manager) = &self.mcp_manager {
             mcp_manager
                 .cancel_all_for_request(http_request_id, reason)
@@ -1565,7 +1573,7 @@ impl Agent {
     ///
     /// # Returns
     /// Total number of cancellation notifications sent
-    pub async fn cancel_and_close_mcp(&self, http_request_id: &str, reason: &str) -> usize {
+    pub async fn cancel_and_close_mcp(&self, http_request_id: &RequestId, reason: &str) -> usize {
         if let Some(mcp_manager) = &self.mcp_manager {
             mcp_manager
                 .cancel_and_close_all(http_request_id, reason)
@@ -1667,6 +1675,7 @@ fn record_completion_result(
 }
 
 // Implement StreamingAgent trait for Agent
+use crate::RequestId;
 use crate::streaming::StreamingAgent;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
@@ -1683,7 +1692,7 @@ impl StreamingAgent for Agent {
         query: &str,
         chat_history: Vec<rig::completion::Message>,
         _cancel_token: CancellationToken,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> Result<BoxStream<'static, Result<StreamItem, StreamError>>, StreamError> {
         if let Some(mcp_manager) = &self.mcp_manager {
             mcp_manager.set_current_request(request_id).await;
@@ -1703,7 +1712,7 @@ impl StreamingAgent for Agent {
         query: &str,
         chat_history: Vec<rig::completion::Message>,
         timeout: Duration,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> (
         BoxStream<'static, Result<StreamItem, StreamError>>,
         watch::Sender<bool>,
@@ -1725,7 +1734,7 @@ impl StreamingAgent for Agent {
         (Box::pin(stream), cancel_tx, usage_state)
     }
 
-    async fn cancel_and_close_mcp(&self, request_id: &str, reason: &str) -> usize {
+    async fn cancel_and_close_mcp(&self, request_id: &RequestId, reason: &str) -> usize {
         Agent::cancel_and_close_mcp(self, request_id, reason).await
     }
 
@@ -1976,6 +1985,7 @@ impl AgentBuilder {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
     use crate::scratchpad::TiktokenCounter;
 
@@ -2268,7 +2278,7 @@ mod tests {
 
         let tmp = tempfile::TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-single-compose")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-single-compose"))
                 .await
                 .unwrap(),
         );

--- a/crates/aura/src/config.rs
+++ b/crates/aura/src/config.rs
@@ -6,6 +6,7 @@
 //! persistence handles, shared chat history, scratchpad runtime state, and the
 //! session id.
 
+use crate::RequestId;
 use crate::hitl::HitlRuntime;
 use crate::scratchpad::ScratchpadToolsConfig;
 use crate::tool_wrapper::{ToolCallContext, ToolWrapper};
@@ -139,7 +140,7 @@ pub struct AgentRuntimeConfig {
     /// Request id (`req_…`) for this build, used to stamp HITL approval requests
     /// and route their SSE events. Threaded from the web server so the
     /// single-agent and orchestration paths share one value.
-    pub request_id: Option<String>,
+    pub request_id: Option<RequestId>,
 
     /// Computed instance UUID for this agent, derived from agent config and
     /// host identity. Threaded into HITL approval requests so webhook

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -16,6 +16,7 @@ use super::decision::{AgentScope, ApprovalOrigin, ApprovalOutcome, DecisionId};
 use super::protocol::{ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
 use super::registry::{ParkedApproval, PendingApprovals};
 use super::route::{ApprovalError, DecisionRoute, GateDecision};
+use crate::RequestId;
 use crate::orchestration::{
     BlockedCell, CallKey, ParkGuard, PendingCall, RecordedDecisions, run_owner_id,
 };
@@ -47,7 +48,7 @@ pub struct HitlApprovalWrapper {
     /// Who this wrapper speaks for, stamped onto every request it raises.
     scope: AgentScope,
     /// Global request id, for SSE event routing.
-    request_id: String,
+    request_id: RequestId,
     /// `[agent].name` of the config that built this agent.
     agent_name: String,
     /// Instance ID of the AURA process that built this wrapper.
@@ -67,7 +68,7 @@ impl HitlApprovalWrapper {
         patterns: Arc<[GlobPattern]>,
         route: Arc<DecisionRoute>,
         scope: AgentScope,
-        request_id: String,
+        request_id: RequestId,
         agent_name: String,
         instance_id: String,
     ) -> Self {
@@ -483,14 +484,14 @@ mod tests {
         fn parked_gate(
             registry: &PendingApprovals,
             route: &Arc<DecisionRoute>,
-            request_id: &str,
+            request_id: &RequestId,
             cell: &Arc<crate::orchestration::BlockedCell>,
         ) -> HitlApprovalWrapper {
             HitlApprovalWrapper::new(
                 Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
                 route.clone(),
                 worker_scope(),
-                request_id.to_string(),
+                request_id.clone(),
                 "test-agent".to_string(),
                 "test-instance".to_string(),
             )
@@ -500,14 +501,15 @@ mod tests {
                 ParkGuard::new(
                     registry.clone(),
                     "0191e8c0-1111-7000-8000-000000000042".to_string(),
-                    request_id.to_string(),
+                    request_id.clone(),
                 ),
             )
         }
 
         #[tokio::test]
         async fn register_error_fails_closed_with_no_cell_entry_and_no_event() {
-            let request_id = format!("req_park_fail_{}", uuid::Uuid::new_v4().simple());
+            let request_id =
+                RequestId::new(format!("req_park_fail_{}", uuid::Uuid::new_v4().simple()));
             let mut events = crate::approval_event_broker::subscribe(&request_id).await;
             let store: Arc<dyn crate::session_store::ApprovalStore> =
                 Arc::new(crate::session_store::FaultInjectingStore::failing_register());
@@ -548,7 +550,8 @@ mod tests {
 
         #[tokio::test]
         async fn happy_path_registers_publishes_appends_and_short_circuits() {
-            let request_id = format!("req_park_ok_{}", uuid::Uuid::new_v4().simple());
+            let request_id =
+                RequestId::new(format!("req_park_ok_{}", uuid::Uuid::new_v4().simple()));
             let mut events = crate::approval_event_broker::subscribe(&request_id).await;
             let store: Arc<dyn crate::session_store::ApprovalStore> =
                 Arc::new(crate::session_store::InMemoryApprovalStore::new());
@@ -630,7 +633,7 @@ mod tests {
         async fn two_gated_calls_append_two_cell_entries() {
             let (registry, route) = conv_route(Duration::from_secs(60));
             let cell = Arc::new(crate::orchestration::BlockedCell::default());
-            let gate = parked_gate(&registry, &route, "req-two-calls", &cell);
+            let gate = parked_gate(&registry, &route, &RequestId::new("req-two-calls"), &cell);
 
             let first = gate
                 .pre_call(
@@ -666,7 +669,7 @@ mod tests {
         async fn ungated_tool_proceeds_without_parking() {
             let (registry, route) = conv_route(Duration::from_secs(60));
             let cell = Arc::new(crate::orchestration::BlockedCell::default());
-            let gate = parked_gate(&registry, &route, "req-ungated", &cell);
+            let gate = parked_gate(&registry, &route, &RequestId::new("req-ungated"), &cell);
 
             let outcome = gate
                 .pre_call(&serde_json::json!({}), &ToolCallContext::new("ls"))
@@ -689,13 +692,13 @@ mod tests {
             let guard = ParkGuard::new(
                 registry.clone(),
                 "0191e8c0-1111-7000-8000-000000000042".to_string(),
-                "req-guard".to_string(),
+                RequestId::new("req-guard"),
             );
             let gate = HitlApprovalWrapper::new(
                 Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
                 route,
                 worker_scope(),
-                "req-guard".to_string(),
+                RequestId::new("req-guard"),
                 "test-agent".to_string(),
                 "test-instance".to_string(),
             )
@@ -763,7 +766,7 @@ mod tests {
                 Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
                 route,
                 AgentScope::Single { session_id: None },
-                "req-recorded".to_string(),
+                RequestId::new("req-recorded"),
                 "test-agent".to_string(),
                 "test-instance".to_string(),
             )
@@ -1081,7 +1084,7 @@ mod tests {
         /// it, plus the flag that reports whether the inner tool ran.
         fn gated_tool(
             route: DecisionRoute,
-            request_id: &str,
+            request_id: &RequestId,
             tool_name: &str,
         ) -> (WrappedTool<StubTool>, Arc<AtomicBool>) {
             let ran = Arc::new(AtomicBool::new(false));
@@ -1093,7 +1096,7 @@ mod tests {
                 Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
                 Arc::new(route),
                 AgentScope::Single { session_id: None },
-                request_id.to_string(),
+                request_id.clone(),
                 "test-agent".to_string(),
                 "test-instance-id".to_string(),
             );
@@ -1114,8 +1117,8 @@ mod tests {
             }
         }
 
-        fn unique_request_id() -> String {
-            format!("req_span_{}", uuid::Uuid::new_v4().simple())
+        fn unique_request_id() -> RequestId {
+            RequestId::new(format!("req_span_{}", uuid::Uuid::new_v4().simple()))
         }
 
         /// The correlation the whole feature exists for: the id the approver

--- a/crates/aura/src/hitl/protocol.rs
+++ b/crates/aura/src/hitl/protocol.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::decision::{AgentScope, ApprovalDecision, ApprovalOrigin, DecisionId};
+use crate::RequestId;
 
 /// Current approval webhook protocol version.
 pub const PROTOCOL_VERSION: u32 = 1;
@@ -22,15 +23,9 @@ pub struct ApprovalRequest {
     pub instance_id: String,
     /// The handle a decision resolves against.
     pub decision_id: DecisionId,
-    /// The global request id (SSE routing + MCP cancellation), modeled as the
-    /// existing bare `String` id used throughout the codebase.
-    ///
-    /// A `RequestId` newtype is deliberately not introduced. Unlike RunId /
-    /// SessionId / TaskIdentity it has no single owning module, and it threads
-    /// through SSE routing, the tool event broker, and MCP cancellation, so
-    /// branding it is a cross-cutting refactor out of scope here. The design
-    /// note's `RequestId` typing is aspirational.
-    pub request_id: String,
+    /// The owner every approval of one request or one parked run shares. A
+    /// live request stamps its own id here; a parked run stamps `run:{run_id}`.
+    pub request_id: RequestId,
     /// Who is asking.
     pub scope: AgentScope,
     /// Why this approval exists.

--- a/crates/aura/src/hitl/registry.rs
+++ b/crates/aura/src/hitl/registry.rs
@@ -35,6 +35,7 @@ use crate::session_store::{
 
 use super::decision::{ApprovalDecision, AwaitingDecision, DecisionId, Timestamp};
 use super::protocol::ApprovalRequest;
+use crate::RequestId;
 
 /// Bus topic carrying the decision for one parked approval.
 fn approval_topic(id: &DecisionId) -> String {
@@ -60,7 +61,7 @@ struct PendingApprovalsInner {
 
 /// The process-local half of one parked approval.
 struct WakeEntry {
-    request_id: String,
+    request_id: RequestId,
     wake: oneshot::Sender<ApprovalDecision>,
     wake_task: AbortHandle,
 }
@@ -246,13 +247,13 @@ impl PendingApprovals {
     /// Synchronously drop the wake handles parked under a request id; their
     /// awaits resolve to `Cancelled`. Leaves store entries in place — use
     /// [`Self::cancel_request`] to also clean the store.
-    pub fn cancel_request_local(&self, request_id: &str) {
+    pub fn cancel_request_local(&self, request_id: &RequestId) {
         self.0
             .wakes
             .lock()
             .expect("registry lock poisoned")
             .retain(|_, entry| {
-                if entry.request_id == request_id {
+                if &entry.request_id == request_id {
                     entry.abort_wake_task();
                     false
                 } else {
@@ -264,12 +265,12 @@ impl PendingApprovals {
     /// Cancel every approval parked under a request id (stream drop /
     /// shutdown); their awaits resolve to `Cancelled`. Returns the approvals
     /// the store cleared, empty on a store fault.
-    pub async fn cancel_request(&self, request_id: &str) -> Vec<ParkedApproval> {
+    pub async fn cancel_request(&self, request_id: &RequestId) -> Vec<ParkedApproval> {
         self.cancel_request_local(request_id);
         match self.0.store.cancel_request(request_id).await {
             Ok(cleared) => cleared,
             Err(err) => {
-                warn!(request_id, error = %err, "approval store cancel_request failed");
+                warn!(%request_id, error = %err, "approval store cancel_request failed");
                 Vec::new()
             }
         }
@@ -371,12 +372,12 @@ mod tests {
     };
     use crate::hitl::protocol::{ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
 
-    fn test_request(request_id: &str) -> ApprovalRequest {
+    fn test_request(request_id: &RequestId) -> ApprovalRequest {
         ApprovalRequest {
             version: PROTOCOL_VERSION,
             instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
-            request_id: request_id.to_string(),
+            request_id: request_id.clone(),
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: "test_*".to_string(),
@@ -393,7 +394,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn register_and_resolve_approved() {
         let registry = PendingApprovals::new();
-        let req = test_request("req-1");
+        let req = test_request(&RequestId::new("req-1"));
         let id = req.decision_id;
         let handle = registry.register(req, Duration::from_secs(60)).await;
         let cancel = RequestCancelToken::unbound();
@@ -412,7 +413,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn register_and_resolve_denied() {
         let registry = PendingApprovals::new();
-        let req = test_request("req-2");
+        let req = test_request(&RequestId::new("req-2"));
         let id = req.decision_id;
         let handle = registry.register(req, Duration::from_secs(60)).await;
         let cancel = RequestCancelToken::unbound();
@@ -448,7 +449,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_twice_returns_not_found_on_second() {
         let registry = PendingApprovals::new();
-        let req = test_request("req-3");
+        let req = test_request(&RequestId::new("req-3"));
         let id = req.decision_id;
         let _handle = registry.register(req, Duration::from_secs(60)).await;
 
@@ -465,7 +466,7 @@ mod tests {
     #[tokio::test]
     async fn remove_makes_resolve_return_not_found() {
         let registry = PendingApprovals::new();
-        let req = test_request("req-remove");
+        let req = test_request(&RequestId::new("req-remove"));
         let id = req.decision_id;
         let _handle = registry.register(req, Duration::from_secs(60)).await;
 
@@ -482,7 +483,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_succeeds_after_awaiting_handle_dropped() {
         let registry = PendingApprovals::new();
-        let req = test_request("req-dropped");
+        let req = test_request(&RequestId::new("req-dropped"));
         let id = req.decision_id;
         let handle = registry.register(req, Duration::from_secs(60)).await;
         drop(handle);
@@ -502,7 +503,7 @@ mod tests {
         let registry = PendingApprovals::with_backend(store, bus.clone());
         let cancel = RequestCancelToken::unbound();
 
-        let req = test_request("req-garbage");
+        let req = test_request(&RequestId::new("req-garbage"));
         let id = req.decision_id;
         let handle = registry.register(req, Duration::from_secs(60)).await;
 
@@ -527,12 +528,12 @@ mod tests {
         let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
         let registry =
             PendingApprovals::with_backend(store.clone(), Arc::new(InMemoryEventBus::new()));
-        let req = test_request("req-local");
+        let req = test_request(&RequestId::new("req-local"));
         let id = req.decision_id;
         let handle = registry.register(req, Duration::from_secs(60)).await;
         let cancel = RequestCancelToken::unbound();
 
-        registry.cancel_request_local("req-local");
+        registry.cancel_request_local(&RequestId::new("req-local"));
 
         assert_eq!(
             handle.outcome(&cancel).await,
@@ -543,22 +544,22 @@ mod tests {
             "store entry remains for the async half"
         );
 
-        registry.cancel_request("req-local").await;
+        registry.cancel_request(&RequestId::new("req-local")).await;
         assert!(store.get(&id).await.unwrap().is_none());
     }
 
     #[tokio::test(start_paused = true)]
     async fn cancel_request_drops_matching_entries() {
         let registry = PendingApprovals::new();
-        let req_a = test_request("req-cancel");
-        let req_b = test_request("req-keep");
+        let req_a = test_request(&RequestId::new("req-cancel"));
+        let req_b = test_request(&RequestId::new("req-keep"));
         let id_a = req_a.decision_id;
         let id_b = req_b.decision_id;
         let handle_a = registry.register(req_a, Duration::from_secs(60)).await;
         let handle_b = registry.register(req_b, Duration::from_secs(60)).await;
         let cancel = RequestCancelToken::unbound();
 
-        registry.cancel_request("req-cancel").await;
+        registry.cancel_request(&RequestId::new("req-cancel")).await;
 
         assert_eq!(
             handle_a.outcome(&cancel).await,
@@ -585,7 +586,7 @@ mod tests {
         let store = Arc::new(InMemoryApprovalStore::new());
         let registry =
             PendingApprovals::with_backend(store.clone(), Arc::new(InMemoryEventBus::new()));
-        let req = test_request("req-ts");
+        let req = test_request(&RequestId::new("req-ts"));
         let id = req.decision_id;
         let timeout = Duration::from_secs(300);
         let before = chrono::Utc::now();
@@ -641,7 +642,7 @@ mod tests {
         let resolver = PendingApprovals::with_backend(store, bus);
         let cancel = RequestCancelToken::unbound();
 
-        let req = test_request("req-lost-wake");
+        let req = test_request(&RequestId::new("req-lost-wake"));
         let id = req.decision_id;
         let started = Instant::now();
         let handle = parker.register(req, Duration::from_secs(60)).await;
@@ -672,7 +673,7 @@ mod tests {
         );
         let cancel = RequestCancelToken::unbound();
 
-        let req = test_request("req-deaf");
+        let req = test_request(&RequestId::new("req-deaf"));
         let id = req.decision_id;
         let handle = registry.register(req, Duration::from_secs(60)).await;
 
@@ -705,7 +706,7 @@ mod tests {
         let instance_b = PendingApprovals::with_backend(store, bus);
         let cancel = RequestCancelToken::unbound();
 
-        let req = test_request("req-cross");
+        let req = test_request(&RequestId::new("req-cross"));
         let id = req.decision_id;
         let handle = instance_a.register(req, Duration::from_secs(60)).await;
 

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -769,6 +769,7 @@ fn header_value(headers: &reqwest::header::HeaderMap, name: &str) -> Option<Stri
 
 #[cfg(test)]
 mod tests {
+    use crate::RequestId;
     use serde_json::json;
 
     use super::super::decision::{
@@ -790,12 +791,12 @@ mod tests {
         (registry, route)
     }
 
-    fn single_request(request_id: &str, origin: ApprovalOrigin) -> ApprovalRequest {
+    fn single_request(request_id: &RequestId, origin: ApprovalOrigin) -> ApprovalRequest {
         ApprovalRequest {
             version: PROTOCOL_VERSION,
             instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
-            request_id: request_id.into(),
+            request_id: request_id.clone(),
             scope: AgentScope::Single { session_id: None },
             origin,
             items: vec![],
@@ -808,7 +809,7 @@ mod tests {
             version: PROTOCOL_VERSION,
             instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
-            request_id: "req-123".to_string(),
+            request_id: RequestId::new("req-123"),
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: "shell*".to_string(),
@@ -854,7 +855,7 @@ mod tests {
             version: PROTOCOL_VERSION,
             instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
-            request_id: "req-9".to_string(),
+            request_id: RequestId::new("req-9"),
             scope: AgentScope::Worker {
                 run_id,
                 task: crate::orchestration::TaskIdentity::new(2, Some("k8s-agent".to_string())),
@@ -891,7 +892,7 @@ mod tests {
             version: PROTOCOL_VERSION,
             instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
-            request_id: "req-cg-intent".to_string(),
+            request_id: RequestId::new("req-cg-intent"),
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: "kubectl_*".to_string(),
@@ -919,7 +920,7 @@ mod tests {
             version: PROTOCOL_VERSION,
             instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
-            request_id: "req-ar-none".to_string(),
+            request_id: RequestId::new("req-ar-none"),
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::AgentRequested {
                 reason: "touches prod".to_string(),
@@ -947,7 +948,7 @@ mod tests {
             version: PROTOCOL_VERSION,
             instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
-            request_id: "req-ar-intent".to_string(),
+            request_id: RequestId::new("req-ar-intent"),
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::AgentRequested {
                 reason: "touches prod".to_string(),
@@ -1001,7 +1002,7 @@ mod tests {
     async fn conversational_decide_approved() {
         let (registry, route) = conv_route(Duration::from_secs(60));
         let request = single_request(
-            "conv-req-1",
+            &RequestId::new("conv-req-1"),
             ApprovalOrigin::AgentRequested {
                 reason: "test".into(),
                 agent_name: "test-agent".to_string(),
@@ -1038,7 +1039,7 @@ mod tests {
     async fn conversational_decide_denied() {
         let (registry, route) = conv_route(Duration::from_secs(60));
         let request = single_request(
-            "conv-req-2",
+            &RequestId::new("conv-req-2"),
             ApprovalOrigin::ConfigGate {
                 matched_pattern: "rm_*".into(),
                 agent_name: "test-agent".to_string(),
@@ -1084,7 +1085,7 @@ mod tests {
 
         let (registry, route) = conv_route(Duration::from_secs(5));
         let request = single_request(
-            "conv-req-3",
+            &RequestId::new("conv-req-3"),
             ApprovalOrigin::AgentRequested {
                 reason: "test".into(),
                 agent_name: "test-agent".to_string(),
@@ -1149,7 +1150,7 @@ mod tests {
             timeout: Duration::from_secs(2),
         };
         let request = single_request(
-            "conv-req-backstop",
+            &RequestId::new("conv-req-backstop"),
             ApprovalOrigin::AgentRequested {
                 reason: "test".into(),
                 agent_name: "test-agent".to_string(),
@@ -1182,7 +1183,7 @@ mod tests {
     async fn conversational_decide_cancelled_on_disconnect() {
         let (_, route) = conv_route(Duration::from_secs(60));
         let request = single_request(
-            "conv-req-4",
+            &RequestId::new("conv-req-4"),
             ApprovalOrigin::AgentRequested {
                 reason: "test".into(),
                 agent_name: "test-agent".to_string(),
@@ -1208,7 +1209,7 @@ mod tests {
 
     #[tokio::test]
     async fn conversational_resolve_at_requested_event_succeeds() {
-        let request_id = format!("req_test_{}", uuid::Uuid::new_v4().simple());
+        let request_id = RequestId::new(format!("req_test_{}", uuid::Uuid::new_v4().simple()));
         let mut rx = crate::approval_event_broker::subscribe(&request_id).await;
 
         let (registry, route) = conv_route(Duration::from_secs(60));
@@ -1253,6 +1254,7 @@ mod tests {
     }
 
     mod webhook_signing {
+        use crate::RequestId;
         use std::collections::HashMap;
         use std::time::Duration;
 
@@ -1289,7 +1291,7 @@ mod tests {
                 version: PROTOCOL_VERSION,
                 instance_id: "test-instance".to_string(),
                 decision_id,
-                request_id: "req-signed".into(),
+                request_id: RequestId::new("req-signed"),
                 scope: AgentScope::Single { session_id: None },
                 origin: ApprovalOrigin::ConfigGate {
                     matched_pattern: "dangerous_*".into(),
@@ -2206,7 +2208,7 @@ mod tests {
 
     #[tokio::test]
     async fn webhook_route_emits_requested_and_completed_on_channel_error() {
-        let request_id = format!("req_test_{}", uuid::Uuid::new_v4().simple());
+        let request_id = RequestId::new(format!("req_test_{}", uuid::Uuid::new_v4().simple()));
         let mut rx = crate::approval_event_broker::subscribe(&request_id).await;
         let route = super::DecisionRoute::Webhook {
             client: super::WebhookClient::new(
@@ -2570,7 +2572,7 @@ mod tests {
             version: PROTOCOL_VERSION,
             instance_id: "test-instance".to_string(),
             decision_id: DecisionId::generate(),
-            request_id: "hdr-test".into(),
+            request_id: RequestId::new("hdr-test"),
             scope: AgentScope::Single { session_id: None },
             origin: ApprovalOrigin::ConfigGate {
                 matched_pattern: "dangerous_*".into(),

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -16,6 +16,7 @@ use serde_json::Value;
 use super::decision::{AgentScope, ApprovalDecision, ApprovalOrigin, ApprovalOutcome, DecisionId};
 use super::protocol::{ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
 use super::route::{ApprovalError, DecisionRoute};
+use crate::RequestId;
 
 /// The `request_approval` tool. Constructs an
 /// [`ApprovalOrigin::AgentRequested`] and dispatches through the shared
@@ -26,7 +27,7 @@ use super::route::{ApprovalError, DecisionRoute};
 pub struct RequestApprovalTool {
     route: Arc<DecisionRoute>,
     scope: AgentScope,
-    request_id: String,
+    request_id: RequestId,
     agent_name: String,
     /// Instance ID of the AURA process that built this tool.
     instance_id: String,
@@ -37,7 +38,7 @@ impl RequestApprovalTool {
     pub fn new(
         route: Arc<DecisionRoute>,
         scope: AgentScope,
-        request_id: String,
+        request_id: RequestId,
         agent_name: String,
         instance_id: String,
     ) -> Self {
@@ -309,7 +310,7 @@ mod tests {
         route: &Arc<DecisionRoute>,
         args: RequestApprovalArgs,
     ) -> ApprovalItem {
-        let request_id = format!("req_w2_{}", uuid::Uuid::new_v4().simple());
+        let request_id = RequestId::new(format!("req_w2_{}", uuid::Uuid::new_v4().simple()));
         let tool = RequestApprovalTool::new(
             route.clone(),
             AgentScope::Single { session_id: None },
@@ -476,7 +477,8 @@ mod tests {
                 timeout: std::time::Duration::from_secs(60),
             });
 
-            let request_id = format!("req_tool_span_{}", uuid::Uuid::new_v4().simple());
+            let request_id =
+                RequestId::new(format!("req_tool_span_{}", uuid::Uuid::new_v4().simple()));
             let mut events = approval_event_broker::subscribe(&request_id).await;
             let tool = RequestApprovalTool::new(
                 route,

--- a/crates/aura/src/lib.rs
+++ b/crates/aura/src/lib.rs
@@ -5,6 +5,7 @@
 //! in web services or other applications that need to build agents
 //! programmatically.
 
+pub mod agent_events;
 pub mod approval_event_broker;
 pub mod approver_headers;
 pub mod bedrock_embedding;
@@ -100,7 +101,7 @@ pub use mcp::{InFlightRequests, McpManager, ProgressEnabledHandler};
 pub use rag_tools::{AutoIngest, VectorIngestTool};
 pub use request_cancellation::{RequestCancellation, RequestId};
 pub use request_progress::{
-    ProgressNotification, RequestProgressBroker, global as request_progress_global,
+    Progress, ProgressNotification, RequestProgressBroker, global as request_progress_global,
     subscribe as request_progress_subscribe, unsubscribe as request_progress_unsubscribe,
 };
 pub use rmcp::model::{NumberOrString, ProgressToken};
@@ -113,7 +114,7 @@ pub use streaming_request_hook::{ResponseContent, StreamingRequestHook, UsageSta
 pub use tool_call_observer::{RetryHint, ToolCallObserver, ToolEvent, ToolOutcome};
 pub use tool_error_detection::{DetectedToolError, ToolResultStatus, detect_tool_error};
 pub use tool_event_broker::{
-    ToolCallId, ToolEventBroker, ToolLifecycleEvent, ToolName, ToolUsageEvent,
+    TokenUsage, ToolCallId, ToolEventBroker, ToolLifecycleEvent, ToolName, ToolUsageEvent,
     global as tool_event_global, peek_tool_call_id, pop_tool_call_id, publish_tool_start,
     publish_tool_usage, push_tool_call_id, subscribe as tool_event_subscribe, tool_usage_subscribe,
     tool_usage_unsubscribe, unsubscribe as tool_event_unsubscribe,

--- a/crates/aura/src/mcp/client.rs
+++ b/crates/aura/src/mcp/client.rs
@@ -28,7 +28,7 @@ use tracing::{debug, error, info, warn};
 use crate::approver_headers::ApproverHeaders;
 use crate::mcp::progress::ProgressEnabledHandler;
 use crate::mcp::response::extract_tool_result;
-use crate::tool_event_broker::{peek_tool_call_id, publish_tool_start};
+use crate::tool_event_broker::{ToolName, peek_tool_call_id, publish_tool_start};
 
 /// Custom HTTP client that captures the underlying HTTP status when a request
 /// fails.
@@ -776,7 +776,7 @@ impl McpClient {
             publish_tool_start(
                 http_request_id,
                 tool_call_id.clone(),
-                tool_name.to_string(),
+                ToolName::new(tool_name),
                 progress_token.clone(),
             )
             .await;

--- a/crates/aura/src/mcp/client.rs
+++ b/crates/aura/src/mcp/client.rs
@@ -8,7 +8,7 @@ use rmcp::{
     RoleClient,
     model::{
         CallToolRequestParam, CancelledNotificationParam, ClientRequest, ProgressNotificationParam,
-        Request, RequestId, Tool,
+        Request, RequestId as McpRequestId, Tool,
     },
     serve_client,
     service::{PeerRequestOptions, RunningService},
@@ -25,6 +25,7 @@ use std::time::Duration;
 use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, error, info, warn};
 
+use crate::RequestId;
 use crate::approver_headers::ApproverHeaders;
 use crate::mcp::progress::ProgressEnabledHandler;
 use crate::mcp::response::extract_tool_result;
@@ -320,7 +321,7 @@ const CANCEL_NOTIFICATION_TIMEOUT: Duration = Duration::from_secs(2);
 /// Maps HTTP request_id → set of MCP request_ids that are in-flight.
 #[derive(Default)]
 pub struct InFlightRequests {
-    requests: RwLock<HashMap<String, HashSet<RequestId>>>,
+    requests: RwLock<HashMap<RequestId, HashSet<McpRequestId>>>,
 }
 
 impl InFlightRequests {
@@ -329,15 +330,15 @@ impl InFlightRequests {
     }
 
     /// Register an in-flight MCP request for an HTTP request
-    pub async fn register(&self, http_request_id: &str, mcp_request_id: RequestId) {
+    pub async fn register(&self, http_request_id: &RequestId, mcp_request_id: McpRequestId) {
         let mut map = self.requests.write().await;
-        map.entry(http_request_id.to_string())
+        map.entry(http_request_id.clone())
             .or_default()
             .insert(mcp_request_id);
     }
 
     /// Remove an MCP request (completed or cancelled)
-    pub async fn remove(&self, http_request_id: &str, mcp_request_id: &RequestId) {
+    pub async fn remove(&self, http_request_id: &RequestId, mcp_request_id: &McpRequestId) {
         let mut map = self.requests.write().await;
         if let Some(set) = map.get_mut(http_request_id) {
             set.remove(mcp_request_id);
@@ -348,7 +349,7 @@ impl InFlightRequests {
     }
 
     /// Get all in-flight MCP request IDs for an HTTP request
-    pub async fn get_all(&self, http_request_id: &str) -> Vec<RequestId> {
+    pub async fn get_all(&self, http_request_id: &RequestId) -> Vec<McpRequestId> {
         let map = self.requests.read().await;
         map.get(http_request_id)
             .map(|set| set.iter().cloned().collect())
@@ -356,7 +357,7 @@ impl InFlightRequests {
     }
 
     /// Clear all in-flight requests for an HTTP request (cleanup)
-    pub async fn clear(&self, http_request_id: &str) {
+    pub async fn clear(&self, http_request_id: &RequestId) {
         let mut map = self.requests.write().await;
         map.remove(http_request_id);
     }
@@ -369,7 +370,7 @@ pub struct McpClient {
     /// Tracks in-flight MCP requests for cancellation support
     in_flight: Arc<InFlightRequests>,
     /// Current HTTP request ID for automatic cancellation tracking.
-    current_http_request_id: Arc<RwLock<Option<String>>>,
+    current_http_request_id: Arc<RwLock<Option<RequestId>>>,
 }
 
 impl Clone for McpClient {
@@ -472,9 +473,9 @@ impl McpClient {
     }
 
     /// Set the current HTTP request ID for cancellation tracking.
-    pub async fn set_current_request(&self, http_request_id: &str) {
+    pub async fn set_current_request(&self, http_request_id: &RequestId) {
         let mut guard = self.current_http_request_id.write().await;
-        *guard = Some(http_request_id.to_string());
+        *guard = Some(http_request_id.clone());
         debug!(
             "Set current HTTP request ID for MCP client: {}",
             http_request_id
@@ -490,7 +491,7 @@ impl McpClient {
         *guard = None;
     }
 
-    pub async fn get_current_request(&self) -> Option<String> {
+    pub async fn get_current_request(&self) -> Option<RequestId> {
         self.current_http_request_id.read().await.clone()
     }
 
@@ -734,7 +735,7 @@ impl McpClient {
         &self,
         tool_name: &str,
         arguments: HashMap<String, Value>,
-        http_request_id: &str,
+        http_request_id: &RequestId,
         approver_overrides: Option<ApproverHeaders>,
     ) -> Result<String> {
         debug!(
@@ -771,8 +772,7 @@ impl McpClient {
         // We peek (not pop) here - the pop happens in on_tool_result to ensure
         // push/pop pairing for ALL tools (MCP and non-MCP like vector stores).
         let progress_token = Some(handle.progress_token.clone());
-        let request_id_string = http_request_id.to_string();
-        if let Some(tool_call_id) = peek_tool_call_id(&request_id_string).await {
+        if let Some(tool_call_id) = peek_tool_call_id(http_request_id).await {
             publish_tool_start(
                 http_request_id,
                 tool_call_id.clone(),
@@ -818,7 +818,7 @@ impl McpClient {
     }
 
     /// Cancel all in-flight MCP requests for an HTTP request.
-    pub async fn cancel_all_for_request(&self, http_request_id: &str, reason: &str) -> usize {
+    pub async fn cancel_all_for_request(&self, http_request_id: &RequestId, reason: &str) -> usize {
         let mcp_request_ids = self.in_flight.get_all(http_request_id).await;
 
         if mcp_request_ids.is_empty() {
@@ -886,7 +886,7 @@ impl McpClient {
     }
 
     /// Cancel all in-flight requests and close the connection.
-    pub async fn cancel_and_close(&self, http_request_id: &str, reason: &str) -> usize {
+    pub async fn cancel_and_close(&self, http_request_id: &RequestId, reason: &str) -> usize {
         let count = self.cancel_all_for_request(http_request_id, reason).await;
 
         // Also clear the request ID to stop routing any straggler progress notifications
@@ -917,8 +917,8 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_in_flight_requests_tracking() {
         let tracker = InFlightRequests::new();
-        let http_id = "http-123";
-        let mcp_id = RequestId::Number(1);
+        let http_id = &RequestId::new("http-123");
+        let mcp_id = McpRequestId::Number(1);
 
         tracker.register(http_id, mcp_id.clone()).await;
         assert_eq!(tracker.get_all(http_id).await.len(), 1);
@@ -1167,7 +1167,7 @@ pub(crate) mod tests {
         let Some(id) = message
             .get("id")
             .cloned()
-            .and_then(|id| serde_json::from_value::<RequestId>(id).ok())
+            .and_then(|id| serde_json::from_value::<McpRequestId>(id).ok())
         else {
             return ("202 Accepted", Vec::new(), String::new());
         };
@@ -1343,7 +1343,9 @@ pub(crate) mod tests {
             .await
             .expect("the untracked call succeeds");
 
-        client.set_current_request("http-req-1").await;
+        client
+            .set_current_request(&RequestId::new("http-req-1"))
+            .await;
         client
             .call_tool(
                 "tracked",

--- a/crates/aura/src/mcp/manager.rs
+++ b/crates/aura/src/mcp/manager.rs
@@ -1,3 +1,4 @@
+use crate::RequestId;
 use crate::config::McpServerConfig;
 use crate::error::BuilderError;
 use crate::mcp::client::McpClient;
@@ -691,7 +692,7 @@ impl McpManager {
     }
 
     /// Cancel all in-flight MCP requests for an HTTP request.
-    pub async fn cancel_all_for_request(&self, http_request_id: &str, reason: &str) -> usize {
+    pub async fn cancel_all_for_request(&self, http_request_id: &RequestId, reason: &str) -> usize {
         let mut total_cancelled = 0;
 
         for (server_name, client) in &self.streamable_clients {
@@ -732,7 +733,7 @@ impl McpManager {
 
     /// Cancel in-flight requests and close all MCP client connections.
     /// After calling this, all MCP clients become unusable until reinitialized.
-    pub async fn cancel_and_close_all(&self, http_request_id: &str, reason: &str) -> usize {
+    pub async fn cancel_and_close_all(&self, http_request_id: &RequestId, reason: &str) -> usize {
         let mut total_cancelled = 0;
 
         for (server_name, client) in &self.streamable_clients {
@@ -772,7 +773,7 @@ impl McpManager {
     }
 
     /// Set the current HTTP request ID for cancellation tracking.
-    pub async fn set_current_request(&self, http_request_id: &str) {
+    pub async fn set_current_request(&self, http_request_id: &RequestId) {
         for client in self.streamable_clients.values() {
             client.set_current_request(http_request_id).await;
         }

--- a/crates/aura/src/mcp/progress.rs
+++ b/crates/aura/src/mcp/progress.rs
@@ -29,6 +29,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
+use crate::RequestId;
 use crate::request_progress::{self, Progress, ProgressNotification};
 
 /// A custom ClientHandler that routes progress notifications to request-scoped channels.
@@ -41,12 +42,12 @@ use crate::request_progress::{self, Progress, ProgressNotification};
 /// # Example
 /// ```ignore
 /// // Create handler with shared request ID reference
-/// let current_request_id = Arc::new(RwLock::new(None));
+/// let current_request_id: Arc<RwLock<Option<RequestId>>> = Arc::new(RwLock::new(None));
 /// let handler = ProgressEnabledHandler::new(current_request_id.clone());
 /// let client = serve_client(handler.clone(), transport).await?;
 ///
 /// // Set request ID before tool execution
-/// *current_request_id.write().await = Some("req_123".to_string());
+/// *current_request_id.write().await = Some(RequestId::new("req_123"));
 ///
 /// // Progress notifications will now be routed to req_123's channel
 /// ```
@@ -55,7 +56,7 @@ pub struct ProgressEnabledHandler {
     progress_dispatcher: ProgressDispatcher,
     /// Shared reference to the current HTTP request ID
     /// This is set by the MCP client before each tool execution
-    current_request_id: Arc<RwLock<Option<String>>>,
+    current_request_id: Arc<RwLock<Option<RequestId>>>,
     /// Flag to log orphaned progress only once (prevents log flood from servers ignoring cancellation)
     logged_orphaned_warning: Arc<AtomicBool>,
     /// Counter for orphaned progress notifications (for diagnostics)
@@ -66,13 +67,13 @@ impl std::fmt::Debug for ProgressEnabledHandler {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProgressEnabledHandler")
             .field("progress_dispatcher", &self.progress_dispatcher)
-            .field("current_request_id", &"Arc<RwLock<Option<String>>>")
+            .field("current_request_id", &"Arc<RwLock<Option<RequestId>>>")
             .finish()
     }
 }
 
 impl ProgressEnabledHandler {
-    pub fn new(current_request_id: Arc<RwLock<Option<String>>>) -> Self {
+    pub fn new(current_request_id: Arc<RwLock<Option<RequestId>>>) -> Self {
         Self {
             progress_dispatcher: ProgressDispatcher::new(),
             current_request_id,
@@ -176,7 +177,7 @@ mod tests {
     use super::*;
 
     fn create_test_handler() -> ProgressEnabledHandler {
-        let current_request_id = Arc::new(RwLock::new(None));
+        let current_request_id: Arc<RwLock<Option<RequestId>>> = Arc::new(RwLock::new(None));
         ProgressEnabledHandler::new(current_request_id)
     }
 
@@ -197,17 +198,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_handler_with_request_id() {
-        let current_request_id = Arc::new(RwLock::new(Some("req_test_123".to_string())));
+        let current_request_id = Arc::new(RwLock::new(Some(RequestId::new("req_test_123"))));
         let handler = ProgressEnabledHandler::new(current_request_id.clone());
 
         // Verify request ID is accessible
         let req_id = handler.current_request_id.read().await;
-        assert_eq!(*req_id, Some("req_test_123".to_string()));
+        assert_eq!(*req_id, Some(RequestId::new("req_test_123")));
     }
 
     #[tokio::test]
     async fn test_handler_request_id_changes() {
-        let current_request_id = Arc::new(RwLock::new(None));
+        let current_request_id: Arc<RwLock<Option<RequestId>>> = Arc::new(RwLock::new(None));
         let handler = ProgressEnabledHandler::new(current_request_id.clone());
 
         // Initially no request ID
@@ -219,13 +220,13 @@ mod tests {
         // Set request ID
         {
             let mut req_id = current_request_id.write().await;
-            *req_id = Some("req_456".to_string());
+            *req_id = Some(RequestId::new("req_456"));
         }
 
         // Handler should see the new value
         {
             let req_id = handler.current_request_id.read().await;
-            assert_eq!(*req_id, Some("req_456".to_string()));
+            assert_eq!(*req_id, Some(RequestId::new("req_456")));
         }
     }
 

--- a/crates/aura/src/mcp/progress.rs
+++ b/crates/aura/src/mcp/progress.rs
@@ -29,7 +29,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
-use crate::request_progress::{self, ProgressNotification};
+use crate::request_progress::{self, Progress, ProgressNotification};
 
 /// A custom ClientHandler that routes progress notifications to request-scoped channels.
 ///
@@ -122,9 +122,12 @@ impl ClientHandler for ProgressEnabledHandler {
             // Build notification for request-scoped broker
             let notification = ProgressNotification {
                 progress_token: params.progress_token.clone(),
-                progress: params.progress,
-                total: params.total,
+                progress: Progress {
+                    current: params.progress,
+                    total: params.total,
+                },
                 message: params.message.clone(),
+                agent: None,
             };
 
             if let Some(ref req_id) = request_id {

--- a/crates/aura/src/orchestration/factory.rs
+++ b/crates/aura/src/orchestration/factory.rs
@@ -12,6 +12,7 @@ use futures::stream::{self, BoxStream};
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
+use crate::RequestId;
 use crate::config::AgentRuntimeConfig;
 use crate::provider_agent::{StreamError, StreamItem};
 use crate::streaming::StreamingAgent;
@@ -47,7 +48,7 @@ impl OrchestratorFactory {
         query: String,
         chat_history: Vec<rig::completion::Message>,
         cancel_token: CancellationToken,
-        request_id: String,
+        request_id: RequestId,
         usage_state: crate::UsageState,
         outer_budget: Option<Duration>,
     ) -> BoxStream<'static, Result<StreamItem, StreamError>> {
@@ -153,7 +154,7 @@ impl StreamingAgent for OrchestratorFactory {
         query: &str,
         chat_history: Vec<rig::completion::Message>,
         cancel_token: CancellationToken,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> Result<BoxStream<'static, Result<StreamItem, StreamError>>, StreamError> {
         // Raw-stream callers don't observe usage; hand the spawn a detached
         // UsageState so the field is populated but nobody reads it.
@@ -161,7 +162,7 @@ impl StreamingAgent for OrchestratorFactory {
             query.to_string(),
             chat_history,
             cancel_token,
-            request_id.to_string(),
+            request_id.clone(),
             crate::UsageState::new(),
             None,
         ))
@@ -172,7 +173,7 @@ impl StreamingAgent for OrchestratorFactory {
         query: &str,
         chat_history: Vec<rig::completion::Message>,
         timeout: Duration,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> (
         BoxStream<'static, Result<StreamItem, StreamError>>,
         watch::Sender<bool>,
@@ -181,7 +182,7 @@ impl StreamingAgent for OrchestratorFactory {
         let (cancel_tx, cancel_rx) = watch::channel(false);
         let cancel_token = CancellationToken::new();
         let watcher_cancel_token = cancel_token.clone();
-        let request_id_owned = request_id.to_string();
+        let request_id_owned = request_id.clone();
 
         // Fire-and-forget: task self-terminates when cancel_tx is dropped or timeout fires.
         let _watcher_handle =
@@ -195,7 +196,7 @@ impl StreamingAgent for OrchestratorFactory {
             query.to_string(),
             chat_history,
             cancel_token,
-            request_id.to_string(),
+            request_id.clone(),
             usage_state.clone(),
             (!timeout.is_zero()).then_some(timeout),
         );
@@ -203,7 +204,7 @@ impl StreamingAgent for OrchestratorFactory {
         (stream, cancel_tx, usage_state)
     }
 
-    async fn cancel_and_close_mcp(&self, _request_id: &str, _reason: &str) -> usize {
+    async fn cancel_and_close_mcp(&self, _request_id: &RequestId, _reason: &str) -> usize {
         // No-op: cancellation is handled inside the spawned task via cancel_token.
         0
     }

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -49,6 +49,7 @@ use tokio::sync::{Mutex, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::Agent;
+use crate::RequestId;
 use crate::config::{AgentRuntimeConfig, LlmConfig};
 use crate::inactivity::{Liveness, STALL_MESSAGE, liveness_of};
 use crate::mcp::McpManager;
@@ -122,7 +123,7 @@ enum TaskOutcome {
 /// the hook looks the cell up by.
 struct WorkerPark {
     cell: Arc<BlockedCell>,
-    key: String,
+    key: RequestId,
 }
 
 /// Named return type for `create_*` coordinator/worker methods.
@@ -202,7 +203,7 @@ pub(super) fn spawn_cancellation_watcher(
     cancel_rx: watch::Receiver<bool>,
     timeout: Duration,
     cancel_token: CancellationToken,
-    request_id: String,
+    request_id: RequestId,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         tokio::select! {
@@ -527,6 +528,16 @@ enum LoopStep {
     Continue,
 }
 
+/// Approval-event topic for `request_id`, falling back to an
+/// orchestrator-scoped value when no HTTP request drives the run. The
+/// fallback is keyed on the orchestrator id so two concurrent request-less
+/// runs never share one topic, and every site resolving it agrees.
+fn approval_topic_for(request_id: &Option<RequestId>, orchestrator_id: &str) -> RequestId {
+    request_id
+        .clone()
+        .unwrap_or_else(|| RequestId::new(format!("local:{orchestrator_id}")))
+}
+
 impl Orchestrator {
     /// Create a new orchestrator from configuration.
     pub async fn new(
@@ -579,7 +590,7 @@ impl Orchestrator {
                     Some(ParkGuard::new(
                         registry.clone(),
                         run_id_str.clone(),
-                        agent_config.request_id.clone().unwrap_or_default(),
+                        approval_topic_for(&agent_config.request_id, &orchestrator_id),
                     ))
                 }
                 crate::hitl::DecisionRoute::Webhook { .. } => None,
@@ -869,7 +880,7 @@ impl Orchestrator {
                 task: super::TaskIdentity::new(task_id, worker_name.map(String::from)),
                 session_id: session_id_owned.map(crate::config::SessionId::new),
             };
-            let request_id = worker_config.request_id.clone().unwrap_or_default();
+            let request_id = approval_topic_for(&worker_config.request_id, &self.orchestrator_id);
             let mut gate = crate::hitl::HitlApprovalWrapper::new(
                 hitl.patterns.clone(),
                 hitl.route.clone(),
@@ -1057,7 +1068,10 @@ impl Orchestrator {
             cell: Arc::new(BlockedCell::default()),
             // A per-stream synthetic id, not the live request id, so the hook's
             // tool-event publishes dead-letter instead of reaching the SSE stream.
-            key: format!("{}:task:{task_id}:attempt:{attempt}", self.orchestrator_id),
+            key: RequestId::new(format!(
+                "{}:task:{task_id}:attempt:{attempt}",
+                self.orchestrator_id
+            )),
         })
     }
 
@@ -1111,7 +1125,7 @@ impl Orchestrator {
             return;
         };
         let scope = self.worker_scope(task_id, worker_name).await;
-        let request_id = self.agent_config.request_id.clone().unwrap_or_default();
+        let request_id = self.approval_topic();
         for call in pending {
             registry.remove(&call.decision_id).await;
             if let Some(ref scope) = scope {
@@ -1367,7 +1381,7 @@ impl Orchestrator {
         params: StreamCallParams<'_>,
         stream_context: Option<StreamContext<'_>>,
         decision_ready: impl Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>>,
-        park_key: Option<&str>,
+        park_key: Option<&RequestId>,
     ) -> Result<ForwardedRun, Box<dyn std::error::Error + Send + Sync>> {
         let StreamCallParams {
             prompt,
@@ -3710,7 +3724,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                         let srd = srd.clone();
                         Box::pin(async move { srd.lock().await.is_some() })
                     },
-                    park.as_ref().map(|p| p.key.as_str()),
+                    park.as_ref().map(|p| &p.key),
                 )
                 .await;
             drop(park_registration);
@@ -5268,6 +5282,10 @@ Assign tasks to the worker whose tools best match the required operations."#,
         }
     }
 
+    fn approval_topic(&self) -> RequestId {
+        approval_topic_for(&self.agent_config.request_id, &self.orchestrator_id)
+    }
+
     /// Sweep the run's parked approvals by owner id, so no decidable
     /// approval outlives a run that has no checkpoint.
     async fn cancel_run_parked_approvals(&self, run_id: &str) {
@@ -5277,7 +5295,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         let crate::hitl::DecisionRoute::Conversational { registry, .. } = &*hitl.route else {
             return;
         };
-        let request_id = self.agent_config.request_id.clone().unwrap_or_default();
+        let request_id = self.approval_topic();
         super::park::cancel_run_approvals(registry, run_id, &request_id)
             .await
             .ok();
@@ -6426,7 +6444,7 @@ mod tests {
             cancel_rx,
             Duration::from_secs(300),
             cancel_token.clone(),
-            "test-normal".to_string(),
+            RequestId::new("test-normal"),
         );
 
         drop(cancel_tx);
@@ -6443,7 +6461,7 @@ mod tests {
             cancel_rx,
             Duration::from_secs(300),
             cancel_token.clone(),
-            "test-cancel".to_string(),
+            RequestId::new("test-cancel"),
         );
 
         cancel_tx.send(true).unwrap();
@@ -6461,7 +6479,7 @@ mod tests {
             cancel_rx,
             Duration::from_secs(60),
             cancel_token.clone(),
-            "test-timeout".to_string(),
+            RequestId::new("test-timeout"),
         );
 
         tokio::time::advance(Duration::from_secs(61)).await;
@@ -6478,7 +6496,7 @@ mod tests {
             cancel_rx,
             Duration::from_secs(60),
             cancel_token.clone(),
-            "test-no-spurious".to_string(),
+            RequestId::new("test-no-spurious"),
         );
 
         // Advance to T=30s, then drop sender (simulating stream completing mid-timeout)
@@ -6511,7 +6529,7 @@ mod tests {
             cancel_rx,
             Duration::from_secs(300),
             cancel_token.clone(),
-            "test-false-signal".to_string(),
+            RequestId::new("test-false-signal"),
         );
 
         // Send false — triggers rx.changed() but borrow_and_update() sees false,
@@ -7418,7 +7436,7 @@ mod tests {
         };
         use crate::session_store::{InMemoryApprovalStore, InMemoryEventBus};
 
-        let request_id = format!("req_cancel_{}", uuid::Uuid::new_v4().simple());
+        let request_id = RequestId::new(format!("req_cancel_{}", uuid::Uuid::new_v4().simple()));
         let mut events = crate::approval_event_broker::subscribe(&request_id).await;
 
         let store: Arc<dyn crate::session_store::ApprovalStore> =
@@ -7450,7 +7468,7 @@ mod tests {
                         version: PROTOCOL_VERSION,
                         instance_id: "test-instance".to_string(),
                         decision_id,
-                        request_id: "run:test".to_string(),
+                        request_id: RequestId::new("run:test"),
                         scope: AgentScope::Single { session_id: None },
                         origin: ApprovalOrigin::ConfigGate {
                             matched_pattern: "kubectl_*".to_string(),
@@ -7548,7 +7566,10 @@ mod tests {
             }),
             memory_dir: Some(memory_dir.to_string_lossy().into_owned()),
             session_id: Some("park-sess".to_string()),
-            request_id: Some(format!("req_park_{}", uuid::Uuid::new_v4().simple())),
+            request_id: Some(RequestId::new(format!(
+                "req_park_{}",
+                uuid::Uuid::new_v4().simple()
+            ))),
             ..AgentRuntimeConfig::default()
         };
         let orchestrator = Orchestrator::new(config).await.unwrap();
@@ -7578,7 +7599,7 @@ mod tests {
                         version: crate::hitl::PROTOCOL_VERSION,
                         instance_id: "test-instance".to_string(),
                         decision_id,
-                        request_id: format!("run:{run_id}"),
+                        request_id: RequestId::new(format!("run:{run_id}")),
                         scope: crate::hitl::AgentScope::Single { session_id: None },
                         origin: crate::hitl::ApprovalOrigin::ConfigGate {
                             matched_pattern: "kubectl_*".to_string(),
@@ -7783,11 +7804,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (orchestrator, store, registry, run_id) = park_orchestrator(dir.path()).await;
         let (plan, records, pending) = awaiting_plan_with_parked_calls(&registry, &run_id).await;
-        let request_id = orchestrator
-            .agent_config
-            .request_id
-            .clone()
-            .unwrap_or_default();
+        let request_id = orchestrator.approval_topic();
         let mut events = crate::approval_event_broker::subscribe(&request_id).await;
         arm_guard(&orchestrator, &plan).await;
 
@@ -7875,11 +7892,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (orchestrator, store, registry, run_id) = park_orchestrator(dir.path()).await;
         let (plan, records, pending) = awaiting_plan_with_parked_calls(&registry, &run_id).await;
-        let request_id = orchestrator
-            .agent_config
-            .request_id
-            .clone()
-            .unwrap_or_default();
+        let request_id = orchestrator.approval_topic();
         let mut events = crate::approval_event_broker::subscribe(&request_id).await;
 
         // The human decides the first call before the commit is attempted.
@@ -7966,11 +7979,7 @@ mod tests {
         let (orchestrator, registry, run_id) =
             park_orchestrator_over(store.clone(), dir.path()).await;
         let (plan, records, pending) = awaiting_plan_with_parked_calls(&registry, &run_id).await;
-        let request_id = orchestrator
-            .agent_config
-            .request_id
-            .clone()
-            .unwrap_or_default();
+        let request_id = orchestrator.approval_topic();
         let mut events = crate::approval_event_broker::subscribe(&request_id).await;
         arm_guard(&orchestrator, &plan).await;
 
@@ -8070,7 +8079,7 @@ mod tests {
         Orchestrator,
         Arc<crate::session_store::InMemoryApprovalStore>,
         crate::hitl::PendingApprovals,
-        String,
+        RequestId,
     ) {
         use crate::hitl::PendingApprovals;
         use crate::session_store::{InMemoryApprovalStore, InMemoryEventBus};
@@ -8093,7 +8102,7 @@ mod tests {
                 skills: None,
             },
         )]);
-        let request_id = format!("req_orphan_{}", uuid::Uuid::new_v4().simple());
+        let request_id = RequestId::new(format!("req_orphan_{}", uuid::Uuid::new_v4().simple()));
         let config = AgentRuntimeConfig {
             hitl: Some(crate::hitl::HitlRuntime {
                 patterns: Arc::from([aura_config::GlobPattern::new("echo_tool").unwrap()]),
@@ -8393,7 +8402,10 @@ mod tests {
             }),
             memory_dir: Some(memory_dir.to_string_lossy().into_owned()),
             session_id: Some(session_id.to_string()),
-            request_id: Some(format!("req_resume_{}", uuid::Uuid::new_v4().simple())),
+            request_id: Some(RequestId::new(format!(
+                "req_resume_{}",
+                uuid::Uuid::new_v4().simple()
+            ))),
             orchestration: Some(OrchestrationConfig {
                 enabled: true,
                 workers,

--- a/crates/aura/src/orchestration/overview.rs
+++ b/crates/aura/src/orchestration/overview.rs
@@ -1,6 +1,7 @@
 //! Projections of an agent [`Config`] into the wire types served by
 //! `GET /aura/info` ([`AgentInfo`], [`WorkerOverview`]).
 
+use crate::RequestId;
 use aura_config::{Config, McpServerConfig};
 use aura_events::{
     AgentInfo, McpServerOverview, McpToolAnnotations, McpToolOverview, WorkerOverview,
@@ -107,7 +108,7 @@ async fn discover_tools(
         .collect();
 
     manager
-        .cancel_and_close_all("aura-info", "tool detail collected")
+        .cancel_and_close_all(&RequestId::new("aura-info"), "tool detail collected")
         .await;
     per_server
 }

--- a/crates/aura/src/orchestration/park/commit.rs
+++ b/crates/aura/src/orchestration/park/commit.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
+use crate::RequestId;
 use crate::config::AgentRuntimeConfig;
 use crate::hitl::{DecisionId, PendingApprovals};
 use crate::orchestration::persistence::is_safe_path_component;
@@ -49,8 +50,8 @@ pub(crate) struct ParkCommitOutcome {
 
 /// The run-scoped owner id every approval parked by `run_id` is registered
 /// under.
-pub(crate) fn run_owner_id(run_id: &str) -> String {
-    format!("run:{run_id}")
+pub(crate) fn run_owner_id(run_id: &str) -> RequestId {
+    RequestId::new(format!("run:{run_id}"))
 }
 
 /// Narrow the plan's awaiting tasks to the calls still parked and undecided,
@@ -216,11 +217,11 @@ pub(crate) async fn publish(
 pub(crate) fn cancel_run_approvals(
     registry: &PendingApprovals,
     run_id: &str,
-    request_id: &str,
+    request_id: &RequestId,
 ) -> tokio::task::JoinHandle<()> {
     let registry = registry.clone();
     let run_id = run_id.to_string();
-    let request_id = request_id.to_string();
+    let request_id = request_id.clone();
     tokio::task::spawn(async move {
         for parked in registry.cancel_request(&run_owner_id(&run_id)).await {
             crate::approval_event_broker::publish(
@@ -311,7 +312,7 @@ mod tests {
 
     fn parked_approval(
         decision_id: DecisionId,
-        owner: &str,
+        owner: &RequestId,
         expires_at: chrono::DateTime<chrono::Utc>,
     ) -> ParkedApproval {
         ParkedApproval {
@@ -319,7 +320,7 @@ mod tests {
                 version: PROTOCOL_VERSION,
                 instance_id: "test-instance".to_string(),
                 decision_id,
-                request_id: owner.to_string(),
+                request_id: owner.clone(),
                 scope: AgentScope::Single { session_id: None },
                 origin: ApprovalOrigin::ConfigGate {
                     matched_pattern: "kubectl_*".to_string(),
@@ -456,7 +457,7 @@ mod tests {
     #[tokio::test]
     async fn refresh_drops_decided_and_takes_earliest_expiry() {
         let (registry, _store) = conv_registry();
-        let owner = "run:0191e8c0-eeee-7000-8000-000000000003";
+        let owner = RequestId::new("run:0191e8c0-eeee-7000-8000-000000000003");
         let now = chrono::Utc::now();
         let decided = DecisionId::generate();
         let removed = DecisionId::generate();
@@ -466,7 +467,7 @@ mod tests {
         registry
             .register_durable(parked_approval(
                 decided,
-                owner,
+                &owner,
                 now + chrono::Duration::hours(2),
             ))
             .await
@@ -474,7 +475,7 @@ mod tests {
         registry
             .register_durable(parked_approval(
                 removed,
-                owner,
+                &owner,
                 now + chrono::Duration::hours(2),
             ))
             .await
@@ -482,7 +483,7 @@ mod tests {
         registry
             .register_durable(parked_approval(
                 earliest,
-                owner,
+                &owner,
                 now + chrono::Duration::minutes(30),
             ))
             .await
@@ -490,7 +491,7 @@ mod tests {
         registry
             .register_durable(parked_approval(
                 latest,
-                owner,
+                &owner,
                 now + chrono::Duration::hours(1),
             ))
             .await
@@ -553,7 +554,7 @@ mod tests {
         let (registry, store) = conv_registry();
         let run_id = "0191e8c0-ffff-7000-8000-000000000006";
         let owner = run_owner_id(run_id);
-        let request_id = format!("req_sweep_{}", uuid::Uuid::new_v4().simple());
+        let request_id = RequestId::new(format!("req_sweep_{}", uuid::Uuid::new_v4().simple()));
         let mut events = crate::approval_event_broker::subscribe(&request_id).await;
 
         let now = chrono::Utc::now();
@@ -622,7 +623,7 @@ mod tests {
         let (registry, store) = conv_registry();
         let run_id = "0191e8c0-aaaa-7000-8000-000000000007";
         let owner = run_owner_id(run_id);
-        let request_id = format!("req_sweep_{}", uuid::Uuid::new_v4().simple());
+        let request_id = RequestId::new(format!("req_sweep_{}", uuid::Uuid::new_v4().simple()));
         let mut events = crate::approval_event_broker::subscribe(&request_id).await;
 
         let now = chrono::Utc::now();
@@ -690,7 +691,7 @@ mod tests {
             .await
             .unwrap();
 
-        cancel_run_approvals(&registry, run_id, "req_late_resolve")
+        cancel_run_approvals(&registry, run_id, &RequestId::new("req_late_resolve"))
             .await
             .unwrap();
 

--- a/crates/aura/src/orchestration/park/continuation.rs
+++ b/crates/aura/src/orchestration/park/continuation.rs
@@ -327,6 +327,7 @@ pub(crate) fn replace_tool_result(current_prompt: &mut Message, call_id: &str, w
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::RequestId;
     use crate::hitl::{
         AgentScope, ApprovalDecision, ApprovalItem, ApprovalOrigin, ApprovalRequest,
         PROTOCOL_VERSION, ParkedApproval,
@@ -387,7 +388,7 @@ mod tests {
                 version: PROTOCOL_VERSION,
                 instance_id: "test-instance".to_string(),
                 decision_id,
-                request_id: "run:test".to_string(),
+                request_id: RequestId::new("run:test"),
                 scope: AgentScope::Worker {
                     run_id: "0191e8c0-aaaa-7000-8000-00000000c0de".parse().unwrap(),
                     task: crate::orchestration::types::TaskIdentity::new(3, None),

--- a/crates/aura/src/orchestration/park/guard.rs
+++ b/crates/aura/src/orchestration/park/guard.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use crate::RequestId;
 use crate::hitl::PendingApprovals;
 
 use super::commit::cancel_run_approvals;
@@ -11,14 +12,18 @@ use super::commit::cancel_run_approvals;
 pub(crate) struct ParkGuard {
     registry: PendingApprovals,
     run_id: String,
-    request_id: String,
+    request_id: RequestId,
     published: AtomicBool,
     armed: AtomicBool,
 }
 
 impl ParkGuard {
     /// Create the guard for a run; inert until the first [`Self::record`].
-    pub(crate) fn new(registry: PendingApprovals, run_id: String, request_id: String) -> Arc<Self> {
+    pub(crate) fn new(
+        registry: PendingApprovals,
+        run_id: String,
+        request_id: RequestId,
+    ) -> Arc<Self> {
         Arc::new(Self {
             registry,
             run_id,
@@ -103,7 +108,7 @@ mod tests {
 
     fn durable_approval(
         decision_id: DecisionId,
-        owner: &str,
+        owner: &RequestId,
         scope: &AgentScope,
     ) -> ParkedApproval {
         ParkedApproval {
@@ -111,7 +116,7 @@ mod tests {
                 version: PROTOCOL_VERSION,
                 instance_id: "test-instance".to_string(),
                 decision_id,
-                request_id: owner.to_string(),
+                request_id: owner.clone(),
                 scope: scope.clone(),
                 origin: ApprovalOrigin::ConfigGate {
                     matched_pattern: "kubectl_*".to_string(),
@@ -141,7 +146,7 @@ mod tests {
     async fn unpublished_guard_drop_cancels_run_approvals() {
         let (registry, store) = registry_with_store();
         let run_id: RunId = "0191e8c0-2222-7000-8000-000000000042".parse().unwrap();
-        let request_id = format!("req_guard_{}", uuid::Uuid::new_v4().simple());
+        let request_id = RequestId::new(format!("req_guard_{}", uuid::Uuid::new_v4().simple()));
         let mut events = crate::approval_event_broker::subscribe(&request_id).await;
 
         let scope = worker_scope(run_id);
@@ -149,7 +154,7 @@ mod tests {
         registry
             .register_durable(durable_approval(
                 decision_id,
-                &format!("run:{run_id}"),
+                &RequestId::new(format!("run:{run_id}")),
                 &scope,
             ))
             .await
@@ -194,13 +199,17 @@ mod tests {
         registry
             .register_durable(durable_approval(
                 decision_id,
-                &format!("run:{run_id}"),
+                &RequestId::new(format!("run:{run_id}")),
                 &scope,
             ))
             .await
             .unwrap();
 
-        let guard = ParkGuard::new(registry.clone(), run_id.to_string(), "req_x".to_string());
+        let guard = ParkGuard::new(
+            registry.clone(),
+            run_id.to_string(),
+            RequestId::new("req_x"),
+        );
         guard.record(std::slice::from_ref(&parked_call(decision_id)));
         guard.mark_published();
         drop(guard);
@@ -228,7 +237,11 @@ mod tests {
             .await
             .unwrap();
 
-        let guard = ParkGuard::new(registry.clone(), run_id.to_string(), "req_y".to_string());
+        let guard = ParkGuard::new(
+            registry.clone(),
+            run_id.to_string(),
+            RequestId::new("req_y"),
+        );
         drop(guard);
 
         tokio::time::sleep(Duration::from_millis(25)).await;

--- a/crates/aura/src/orchestration/persistence_wrapper.rs
+++ b/crates/aura/src/orchestration/persistence_wrapper.rs
@@ -424,6 +424,7 @@ pub fn extract_reasoning(mut args: Value) -> (Option<String>, Value) {
 
 #[cfg(test)]
 mod tests {
+    use crate::RequestId;
     use crate::WrappedTool;
     use crate::hitl::ApprovalItem;
     use rig::tool::{Tool as RigTool, ToolError};
@@ -881,7 +882,7 @@ mod tests {
 
         let tmp = tempfile::TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-compose-1")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-compose-1"))
                 .await
                 .unwrap(),
         );
@@ -1450,7 +1451,7 @@ mod tests {
             session_id: None,
         };
 
-        let request_id = format!("req_w2_{}", uuid::Uuid::new_v4().simple());
+        let request_id = RequestId::new(format!("req_w2_{}", uuid::Uuid::new_v4().simple()));
 
         let gate: Arc<dyn ToolWrapper> = Arc::new(HitlApprovalWrapper::new(
             Arc::from([GlobPattern::new("kubectl_*").unwrap()]),

--- a/crates/aura/src/orchestration/test_rig.rs
+++ b/crates/aura/src/orchestration/test_rig.rs
@@ -30,6 +30,7 @@
 //! scripted model and registers its tools through the worker's own wrapper
 //! chain, so execute_task-level tests drive the production path unmodified.
 
+use crate::RequestId;
 use std::collections::VecDeque;
 use std::path::Path;
 use std::sync::Arc;
@@ -620,7 +621,7 @@ pub(crate) async fn drive_worker(
     history: Vec<rig::completion::Message>,
     max_depth: usize,
 ) -> Result<StreamRun, Box<dyn std::error::Error + Send + Sync>> {
-    let request_id = format!("rig_{}", uuid::Uuid::new_v4().simple());
+    let request_id = RequestId::new(format!("rig_{}", uuid::Uuid::new_v4().simple()));
     let (hook, cancel_tx, usage_state) =
         StreamingRequestHook::with_scratchpad_budget(Duration::from_secs(60), request_id, None);
 
@@ -737,7 +738,10 @@ pub(crate) async fn park_orchestrator_in(
         }),
         memory_dir: Some(memory_dir.to_string_lossy().into_owned()),
         session_id: Some("park-sess".to_string()),
-        request_id: Some(format!("req_rig_{}", uuid::Uuid::new_v4().simple())),
+        request_id: Some(RequestId::new(format!(
+            "req_rig_{}",
+            uuid::Uuid::new_v4().simple()
+        ))),
         orchestration: Some(super::OrchestrationConfig {
             enabled: true,
             workers,

--- a/crates/aura/src/provider_agent.rs
+++ b/crates/aura/src/provider_agent.rs
@@ -19,6 +19,7 @@ use std::pin::Pin;
 use std::time::Duration;
 use tokio::sync::watch;
 
+use crate::RequestId;
 use crate::orchestration::OrchestratorEvent;
 use crate::scratchpad::ContextBudget;
 use crate::streaming_request_hook::StreamingRequestHook;
@@ -110,7 +111,7 @@ impl ProviderAgent {
         chat_history: Vec<rig::completion::Message>,
         max_depth: usize,
         timeout: Duration,
-        request_id: &str,
+        request_id: &RequestId,
         scratchpad_budget: Option<ContextBudget>,
         client_tool_names: HashSet<String>,
     ) -> (
@@ -118,8 +119,11 @@ impl ProviderAgent {
         watch::Sender<bool>,
         crate::streaming_request_hook::UsageState,
     ) {
-        let (hook, cancel_tx, usage_state) =
-            StreamingRequestHook::with_scratchpad_budget(timeout, request_id, scratchpad_budget);
+        let (hook, cancel_tx, usage_state) = StreamingRequestHook::with_scratchpad_budget(
+            timeout,
+            request_id.clone(),
+            scratchpad_budget,
+        );
         let hook = hook.with_client_tool_names(client_tool_names);
 
         match self {
@@ -325,7 +329,7 @@ impl ProviderAgent {
         query: &str,
         max_depth: usize,
         timeout: Duration,
-        request_id: &str,
+        request_id: &RequestId,
         scratchpad_budget: Option<ContextBudget>,
         client_tool_names: HashSet<String>,
     ) -> (
@@ -333,8 +337,11 @@ impl ProviderAgent {
         watch::Sender<bool>,
         crate::streaming_request_hook::UsageState,
     ) {
-        let (hook, cancel_tx, usage_state) =
-            StreamingRequestHook::with_scratchpad_budget(timeout, request_id, scratchpad_budget);
+        let (hook, cancel_tx, usage_state) = StreamingRequestHook::with_scratchpad_budget(
+            timeout,
+            request_id.clone(),
+            scratchpad_budget,
+        );
         let hook = hook.with_client_tool_names(client_tool_names);
 
         match self {
@@ -439,7 +446,7 @@ impl ProviderAgent {
         chat_history: Vec<rig::completion::Message>,
         max_depth: usize,
         timeout: Duration,
-        request_id: &str,
+        request_id: &RequestId,
         scratchpad_budget: Option<ContextBudget>,
         client_tool_names: HashSet<String>,
     ) -> (
@@ -447,8 +454,11 @@ impl ProviderAgent {
         watch::Sender<bool>,
         crate::streaming_request_hook::UsageState,
     ) {
-        let (hook, cancel_tx, usage_state) =
-            StreamingRequestHook::with_scratchpad_budget(timeout, request_id, scratchpad_budget);
+        let (hook, cancel_tx, usage_state) = StreamingRequestHook::with_scratchpad_budget(
+            timeout,
+            request_id.clone(),
+            scratchpad_budget,
+        );
         let hook = hook.with_client_tool_names(client_tool_names);
 
         match self {

--- a/crates/aura/src/request_cancellation.rs
+++ b/crates/aura/src/request_cancellation.rs
@@ -13,7 +13,12 @@ use tracing::{debug, info};
 
 use crate::mcp::McpClient;
 
-pub type RequestId = String;
+aura_events::string_newtype! {
+    /// Routing key for the request-scoped brokers and the cancellation
+    /// registry. Two values that differ by one byte address different
+    /// subscribers, so an id is only ever passed along, never rebuilt.
+    RequestId
+}
 
 /// Request-scoped cancellation signal. Fired by the handler on client
 /// disconnect, timeout, or server shutdown. Observed by MCP notifications,
@@ -68,8 +73,8 @@ pub struct RequestCancellation {
 
 impl RequestCancellation {
     /// Register a new request in the global cancellation registry.
-    pub fn register(request_id: impl Into<RequestId>) -> Self {
-        let request_id = request_id.into();
+    pub fn register(request_id: &RequestId) -> Self {
+        let request_id = request_id.clone();
         let raw = CancellationToken::new();
 
         registry()
@@ -91,7 +96,7 @@ impl RequestCancellation {
 
     /// Look up the cancel token for a request id. Returns `None` if the
     /// request was never registered (e.g. CLI standalone mode).
-    pub fn token_for_id(request_id: &str) -> Option<RequestCancelToken> {
+    pub fn token_for_id(request_id: &RequestId) -> Option<RequestCancelToken> {
         registry()
             .requests
             .read()
@@ -104,7 +109,7 @@ impl RequestCancellation {
     }
 
     /// Cancel a request by ID. Called on timeout or client disconnect.
-    pub fn cancel(request_id: &str, reason: &str) {
+    pub fn cancel(request_id: &RequestId, reason: &str) {
         let requests = registry().requests.read().unwrap_or_else(|poisoned| {
             tracing::error!("Cancellation registry read lock poisoned, recovering");
             poisoned.into_inner()
@@ -116,7 +121,7 @@ impl RequestCancellation {
     }
 
     /// Remove a completed request from the registry.
-    pub fn unregister(request_id: &str) {
+    pub fn unregister(request_id: &RequestId) {
         registry()
             .requests
             .write()
@@ -149,38 +154,38 @@ mod tests {
 
     #[test]
     fn test_register_and_cancel() {
-        let ctx = RequestCancellation::register("test_req_cancel_1");
+        let ctx = RequestCancellation::register(&RequestId::new("test_req_cancel_1"));
         assert!(!ctx.is_cancelled());
 
-        RequestCancellation::cancel("test_req_cancel_1", "test");
+        RequestCancellation::cancel(&RequestId::new("test_req_cancel_1"), "test");
         assert!(ctx.is_cancelled());
 
-        RequestCancellation::unregister("test_req_cancel_1");
+        RequestCancellation::unregister(&RequestId::new("test_req_cancel_1"));
     }
 
     #[test]
     fn test_multiple_requests_independent() {
-        let ctx1 = RequestCancellation::register("test_req_cancel_a");
-        let ctx2 = RequestCancellation::register("test_req_cancel_b");
+        let ctx1 = RequestCancellation::register(&RequestId::new("test_req_cancel_a"));
+        let ctx2 = RequestCancellation::register(&RequestId::new("test_req_cancel_b"));
 
-        RequestCancellation::cancel("test_req_cancel_a", "test");
+        RequestCancellation::cancel(&RequestId::new("test_req_cancel_a"), "test");
 
         assert!(ctx1.is_cancelled());
         assert!(!ctx2.is_cancelled()); // Independent
 
-        RequestCancellation::unregister("test_req_cancel_a");
-        RequestCancellation::unregister("test_req_cancel_b");
+        RequestCancellation::unregister(&RequestId::new("test_req_cancel_a"));
+        RequestCancellation::unregister(&RequestId::new("test_req_cancel_b"));
     }
 
     #[test]
     fn test_cancel_nonexistent_request_safe() {
         // Should not panic
-        RequestCancellation::cancel("nonexistent_request", "test");
+        RequestCancellation::cancel(&RequestId::new("nonexistent_request"), "test");
     }
 
     #[test]
     fn test_unregister_nonexistent_request_safe() {
         // Should not panic
-        RequestCancellation::unregister("nonexistent_request");
+        RequestCancellation::unregister(&RequestId::new("nonexistent_request"));
     }
 }

--- a/crates/aura/src/request_progress.rs
+++ b/crates/aura/src/request_progress.rs
@@ -3,6 +3,7 @@
 //! Routes progress notifications to specific HTTP requests only (no cross-customer leakage).
 //! Channels auto-cleanup when receiver is dropped at request end.
 
+use crate::RequestId;
 use rmcp::model::ProgressToken;
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -35,7 +36,7 @@ impl ProgressNotification {
 /// to specific HTTP requests only.
 pub struct RequestProgressBroker {
     /// Map of request_id -> progress channel sender
-    senders: RwLock<HashMap<String, mpsc::Sender<ProgressNotification>>>,
+    senders: RwLock<HashMap<RequestId, mpsc::Sender<ProgressNotification>>>,
 }
 
 impl RequestProgressBroker {
@@ -46,11 +47,11 @@ impl RequestProgressBroker {
     }
 
     /// Subscribe to progress notifications for a request. Auto-unsubscribes when receiver dropped.
-    pub async fn subscribe(&self, request_id: &str) -> mpsc::Receiver<ProgressNotification> {
+    pub async fn subscribe(&self, request_id: &RequestId) -> mpsc::Receiver<ProgressNotification> {
         let (tx, rx) = mpsc::channel(PROGRESS_CHANNEL_CAPACITY);
 
         let mut senders = self.senders.write().await;
-        senders.insert(request_id.to_string(), tx);
+        senders.insert(request_id.clone(), tx);
 
         debug!(
             "Progress subscription created for request '{}' (total active: {})",
@@ -61,7 +62,7 @@ impl RequestProgressBroker {
         rx
     }
 
-    pub async fn unsubscribe(&self, request_id: &str) {
+    pub async fn unsubscribe(&self, request_id: &RequestId) {
         let mut senders = self.senders.write().await;
         if senders.remove(request_id).is_some() {
             debug!(
@@ -74,7 +75,11 @@ impl RequestProgressBroker {
 
     /// Publish a progress notification. Returns true if sent, false if no subscriber.
     /// Automatically cleans up stale entries when receiver has been dropped.
-    pub async fn publish(&self, request_id: &str, notification: ProgressNotification) -> bool {
+    pub async fn publish(
+        &self,
+        request_id: &RequestId,
+        notification: ProgressNotification,
+    ) -> bool {
         // First try with read lock
         let send_result = {
             let senders = self.senders.read().await;
@@ -126,15 +131,15 @@ pub fn global() -> &'static RequestProgressBroker {
     GLOBAL_BROKER.get_or_init(RequestProgressBroker::new)
 }
 
-pub async fn subscribe(request_id: &str) -> mpsc::Receiver<ProgressNotification> {
+pub async fn subscribe(request_id: &RequestId) -> mpsc::Receiver<ProgressNotification> {
     global().subscribe(request_id).await
 }
 
-pub async fn unsubscribe(request_id: &str) {
+pub async fn unsubscribe(request_id: &RequestId) {
     global().unsubscribe(request_id).await
 }
 
-pub async fn publish(request_id: &str, notification: ProgressNotification) -> bool {
+pub async fn publish(request_id: &RequestId, notification: ProgressNotification) -> bool {
     global().publish(request_id, notification).await
 }
 
@@ -163,24 +168,24 @@ mod tests {
     #[tokio::test]
     async fn test_subscribe_creates_channel() {
         let broker = RequestProgressBroker::new();
-        let _rx = broker.subscribe("req_123").await;
+        let _rx = broker.subscribe(&RequestId::new("req_123")).await;
         assert_eq!(broker.active_subscriptions().await, 1);
     }
 
     #[tokio::test]
     async fn test_unsubscribe_removes_channel() {
         let broker = RequestProgressBroker::new();
-        let _rx = broker.subscribe("req_123").await;
+        let _rx = broker.subscribe(&RequestId::new("req_123")).await;
         assert_eq!(broker.active_subscriptions().await, 1);
 
-        broker.unsubscribe("req_123").await;
+        broker.unsubscribe(&RequestId::new("req_123")).await;
         assert_eq!(broker.active_subscriptions().await, 0);
     }
 
     #[tokio::test]
     async fn test_publish_to_subscribed_request() {
         let broker = RequestProgressBroker::new();
-        let mut rx = broker.subscribe("req_123").await;
+        let mut rx = broker.subscribe(&RequestId::new("req_123")).await;
 
         let notification = ProgressNotification {
             progress_token: numeric_token(1),
@@ -189,7 +194,9 @@ mod tests {
             agent: None,
         };
 
-        let sent = broker.publish("req_123", notification).await;
+        let sent = broker
+            .publish(&RequestId::new("req_123"), notification)
+            .await;
         assert!(sent);
 
         let received = rx.recv().await.unwrap();
@@ -209,15 +216,17 @@ mod tests {
         };
 
         // No subscriber - should return false
-        let sent = broker.publish("req_nonexistent", notification).await;
+        let sent = broker
+            .publish(&RequestId::new("req_nonexistent"), notification)
+            .await;
         assert!(!sent);
     }
 
     #[tokio::test]
     async fn test_requests_are_isolated() {
         let broker = RequestProgressBroker::new();
-        let mut rx1 = broker.subscribe("req_1").await;
-        let mut rx2 = broker.subscribe("req_2").await;
+        let mut rx1 = broker.subscribe(&RequestId::new("req_1")).await;
+        let mut rx2 = broker.subscribe(&RequestId::new("req_2")).await;
 
         // Send to req_1 only
         let notification = ProgressNotification {
@@ -226,7 +235,7 @@ mod tests {
             message: Some("Request 1 progress".to_string()),
             agent: None,
         };
-        broker.publish("req_1", notification).await;
+        broker.publish(&RequestId::new("req_1"), notification).await;
 
         // req_1 should receive it
         let received = rx1.recv().await.unwrap();
@@ -239,7 +248,7 @@ mod tests {
     #[tokio::test]
     async fn test_multiple_notifications_same_request() {
         let broker = RequestProgressBroker::new();
-        let mut rx = broker.subscribe("req_123").await;
+        let mut rx = broker.subscribe(&RequestId::new("req_123")).await;
 
         // Send multiple notifications
         for i in 1..=5 {
@@ -249,7 +258,9 @@ mod tests {
                 message: Some(format!("Step {}", i)),
                 agent: None,
             };
-            broker.publish("req_123", notification).await;
+            broker
+                .publish(&RequestId::new("req_123"), notification)
+                .await;
         }
 
         // Should receive all 5
@@ -266,7 +277,7 @@ mod tests {
 
         // Subscribe and verify entry exists
         {
-            let _rx = broker.subscribe("req_cleanup").await;
+            let _rx = broker.subscribe(&RequestId::new("req_cleanup")).await;
             assert_eq!(broker.active_subscriptions().await, 1);
         } // Receiver dropped here
 
@@ -278,7 +289,9 @@ mod tests {
             message: Some("Should fail".to_string()),
             agent: None,
         };
-        let sent = broker.publish("req_cleanup", notification).await;
+        let sent = broker
+            .publish(&RequestId::new("req_cleanup"), notification)
+            .await;
 
         // Publish returns false when receiver is dropped
         assert!(!sent);
@@ -292,7 +305,7 @@ mod tests {
         let broker = RequestProgressBroker::new();
 
         // Subscribe and keep receiver alive
-        let mut rx = broker.subscribe("req_active").await;
+        let mut rx = broker.subscribe(&RequestId::new("req_active")).await;
         assert_eq!(broker.active_subscriptions().await, 1);
 
         // Publish should succeed
@@ -302,7 +315,9 @@ mod tests {
             message: Some("Should succeed".to_string()),
             agent: None,
         };
-        let sent = broker.publish("req_active", notification).await;
+        let sent = broker
+            .publish(&RequestId::new("req_active"), notification)
+            .await;
         assert!(sent);
 
         // Receiver should get the message
@@ -323,7 +338,7 @@ mod tests {
     #[tokio::test]
     async fn test_channel_backpressure_behavior() {
         let broker = RequestProgressBroker::new();
-        let _rx = broker.subscribe("req_backpressure").await;
+        let _rx = broker.subscribe(&RequestId::new("req_backpressure")).await;
         // Don't read from _rx - simulate slow consumer
 
         // Send more messages than channel capacity (1024)
@@ -339,7 +354,9 @@ mod tests {
                     message: Some(format!("msg {}", i)),
                     agent: None,
                 };
-                broker.publish("req_backpressure", notification).await;
+                broker
+                    .publish(&RequestId::new("req_backpressure"), notification)
+                    .await;
             }
         })
         .await;
@@ -355,7 +372,7 @@ mod tests {
     #[tokio::test]
     async fn test_channel_drains_properly() {
         let broker = RequestProgressBroker::new();
-        let mut rx = broker.subscribe("req_drain").await;
+        let mut rx = broker.subscribe(&RequestId::new("req_drain")).await;
 
         // Send exactly capacity messages
         for i in 0..PROGRESS_CHANNEL_CAPACITY {
@@ -365,7 +382,11 @@ mod tests {
                 message: None,
                 agent: None,
             };
-            assert!(broker.publish("req_drain", notification).await);
+            assert!(
+                broker
+                    .publish(&RequestId::new("req_drain"), notification)
+                    .await
+            );
         }
 
         // Drain all messages
@@ -383,7 +404,7 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_publish_to_same_request() {
         let broker = std::sync::Arc::new(RequestProgressBroker::new());
-        let mut rx = broker.subscribe("req_concurrent").await;
+        let mut rx = broker.subscribe(&RequestId::new("req_concurrent")).await;
 
         // Spawn multiple publishers
         let handles: Vec<_> = (0..10)
@@ -397,7 +418,9 @@ mod tests {
                             message: Some(format!("pub {} msg {}", publisher_id, i)),
                             agent: None,
                         };
-                        broker.publish("req_concurrent", notification).await;
+                        broker
+                            .publish(&RequestId::new("req_concurrent"), notification)
+                            .await;
                     }
                 })
             })

--- a/crates/aura/src/request_progress.rs
+++ b/crates/aura/src/request_progress.rs
@@ -9,6 +9,8 @@ use std::sync::OnceLock;
 use tokio::sync::{RwLock, mpsc};
 use tracing::debug;
 
+pub use aura_events::{AgentContext, Progress};
+
 /// Channel capacity for progress notifications per request
 const PROGRESS_CHANNEL_CAPACITY: usize = 1024;
 
@@ -17,24 +19,15 @@ const PROGRESS_CHANNEL_CAPACITY: usize = 1024;
 pub struct ProgressNotification {
     /// The progress token (correlates to tool call)
     pub progress_token: ProgressToken,
-    /// Current progress value (rmcp uses f64 for JSON-RPC compatibility)
-    pub progress: f64,
-    /// Total progress value (if known)
-    pub total: Option<f64>,
+    pub progress: Progress,
     /// Optional message describing current step
     pub message: Option<String>,
+    pub agent: Option<AgentContext>,
 }
 
 impl ProgressNotification {
-    /// Calculate percent completion (0-100) if total is known
     pub fn percent(&self) -> Option<u8> {
-        self.total.map(|total| {
-            if total == 0.0 {
-                100
-            } else {
-                ((self.progress / total) * 100.0).min(100.0) as u8
-            }
-        })
+        self.progress.percent()
     }
 }
 
@@ -191,16 +184,16 @@ mod tests {
 
         let notification = ProgressNotification {
             progress_token: numeric_token(1),
-            progress: 50.0,
-            total: Some(100.0),
+            progress: Progress::ratio(50.0, 100.0),
             message: Some("Halfway there".to_string()),
+            agent: None,
         };
 
         let sent = broker.publish("req_123", notification).await;
         assert!(sent);
 
         let received = rx.recv().await.unwrap();
-        assert_eq!(received.progress, 50.0);
+        assert_eq!(received.progress.current, 50.0);
         assert_eq!(received.message, Some("Halfway there".to_string()));
     }
 
@@ -210,9 +203,9 @@ mod tests {
 
         let notification = ProgressNotification {
             progress_token: numeric_token(1),
-            progress: 50.0,
-            total: Some(100.0),
+            progress: Progress::ratio(50.0, 100.0),
             message: None,
+            agent: None,
         };
 
         // No subscriber - should return false
@@ -229,9 +222,9 @@ mod tests {
         // Send to req_1 only
         let notification = ProgressNotification {
             progress_token: string_token("token_1"),
-            progress: 25.0,
-            total: Some(100.0),
+            progress: Progress::ratio(25.0, 100.0),
             message: Some("Request 1 progress".to_string()),
+            agent: None,
         };
         broker.publish("req_1", notification).await;
 
@@ -244,33 +237,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_percent_calculation() {
-        let notification = ProgressNotification {
-            progress_token: numeric_token(1),
-            progress: 50.0,
-            total: Some(100.0),
-            message: None,
-        };
-        assert_eq!(notification.percent(), Some(50));
-
-        let notification_no_total = ProgressNotification {
-            progress_token: numeric_token(2),
-            progress: 50.0,
-            total: None,
-            message: None,
-        };
-        assert_eq!(notification_no_total.percent(), None);
-
-        let notification_zero_total = ProgressNotification {
-            progress_token: numeric_token(3),
-            progress: 0.0,
-            total: Some(0.0),
-            message: None,
-        };
-        assert_eq!(notification_zero_total.percent(), Some(100));
-    }
-
-    #[tokio::test]
     async fn test_multiple_notifications_same_request() {
         let broker = RequestProgressBroker::new();
         let mut rx = broker.subscribe("req_123").await;
@@ -279,9 +245,9 @@ mod tests {
         for i in 1..=5 {
             let notification = ProgressNotification {
                 progress_token: numeric_token(1),
-                progress: i as f64 * 20.0,
-                total: Some(100.0),
+                progress: Progress::ratio(i as f64 * 20.0, 100.0),
                 message: Some(format!("Step {}", i)),
+                agent: None,
             };
             broker.publish("req_123", notification).await;
         }
@@ -289,7 +255,7 @@ mod tests {
         // Should receive all 5
         for i in 1..=5 {
             let received = rx.recv().await.unwrap();
-            assert_eq!(received.progress, i as f64 * 20.0);
+            assert_eq!(received.progress.current, i as f64 * 20.0);
             assert_eq!(received.message, Some(format!("Step {}", i)));
         }
     }
@@ -308,9 +274,9 @@ mod tests {
         // Publish should fail because receiver is gone, triggering cleanup
         let notification = ProgressNotification {
             progress_token: numeric_token(1),
-            progress: 50.0,
-            total: Some(100.0),
+            progress: Progress::ratio(50.0, 100.0),
             message: Some("Should fail".to_string()),
+            agent: None,
         };
         let sent = broker.publish("req_cleanup", notification).await;
 
@@ -332,9 +298,9 @@ mod tests {
         // Publish should succeed
         let notification = ProgressNotification {
             progress_token: numeric_token(1),
-            progress: 75.0,
-            total: Some(100.0),
+            progress: Progress::ratio(75.0, 100.0),
             message: Some("Should succeed".to_string()),
+            agent: None,
         };
         let sent = broker.publish("req_active", notification).await;
         assert!(sent);
@@ -343,7 +309,7 @@ mod tests {
         let received = rx.recv().await;
         assert!(received.is_some());
         let msg = received.unwrap();
-        assert_eq!(msg.progress, 75.0);
+        assert_eq!(msg.progress.current, 75.0);
         assert_eq!(msg.message, Some("Should succeed".to_string()));
 
         // Subscription still active
@@ -369,9 +335,9 @@ mod tests {
             for i in 0..send_count {
                 let notification = ProgressNotification {
                     progress_token: numeric_token(i as i64),
-                    progress: i as f64,
-                    total: Some(send_count as f64),
+                    progress: Progress::ratio(i as f64, send_count as f64),
                     message: Some(format!("msg {}", i)),
+                    agent: None,
                 };
                 broker.publish("req_backpressure", notification).await;
             }
@@ -395,9 +361,9 @@ mod tests {
         for i in 0..PROGRESS_CHANNEL_CAPACITY {
             let notification = ProgressNotification {
                 progress_token: numeric_token(i as i64),
-                progress: i as f64,
-                total: Some(PROGRESS_CHANNEL_CAPACITY as f64),
+                progress: Progress::ratio(i as f64, PROGRESS_CHANNEL_CAPACITY as f64),
                 message: None,
+                agent: None,
             };
             assert!(broker.publish("req_drain", notification).await);
         }
@@ -427,9 +393,9 @@ mod tests {
                     for i in 0..10 {
                         let notification = ProgressNotification {
                             progress_token: numeric_token((publisher_id * 10 + i) as i64),
-                            progress: i as f64,
-                            total: Some(10.0),
+                            progress: Progress::ratio(i as f64, 10.0),
                             message: Some(format!("pub {} msg {}", publisher_id, i)),
+                            agent: None,
                         };
                         broker.publish("req_concurrent", notification).await;
                     }

--- a/crates/aura/src/rig_builder.rs
+++ b/crates/aura/src/rig_builder.rs
@@ -8,6 +8,7 @@
 //! handles request-scoped MCP header resolution (`headers_from_request`) so the
 //! web server can inject per-request credentials into MCP calls.
 
+use crate::RequestId;
 use crate::builder::{Agent, ClientTool, build_streaming_agent};
 use crate::config::{AgentRuntimeConfig, WorkerSkills};
 use crate::error::BuilderError;
@@ -140,7 +141,7 @@ impl RigBuilder {
         req_headers: Option<&HashMap<String, String>>,
         additional_tools: Vec<Box<dyn rig::tool::ToolDyn>>,
         client_tools: Option<Vec<ClientTool>>,
-        request_id: Option<String>,
+        request_id: Option<RequestId>,
         session_id: Option<String>,
     ) -> Result<Agent, BuilderError> {
         let mut agent_config = self.discovered_agent_config(req_headers)?;
@@ -167,7 +168,7 @@ impl RigBuilder {
         req_headers: Option<&HashMap<String, String>>,
         session_id: Option<String>,
         client_tools: Option<Vec<ClientTool>>,
-        request_id: Option<String>,
+        request_id: Option<RequestId>,
     ) -> Result<Arc<dyn StreamingAgent>, BuilderError> {
         let mut agent_config = self.discovered_agent_config(req_headers)?;
         resolve_mcp_headers(&mut agent_config, req_headers);

--- a/crates/aura/src/scratchpad/storage.rs
+++ b/crates/aura/src/scratchpad/storage.rs
@@ -1,5 +1,6 @@
 //! Scratchpad storage: file I/O, path validation, format detection, cleanup.
 
+use crate::RequestId;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 use tracing::{debug, info, warn};
@@ -141,8 +142,19 @@ impl ScratchpadStorage {
     }
 
     /// Create storage with a specific base directory (for testing).
-    pub async fn with_base_dir(base: &Path, request_id: &str) -> std::io::Result<Self> {
-        let dir = base.join(request_id);
+    ///
+    /// Rejects an id that would not name a child of `base`, because `dir` is
+    /// what [`cleanup`](Self::cleanup) hands to `remove_dir_all`: an empty or
+    /// traversing id would aim that at `base` itself or above it.
+    pub async fn with_base_dir(base: &Path, request_id: &RequestId) -> std::io::Result<Self> {
+        let id = request_id.as_str();
+        if id.is_empty() || Path::new(id).components().count() != 1 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("request id {id:?} does not name a scratchpad directory"),
+            ));
+        }
+        let dir = base.join(id);
         fs::create_dir_all(&dir).await?;
         Ok(Self {
             read_root: dir.clone(),
@@ -621,7 +633,7 @@ mod tests {
     #[tokio::test]
     async fn test_write_and_read() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-1")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-1"))
             .await
             .unwrap();
 
@@ -640,7 +652,7 @@ mod tests {
     #[tokio::test]
     async fn test_text_format_detection() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-2")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-2"))
             .await
             .unwrap();
 
@@ -700,7 +712,7 @@ mod tests {
     #[tokio::test]
     async fn test_companion_extraction() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-comp")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-comp"))
             .await
             .unwrap();
 
@@ -736,9 +748,10 @@ mod tests {
     #[tokio::test]
     async fn test_companion_path_traversal_is_sanitized() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-traversal")
-            .await
-            .unwrap();
+        let storage =
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-traversal"))
+                .await
+                .unwrap();
 
         // A malicious tool output with a JSON key that tries to escape the
         // scratchpad directory. Content is large enough to trigger companion
@@ -789,7 +802,7 @@ mod tests {
     #[tokio::test]
     async fn test_companion_not_extracted_for_small_strings() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-small")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-small"))
             .await
             .unwrap();
 
@@ -804,7 +817,7 @@ mod tests {
     #[tokio::test]
     async fn test_companion_extraction_escaped_json() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-esc")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-esc"))
             .await
             .unwrap();
 
@@ -848,7 +861,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_path_ok() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-3")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-3"))
             .await
             .unwrap();
 
@@ -924,7 +937,7 @@ mod tests {
     #[tokio::test]
     async fn test_with_read_root_ignores_non_ancestor() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-rr")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-rr"))
             .await
             .unwrap();
         let dir = storage.dir().to_path_buf();
@@ -937,7 +950,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_path_traversal_rejected() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-4")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-4"))
             .await
             .unwrap();
 
@@ -961,7 +974,7 @@ mod tests {
         let secret = outside_tmp.path().join("secret.txt");
         std::fs::write(&secret, "out of bounds").unwrap();
 
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-symlink")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-symlink"))
             .await
             .unwrap();
         // Plant a symlink inside the scratchpad dir that points at `secret`.
@@ -983,7 +996,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_path_nonexistent_path_passes() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-nx")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-nx"))
             .await
             .unwrap();
         let result = storage.validate_path("not_yet_written.json").await;
@@ -1000,7 +1013,7 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-io")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-io"))
             .await
             .unwrap();
         let sub = storage.dir().join("locked");
@@ -1031,7 +1044,7 @@ mod tests {
     async fn test_validate_path_dangling_symlink_rejected() {
         let tmp = TempDir::new().unwrap();
         let outside = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-dangle")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-dangle"))
             .await
             .unwrap();
 
@@ -1051,7 +1064,7 @@ mod tests {
     async fn test_validate_path_symlinked_ancestor_rejected() {
         let tmp = TempDir::new().unwrap();
         let outside = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-alias")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-alias"))
             .await
             .unwrap();
 
@@ -1071,7 +1084,7 @@ mod tests {
     #[cfg(unix)]
     async fn test_validate_path_in_root_symlink_ancestor_accepted() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-inlink")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-inlink"))
             .await
             .unwrap();
 
@@ -1089,7 +1102,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_files() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-5")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-5"))
             .await
             .unwrap();
 
@@ -1105,7 +1118,7 @@ mod tests {
     #[tokio::test]
     async fn test_cleanup() {
         let tmp = TempDir::new().unwrap();
-        let storage = ScratchpadStorage::with_base_dir(tmp.path(), "req-6")
+        let storage = ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-6"))
             .await
             .unwrap();
 

--- a/crates/aura/src/scratchpad/tools.rs
+++ b/crates/aura/src/scratchpad/tools.rs
@@ -1812,13 +1812,14 @@ pub fn emit_scratchpad_tool_events_enabled() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::RequestId;
     use crate::scratchpad::context_budget::{TiktokenCounter, TokenCounter};
     use tempfile::TempDir;
 
     async fn setup() -> (TempDir, Arc<ScratchpadStorage>, ContextBudget) {
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "test-req")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("test-req"))
                 .await
                 .unwrap(),
         );

--- a/crates/aura/src/scratchpad/wrapper.rs
+++ b/crates/aura/src/scratchpad/wrapper.rs
@@ -230,6 +230,7 @@ impl ToolWrapper for ScratchpadWrapper {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::RequestId;
     use crate::scratchpad::context_budget::{TiktokenCounter, TokenCounter};
     use crate::tool_wrapper::ToolCallContext;
     use tempfile::TempDir;
@@ -255,7 +256,7 @@ mod tests {
     async fn test_wrapper_intercepts_via_resolved_tool_name() {
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-glob")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-wrap-glob"))
                 .await
                 .unwrap(),
         );
@@ -300,7 +301,7 @@ mod tests {
     async fn test_wrapper_pointer_is_deterministic_for_identical_output() {
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-deterministic")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-wrap-deterministic"))
                 .await
                 .unwrap(),
         );
@@ -332,7 +333,7 @@ mod tests {
     async fn test_wrapper_intercepts_large_output() {
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-1")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-wrap-1"))
                 .await
                 .unwrap(),
         );
@@ -383,7 +384,7 @@ mod tests {
     async fn test_wrapper_strips_persistence_footer_before_write() {
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-footer")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-wrap-footer"))
                 .await
                 .unwrap(),
         );
@@ -437,7 +438,7 @@ mod tests {
     async fn test_wrapper_passes_through_small_output() {
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-2")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-wrap-2"))
                 .await
                 .unwrap(),
         );
@@ -475,7 +476,7 @@ mod tests {
     async fn test_wrapper_ignores_non_scratchpad_tools() {
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-3")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-wrap-3"))
                 .await
                 .unwrap(),
         );
@@ -503,7 +504,7 @@ mod tests {
     async fn test_wrapper_passes_through_skill_tool_outputs() {
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-skills")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-wrap-skills"))
                 .await
                 .unwrap(),
         );
@@ -535,7 +536,7 @@ mod tests {
     async fn test_wrapper_intercepts_at_exact_threshold() {
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-boundary")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-wrap-boundary"))
                 .await
                 .unwrap(),
         );
@@ -585,7 +586,7 @@ mod tests {
     async fn test_wrapper_records_intercepted_tokens() {
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-counter")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-wrap-counter"))
                 .await
                 .unwrap(),
         );
@@ -623,7 +624,7 @@ mod tests {
         // so the write will fail with an I/O error.
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-fail")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-wrap-fail"))
                 .await
                 .unwrap(),
         );
@@ -680,7 +681,7 @@ mod tests {
     async fn test_wrapper_json_companion_pointer_recommends_get_in() {
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-json-comp")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-wrap-json-comp"))
                 .await
                 .unwrap(),
         );
@@ -743,7 +744,7 @@ mod tests {
     async fn test_wrapper_companion_files_in_pointer() {
         let tmp = TempDir::new().unwrap();
         let storage = Arc::new(
-            ScratchpadStorage::with_base_dir(tmp.path(), "req-wrap-comp")
+            ScratchpadStorage::with_base_dir(tmp.path(), &RequestId::new("req-wrap-comp"))
                 .await
                 .unwrap(),
         );

--- a/crates/aura/src/session_store/fault_store.rs
+++ b/crates/aura/src/session_store/fault_store.rs
@@ -1,5 +1,6 @@
 //! An approval-store double for fault injection in tests.
 
+use crate::RequestId;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
@@ -73,7 +74,7 @@ impl ApprovalStore for FaultInjectingStore {
 
     async fn cancel_request(
         &self,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> Result<Vec<ParkedApproval>, SessionStoreError> {
         self.inner.cancel_request(request_id).await
     }

--- a/crates/aura/src/session_store/file.rs
+++ b/crates/aura/src/session_store/file.rs
@@ -47,6 +47,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tokio::task::{JoinError, spawn_blocking};
 
+use crate::RequestId;
 use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
 
 use super::{ApprovalStore, DecisionRecord, ParkedApprovalRecord, SessionStoreError};
@@ -251,7 +252,7 @@ impl Inner {
 
     fn cancel_request_sync(
         &self,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> Result<Vec<ParkedApproval>, SessionStoreError> {
         let _guard = self.lock();
         let entries = match fs::read_dir(self.approvals_dir()) {
@@ -286,7 +287,7 @@ impl Inner {
                     continue;
                 }
             };
-            if parked.request.request_id != request_id {
+            if &parked.request.request_id != request_id {
                 continue;
             }
             // resolve writes the decision before its best-effort approval
@@ -377,7 +378,7 @@ impl ApprovalStore for FileApprovalStore {
 
     async fn cancel_request(
         &self,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> Result<Vec<ParkedApproval>, SessionStoreError> {
         let inner = Arc::clone(&self.inner);
         let request_id = request_id.to_owned();

--- a/crates/aura/src/session_store/memory.rs
+++ b/crates/aura/src/session_store/memory.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use tokio::sync::broadcast;
 
+use crate::RequestId;
 use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError, Timestamp};
 
 use super::{ApprovalStore, EventBus, SessionStoreError, Subscription};
@@ -104,11 +105,11 @@ impl ApprovalStore for InMemoryApprovalStore {
 
     async fn cancel_request(
         &self,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> Result<Vec<ParkedApproval>, SessionStoreError> {
         let cleared: Vec<ParkedApproval> = self
             .lock()
-            .extract_if(.., |_, parked| parked.request.request_id == request_id)
+            .extract_if(.., |_, parked| &parked.request.request_id == request_id)
             .map(|(_, parked)| parked)
             .collect();
         Ok(cleared)
@@ -202,14 +203,14 @@ mod tests {
         AgentScope, ApprovalItem, ApprovalOrigin, ApprovalRequest, PROTOCOL_VERSION,
     };
 
-    fn parked(request_id: &str) -> ParkedApproval {
+    fn parked(request_id: &RequestId) -> ParkedApproval {
         let now = chrono::Utc::now();
         ParkedApproval {
             request: ApprovalRequest {
                 version: PROTOCOL_VERSION,
                 instance_id: "test-instance".to_string(),
                 decision_id: DecisionId::generate(),
-                request_id: request_id.to_string(),
+                request_id: request_id.clone(),
                 scope: AgentScope::Single { session_id: None },
                 origin: ApprovalOrigin::ConfigGate {
                     matched_pattern: "test_*".to_string(),
@@ -229,7 +230,7 @@ mod tests {
     #[tokio::test]
     async fn approval_store_register_get_resolve() {
         let store = InMemoryApprovalStore::new();
-        let entry = parked("req-1");
+        let entry = parked(&RequestId::new("req-1"));
         let id = entry.request.decision_id;
 
         store.register(entry).await.unwrap();
@@ -249,7 +250,7 @@ mod tests {
     #[tokio::test]
     async fn approval_store_resolve_records_readable_decision() {
         let store = InMemoryApprovalStore::new();
-        let entry = parked("req-durable");
+        let entry = parked(&RequestId::new("req-durable"));
         let id = entry.request.decision_id;
         store.register(entry).await.unwrap();
 
@@ -272,7 +273,7 @@ mod tests {
     #[tokio::test]
     async fn recorded_decision_is_pruned_after_retention_window() {
         let store = InMemoryApprovalStore::new();
-        let id = parked("req-prune").request.decision_id;
+        let id = parked(&RequestId::new("req-prune")).request.decision_id;
         store.lock_decided().insert(
             id,
             DecidedEntry {
@@ -288,7 +289,7 @@ mod tests {
     #[tokio::test]
     async fn expired_ticket_refuses_resolve() {
         let store = InMemoryApprovalStore::new();
-        let mut entry = parked("req-expired");
+        let mut entry = parked(&RequestId::new("req-expired"));
         entry.expires_at = chrono::Utc::now() - chrono::Duration::seconds(1);
         let id = entry.request.decision_id;
         store.register(entry).await.unwrap();
@@ -305,7 +306,7 @@ mod tests {
     #[tokio::test]
     async fn expired_ticket_is_returned_by_get_until_remove() {
         let store = InMemoryApprovalStore::new();
-        let mut entry = parked("req-expired-get");
+        let mut entry = parked(&RequestId::new("req-expired-get"));
         entry.expires_at = chrono::Utc::now() - chrono::Duration::seconds(1);
         let id = entry.request.decision_id;
         store.register(entry).await.unwrap();
@@ -318,14 +319,17 @@ mod tests {
     #[tokio::test]
     async fn approval_store_cancel_request_removes_only_matching() {
         let store = InMemoryApprovalStore::new();
-        let cancel = parked("req-cancel");
+        let cancel = parked(&RequestId::new("req-cancel"));
         let cancel_id = cancel.request.decision_id;
-        let keep = parked("req-keep");
+        let keep = parked(&RequestId::new("req-keep"));
         let keep_id = keep.request.decision_id;
         store.register(cancel).await.unwrap();
         store.register(keep).await.unwrap();
 
-        let cleared = store.cancel_request("req-cancel").await.unwrap();
+        let cleared = store
+            .cancel_request(&RequestId::new("req-cancel"))
+            .await
+            .unwrap();
 
         assert_eq!(cleared.len(), 1, "only the matching ticket is cleared");
         assert_eq!(cleared[0].request.decision_id, cancel_id);

--- a/crates/aura/src/session_store/mod.rs
+++ b/crates/aura/src/session_store/mod.rs
@@ -22,6 +22,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::Stream;
 
+use crate::RequestId;
 use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
 
 #[cfg(test)]
@@ -90,7 +91,7 @@ pub trait ApprovalStore: Send + Sync {
     /// the cancellation applies to.
     async fn cancel_request(
         &self,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> Result<Vec<ParkedApproval>, SessionStoreError>;
 }
 

--- a/crates/aura/src/session_store/record.rs
+++ b/crates/aura/src/session_store/record.rs
@@ -13,6 +13,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::RequestId;
 use crate::config::SessionId;
 use crate::hitl::{
     AgentScope, ApprovalDecision, ApprovalItem, ApprovalOrigin, ApprovalRequest, DecisionId,
@@ -29,7 +30,7 @@ pub struct ParkedApprovalRecord {
     #[serde(default)]
     pub instance_id: String,
     pub decision_id: DecisionId,
-    pub request_id: String,
+    pub request_id: RequestId,
     pub scope: ScopeRecord,
     pub origin: OriginRecord,
     pub items: Vec<ApprovalItem>,
@@ -251,7 +252,7 @@ mod tests {
                 version: PROTOCOL_VERSION,
                 instance_id: "test-instance".to_string(),
                 decision_id: DecisionId::generate(),
-                request_id: "req-1".to_string(),
+                request_id: RequestId::new("req-1"),
                 scope,
                 origin,
                 items: vec![ApprovalItem {
@@ -274,6 +275,28 @@ mod tests {
         assert_eq!(stored, record);
         let restored = ParkedApproval::try_from(stored).expect("record restores");
         assert_eq!(ParkedApprovalRecord::from(&restored), record);
+    }
+
+    /// The stored record carries `request_id` as a bare JSON string. Every
+    /// instance reading the store depends on that shape.
+    #[test]
+    fn request_id_persists_as_a_bare_string() {
+        let record = ParkedApprovalRecord::from(&parked(
+            AgentScope::Single { session_id: None },
+            ApprovalOrigin::ConfigGate {
+                matched_pattern: "kubectl_*".to_string(),
+                agent_name: "test-agent".to_string(),
+            },
+        ));
+
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&record).expect("record serializes"))
+                .expect("record is json");
+        assert_eq!(json["request_id"], "req-1");
+
+        let stored: ParkedApprovalRecord =
+            serde_json::from_value(json).expect("bare string parses back");
+        assert_eq!(stored.request_id, "req-1");
     }
 
     #[test]

--- a/crates/aura/src/streaming.rs
+++ b/crates/aura/src/streaming.rs
@@ -31,6 +31,7 @@
 //! }
 //! ```
 
+use crate::RequestId;
 use crate::provider_agent::{StreamError, StreamItem};
 use crate::streaming_request_hook::UsageState;
 use async_trait::async_trait;
@@ -86,7 +87,7 @@ pub trait StreamingAgent: Send + Sync {
         query: &str,
         chat_history: Vec<Message>,
         cancel_token: CancellationToken,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> Result<BoxStream<'static, Result<StreamItem, StreamError>>, StreamError>;
 
     /// Stream with timeout support.
@@ -111,7 +112,7 @@ pub trait StreamingAgent: Send + Sync {
         query: &str,
         chat_history: Vec<Message>,
         timeout: Duration,
-        request_id: &str,
+        request_id: &RequestId,
     ) -> (
         BoxStream<'static, Result<StreamItem, StreamError>>,
         tokio::sync::watch::Sender<bool>,
@@ -122,7 +123,7 @@ pub trait StreamingAgent: Send + Sync {
     ///
     /// Called on client disconnect or timeout to propagate `notifications/cancelled`
     /// to MCP servers. Returns the number of cancelled requests.
-    async fn cancel_and_close_mcp(&self, request_id: &str, reason: &str) -> usize;
+    async fn cancel_and_close_mcp(&self, request_id: &RequestId, reason: &str) -> usize;
 
     /// Return the configured context window size in tokens (from TOML config).
     /// Returns `None` if not configured (e.g., Orchestrator).

--- a/crates/aura/src/streaming_request_hook.rs
+++ b/crates/aura/src/streaming_request_hook.rs
@@ -51,7 +51,8 @@ use tokio::sync::watch;
 use crate::orchestration::BlockedCell;
 use crate::scratchpad::{self, ContextBudget};
 use crate::tool_event_broker::{
-    pop_tool_call_id, publish_tool_requested, publish_tool_usage, push_tool_call_id,
+    TokenUsage, ToolCallId, ToolName, pop_tool_call_id, publish_tool_requested, publish_tool_usage,
+    push_tool_call_id,
 };
 
 /// Maximum pending tool IDs before warning. Prevents unbounded growth if
@@ -140,7 +141,7 @@ pub struct UsageState {
     /// Output tokens of the most recent turn.
     last_output_tokens: Arc<AtomicU64>,
     /// Tool IDs completed since the last usage event (for aura.tool_usage correlation)
-    pending_tool_ids: Arc<Mutex<Vec<String>>>,
+    pending_tool_ids: Arc<Mutex<Vec<ToolCallId>>>,
 }
 
 impl UsageState {
@@ -255,7 +256,7 @@ impl UsageState {
     /// Add a tool ID to the pending list.
     ///
     /// Called from on_tool_result when a tool completes.
-    pub fn add_pending_tool_id(&self, tool_id: String) {
+    pub fn add_pending_tool_id(&self, tool_id: ToolCallId) {
         match self.pending_tool_ids.lock() {
             Ok(mut pending) => {
                 if pending.len() >= MAX_PENDING_TOOL_IDS {
@@ -283,7 +284,7 @@ impl UsageState {
     /// Take all pending tool IDs, leaving the list empty.
     ///
     /// Called when usage becomes available to associate tools with usage snapshot.
-    pub fn take_pending_tool_ids(&self) -> Vec<String> {
+    pub fn take_pending_tool_ids(&self) -> Vec<ToolCallId> {
         match self.pending_tool_ids.lock() {
             Ok(mut pending) => std::mem::take(&mut *pending),
             Err(poisoned) => {
@@ -592,8 +593,9 @@ where
 
                 // Rig 0.28+ passes correct tool_call_id; register for event correlation
                 if let Some(id) = &tool_call_id {
+                    let id = ToolCallId::new(id);
                     push_tool_call_id(&request_id, id.clone()).await;
-                    publish_tool_requested(&request_id, id.clone(), tool_name.clone(), arguments)
+                    publish_tool_requested(&request_id, id, ToolName::new(&tool_name), arguments)
                         .await;
                 } else {
                     tracing::warn!(
@@ -660,7 +662,7 @@ where
                 // This allows us to correlate tools with the usage snapshot when
                 // on_stream_completion_response_finish fires
                 if let Some(id) = tool_call_id {
-                    usage_state.add_pending_tool_id(id);
+                    usage_state.add_pending_tool_id(ToolCallId::new(id));
                 }
 
                 tracing::debug!(
@@ -733,9 +735,11 @@ where
                     publish_tool_usage(
                         &request_id,
                         tool_ids,
-                        usage.input_tokens,
-                        usage.output_tokens,
-                        usage.total_tokens,
+                        TokenUsage {
+                            prompt_tokens: usage.input_tokens.into(),
+                            completion_tokens: usage.output_tokens.into(),
+                            total_tokens: usage.total_tokens.into(),
+                        },
                     )
                     .await;
                 }
@@ -939,8 +943,8 @@ mod tests {
     fn test_usage_state_pending_tool_ids() {
         let usage_state = UsageState::new();
 
-        usage_state.add_pending_tool_id("call_abc".to_string());
-        usage_state.add_pending_tool_id("call_def".to_string());
+        usage_state.add_pending_tool_id(ToolCallId::new("call_abc"));
+        usage_state.add_pending_tool_id(ToolCallId::new("call_def"));
 
         let tool_ids = usage_state.take_pending_tool_ids();
         assert_eq!(tool_ids, vec!["call_abc", "call_def"]);
@@ -973,11 +977,11 @@ mod tests {
 
         // Fill to capacity
         for i in 0..MAX_PENDING_TOOL_IDS {
-            usage_state.add_pending_tool_id(format!("call_{}", i));
+            usage_state.add_pending_tool_id(ToolCallId::new(format!("call_{}", i)));
         }
 
         // Add one more - should drop oldest
-        usage_state.add_pending_tool_id("call_overflow".to_string());
+        usage_state.add_pending_tool_id(ToolCallId::new("call_overflow"));
 
         let tool_ids = usage_state.take_pending_tool_ids();
         assert_eq!(tool_ids.len(), MAX_PENDING_TOOL_IDS);

--- a/crates/aura/src/streaming_request_hook.rs
+++ b/crates/aura/src/streaming_request_hook.rs
@@ -25,7 +25,7 @@
 //! # Usage
 //!
 //! ```ignore
-//! let (hook, cancel_sender, usage_state) = StreamingRequestHook::new(Duration::from_secs(60), "req_123");
+//! let (hook, cancel_sender, usage_state) = StreamingRequestHook::new(Duration::from_secs(60), RequestId::new("req_123"));
 //!
 //! // Pass hook to streaming request
 //! agent.stream_prompt(query).with_hook(hook).multi_turn(depth).await;
@@ -48,6 +48,7 @@ use rig::agent::{CancelSignal, StreamingPromptHook};
 use rig::completion::{CompletionModel, GetTokenUsage, Message};
 use tokio::sync::watch;
 
+use crate::RequestId;
 use crate::orchestration::BlockedCell;
 use crate::scratchpad::{self, ContextBudget};
 use crate::tool_event_broker::{
@@ -70,23 +71,24 @@ pub(crate) const PARK_CANCEL_REASON: &str = "parked";
 /// id the orchestrator passes as the hook's `request_id`. The hook is built
 /// inside the streaming layer and cannot take the cell as a parameter, so it
 /// travels through this request-keyed global like the tool-event broker.
-static PARK_CELLS: OnceLock<std::sync::RwLock<HashMap<String, Arc<BlockedCell>>>> = OnceLock::new();
+static PARK_CELLS: OnceLock<std::sync::RwLock<HashMap<RequestId, Arc<BlockedCell>>>> =
+    OnceLock::new();
 
-fn park_cells() -> &'static std::sync::RwLock<HashMap<String, Arc<BlockedCell>>> {
+fn park_cells() -> &'static std::sync::RwLock<HashMap<RequestId, Arc<BlockedCell>>> {
     PARK_CELLS.get_or_init(|| std::sync::RwLock::new(HashMap::new()))
 }
 
 /// A worker stream's park-cell registration; dropping it removes the cell
 /// and the stream's tool-event subscription.
-pub(crate) struct ParkCellRegistration(String);
+pub(crate) struct ParkCellRegistration(RequestId);
 
 impl ParkCellRegistration {
-    pub(crate) fn new(key: &str, cell: Arc<BlockedCell>) -> Self {
+    pub(crate) fn new(key: &RequestId, cell: Arc<BlockedCell>) -> Self {
         park_cells()
             .write()
             .expect("park cell registry poisoned")
-            .insert(key.to_string(), cell);
-        Self(key.to_string())
+            .insert(key.clone(), cell);
+        Self(key.clone())
     }
 }
 
@@ -99,14 +101,14 @@ impl Drop for ParkCellRegistration {
         // The hook keyed its tool-event FIFO under the same id; the broker is
         // async, so that cleanup runs as its own task when a runtime exists.
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            let key = std::mem::take(&mut self.0);
+            let key = self.0.clone();
             handle.spawn(async move { crate::tool_event_broker::unsubscribe(&key).await });
         }
     }
 }
 
 /// The blocked cell for `key`, if this stream is in park mode.
-pub(crate) fn park_cell_for(key: &str) -> Option<Arc<BlockedCell>> {
+pub(crate) fn park_cell_for(key: &RequestId) -> Option<Arc<BlockedCell>> {
     park_cells()
         .read()
         .expect("park cell registry poisoned")
@@ -370,7 +372,7 @@ pub struct StreamingRequestHook {
     /// External cancellation signal (e.g., from client disconnect)
     cancelled: watch::Receiver<bool>,
     /// Request ID for event correlation
-    request_id: String,
+    request_id: RequestId,
     /// Shared usage state (returned separately for handler access)
     usage_state: UsageState,
     /// Optional per-agent scratchpad budget. When set, the hook feeds the
@@ -395,7 +397,7 @@ impl StreamingRequestHook {
     /// - `usage_state`: Shared state - handler keeps clone to read final usage at stream end
     pub fn new(
         timeout: Duration,
-        request_id: impl Into<String>,
+        request_id: RequestId,
     ) -> (Self, watch::Sender<bool>, UsageState) {
         Self::with_scratchpad_budget(timeout, request_id, None)
     }
@@ -406,7 +408,7 @@ impl StreamingRequestHook {
     /// `StreamItem::TurnUsage`).
     pub fn with_scratchpad_budget(
         timeout: Duration,
-        request_id: impl Into<String>,
+        request_id: RequestId,
         scratchpad_budget: Option<ContextBudget>,
     ) -> (Self, watch::Sender<bool>, UsageState) {
         let (tx, rx) = watch::channel(false);
@@ -415,7 +417,7 @@ impl StreamingRequestHook {
             start_time: Instant::now(),
             timeout,
             cancelled: rx,
-            request_id: request_id.into(),
+            request_id,
             usage_state: usage_state.clone(),
             scratchpad_budget,
             client_tool_names: HashSet::new(),
@@ -766,7 +768,7 @@ mod tests {
     #[test]
     fn test_streaming_request_hook_creation() {
         let (hook, _tx, _usage_state) =
-            StreamingRequestHook::new(Duration::from_secs(60), "test_req_1");
+            StreamingRequestHook::new(Duration::from_secs(60), RequestId::new("test_req_1"));
         assert!(!hook.should_cancel());
         assert_eq!(hook.request_id, "test_req_1");
     }
@@ -779,8 +781,8 @@ mod tests {
     async fn park_cell_registration_isolates_keys_and_removes_on_drop() {
         let cell_a = Arc::new(BlockedCell::default());
         let cell_b = Arc::new(BlockedCell::default());
-        let key_a = format!("park_reg_{}", uuid::Uuid::new_v4().simple());
-        let key_b = format!("park_reg_{}", uuid::Uuid::new_v4().simple());
+        let key_a = RequestId::new(format!("park_reg_{}", uuid::Uuid::new_v4().simple()));
+        let key_b = RequestId::new(format!("park_reg_{}", uuid::Uuid::new_v4().simple()));
 
         assert!(park_cell_for(&key_a).is_none());
         let reg_a = ParkCellRegistration::new(&key_a, cell_a.clone());
@@ -808,7 +810,7 @@ mod tests {
     #[test]
     fn test_external_cancellation() {
         let (hook, tx, _usage_state) =
-            StreamingRequestHook::new(Duration::from_secs(60), "test_req_2");
+            StreamingRequestHook::new(Duration::from_secs(60), RequestId::new("test_req_2"));
         assert!(!hook.should_cancel());
 
         // Signal cancellation
@@ -820,7 +822,7 @@ mod tests {
     fn test_timeout_detection() {
         // Create hook with very short timeout
         let (hook, _tx, _usage_state) =
-            StreamingRequestHook::new(Duration::from_millis(1), "test_req_3");
+            StreamingRequestHook::new(Duration::from_millis(1), RequestId::new("test_req_3"));
 
         // Wait for timeout
         std::thread::sleep(Duration::from_millis(5));
@@ -830,7 +832,7 @@ mod tests {
     #[test]
     fn test_usage_state_creation() {
         let (_hook, _tx, usage_state) =
-            StreamingRequestHook::new(Duration::from_secs(60), "test_req_4");
+            StreamingRequestHook::new(Duration::from_secs(60), RequestId::new("test_req_4"));
 
         // Initially all zeros
         let (prompt, completion, total) = usage_state.get_final_usage();
@@ -957,7 +959,7 @@ mod tests {
     #[test]
     fn test_usage_state_shared_between_clones() {
         let (_hook, _tx, usage_state) =
-            StreamingRequestHook::new(Duration::from_secs(60), "test_req_5");
+            StreamingRequestHook::new(Duration::from_secs(60), RequestId::new("test_req_5"));
         let usage_state_clone = usage_state.clone();
 
         // Modify through original (tool turn)
@@ -1017,9 +1019,13 @@ mod tests {
 
     #[test]
     fn test_with_scratchpad_budget_none_matches_new() {
-        let (hook_a, _, _) = StreamingRequestHook::new(Duration::from_secs(60), "req_a");
-        let (hook_b, _, _) =
-            StreamingRequestHook::with_scratchpad_budget(Duration::from_secs(60), "req_b", None);
+        let (hook_a, _, _) =
+            StreamingRequestHook::new(Duration::from_secs(60), RequestId::new("req_a"));
+        let (hook_b, _, _) = StreamingRequestHook::with_scratchpad_budget(
+            Duration::from_secs(60),
+            RequestId::new("req_b"),
+            None,
+        );
         // Both hooks should report no scratchpad budget.
         assert!(hook_a.scratchpad_budget.is_none());
         assert!(hook_b.scratchpad_budget.is_none());
@@ -1032,7 +1038,7 @@ mod tests {
         let budget = ContextBudget::new(128_000, 0.20, 0, counter);
         let (hook, _, _) = StreamingRequestHook::with_scratchpad_budget(
             Duration::from_secs(60),
-            "req_with_budget",
+            RequestId::new("req_with_budget"),
             Some(budget.clone()),
         );
         let stored = hook

--- a/crates/aura/src/tool_event_broker.rs
+++ b/crates/aura/src/tool_event_broker.rs
@@ -19,7 +19,7 @@
 //! See `docs/rig-fork-changes.md` for analysis.
 //! The FIFO queue is safe because: hook fires → tool executes → hook fires → next tool.
 
-use crate::request_cancellation::RequestId;
+use crate::RequestId;
 use rmcp::model::ProgressToken;
 use std::collections::{HashMap, VecDeque};
 use std::sync::OnceLock;
@@ -96,13 +96,13 @@ pub struct ToolUsageEvent {
 /// - This works because Rig's streaming mode executes tools sequentially (see module docs)
 pub struct ToolEventBroker {
     /// Map of request_id -> event channel sender
-    senders: RwLock<HashMap<String, mpsc::Sender<ToolLifecycleEvent>>>,
+    senders: RwLock<HashMap<RequestId, mpsc::Sender<ToolLifecycleEvent>>>,
 
     /// Map of request_id -> FIFO queue of tool_call_ids
     /// Hook pushes when on_tool_call fires, execution peeks when tool starts,
     /// hook pops when on_tool_result fires.
     /// Sequential execution in streaming mode guarantees correct ordering.
-    pending_tool_calls: RwLock<HashMap<String, VecDeque<ToolCallId>>>,
+    pending_tool_calls: RwLock<HashMap<RequestId, VecDeque<ToolCallId>>>,
 }
 
 impl ToolEventBroker {
@@ -118,11 +118,11 @@ impl ToolEventBroker {
     ///
     /// Returns a receiver that will only get tool events for this request.
     /// When the receiver is dropped, the request is automatically unsubscribed.
-    pub async fn subscribe(&self, request_id: &str) -> mpsc::Receiver<ToolLifecycleEvent> {
+    pub async fn subscribe(&self, request_id: &RequestId) -> mpsc::Receiver<ToolLifecycleEvent> {
         let (tx, rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
 
         let mut senders = self.senders.write().await;
-        senders.insert(request_id.to_string(), tx);
+        senders.insert(request_id.clone(), tx);
 
         debug!(
             "Tool event subscription created for request '{}' (total active: {})",
@@ -134,7 +134,7 @@ impl ToolEventBroker {
     }
 
     /// Unsubscribe a request from tool events and clean up pending tool_call_ids.
-    pub async fn unsubscribe(&self, request_id: &str) {
+    pub async fn unsubscribe(&self, request_id: &RequestId) {
         // Release senders lock before acquiring pending lock to reduce contention
         {
             let mut senders = self.senders.write().await;
@@ -159,9 +159,13 @@ impl ToolEventBroker {
     /// Called when the hook's `on_tool_call` fires. The execution context
     /// will peek this ID when the tool actually starts executing.
     /// FIFO order is guaranteed by sequential tool execution in streaming mode.
-    pub async fn push_tool_call_id(&self, request_id: &str, tool_call_id: impl Into<ToolCallId>) {
+    pub async fn push_tool_call_id(
+        &self,
+        request_id: &RequestId,
+        tool_call_id: impl Into<ToolCallId>,
+    ) {
         let mut pending = self.pending_tool_calls.write().await;
-        let queue = pending.entry(request_id.to_string()).or_default();
+        let queue = pending.entry(request_id.clone()).or_default();
         let tool_call_id = tool_call_id.into();
 
         debug!(
@@ -181,7 +185,7 @@ impl ToolEventBroker {
     /// This ensures push/pop pairing regardless of tool type.
     ///
     /// Returns `None` if no pending tool_call_id exists.
-    pub async fn peek_tool_call_id(&self, request_id: &str) -> Option<ToolCallId> {
+    pub async fn peek_tool_call_id(&self, request_id: &RequestId) -> Option<ToolCallId> {
         let pending = self.pending_tool_calls.read().await;
 
         let queue = pending.get(request_id)?;
@@ -207,7 +211,7 @@ impl ToolEventBroker {
     /// This ensures push/pop pairing for ALL tools (MCP and non-MCP).
     ///
     /// Returns `None` if no pending tool_call_id exists.
-    pub async fn pop_tool_call_id(&self, request_id: &str) -> Option<ToolCallId> {
+    pub async fn pop_tool_call_id(&self, request_id: &RequestId) -> Option<ToolCallId> {
         let mut pending = self.pending_tool_calls.write().await;
 
         let queue = pending.get_mut(request_id)?;
@@ -235,7 +239,7 @@ impl ToolEventBroker {
     /// Publish a tool event to a specific request.
     ///
     /// Returns `true` if the event was sent, `false` if no subscriber exists.
-    pub async fn publish(&self, request_id: &str, event: ToolLifecycleEvent) -> bool {
+    pub async fn publish(&self, request_id: &RequestId, event: ToolLifecycleEvent) -> bool {
         let sender = {
             let senders = self.senders.read().await;
             senders.get(request_id).cloned()
@@ -285,23 +289,23 @@ pub fn global() -> &'static ToolEventBroker {
 }
 
 /// Convenience function to subscribe to tool events for a request
-pub async fn subscribe(request_id: &str) -> mpsc::Receiver<ToolLifecycleEvent> {
+pub async fn subscribe(request_id: &RequestId) -> mpsc::Receiver<ToolLifecycleEvent> {
     global().subscribe(request_id).await
 }
 
 /// Convenience function to unsubscribe a request
-pub async fn unsubscribe(request_id: &str) {
+pub async fn unsubscribe(request_id: &RequestId) {
     global().unsubscribe(request_id).await
 }
 
 /// Convenience function to publish a tool event to a request
-pub async fn publish(request_id: &str, event: ToolLifecycleEvent) -> bool {
+pub async fn publish(request_id: &RequestId, event: ToolLifecycleEvent) -> bool {
     global().publish(request_id, event).await
 }
 
 /// Convenience function to publish a tool_requested event
 pub async fn publish_tool_requested(
-    request_id: &str,
+    request_id: &RequestId,
     tool_id: ToolCallId,
     tool_name: ToolName,
     arguments: serde_json::Value,
@@ -320,7 +324,7 @@ pub async fn publish_tool_requested(
 
 /// Convenience function to publish a tool_start event
 pub async fn publish_tool_start(
-    request_id: &str,
+    request_id: &RequestId,
     tool_id: ToolCallId,
     tool_name: ToolName,
     progress_token: Option<ProgressToken>,
@@ -367,7 +371,7 @@ static TOOL_USAGE_BROKER: OnceLock<ToolUsageBroker> = OnceLock::new();
 /// This handles the `aura.tool_usage` events that associate completed tools
 /// with usage snapshots.
 struct ToolUsageBroker {
-    senders: RwLock<HashMap<String, mpsc::Sender<ToolUsageEvent>>>,
+    senders: RwLock<HashMap<RequestId, mpsc::Sender<ToolUsageEvent>>>,
 }
 
 impl ToolUsageBroker {
@@ -377,10 +381,10 @@ impl ToolUsageBroker {
         }
     }
 
-    async fn subscribe(&self, request_id: &str) -> mpsc::Receiver<ToolUsageEvent> {
+    async fn subscribe(&self, request_id: &RequestId) -> mpsc::Receiver<ToolUsageEvent> {
         let (tx, rx) = mpsc::channel(USAGE_EVENT_CHANNEL_CAPACITY);
         let mut senders = self.senders.write().await;
-        senders.insert(request_id.to_string(), tx);
+        senders.insert(request_id.clone(), tx);
         debug!(
             "Tool usage subscription created for request '{}' (total: {})",
             request_id,
@@ -389,7 +393,7 @@ impl ToolUsageBroker {
         rx
     }
 
-    async fn unsubscribe(&self, request_id: &str) {
+    async fn unsubscribe(&self, request_id: &RequestId) {
         let mut senders = self.senders.write().await;
         if senders.remove(request_id).is_some() {
             debug!(
@@ -400,7 +404,7 @@ impl ToolUsageBroker {
         }
     }
 
-    async fn publish(&self, request_id: &str, event: ToolUsageEvent) -> bool {
+    async fn publish(&self, request_id: &RequestId, event: ToolUsageEvent) -> bool {
         let sender = {
             let senders = self.senders.read().await;
             senders.get(request_id).cloned()
@@ -438,12 +442,12 @@ fn usage_broker_global() -> &'static ToolUsageBroker {
 /// Subscribe to tool usage events for a request.
 ///
 /// Returns a receiver that will get `aura.tool_usage` events for this request.
-pub async fn tool_usage_subscribe(request_id: &str) -> mpsc::Receiver<ToolUsageEvent> {
+pub async fn tool_usage_subscribe(request_id: &RequestId) -> mpsc::Receiver<ToolUsageEvent> {
     usage_broker_global().subscribe(request_id).await
 }
 
 /// Unsubscribe from tool usage events.
-pub async fn tool_usage_unsubscribe(request_id: &str) {
+pub async fn tool_usage_unsubscribe(request_id: &RequestId) {
     usage_broker_global().unsubscribe(request_id).await
 }
 
@@ -452,7 +456,7 @@ pub async fn tool_usage_unsubscribe(request_id: &str) {
 /// Called from `on_stream_completion_response_finish` when usage becomes available.
 /// Associates the listed tool_ids with the usage snapshot.
 pub async fn publish_tool_usage(
-    request_id: &str,
+    request_id: &RequestId,
     tool_ids: Vec<ToolCallId>,
     usage: TokenUsage,
 ) -> bool {
@@ -485,24 +489,24 @@ mod tests {
     #[tokio::test]
     async fn test_subscribe_creates_channel() {
         let broker = ToolEventBroker::new();
-        let _rx = broker.subscribe("req_123").await;
+        let _rx = broker.subscribe(&RequestId::new("req_123")).await;
         assert_eq!(broker.active_subscriptions().await, 1);
     }
 
     #[tokio::test]
     async fn test_unsubscribe_removes_channel() {
         let broker = ToolEventBroker::new();
-        let _rx = broker.subscribe("req_123").await;
+        let _rx = broker.subscribe(&RequestId::new("req_123")).await;
         assert_eq!(broker.active_subscriptions().await, 1);
 
-        broker.unsubscribe("req_123").await;
+        broker.unsubscribe(&RequestId::new("req_123")).await;
         assert_eq!(broker.active_subscriptions().await, 0);
     }
 
     #[tokio::test]
     async fn test_publish_start_event() {
         let broker = ToolEventBroker::new();
-        let mut rx = broker.subscribe("req_123").await;
+        let mut rx = broker.subscribe(&RequestId::new("req_123")).await;
 
         let event = ToolLifecycleEvent::Start {
             tool_id: ToolCallId::new("call_abc"),
@@ -511,7 +515,7 @@ mod tests {
             agent: None,
         };
 
-        let sent = broker.publish("req_123", event).await;
+        let sent = broker.publish(&RequestId::new("req_123"), event).await;
         assert!(sent);
 
         let received = rx.recv().await.unwrap();
@@ -533,7 +537,7 @@ mod tests {
     #[tokio::test]
     async fn test_publish_requested_event() {
         let broker = ToolEventBroker::new();
-        let mut rx = broker.subscribe("req_123").await;
+        let mut rx = broker.subscribe(&RequestId::new("req_123")).await;
 
         let event = ToolLifecycleEvent::Requested {
             tool_id: ToolCallId::new("call_abc"),
@@ -542,7 +546,7 @@ mod tests {
             agent: None,
         };
 
-        let sent = broker.publish("req_123", event).await;
+        let sent = broker.publish(&RequestId::new("req_123"), event).await;
         assert!(sent);
 
         let received = rx.recv().await.unwrap();
@@ -572,15 +576,17 @@ mod tests {
             agent: None,
         };
 
-        let sent = broker.publish("req_nonexistent", event).await;
+        let sent = broker
+            .publish(&RequestId::new("req_nonexistent"), event)
+            .await;
         assert!(!sent);
     }
 
     #[tokio::test]
     async fn test_requests_are_isolated() {
         let broker = ToolEventBroker::new();
-        let mut rx1 = broker.subscribe("req_1").await;
-        let mut rx2 = broker.subscribe("req_2").await;
+        let mut rx1 = broker.subscribe(&RequestId::new("req_1")).await;
+        let mut rx2 = broker.subscribe(&RequestId::new("req_2")).await;
 
         let event = ToolLifecycleEvent::Start {
             tool_id: ToolCallId::new("call_1"),
@@ -588,7 +594,7 @@ mod tests {
             progress_token: Some(string_token("token_1")),
             agent: None,
         };
-        broker.publish("req_1", event).await;
+        broker.publish(&RequestId::new("req_1"), event).await;
 
         // req_1 should receive it
         let received = rx1.recv().await.unwrap();
@@ -601,7 +607,7 @@ mod tests {
     #[tokio::test]
     async fn test_tool_start_without_progress_token() {
         let broker = ToolEventBroker::new();
-        let mut rx = broker.subscribe("req_123").await;
+        let mut rx = broker.subscribe(&RequestId::new("req_123")).await;
 
         let event = ToolLifecycleEvent::Start {
             tool_id: ToolCallId::new("call_xyz"),
@@ -610,7 +616,7 @@ mod tests {
             agent: None,
         };
 
-        broker.publish("req_123", event).await;
+        broker.publish(&RequestId::new("req_123"), event).await;
 
         let received = rx.recv().await.unwrap();
         match received {
@@ -632,13 +638,15 @@ mod tests {
     async fn test_push_and_pop_tool_call_id() {
         let broker = ToolEventBroker::new();
 
-        broker.push_tool_call_id("req_1", "call_abc123").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_abc123")
+            .await;
 
-        let result = broker.pop_tool_call_id("req_1").await;
+        let result = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(result, Some(ToolCallId::new("call_abc123")));
 
         // Second pop should return None (consumed)
-        let result2 = broker.pop_tool_call_id("req_1").await;
+        let result2 = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(result2, None);
     }
 
@@ -646,7 +654,9 @@ mod tests {
     async fn test_pop_nonexistent_returns_none() {
         let broker = ToolEventBroker::new();
 
-        let result = broker.pop_tool_call_id("req_nonexistent").await;
+        let result = broker
+            .pop_tool_call_id(&RequestId::new("req_nonexistent"))
+            .await;
         assert_eq!(result, None);
     }
 
@@ -655,22 +665,28 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         // Push multiple tool calls (simulating sequential tool execution)
-        broker.push_tool_call_id("req_1", "call_first").await;
-        broker.push_tool_call_id("req_1", "call_second").await;
-        broker.push_tool_call_id("req_1", "call_third").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_first")
+            .await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_second")
+            .await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_third")
+            .await;
 
         // Pops should return in FIFO order
-        let first = broker.pop_tool_call_id("req_1").await;
+        let first = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(first, Some(ToolCallId::new("call_first")));
 
-        let second = broker.pop_tool_call_id("req_1").await;
+        let second = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(second, Some(ToolCallId::new("call_second")));
 
-        let third = broker.pop_tool_call_id("req_1").await;
+        let third = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(third, Some(ToolCallId::new("call_third")));
 
         // Fourth should be None
-        let fourth = broker.pop_tool_call_id("req_1").await;
+        let fourth = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(fourth, None);
     }
 
@@ -678,14 +694,18 @@ mod tests {
     async fn test_different_requests_isolated_fifo() {
         let broker = ToolEventBroker::new();
 
-        broker.push_tool_call_id("req_1", "call_for_req_1").await;
-        broker.push_tool_call_id("req_2", "call_for_req_2").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_for_req_1")
+            .await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_2"), "call_for_req_2")
+            .await;
 
         // Each request gets its own tool_call_id
-        let result1 = broker.pop_tool_call_id("req_1").await;
+        let result1 = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(result1, Some(ToolCallId::new("call_for_req_1")));
 
-        let result2 = broker.pop_tool_call_id("req_2").await;
+        let result2 = broker.pop_tool_call_id(&RequestId::new("req_2")).await;
         assert_eq!(result2, Some(ToolCallId::new("call_for_req_2")));
     }
 
@@ -693,14 +713,16 @@ mod tests {
     async fn test_unsubscribe_cleans_up_pending_tool_calls() {
         let broker = ToolEventBroker::new();
 
-        let _rx = broker.subscribe("req_1").await;
-        broker.push_tool_call_id("req_1", "call_abc").await;
+        let _rx = broker.subscribe(&RequestId::new("req_1")).await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_abc")
+            .await;
 
         // Unsubscribe should clean up both channel and pending tool_call_ids
-        broker.unsubscribe("req_1").await;
+        broker.unsubscribe(&RequestId::new("req_1")).await;
 
         // Pop should now return None
-        let result = broker.pop_tool_call_id("req_1").await;
+        let result = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(result, None);
     }
 
@@ -710,22 +732,24 @@ mod tests {
     async fn test_peek_returns_front_without_removing() {
         let broker = ToolEventBroker::new();
 
-        broker.push_tool_call_id("req_1", "call_abc").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_abc")
+            .await;
 
         // Peek should return the item
-        let result = broker.peek_tool_call_id("req_1").await;
+        let result = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(result, Some(ToolCallId::new("call_abc")));
 
         // Peek again should return the same item (not consumed)
-        let result2 = broker.peek_tool_call_id("req_1").await;
+        let result2 = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(result2, Some(ToolCallId::new("call_abc")));
 
         // Pop should also return the same item
-        let result3 = broker.pop_tool_call_id("req_1").await;
+        let result3 = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(result3, Some(ToolCallId::new("call_abc")));
 
         // Now it's consumed
-        let result4 = broker.peek_tool_call_id("req_1").await;
+        let result4 = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(result4, None);
     }
 
@@ -733,7 +757,9 @@ mod tests {
     async fn test_peek_nonexistent_returns_none() {
         let broker = ToolEventBroker::new();
 
-        let result = broker.peek_tool_call_id("req_nonexistent").await;
+        let result = broker
+            .peek_tool_call_id(&RequestId::new("req_nonexistent"))
+            .await;
         assert_eq!(result, None);
     }
 
@@ -742,28 +768,38 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         // Push multiple items
-        broker.push_tool_call_id("req_1", "call_first").await;
-        broker.push_tool_call_id("req_1", "call_second").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_first")
+            .await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_second")
+            .await;
 
         // Peek returns first item
-        let peek1 = broker.peek_tool_call_id("req_1").await;
+        let peek1 = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(peek1, Some(ToolCallId::new("call_first")));
 
         // Pop removes first item
-        let pop1 = broker.pop_tool_call_id("req_1").await;
+        let pop1 = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(pop1, Some(ToolCallId::new("call_first")));
 
         // Peek now returns second item
-        let peek2 = broker.peek_tool_call_id("req_1").await;
+        let peek2 = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(peek2, Some(ToolCallId::new("call_second")));
 
         // Pop removes second item
-        let pop2 = broker.pop_tool_call_id("req_1").await;
+        let pop2 = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(pop2, Some(ToolCallId::new("call_second")));
 
         // Both are now empty
-        assert_eq!(broker.peek_tool_call_id("req_1").await, None);
-        assert_eq!(broker.pop_tool_call_id("req_1").await, None);
+        assert_eq!(
+            broker.peek_tool_call_id(&RequestId::new("req_1")).await,
+            None
+        );
+        assert_eq!(
+            broker.pop_tool_call_id(&RequestId::new("req_1")).await,
+            None
+        );
     }
 
     #[tokio::test]
@@ -775,18 +811,23 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         // Simulate on_tool_call
-        broker.push_tool_call_id("req_1", "call_mcp_1").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_mcp_1")
+            .await;
 
         // Simulate MCP execution (peek)
-        let for_tool_start = broker.peek_tool_call_id("req_1").await;
+        let for_tool_start = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(for_tool_start, Some(ToolCallId::new("call_mcp_1")));
 
         // Simulate on_tool_result (pop)
-        let cleanup = broker.pop_tool_call_id("req_1").await;
+        let cleanup = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(cleanup, Some(ToolCallId::new("call_mcp_1")));
 
         // Queue is now empty
-        assert_eq!(broker.peek_tool_call_id("req_1").await, None);
+        assert_eq!(
+            broker.peek_tool_call_id(&RequestId::new("req_1")).await,
+            None
+        );
     }
 
     #[tokio::test]
@@ -798,16 +839,21 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         // Simulate on_tool_call for vector store
-        broker.push_tool_call_id("req_1", "call_vector_1").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_vector_1")
+            .await;
 
         // No MCP execution (no peek)
 
         // Simulate on_tool_result (pop)
-        let cleanup = broker.pop_tool_call_id("req_1").await;
+        let cleanup = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(cleanup, Some(ToolCallId::new("call_vector_1")));
 
         // Queue is clean
-        assert_eq!(broker.peek_tool_call_id("req_1").await, None);
+        assert_eq!(
+            broker.peek_tool_call_id(&RequestId::new("req_1")).await,
+            None
+        );
     }
 
     #[tokio::test]
@@ -817,25 +863,34 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         // Tool 1: Vector store (non-MCP)
-        broker.push_tool_call_id("req_1", "call_vector").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_vector")
+            .await;
         // Vector store executes (no peek)
-        let pop1 = broker.pop_tool_call_id("req_1").await; // on_tool_result
+        let pop1 = broker.pop_tool_call_id(&RequestId::new("req_1")).await; // on_tool_result
         assert_eq!(pop1, Some(ToolCallId::new("call_vector")));
 
         // Tool 2: MCP HTTP tool
-        broker.push_tool_call_id("req_1", "call_mcp").await;
-        let peek2 = broker.peek_tool_call_id("req_1").await; // MCP execution
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_mcp")
+            .await;
+        let peek2 = broker.peek_tool_call_id(&RequestId::new("req_1")).await; // MCP execution
         assert_eq!(peek2, Some(ToolCallId::new("call_mcp")));
-        let pop2 = broker.pop_tool_call_id("req_1").await; // on_tool_result
+        let pop2 = broker.pop_tool_call_id(&RequestId::new("req_1")).await; // on_tool_result
         assert_eq!(pop2, Some(ToolCallId::new("call_mcp")));
 
         // Tool 3: Another vector store
-        broker.push_tool_call_id("req_1", "call_vector_2").await;
-        let pop3 = broker.pop_tool_call_id("req_1").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_vector_2")
+            .await;
+        let pop3 = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(pop3, Some(ToolCallId::new("call_vector_2")));
 
         // Queue integrity maintained - all clean
-        assert_eq!(broker.peek_tool_call_id("req_1").await, None);
+        assert_eq!(
+            broker.peek_tool_call_id(&RequestId::new("req_1")).await,
+            None
+        );
     }
 
     #[tokio::test]
@@ -846,21 +901,26 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         // on_tool_call pushes
-        broker.push_tool_call_id("req_1", "call_failing_tool").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_failing_tool")
+            .await;
 
         // MCP execution peeks
-        let peek = broker.peek_tool_call_id("req_1").await;
+        let peek = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(peek, Some(ToolCallId::new("call_failing_tool")));
 
         // Tool execution fails... but on_tool_result still fires
         // (Rig converts Err(e) to e.to_string() and calls on_tool_result)
 
         // on_tool_result pops (even on failure)
-        let pop = broker.pop_tool_call_id("req_1").await;
+        let pop = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(pop, Some(ToolCallId::new("call_failing_tool")));
 
         // Queue is clean despite failure
-        assert_eq!(broker.peek_tool_call_id("req_1").await, None);
+        assert_eq!(
+            broker.peek_tool_call_id(&RequestId::new("req_1")).await,
+            None
+        );
     }
 
     #[tokio::test]
@@ -870,30 +930,39 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         // Tool 1: Success
-        broker.push_tool_call_id("req_1", "call_1_success").await;
-        let peek1 = broker.peek_tool_call_id("req_1").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_1_success")
+            .await;
+        let peek1 = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(peek1, Some(ToolCallId::new("call_1_success")));
         // Tool executes successfully
-        let pop1 = broker.pop_tool_call_id("req_1").await;
+        let pop1 = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(pop1, Some(ToolCallId::new("call_1_success")));
 
         // Tool 2: Failure (but on_tool_result still fires)
-        broker.push_tool_call_id("req_1", "call_2_failure").await;
-        let peek2 = broker.peek_tool_call_id("req_1").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_2_failure")
+            .await;
+        let peek2 = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(peek2, Some(ToolCallId::new("call_2_failure")));
         // Tool execution fails...
-        let pop2 = broker.pop_tool_call_id("req_1").await; // on_tool_result still fires
+        let pop2 = broker.pop_tool_call_id(&RequestId::new("req_1")).await; // on_tool_result still fires
         assert_eq!(pop2, Some(ToolCallId::new("call_2_failure")));
 
         // Tool 3: Success - must get correct tool_call_id, not stale one
-        broker.push_tool_call_id("req_1", "call_3_success").await;
-        let peek3 = broker.peek_tool_call_id("req_1").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_3_success")
+            .await;
+        let peek3 = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(peek3, Some(ToolCallId::new("call_3_success"))); // Not call_2!
-        let pop3 = broker.pop_tool_call_id("req_1").await;
+        let pop3 = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(pop3, Some(ToolCallId::new("call_3_success")));
 
         // Queue integrity maintained
-        assert_eq!(broker.peek_tool_call_id("req_1").await, None);
+        assert_eq!(
+            broker.peek_tool_call_id(&RequestId::new("req_1")).await,
+            None
+        );
     }
 
     #[tokio::test]
@@ -903,21 +972,26 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         // Vector store tool (non-MCP) - no peek
-        broker.push_tool_call_id("req_1", "call_vector_fails").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_vector_fails")
+            .await;
         // Tool execution fails... no peek happened
-        let pop1 = broker.pop_tool_call_id("req_1").await; // on_tool_result
+        let pop1 = broker.pop_tool_call_id(&RequestId::new("req_1")).await; // on_tool_result
         assert_eq!(pop1, Some(ToolCallId::new("call_vector_fails")));
 
         // Next MCP tool should work correctly
         broker
-            .push_tool_call_id("req_1", "call_mcp_after_failure")
+            .push_tool_call_id(&RequestId::new("req_1"), "call_mcp_after_failure")
             .await;
-        let peek2 = broker.peek_tool_call_id("req_1").await;
+        let peek2 = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(peek2, Some(ToolCallId::new("call_mcp_after_failure")));
-        let pop2 = broker.pop_tool_call_id("req_1").await;
+        let pop2 = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(pop2, Some(ToolCallId::new("call_mcp_after_failure")));
 
-        assert_eq!(broker.peek_tool_call_id("req_1").await, None);
+        assert_eq!(
+            broker.peek_tool_call_id(&RequestId::new("req_1")).await,
+            None
+        );
     }
 
     #[tokio::test]
@@ -927,26 +1001,36 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         // Request 1: Tool fails
-        broker.push_tool_call_id("req_1", "call_1_fail").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_1_fail")
+            .await;
 
         // Request 2: Tool succeeds (interleaved)
-        broker.push_tool_call_id("req_2", "call_2_success").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_2"), "call_2_success")
+            .await;
 
         // Request 2 peeks and pops (success)
-        let peek_r2 = broker.peek_tool_call_id("req_2").await;
+        let peek_r2 = broker.peek_tool_call_id(&RequestId::new("req_2")).await;
         assert_eq!(peek_r2, Some(ToolCallId::new("call_2_success")));
-        let pop_r2 = broker.pop_tool_call_id("req_2").await;
+        let pop_r2 = broker.pop_tool_call_id(&RequestId::new("req_2")).await;
         assert_eq!(pop_r2, Some(ToolCallId::new("call_2_success")));
 
         // Request 1 still has its item (failure doesn't affect isolation)
-        let peek_r1 = broker.peek_tool_call_id("req_1").await;
+        let peek_r1 = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(peek_r1, Some(ToolCallId::new("call_1_fail")));
-        let pop_r1 = broker.pop_tool_call_id("req_1").await;
+        let pop_r1 = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(pop_r1, Some(ToolCallId::new("call_1_fail")));
 
         // Both queues clean
-        assert_eq!(broker.peek_tool_call_id("req_1").await, None);
-        assert_eq!(broker.peek_tool_call_id("req_2").await, None);
+        assert_eq!(
+            broker.peek_tool_call_id(&RequestId::new("req_1")).await,
+            None
+        );
+        assert_eq!(
+            broker.peek_tool_call_id(&RequestId::new("req_2")).await,
+            None
+        );
     }
 
     #[tokio::test]
@@ -958,22 +1042,29 @@ mod tests {
         for i in 0..100 {
             let tool_id = format!("call_{}", i);
             broker
-                .push_tool_call_id("req_stress", tool_id.as_str())
+                .push_tool_call_id(&RequestId::new("req_stress"), tool_id.as_str())
                 .await;
 
             // Simulate MCP tool (peek)
             if i % 2 == 0 {
-                let peek = broker.peek_tool_call_id("req_stress").await;
+                let peek = broker
+                    .peek_tool_call_id(&RequestId::new("req_stress"))
+                    .await;
                 assert_eq!(peek, Some(ToolCallId::new(&tool_id)));
             }
 
             // on_tool_result (pop) - always fires
-            let pop = broker.pop_tool_call_id("req_stress").await;
+            let pop = broker.pop_tool_call_id(&RequestId::new("req_stress")).await;
             assert_eq!(pop, Some(ToolCallId::new(tool_id)));
         }
 
         // Queue should be empty after 100 push/pop cycles
-        assert_eq!(broker.peek_tool_call_id("req_stress").await, None);
+        assert_eq!(
+            broker
+                .peek_tool_call_id(&RequestId::new("req_stress"))
+                .await,
+            None
+        );
     }
 
     #[tokio::test]
@@ -983,12 +1074,14 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         // Simulate MCP execution trying to peek without prior hook push
-        let result = broker.peek_tool_call_id("req_no_hook").await;
+        let result = broker
+            .peek_tool_call_id(&RequestId::new("req_no_hook"))
+            .await;
         assert_eq!(result, None);
 
         // Verify queue was never created for this request
         let pending = broker.pending_tool_calls.read().await;
-        assert!(!pending.contains_key("req_no_hook"));
+        assert!(!pending.contains_key(&RequestId::new("req_no_hook")));
     }
 
     #[tokio::test]
@@ -997,16 +1090,18 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         // Normal flow: push, then pop
-        broker.push_tool_call_id("req_1", "call_123").await;
-        let _ = broker.pop_tool_call_id("req_1").await;
+        broker
+            .push_tool_call_id(&RequestId::new("req_1"), "call_123")
+            .await;
+        let _ = broker.pop_tool_call_id(&RequestId::new("req_1")).await;
 
         // Now peek returns None (queue consumed)
-        let result = broker.peek_tool_call_id("req_1").await;
+        let result = broker.peek_tool_call_id(&RequestId::new("req_1")).await;
         assert_eq!(result, None);
 
         // Queue entry was cleaned up (empty queue removed)
         let pending = broker.pending_tool_calls.read().await;
-        assert!(!pending.contains_key("req_1"));
+        assert!(!pending.contains_key(&RequestId::new("req_1")));
     }
 
     // ========================================================================
@@ -1016,7 +1111,7 @@ mod tests {
     #[tokio::test]
     async fn test_tool_usage_subscribe_and_publish() {
         let broker = ToolUsageBroker::new();
-        let mut rx = broker.subscribe("req_usage_1").await;
+        let mut rx = broker.subscribe(&RequestId::new("req_usage_1")).await;
 
         let event = ToolUsageEvent {
             tool_ids: vec![ToolCallId::new("call_abc"), ToolCallId::new("call_def")],
@@ -1027,7 +1122,7 @@ mod tests {
             },
         };
 
-        let sent = broker.publish("req_usage_1", event).await;
+        let sent = broker.publish(&RequestId::new("req_usage_1"), event).await;
         assert!(sent);
 
         let received = rx.recv().await.unwrap();
@@ -1040,13 +1135,13 @@ mod tests {
     #[tokio::test]
     async fn test_tool_usage_unsubscribe() {
         let broker = ToolUsageBroker::new();
-        let _rx = broker.subscribe("req_usage_2").await;
-        broker.unsubscribe("req_usage_2").await;
+        let _rx = broker.subscribe(&RequestId::new("req_usage_2")).await;
+        broker.unsubscribe(&RequestId::new("req_usage_2")).await;
 
         // Publish should return false after unsubscribe
         let sent = broker
             .publish(
-                "req_usage_2",
+                &RequestId::new("req_usage_2"),
                 ToolUsageEvent {
                     tool_ids: vec![],
                     usage: TokenUsage {
@@ -1063,13 +1158,13 @@ mod tests {
     #[tokio::test]
     async fn test_tool_usage_request_isolation() {
         let broker = ToolUsageBroker::new();
-        let mut rx1 = broker.subscribe("req_usage_a").await;
-        let mut rx2 = broker.subscribe("req_usage_b").await;
+        let mut rx1 = broker.subscribe(&RequestId::new("req_usage_a")).await;
+        let mut rx2 = broker.subscribe(&RequestId::new("req_usage_b")).await;
 
         // Publish to request A
         broker
             .publish(
-                "req_usage_a",
+                &RequestId::new("req_usage_a"),
                 ToolUsageEvent {
                     tool_ids: vec![ToolCallId::new("tool_for_a")],
                     usage: TokenUsage {

--- a/crates/aura/src/tool_event_broker.rs
+++ b/crates/aura/src/tool_event_broker.rs
@@ -26,14 +26,10 @@ use std::sync::OnceLock;
 use tokio::sync::{RwLock, mpsc};
 use tracing::debug;
 
+pub use aura_events::{AgentContext, TokenUsage, ToolCallId, ToolName};
+
 /// Channel capacity for tool events per request
 const EVENT_CHANNEL_CAPACITY: usize = 32;
-
-// Type aliases for tool identifiers - upgrade to newtypes later
-/// The unique ID assigned by the LLM to a specific tool call
-pub type ToolCallId = String;
-/// The name of a tool (e.g., "search", "list_files")
-pub type ToolName = String;
 
 /// Tool lifecycle events routed through the broker.
 ///
@@ -49,6 +45,7 @@ pub enum ToolLifecycleEvent {
         tool_name: ToolName,
         /// The tool arguments as JSON
         arguments: serde_json::Value,
+        agent: Option<AgentContext>,
     },
     /// Emitted from execution context when MCP actually begins.
     /// Provides the progress_token for correlating with aura.progress events.
@@ -56,12 +53,13 @@ pub enum ToolLifecycleEvent {
         tool_id: ToolCallId,
         tool_name: ToolName,
         progress_token: Option<ProgressToken>,
+        agent: Option<AgentContext>,
     },
 }
 
 impl ToolLifecycleEvent {
     /// Get the tool_id regardless of event variant
-    pub fn tool_id(&self) -> &str {
+    pub fn tool_id(&self) -> &ToolCallId {
         match self {
             ToolLifecycleEvent::Requested { tool_id, .. } => tool_id,
             ToolLifecycleEvent::Start { tool_id, .. } => tool_id,
@@ -69,7 +67,7 @@ impl ToolLifecycleEvent {
     }
 
     /// Get the tool_name regardless of event variant
-    pub fn tool_name(&self) -> &str {
+    pub fn tool_name(&self) -> &ToolName {
         match self {
             ToolLifecycleEvent::Requested { tool_name, .. } => tool_name,
             ToolLifecycleEvent::Start { tool_name, .. } => tool_name,
@@ -77,21 +75,10 @@ impl ToolLifecycleEvent {
     }
 }
 
-/// Tool usage event emitted when usage information becomes available.
-///
-/// This associates tool calls with their usage snapshot. When
-/// `on_stream_completion_response_finish` fires, all tools that completed
-/// since the last usage event are grouped together.
 #[derive(Clone, Debug)]
 pub struct ToolUsageEvent {
-    /// Tool IDs that share this usage snapshot
-    pub tool_ids: Vec<String>,
-    /// Prompt tokens (context size at this point)
-    pub prompt_tokens: u64,
-    /// Completion tokens generated
-    pub completion_tokens: u64,
-    /// Total tokens used
-    pub total_tokens: u64,
+    pub tool_ids: Vec<ToolCallId>,
+    pub usage: TokenUsage,
 }
 
 /// Request-scoped tool event broker that routes MCP tool events
@@ -115,7 +102,7 @@ pub struct ToolEventBroker {
     /// Hook pushes when on_tool_call fires, execution peeks when tool starts,
     /// hook pops when on_tool_result fires.
     /// Sequential execution in streaming mode guarantees correct ordering.
-    pending_tool_calls: RwLock<HashMap<String, VecDeque<String>>>,
+    pending_tool_calls: RwLock<HashMap<String, VecDeque<ToolCallId>>>,
 }
 
 impl ToolEventBroker {
@@ -172,7 +159,7 @@ impl ToolEventBroker {
     /// Called when the hook's `on_tool_call` fires. The execution context
     /// will peek this ID when the tool actually starts executing.
     /// FIFO order is guaranteed by sequential tool execution in streaming mode.
-    pub async fn push_tool_call_id(&self, request_id: &str, tool_call_id: impl Into<String>) {
+    pub async fn push_tool_call_id(&self, request_id: &str, tool_call_id: impl Into<ToolCallId>) {
         let mut pending = self.pending_tool_calls.write().await;
         let queue = pending.entry(request_id.to_string()).or_default();
         let tool_call_id = tool_call_id.into();
@@ -194,7 +181,7 @@ impl ToolEventBroker {
     /// This ensures push/pop pairing regardless of tool type.
     ///
     /// Returns `None` if no pending tool_call_id exists.
-    pub async fn peek_tool_call_id(&self, request_id: &str) -> Option<String> {
+    pub async fn peek_tool_call_id(&self, request_id: &str) -> Option<ToolCallId> {
         let pending = self.pending_tool_calls.read().await;
 
         let queue = pending.get(request_id)?;
@@ -220,7 +207,7 @@ impl ToolEventBroker {
     /// This ensures push/pop pairing for ALL tools (MCP and non-MCP).
     ///
     /// Returns `None` if no pending tool_call_id exists.
-    pub async fn pop_tool_call_id(&self, request_id: &str) -> Option<String> {
+    pub async fn pop_tool_call_id(&self, request_id: &str) -> Option<ToolCallId> {
         let mut pending = self.pending_tool_calls.write().await;
 
         let queue = pending.get_mut(request_id)?;
@@ -325,6 +312,7 @@ pub async fn publish_tool_requested(
             tool_id,
             tool_name,
             arguments,
+            agent: None,
         },
     )
     .await
@@ -343,23 +331,24 @@ pub async fn publish_tool_start(
             tool_id,
             tool_name,
             progress_token,
+            agent: None,
         },
     )
     .await
 }
 
 /// Convenience function to push a tool_call_id from hook context.
-pub async fn push_tool_call_id(request_id: &RequestId, tool_call_id: String) {
+pub async fn push_tool_call_id(request_id: &RequestId, tool_call_id: ToolCallId) {
     global().push_tool_call_id(request_id, tool_call_id).await
 }
 
 /// Convenience function to peek at the next tool_call_id (for MCP execution).
-pub async fn peek_tool_call_id(request_id: &RequestId) -> Option<String> {
+pub async fn peek_tool_call_id(request_id: &RequestId) -> Option<ToolCallId> {
     global().peek_tool_call_id(request_id).await
 }
 
 /// Convenience function to pop a tool_call_id (from on_tool_result).
-pub async fn pop_tool_call_id(request_id: &RequestId) -> Option<String> {
+pub async fn pop_tool_call_id(request_id: &RequestId) -> Option<ToolCallId> {
     global().pop_tool_call_id(request_id).await
 }
 
@@ -464,27 +453,18 @@ pub async fn tool_usage_unsubscribe(request_id: &str) {
 /// Associates the listed tool_ids with the usage snapshot.
 pub async fn publish_tool_usage(
     request_id: &str,
-    tool_ids: Vec<String>,
-    prompt_tokens: u64,
-    completion_tokens: u64,
-    total_tokens: u64,
+    tool_ids: Vec<ToolCallId>,
+    usage: TokenUsage,
 ) -> bool {
     usage_broker_global()
-        .publish(
-            request_id,
-            ToolUsageEvent {
-                tool_ids,
-                prompt_tokens,
-                completion_tokens,
-                total_tokens,
-            },
-        )
+        .publish(request_id, ToolUsageEvent { tool_ids, usage })
         .await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aura_events::TokenCount;
     use rmcp::model::NumberOrString;
     use std::sync::Arc;
 
@@ -525,9 +505,10 @@ mod tests {
         let mut rx = broker.subscribe("req_123").await;
 
         let event = ToolLifecycleEvent::Start {
-            tool_id: "call_abc".to_string(),
-            tool_name: "list_pipelines".to_string(),
+            tool_id: ToolCallId::new("call_abc"),
+            tool_name: ToolName::new("list_pipelines"),
             progress_token: Some(numeric_token(42)),
+            agent: None,
         };
 
         let sent = broker.publish("req_123", event).await;
@@ -539,6 +520,7 @@ mod tests {
                 tool_id,
                 tool_name,
                 progress_token,
+                ..
             } => {
                 assert_eq!(tool_id, "call_abc");
                 assert_eq!(tool_name, "list_pipelines");
@@ -554,9 +536,10 @@ mod tests {
         let mut rx = broker.subscribe("req_123").await;
 
         let event = ToolLifecycleEvent::Requested {
-            tool_id: "call_abc".to_string(),
-            tool_name: "search".to_string(),
+            tool_id: ToolCallId::new("call_abc"),
+            tool_name: ToolName::new("search"),
             arguments: serde_json::json!({"query": "test"}),
+            agent: None,
         };
 
         let sent = broker.publish("req_123", event).await;
@@ -568,6 +551,7 @@ mod tests {
                 tool_id,
                 tool_name,
                 arguments,
+                ..
             } => {
                 assert_eq!(tool_id, "call_abc");
                 assert_eq!(tool_name, "search");
@@ -582,9 +566,10 @@ mod tests {
         let broker = ToolEventBroker::new();
 
         let event = ToolLifecycleEvent::Start {
-            tool_id: "call_abc".to_string(),
-            tool_name: "list_pipelines".to_string(),
+            tool_id: ToolCallId::new("call_abc"),
+            tool_name: ToolName::new("list_pipelines"),
             progress_token: None,
+            agent: None,
         };
 
         let sent = broker.publish("req_nonexistent", event).await;
@@ -598,9 +583,10 @@ mod tests {
         let mut rx2 = broker.subscribe("req_2").await;
 
         let event = ToolLifecycleEvent::Start {
-            tool_id: "call_1".to_string(),
-            tool_name: "tool_for_req_1".to_string(),
+            tool_id: ToolCallId::new("call_1"),
+            tool_name: ToolName::new("tool_for_req_1"),
             progress_token: Some(string_token("token_1")),
+            agent: None,
         };
         broker.publish("req_1", event).await;
 
@@ -618,9 +604,10 @@ mod tests {
         let mut rx = broker.subscribe("req_123").await;
 
         let event = ToolLifecycleEvent::Start {
-            tool_id: "call_xyz".to_string(),
-            tool_name: "some_tool".to_string(),
+            tool_id: ToolCallId::new("call_xyz"),
+            tool_name: ToolName::new("some_tool"),
             progress_token: None,
+            agent: None,
         };
 
         broker.publish("req_123", event).await;
@@ -648,7 +635,7 @@ mod tests {
         broker.push_tool_call_id("req_1", "call_abc123").await;
 
         let result = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(result, Some("call_abc123".to_string()));
+        assert_eq!(result, Some(ToolCallId::new("call_abc123")));
 
         // Second pop should return None (consumed)
         let result2 = broker.pop_tool_call_id("req_1").await;
@@ -674,13 +661,13 @@ mod tests {
 
         // Pops should return in FIFO order
         let first = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(first, Some("call_first".to_string()));
+        assert_eq!(first, Some(ToolCallId::new("call_first")));
 
         let second = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(second, Some("call_second".to_string()));
+        assert_eq!(second, Some(ToolCallId::new("call_second")));
 
         let third = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(third, Some("call_third".to_string()));
+        assert_eq!(third, Some(ToolCallId::new("call_third")));
 
         // Fourth should be None
         let fourth = broker.pop_tool_call_id("req_1").await;
@@ -696,10 +683,10 @@ mod tests {
 
         // Each request gets its own tool_call_id
         let result1 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(result1, Some("call_for_req_1".to_string()));
+        assert_eq!(result1, Some(ToolCallId::new("call_for_req_1")));
 
         let result2 = broker.pop_tool_call_id("req_2").await;
-        assert_eq!(result2, Some("call_for_req_2".to_string()));
+        assert_eq!(result2, Some(ToolCallId::new("call_for_req_2")));
     }
 
     #[tokio::test]
@@ -727,15 +714,15 @@ mod tests {
 
         // Peek should return the item
         let result = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(result, Some("call_abc".to_string()));
+        assert_eq!(result, Some(ToolCallId::new("call_abc")));
 
         // Peek again should return the same item (not consumed)
         let result2 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(result2, Some("call_abc".to_string()));
+        assert_eq!(result2, Some(ToolCallId::new("call_abc")));
 
         // Pop should also return the same item
         let result3 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(result3, Some("call_abc".to_string()));
+        assert_eq!(result3, Some(ToolCallId::new("call_abc")));
 
         // Now it's consumed
         let result4 = broker.peek_tool_call_id("req_1").await;
@@ -760,19 +747,19 @@ mod tests {
 
         // Peek returns first item
         let peek1 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek1, Some("call_first".to_string()));
+        assert_eq!(peek1, Some(ToolCallId::new("call_first")));
 
         // Pop removes first item
         let pop1 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop1, Some("call_first".to_string()));
+        assert_eq!(pop1, Some(ToolCallId::new("call_first")));
 
         // Peek now returns second item
         let peek2 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek2, Some("call_second".to_string()));
+        assert_eq!(peek2, Some(ToolCallId::new("call_second")));
 
         // Pop removes second item
         let pop2 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop2, Some("call_second".to_string()));
+        assert_eq!(pop2, Some(ToolCallId::new("call_second")));
 
         // Both are now empty
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -792,11 +779,11 @@ mod tests {
 
         // Simulate MCP execution (peek)
         let for_tool_start = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(for_tool_start, Some("call_mcp_1".to_string()));
+        assert_eq!(for_tool_start, Some(ToolCallId::new("call_mcp_1")));
 
         // Simulate on_tool_result (pop)
         let cleanup = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(cleanup, Some("call_mcp_1".to_string()));
+        assert_eq!(cleanup, Some(ToolCallId::new("call_mcp_1")));
 
         // Queue is now empty
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -817,7 +804,7 @@ mod tests {
 
         // Simulate on_tool_result (pop)
         let cleanup = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(cleanup, Some("call_vector_1".to_string()));
+        assert_eq!(cleanup, Some(ToolCallId::new("call_vector_1")));
 
         // Queue is clean
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -833,19 +820,19 @@ mod tests {
         broker.push_tool_call_id("req_1", "call_vector").await;
         // Vector store executes (no peek)
         let pop1 = broker.pop_tool_call_id("req_1").await; // on_tool_result
-        assert_eq!(pop1, Some("call_vector".to_string()));
+        assert_eq!(pop1, Some(ToolCallId::new("call_vector")));
 
         // Tool 2: MCP HTTP tool
         broker.push_tool_call_id("req_1", "call_mcp").await;
         let peek2 = broker.peek_tool_call_id("req_1").await; // MCP execution
-        assert_eq!(peek2, Some("call_mcp".to_string()));
+        assert_eq!(peek2, Some(ToolCallId::new("call_mcp")));
         let pop2 = broker.pop_tool_call_id("req_1").await; // on_tool_result
-        assert_eq!(pop2, Some("call_mcp".to_string()));
+        assert_eq!(pop2, Some(ToolCallId::new("call_mcp")));
 
         // Tool 3: Another vector store
         broker.push_tool_call_id("req_1", "call_vector_2").await;
         let pop3 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop3, Some("call_vector_2".to_string()));
+        assert_eq!(pop3, Some(ToolCallId::new("call_vector_2")));
 
         // Queue integrity maintained - all clean
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -863,14 +850,14 @@ mod tests {
 
         // MCP execution peeks
         let peek = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek, Some("call_failing_tool".to_string()));
+        assert_eq!(peek, Some(ToolCallId::new("call_failing_tool")));
 
         // Tool execution fails... but on_tool_result still fires
         // (Rig converts Err(e) to e.to_string() and calls on_tool_result)
 
         // on_tool_result pops (even on failure)
         let pop = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop, Some("call_failing_tool".to_string()));
+        assert_eq!(pop, Some(ToolCallId::new("call_failing_tool")));
 
         // Queue is clean despite failure
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -885,25 +872,25 @@ mod tests {
         // Tool 1: Success
         broker.push_tool_call_id("req_1", "call_1_success").await;
         let peek1 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek1, Some("call_1_success".to_string()));
+        assert_eq!(peek1, Some(ToolCallId::new("call_1_success")));
         // Tool executes successfully
         let pop1 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop1, Some("call_1_success".to_string()));
+        assert_eq!(pop1, Some(ToolCallId::new("call_1_success")));
 
         // Tool 2: Failure (but on_tool_result still fires)
         broker.push_tool_call_id("req_1", "call_2_failure").await;
         let peek2 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek2, Some("call_2_failure".to_string()));
+        assert_eq!(peek2, Some(ToolCallId::new("call_2_failure")));
         // Tool execution fails...
         let pop2 = broker.pop_tool_call_id("req_1").await; // on_tool_result still fires
-        assert_eq!(pop2, Some("call_2_failure".to_string()));
+        assert_eq!(pop2, Some(ToolCallId::new("call_2_failure")));
 
         // Tool 3: Success - must get correct tool_call_id, not stale one
         broker.push_tool_call_id("req_1", "call_3_success").await;
         let peek3 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek3, Some("call_3_success".to_string())); // Not call_2!
+        assert_eq!(peek3, Some(ToolCallId::new("call_3_success"))); // Not call_2!
         let pop3 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop3, Some("call_3_success".to_string()));
+        assert_eq!(pop3, Some(ToolCallId::new("call_3_success")));
 
         // Queue integrity maintained
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -919,16 +906,16 @@ mod tests {
         broker.push_tool_call_id("req_1", "call_vector_fails").await;
         // Tool execution fails... no peek happened
         let pop1 = broker.pop_tool_call_id("req_1").await; // on_tool_result
-        assert_eq!(pop1, Some("call_vector_fails".to_string()));
+        assert_eq!(pop1, Some(ToolCallId::new("call_vector_fails")));
 
         // Next MCP tool should work correctly
         broker
             .push_tool_call_id("req_1", "call_mcp_after_failure")
             .await;
         let peek2 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek2, Some("call_mcp_after_failure".to_string()));
+        assert_eq!(peek2, Some(ToolCallId::new("call_mcp_after_failure")));
         let pop2 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop2, Some("call_mcp_after_failure".to_string()));
+        assert_eq!(pop2, Some(ToolCallId::new("call_mcp_after_failure")));
 
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
     }
@@ -947,15 +934,15 @@ mod tests {
 
         // Request 2 peeks and pops (success)
         let peek_r2 = broker.peek_tool_call_id("req_2").await;
-        assert_eq!(peek_r2, Some("call_2_success".to_string()));
+        assert_eq!(peek_r2, Some(ToolCallId::new("call_2_success")));
         let pop_r2 = broker.pop_tool_call_id("req_2").await;
-        assert_eq!(pop_r2, Some("call_2_success".to_string()));
+        assert_eq!(pop_r2, Some(ToolCallId::new("call_2_success")));
 
         // Request 1 still has its item (failure doesn't affect isolation)
         let peek_r1 = broker.peek_tool_call_id("req_1").await;
-        assert_eq!(peek_r1, Some("call_1_fail".to_string()));
+        assert_eq!(peek_r1, Some(ToolCallId::new("call_1_fail")));
         let pop_r1 = broker.pop_tool_call_id("req_1").await;
-        assert_eq!(pop_r1, Some("call_1_fail".to_string()));
+        assert_eq!(pop_r1, Some(ToolCallId::new("call_1_fail")));
 
         // Both queues clean
         assert_eq!(broker.peek_tool_call_id("req_1").await, None);
@@ -970,17 +957,19 @@ mod tests {
 
         for i in 0..100 {
             let tool_id = format!("call_{}", i);
-            broker.push_tool_call_id("req_stress", &tool_id).await;
+            broker
+                .push_tool_call_id("req_stress", tool_id.as_str())
+                .await;
 
             // Simulate MCP tool (peek)
             if i % 2 == 0 {
                 let peek = broker.peek_tool_call_id("req_stress").await;
-                assert_eq!(peek, Some(tool_id.clone()));
+                assert_eq!(peek, Some(ToolCallId::new(&tool_id)));
             }
 
             // on_tool_result (pop) - always fires
             let pop = broker.pop_tool_call_id("req_stress").await;
-            assert_eq!(pop, Some(tool_id));
+            assert_eq!(pop, Some(ToolCallId::new(tool_id)));
         }
 
         // Queue should be empty after 100 push/pop cycles
@@ -1030,10 +1019,12 @@ mod tests {
         let mut rx = broker.subscribe("req_usage_1").await;
 
         let event = ToolUsageEvent {
-            tool_ids: vec!["call_abc".to_string(), "call_def".to_string()],
-            prompt_tokens: 18777,
-            completion_tokens: 500,
-            total_tokens: 19277,
+            tool_ids: vec![ToolCallId::new("call_abc"), ToolCallId::new("call_def")],
+            usage: TokenUsage {
+                prompt_tokens: TokenCount::new(18777),
+                completion_tokens: TokenCount::new(500),
+                total_tokens: TokenCount::new(19277),
+            },
         };
 
         let sent = broker.publish("req_usage_1", event).await;
@@ -1041,9 +1032,9 @@ mod tests {
 
         let received = rx.recv().await.unwrap();
         assert_eq!(received.tool_ids, vec!["call_abc", "call_def"]);
-        assert_eq!(received.prompt_tokens, 18777);
-        assert_eq!(received.completion_tokens, 500);
-        assert_eq!(received.total_tokens, 19277);
+        assert_eq!(received.usage.prompt_tokens.get(), 18777);
+        assert_eq!(received.usage.completion_tokens.get(), 500);
+        assert_eq!(received.usage.total_tokens.get(), 19277);
     }
 
     #[tokio::test]
@@ -1058,9 +1049,11 @@ mod tests {
                 "req_usage_2",
                 ToolUsageEvent {
                     tool_ids: vec![],
-                    prompt_tokens: 0,
-                    completion_tokens: 0,
-                    total_tokens: 0,
+                    usage: TokenUsage {
+                        prompt_tokens: TokenCount::new(0),
+                        completion_tokens: TokenCount::new(0),
+                        total_tokens: TokenCount::new(0),
+                    },
                 },
             )
             .await;
@@ -1078,10 +1071,12 @@ mod tests {
             .publish(
                 "req_usage_a",
                 ToolUsageEvent {
-                    tool_ids: vec!["tool_for_a".to_string()],
-                    prompt_tokens: 1000,
-                    completion_tokens: 100,
-                    total_tokens: 1100,
+                    tool_ids: vec![ToolCallId::new("tool_for_a")],
+                    usage: TokenUsage {
+                        prompt_tokens: TokenCount::new(1000),
+                        completion_tokens: TokenCount::new(100),
+                        total_tokens: TokenCount::new(1100),
+                    },
                 },
             )
             .await;


### PR DESCRIPTION
RequestId becomes a newtype over String instead of a type alias, so a bare string can no longer stand in for a request id. It threads through SSE routing, the tool-event broker, MCP cancellation, HITL approval gates, the session store, and the scratchpad's per-request directory.

The brokers and the cancellation registry key their maps by RequestId rather than String. In mcp/client.rs, rmcp's own RequestId is imported as McpRequestId, so the HTTP request id and the MCP protocol request id are no longer the same type in signatures that take both.

The webhook payload and stored approval records keep their bare-string shape, which serde(transparent) guarantees and a record test now pins.