### PR TITLE
fix(orchestration): replay blank assistant turns with a placeholder

### DIFF
--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -524,6 +524,24 @@ struct ForwardedRun {
     last_turn: rig::completion::Usage,
 }
 
+/// Replay an assistant turn as conversation history.
+///
+/// Anthropic-family providers reject a message whose text block is empty
+/// (`messages: text content blocks must be non-empty`), and a turn spent
+/// entirely on reasoning or cut off before any output yields exactly that.
+/// Blank content is replaced with
+/// [`prompt_constants::corrections::EMPTY_ASSISTANT_TURN`] so the correction
+/// call that follows is accepted.
+fn assistant_history_message(content: &str) -> rig::completion::Message {
+    if content.trim().is_empty() {
+        rig::completion::Message::assistant(
+            super::prompt_constants::corrections::EMPTY_ASSISTANT_TURN,
+        )
+    } else {
+        rig::completion::Message::assistant(content)
+    }
+}
+
 /// One guarded step of a deadline-wrapped stream loop.
 enum LoopStep {
     End,
@@ -1999,7 +2017,7 @@ impl Orchestrator {
             let response_text = response.content.clone();
             coordinator_state
                 .conversation
-                .push(rig::completion::Message::assistant(&response_text));
+                .push(assistant_history_message(&response_text));
 
             {
                 let persistence = self.persistence.lock().await;
@@ -3687,7 +3705,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
                     super::prompt_constants::corrections::WORKER_SUBMIT_RESULT.to_string();
                 let history = vec![
                     rig::completion::Message::user(base_worker_prompt.clone()),
-                    rig::completion::Message::assistant(last_raw_response.clone()),
+                    assistant_history_message(&last_raw_response),
                 ];
                 (correction, history)
             };
@@ -5620,6 +5638,38 @@ fn context_overflow_suggestion(phase: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assistant_text(msg: &rig::completion::Message) -> String {
+        match msg {
+            rig::completion::Message::Assistant { content, .. } => content
+                .iter()
+                .map(|c| match c {
+                    rig::message::AssistantContent::Text(t) => t.text.clone(),
+                    other => panic!("expected text content, got {other:?}"),
+                })
+                .collect(),
+            other => panic!("expected assistant message, got {other:?}"),
+        }
+    }
+
+    /// Blank assistant turns must be replayed as non-empty text so providers
+    /// accept the correction request.
+    #[test]
+    fn assistant_history_message_replaces_blank_content() {
+        for blank in ["", " ", "\n\t "] {
+            assert_eq!(
+                assistant_text(&assistant_history_message(blank)),
+                super::super::prompt_constants::corrections::EMPTY_ASSISTANT_TURN,
+                "blank {blank:?} must be replaced",
+            );
+        }
+    }
+
+    #[test]
+    fn assistant_history_message_keeps_real_content() {
+        let text = "I fetched the check runs but forgot to submit.";
+        assert_eq!(assistant_text(&assistant_history_message(text)), text);
+    }
 
     fn usage(input_tokens: u64, output_tokens: u64) -> rig::completion::Usage {
         rig::completion::Usage {

--- a/crates/aura/src/orchestration/prompt_constants.rs
+++ b/crates/aura/src/orchestration/prompt_constants.rs
@@ -54,6 +54,9 @@ pub(crate) mod guidance {
 pub(crate) mod corrections {
     pub const ROUTING_TOOL_REQUIRED: &str = "You must call one of the routing tools (respond_directly, create_plan, or request_clarification). Do not respond with text — call a tool.";
     pub const WORKER_SUBMIT_RESULT: &str = "[SYSTEM CORRECTION] You did not call the submit_result tool in your previous response. You MUST call submit_result to complete this task. Please try again.";
+    /// Stands in for an assistant turn that produced no text when that turn
+    /// is replayed as history.
+    pub const EMPTY_ASSISTANT_TURN: &str = "(the previous turn produced no text)";
 }
 
 /// User-facing suggestions when context overflow occurs.


### PR DESCRIPTION
## Summary

A coordinator or worker turn that produces neither text nor a tool call
was replayed into history as `Message::assistant("")`. Rig maps that to
an empty text block, which Anthropic-family providers reject with
`messages: text content blocks must be non-empty`.

- **Coordinator**: the empty turn is pushed into the persistent
  conversation, so every later planning call in the run fails in
  ~0.3s before generation.
- **Worker**: the `submit_result` correction retry replays the empty
  turn, so the retry is a guaranteed provider error. The task fails and
  the coordinator re-plans from scratch.

Both sites now build the replayed turn through a shared helper,
`assistant_history_message`, which substitutes a placeholder for blank
or whitespace-only content. This matches the guard the coordinator's
success path already applies when it serializes the routing decision.

Observed on Bedrock `claude-sonnet-5`: a worker spent a 20s turn on
reasoning only, skipped `submit_result`, and the correction retry was
rejected. Iteration 2 redid the same fetches to recover.

## Not addressed

Issue #590's second and third suggestions (a distinct correction prompt
for empty responses, and retrying a self-inflicted 400 after sanitising
history) are left for follow-up. The worker retry also still starts
cold: rig does not expose the multi-turn chat history when a stream
ends normally, so the failed attempt's tool results are not carried
forward.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets`
- [x] New unit tests: blank and whitespace content is replaced, real
  content passes through unchanged

Fixes #590
