### PR TITLE
feat(ci): record docker pulls per tag

### DIFF
--- a/.github/workflows/cloudsmith-download-metrics.yml
+++ b/.github/workflows/cloudsmith-download-metrics.yml
@@ -21,6 +21,7 @@ on:
   pull_request:
     paths:
       - "scripts/sync-cloudsmith-downloads.sh"
+      - "scripts/lib/posthog-snapshot.sh"
       - ".github/workflows/cloudsmith-download-metrics.yml"
 
 permissions:

--- a/.github/workflows/docker-download-metrics.yml
+++ b/.github/workflows/docker-download-metrics.yml
@@ -17,6 +17,13 @@ on:
         required: false
         default: false
         type: boolean
+  # TEMPORARY: remove before merging. schedule only fires on the default branch
+  # and workflow_dispatch only appears once the file is on it, so a push
+  # trigger is the only way to exercise the credentialed sync job beforehand.
+  # It also hands the secrets to whatever is pushed, ahead of review.
+  push:
+    branches:
+      - "justingross/GH-647-docker-download-totals-to-posthog"
   pull_request:
     paths:
       - "scripts/sync-docker-downloads.sh"

--- a/.github/workflows/docker-download-metrics.yml
+++ b/.github/workflows/docker-download-metrics.yml
@@ -17,13 +17,6 @@ on:
         required: false
         default: false
         type: boolean
-  # TEMPORARY: remove before merging. schedule only fires on the default branch
-  # and workflow_dispatch only appears once the file is on it, so a push
-  # trigger is the only way to exercise the credentialed sync job beforehand.
-  # It also hands the secrets to whatever is pushed, ahead of review.
-  push:
-    branches:
-      - "justingross/GH-647-docker-download-totals-to-posthog"
   pull_request:
     paths:
       - "scripts/sync-docker-downloads.sh"

--- a/.github/workflows/docker-download-metrics.yml
+++ b/.github/workflows/docker-download-metrics.yml
@@ -1,0 +1,103 @@
+name: "Docker download metrics"
+
+on:
+  schedule:
+    # 01:29 UTC daily, snapshotting the previous UTC day. Offset from the other
+    # snapshot workflows so they do not contend, and off the hour because
+    # GitHub drops queued scheduled jobs when load peaks there.
+    - cron: "29 1 * * *"
+  workflow_dispatch:
+    inputs:
+      date:
+        description: "Snapshot date (YYYY-MM-DD, UTC). Defaults to yesterday."
+        required: false
+        type: string
+      dry_run:
+        description: "Build the payload without sending it"
+        required: false
+        default: false
+        type: boolean
+  pull_request:
+    paths:
+      - "scripts/sync-docker-downloads.sh"
+      - "scripts/lib/posthog-snapshot.sh"
+      - ".github/workflows/docker-download-metrics.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-download-metrics
+  cancel-in-progress: false
+
+jobs:
+  # Pull requests run code from the PR revision, which a contributor with push
+  # access controls before review. It is given no PostHog credentials and no
+  # write permissions: --selftest and --dry-run need neither, and a modified
+  # script would not be bound by DRY_RUN.
+  verify:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Self-test
+        run: scripts/sync-docker-downloads.sh --selftest
+
+      - name: Dry run
+        env:
+          DRY_RUN: "1"
+        run: scripts/sync-docker-downloads.sh
+
+  sync:
+    # A manual dispatch names the ref it runs, so without the branch test this
+    # job would check out an unreviewed revision and hand it the credentials.
+    # The schedule only ever fires on the default branch, so a dispatch from
+    # anywhere else has nothing legitimate to do.
+    if: >-
+      github.event_name != 'pull_request' &&
+      (github.event_name != 'workflow_dispatch' ||
+       github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Self-test
+        run: scripts/sync-docker-downloads.sh --selftest
+
+      - name: Snapshot Docker pull totals
+        env:
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          POSTHOG_API_READ_KEY: ${{ secrets.POSTHOG_API_READ_KEY }}
+          POSTHOG_PROJECT_ID: ${{ vars.POSTHOG_PROJECT_ID }}
+          # Inputs arrive as environment variables the script already reads, so
+          # nothing user-supplied is interpolated into a shell command.
+          SNAPSHOT_DATE: ${{ inputs.date }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+        run: scripts/sync-docker-downloads.sh
+
+      - name: Report failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          set -euo pipefail
+          title="Docker download metrics sync failed"
+          body=$(printf '%s\n\n%s\n' \
+              "The scheduled snapshot failed: ${RUN_URL}" \
+              "Re-run it from the Actions tab with workflow_dispatch, passing the snapshot date it was covering. Events are keyed by that date, so a retry re-sends the same events and PostHog deduplicates them.")
+          existing=$(gh issue list --state open --search "${title} in:title" \
+              --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+              gh issue comment "${existing}" --body "${body}"
+          else
+              gh issue create --title "${title}" --body "${body}"
+          fi

--- a/.github/workflows/docker-dvp-metrics.yml
+++ b/.github/workflows/docker-dvp-metrics.yml
@@ -94,6 +94,22 @@ jobs:
           [ -z "${PERIOD}" ] || args+=(--period "${PERIOD}")
           scripts/sync-docker-dvp-reports.sh "${args[@]}"
 
+      - name: Sync Docker DVP audience
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          POSTHOG_API_READ_KEY: ${{ secrets.POSTHOG_API_READ_KEY }}
+          POSTHOG_PROJECT_ID: ${{ vars.POSTHOG_PROJECT_ID }}
+          REPORT_TYPE: technographic
+          PERIOD: ${{ inputs.period }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+        run: |
+          set -euo pipefail
+          args=()
+          [ -z "${PERIOD}" ] || args+=(--period "${PERIOD}")
+          scripts/sync-docker-dvp-reports.sh "${args[@]}"
+
       - name: Report failure
         if: failure() && github.event_name == 'schedule'
         env:

--- a/.github/workflows/docker-dvp-metrics.yml
+++ b/.github/workflows/docker-dvp-metrics.yml
@@ -17,13 +17,6 @@ on:
         required: false
         default: false
         type: boolean
-  # TEMPORARY: remove before merging. schedule only fires on the default branch
-  # and workflow_dispatch only appears once the file is on it, so a push
-  # trigger is the only way to exercise the credentialed sync job beforehand.
-  # It also hands the secrets to whatever is pushed, ahead of review.
-  push:
-    branches:
-      - "justingross/GH-647-docker-download-totals-to-posthog"
   pull_request:
     paths:
       - "scripts/sync-docker-dvp-reports.sh"

--- a/.github/workflows/docker-dvp-metrics.yml
+++ b/.github/workflows/docker-dvp-metrics.yml
@@ -17,6 +17,13 @@ on:
         required: false
         default: false
         type: boolean
+  # TEMPORARY: remove before merging. schedule only fires on the default branch
+  # and workflow_dispatch only appears once the file is on it, so a push
+  # trigger is the only way to exercise the credentialed sync job beforehand.
+  # It also hands the secrets to whatever is pushed, ahead of review.
+  push:
+    branches:
+      - "justingross/GH-647-docker-download-totals-to-posthog"
   pull_request:
     paths:
       - "scripts/sync-docker-dvp-reports.sh"

--- a/.github/workflows/docker-dvp-metrics.yml
+++ b/.github/workflows/docker-dvp-metrics.yml
@@ -1,0 +1,107 @@
+name: "Docker DVP metrics"
+
+on:
+  schedule:
+    # 01:35 UTC daily, after the other snapshot workflows. Docker publishes a
+    # new weekly report once a week and keeps only the last few, so checking
+    # daily is about not missing one rather than about daily resolution.
+    - cron: "35 1 * * *"
+  workflow_dispatch:
+    inputs:
+      period:
+        description: "Process only the report starting on this date (YYYY-MM-DD)."
+        required: false
+        type: string
+      dry_run:
+        description: "Build the payloads without sending them"
+        required: false
+        default: false
+        type: boolean
+  pull_request:
+    paths:
+      - "scripts/sync-docker-dvp-reports.sh"
+      - "scripts/lib/posthog-snapshot.sh"
+      - ".github/workflows/docker-dvp-metrics.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-dvp-metrics
+  cancel-in-progress: false
+
+jobs:
+  # Pull requests run code from the PR revision, which a contributor with push
+  # access controls before review, so this job gets no credentials at all.
+  # Unlike the other snapshots it cannot dry-run: the report catalogue is not
+  # public, so a dry run would need the Docker credentials this job must not
+  # have. Self-test covers what can be checked without them.
+  verify:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Self-test
+        run: scripts/sync-docker-dvp-reports.sh --selftest
+
+  sync:
+    # A manual dispatch names the ref it runs, so without the branch test this
+    # job would check out an unreviewed revision and hand it the credentials.
+    # The schedule only ever fires on the default branch, so a dispatch from
+    # anywhere else has nothing legitimate to do.
+    if: >-
+      github.event_name != 'pull_request' &&
+      (github.event_name != 'workflow_dispatch' ||
+       github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+    runs-on: ubuntu-latest
+    # Each report is verified on its own, so the read-back budget is per report
+    # rather than per run.
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Self-test
+        run: scripts/sync-docker-dvp-reports.sh --selftest
+
+      - name: Sync Docker DVP reports
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          POSTHOG_API_READ_KEY: ${{ secrets.POSTHOG_API_READ_KEY }}
+          POSTHOG_PROJECT_ID: ${{ vars.POSTHOG_PROJECT_ID }}
+          # Inputs arrive as environment variables the script already reads, so
+          # nothing user-supplied is interpolated into a shell command.
+          PERIOD: ${{ inputs.period }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+        run: |
+          set -euo pipefail
+          args=()
+          [ -z "${PERIOD}" ] || args+=(--period "${PERIOD}")
+          scripts/sync-docker-dvp-reports.sh "${args[@]}"
+
+      - name: Report failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          set -euo pipefail
+          title="Docker DVP metrics sync failed"
+          body=$(printf '%s\n\n%s\n' \
+              "The scheduled sync failed: ${RUN_URL}" \
+              "Re-run it from the Actions tab with workflow_dispatch. Reports are keyed by the period they describe, so a retry re-sends the same events and PostHog deduplicates them. Docker retains only the last few reports, so a period that ages out cannot be recovered.")
+          existing=$(gh issue list --state open --search "${title} in:title" \
+              --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+              gh issue comment "${existing}" --body "${body}"
+          else
+              gh issue create --title "${title}" --body "${body}"
+          fi

--- a/.github/workflows/release-download-metrics.yml
+++ b/.github/workflows/release-download-metrics.yml
@@ -21,6 +21,7 @@ on:
   pull_request:
     paths:
       - "scripts/sync-release-downloads.sh"
+      - "scripts/lib/posthog-snapshot.sh"
       - ".github/workflows/release-download-metrics.yml"
 
 permissions:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,7 +13,8 @@ Release and install helpers.
 | [`sync-release-downloads.sh`](sync-release-downloads.sh) | Snapshot cumulative release-asset download totals into PostHog |
 | [`sync-cloudsmith-downloads.sh`](sync-cloudsmith-downloads.sh) | Snapshot cumulative Cloudsmith package download totals into PostHog |
 | [`sync-docker-downloads.sh`](sync-docker-downloads.sh) | Snapshot cumulative Docker Hub pull totals into PostHog |
-| [`lib/posthog-snapshot.sh`](lib/posthog-snapshot.sh) | Shared machinery the three snapshot scripts source |
+| [`sync-docker-dvp-reports.sh`](sync-docker-dvp-reports.sh) | Snapshot Docker Verified Publisher pull reports into PostHog |
+| [`lib/posthog-snapshot.sh`](lib/posthog-snapshot.sh) | Shared machinery the snapshot scripts source |
 
 `BRANCH_NAME` selects the release channel; see
 [the release channels design note](../docs/design/release-channels.md).
@@ -277,6 +278,52 @@ add them together.
 | `DOCKER_HUB_HOST` | `https://hub.docker.com` | Docker Hub API host. |
 
 The PostHog variables are the same as the other two snapshots.
+
+## `sync-docker-dvp-reports.sh`
+
+```
+sync-docker-dvp-reports.sh [--dry-run] [--period YYYY-MM-DD] [--selftest]
+```
+
+Reads Docker Verified Publisher analytics reports and files them into PostHog.
+Run daily at 01:35 UTC by
+[the `Docker DVP metrics` workflow](../.github/workflows/docker-dvp-metrics.yml).
+
+Unlike the other snapshots this is not a cumulative counter sampled at run
+time. Each report states the counts for a closed period, so a period's value is
+final and needs no day-over-day differencing. Events are keyed by
+`(repository, granularity, period start)` and timestamped at the end of the
+period, so re-reading a report on any later day produces byte-identical events.
+
+Docker retains only the last few reports and nothing reconstructs one that ages
+out, which is the reason to run this daily even though reports appear weekly.
+
+`DATA_DOWNLOADS` counts image layer transfers; `VERSION_CHECKS` counts manifest
+requests that transferred no layers, and `EVENT_COUNT` is their sum. These are
+**not** comparable with the public counter that
+[`sync-docker-downloads.sh`](sync-docker-downloads.sh) records — a week of DVP
+events annualises far above that counter's all-time total, because the two
+measure different things. Keep the series apart and never add them together.
+
+Two implementation details worth knowing. The endpoint is
+`/api/publisher/proxylytics/v1`, not the `/api/publisher/analytics/v1` in
+Docker's published spec, which answers this namespace with no data at all. And
+each report restates the same aggregate at three `LEVEL`s — `namespace`,
+`publisher` and `repository` — so only repository rows are kept; taking all
+three double-counts.
+
+| Switch | Default | Effect |
+| --- | --- | --- |
+| `--period` | every retained report | Process only the report starting on this date. |
+| `--dry-run` / `DRY_RUN=1` | off | Fetch and build payloads, print them, send nothing. Still needs Docker credentials, since the catalogue is not public. |
+| `--selftest` | off | Run the built-in assertions and exit. Reaches no network. |
+| `DOCKER_USERNAME` | unset | Docker Hub account the token belongs to. Required. |
+| `DOCKER_TOKEN` | unset | Docker Hub personal access token, exchanged for a short-lived JWT on every run. Required. |
+| `DOCKER_NAMESPACE` | `mezmo` | Publisher namespace to read reports for. |
+| `DOCKER_IMAGES` | `mezmo/aura` | Space-separated repositories to keep from each report. |
+| `DVP_GRANULARITY` | `weekly` | `weekly` or `monthly`. Mixing both in one series double-counts. |
+
+The PostHog variables are the same as the other snapshots.
 
 ## `bump-homebrew-tap.sh`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,7 +13,7 @@ Release and install helpers.
 | [`sync-release-downloads.sh`](sync-release-downloads.sh) | Snapshot cumulative release-asset download totals into PostHog |
 | [`sync-cloudsmith-downloads.sh`](sync-cloudsmith-downloads.sh) | Snapshot cumulative Cloudsmith package download totals into PostHog |
 | [`sync-docker-downloads.sh`](sync-docker-downloads.sh) | Snapshot cumulative Docker Hub pull totals into PostHog |
-| [`sync-docker-dvp-reports.sh`](sync-docker-dvp-reports.sh) | Snapshot Docker Verified Publisher pull reports into PostHog |
+| [`sync-docker-dvp-reports.sh`](sync-docker-dvp-reports.sh) | Snapshot Docker Verified Publisher pulls per tag into PostHog |
 | [`lib/posthog-snapshot.sh`](lib/posthog-snapshot.sh) | Shared machinery the snapshot scripts source |
 
 `BRANCH_NAME` selects the release channel; see
@@ -298,8 +298,18 @@ period, so re-reading a report on any later day produces byte-identical events.
 Docker retains only the last few reports and nothing reconstructs one that ages
 out, which is the reason to run this daily even though reports appear weekly.
 
+Events are one per `(repository, tag)`. The trend report splits each tag
+further by country, cloud provider and client; those rows are summed back up,
+since the tag is what this records, and summing every tag reproduces the totals
+the summary report states.
+
+Most pulls carry **no tag** — they are pulls by digest, which the export marks
+with a literal `\\N`. Those arrive as `tag: null` with `by_digest: true`. For
+`mezmo/aura` they were 963 of 1,614 pulls in the week of 2026-08-31, so a query
+that filters to named tags only sees a minority of activity.
+
 `DATA_DOWNLOADS` counts image layer transfers; `VERSION_CHECKS` counts manifest
-requests that transferred no layers, and `EVENT_COUNT` is their sum. These are
+requests that transferred no layers, and `PULLS` is their sum. These are
 **not** comparable with the public counter that
 [`sync-docker-downloads.sh`](sync-docker-downloads.sh) records — a week of DVP
 events annualises far above that counter's all-time total, because the two

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -331,9 +331,8 @@ measure different things. Keep the series apart and never add them together.
 Two implementation details worth knowing. The endpoint is
 `/api/publisher/proxylytics/v1`, not the `/api/publisher/analytics/v1` in
 Docker's published spec, which answers this namespace with no data at all. And
-each report restates the same aggregate at three `LEVEL`s — `namespace`,
-`publisher` and `repository` — so only repository rows are kept; taking all
-three double-counts.
+report rows are parsed with a quote-aware CSV split, so a field that grows a
+comma shifts no columns.
 
 | Switch | Default | Effect |
 | --- | --- | --- |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,8 @@ Release and install helpers.
 | [`next-version.mjs`](next-version.mjs) | Print the version semantic-release would release next |
 | [`sync-release-downloads.sh`](sync-release-downloads.sh) | Snapshot cumulative release-asset download totals into PostHog |
 | [`sync-cloudsmith-downloads.sh`](sync-cloudsmith-downloads.sh) | Snapshot cumulative Cloudsmith package download totals into PostHog |
+| [`sync-docker-downloads.sh`](sync-docker-downloads.sh) | Snapshot cumulative Docker Hub pull totals into PostHog |
+| [`lib/posthog-snapshot.sh`](lib/posthog-snapshot.sh) | Shared machinery the three snapshot scripts source |
 
 `BRANCH_NAME` selects the release channel; see
 [the release channels design note](../docs/design/release-channels.md).
@@ -244,6 +246,37 @@ read fails rather than returning a shorter list.
 | `CLOUDSMITH_HOST` | `https://api.cloudsmith.io` | Cloudsmith API host. |
 | `PAGE_SIZE` | `500` | Packages per Cloudsmith page. `500` is the server's maximum; a larger value is clamped to it. |
 | `BATCH_SIZE` | `1000` | Events per PostHog `/batch` request. |
+
+## `sync-docker-downloads.sh`
+
+```
+sync-docker-downloads.sh [--dry-run] [--date YYYY-MM-DD] [--selftest]
+```
+
+Sends one PostHog event per Docker Hub image, carrying that image's cumulative
+pull count as of a snapshot date. Run daily at 01:29 UTC by
+[the `Docker download metrics` workflow](../.github/workflows/docker-download-metrics.yml).
+Needs no Docker credentials: the repository endpoint is public.
+
+Shares [`lib/posthog-snapshot.sh`](lib/posthog-snapshot.sh) with the other two
+snapshots, so identifiers, batching, sending, the per-batch probe and the
+read-back all behave identically. Report with `max(pull_count)` per image and
+snapshot date, for the reason given under `sync-release-downloads.sh`.
+
+The public counter is not the same measure as the Docker Verified Publisher
+reports: a week of DVP events annualises far above this counter's all-time
+total, because the two count different things. Keep the series apart and never
+add them together.
+
+| Switch | Default | Effect |
+| --- | --- | --- |
+| `--date` / `SNAPSHOT_DATE` | yesterday, UTC | Date to snapshot. Re-running a past date stamps today's counters with it. |
+| `--dry-run` / `DRY_RUN=1` | off | Collect and build the payload, print the first event, send nothing. |
+| `--selftest` | off | Run the built-in assertions and exit. Reaches no network. |
+| `DOCKER_IMAGES` | `mezmo/aura` | Space-separated `namespace/image` list to snapshot. |
+| `DOCKER_HUB_HOST` | `https://hub.docker.com` | Docker Hub API host. |
+
+The PostHog variables are the same as the other two snapshots.
 
 ## `bump-homebrew-tap.sh`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -282,7 +282,8 @@ The PostHog variables are the same as the other two snapshots.
 ## `sync-docker-dvp-reports.sh`
 
 ```
-sync-docker-dvp-reports.sh [--dry-run] [--period YYYY-MM-DD] [--selftest]
+sync-docker-dvp-reports.sh [--dry-run] [--period YYYY-MM-DD]
+                           [--report trend|technographic] [--selftest]
 ```
 
 Reads Docker Verified Publisher analytics reports and files them into PostHog.
@@ -298,10 +299,22 @@ period, so re-reading a report on any later day produces byte-identical events.
 Docker retains only the last few reports and nothing reconstructs one that ages
 out, which is the reason to run this daily even though reports appear weekly.
 
-Events are one per `(repository, tag)`. The trend report splits each tag
-further by country, cloud provider and client; those rows are summed back up,
-since the tag is what this records, and summing every tag reproduces the totals
-the summary report states.
+`--report trend` emits one event per `(repository, tag, user_agent,
+cloud_service_provider)` — 95 a week for `mezmo/aura`. Country is summed back
+up. Summing every group reproduces the totals the summary report states.
+
+The client and cloud provider are what separate a person from a pipeline:
+`containerd` and `buildkit` are never someone's laptop, and a pull from a cloud
+provider is infrastructure by definition. Neither is proof alone, so both are
+recorded rather than folded into a verdict.
+
+`--report technographic` answers "how many people", which the trend report
+cannot: its per-row unique counts cannot be added up, because one person
+pulling two tags appears in both rows. This report states `TOTAL_PULLERS` and
+`TOTAL_DOMAINS` deduplicated for the whole period — 55 users across 10 domains
+for `mezmo/aura` in the week of 2026-08-24. It emits one event per image
+carrying those totals, plus one per image its pullers also pull. The totals
+repeat on every row, so report them with `max()`, never `sum()`.
 
 Most pulls carry **no tag** — they are pulls by digest, which the export marks
 with a literal `\\N`. Those arrive as `tag: null` with `by_digest: true`. For
@@ -324,6 +337,7 @@ three double-counts.
 
 | Switch | Default | Effect |
 | --- | --- | --- |
+| `--report` / `REPORT_TYPE` | `trend` | Which report to read. `trend` counts pulls per tag, client and cloud provider; `technographic` counts the distinct people and organisations pulling. |
 | `--period` | every retained report | Process only the report starting on this date. |
 | `--dry-run` / `DRY_RUN=1` | off | Fetch and build payloads, print them, send nothing. Still needs Docker credentials, since the catalogue is not public. |
 | `--selftest` | off | Run the built-in assertions and exit. Reaches no network. |

--- a/scripts/lib/posthog-snapshot.sh
+++ b/scripts/lib/posthog-snapshot.sh
@@ -1,0 +1,241 @@
+# Shared machinery for the PostHog download-snapshot scripts.
+#
+# Each snapshot script collects download counters from one source and files
+# them against a date. Everything here is the part that does not depend on
+# which source: identifiers, batching, sending, and the read-back that proves
+# the send landed. A caller supplies the collector and its own main.
+#
+# Set before sourcing:
+#   EVENT_NAME      - PostHog event name for one snapshot record
+#   UUID_NAMESPACE  - namespace for the version-5 event UUIDs, permanent
+#   SUBJECT_PREFIX  - distinct_id prefix naming the source, e.g. "github"
+#   COUNT_PROPERTY  - event property holding the counter (default download_count)
+#
+# The configuration variables below are defaulted here and read by callers.
+# A caller owns WORK_DIR and must point it at a directory it created.
+
+POSTHOG_HOST="${POSTHOG_HOST:-https://us.i.posthog.com}"
+POSTHOG_API_HOST="${POSTHOG_API_HOST:-https://us.posthog.com}"
+POSTHOG_PROJECT_ID="${POSTHOG_PROJECT_ID:-443794}"
+BATCH_SIZE="${BATCH_SIZE:-1000}"
+VERIFY_TIMEOUT="${VERIFY_TIMEOUT:-600}"
+SKIP_VERIFY="${SKIP_VERIFY:-0}"
+DRY_RUN="${DRY_RUN:-0}"
+SNAPSHOT_DATE="${SNAPSHOT_DATE:-}"
+COUNT_PROPERTY="${COUNT_PROPERTY:-download_count}"
+WORK_DIR=""
+
+# RFC 4122 version-5 UUID: sha1(namespace bytes || name), with the version and
+# variant nibbles forced. Matches Python's uuid.uuid5 byte for byte.
+uuid5() {
+    local ns_hex=${1//-/} name=$2 h b6 b8
+    h=$( { printf '%b' "$(printf '%s' "${ns_hex}" | sed 's/../\\x&/g')"; printf '%s' "${name}"; } \
+         | openssl dgst -sha1 -r | cut -d' ' -f1 )
+    printf -v b6 '%02x' $(( 0x${h:12:2} & 0x0f | 0x50 ))
+    printf -v b8 '%02x' $(( 0x${h:16:2} & 0x3f | 0x80 ))
+    printf '%s-%s-%s%s-%s%s-%s\n' \
+        "${h:0:8}" "${h:8:4}" "${b6}" "${h:14:2}" "${b8}" "${h:18:2}" "${h:20:12}"
+}
+
+# Dates go through jq rather than date(1): GNU and BSD date disagree on both
+# relative-date syntaxes, and jq is already a hard dependency here. jq's
+# strftime formats UTC regardless of the runner's timezone.
+# A fresh UUID, so nothing an earlier run wrote can be mistaken for it.
+uuid4() {
+    local h b6 b8
+    h=$(openssl rand -hex 16)
+    printf -v b6 '%02x' $(( 0x${h:12:2} & 0x0f | 0x40 ))
+    printf -v b8 '%02x' $(( 0x${h:16:2} & 0x3f | 0x80 ))
+    printf '%s-%s-%s%s-%s%s-%s\n' \
+        "${h:0:8}" "${h:8:4}" "${b6}" "${h:14:2}" "${b8}" "${h:18:2}" "${h:20:12}"
+}
+
+yesterday_utc() {
+    jq -rn 'now - 86400 | strftime("%Y-%m-%d")'
+}
+
+day_before() {
+    jq -rn --arg d "$1" '($d + "T00:00:00Z" | fromdateiso8601) - 86400 | strftime("%Y-%m-%d")'
+}
+
+# A shell glob accepts digit-shaped nonsense like 2026-99-99, and an invalid
+# date reaches the wire as a malformed event timestamp. Round-trip the value
+# through jq's calendar and require it back unchanged: that rejects impossible
+# dates outright and catches the ones a parser silently rolls over, such as
+# 2026-02-30 becoming 2026-03-02.
+valid_date() {
+    local d=$1 normalized
+    case "${d}" in
+        [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+        *) return 1 ;;
+    esac
+    normalized=$(jq -rn --arg d "${d}" \
+        'try ($d + "T00:00:00Z" | fromdateiso8601 | strftime("%Y-%m-%d")) catch ""')
+    [ "${normalized}" = "${d}" ]
+}
+
+# Run a HogQL query and print the response body.
+#
+# Plain --retry covers the transient cases (timeouts, 429, 5xx) and leaves
+# 4xx alone: an auth or project error repeated four times is noise, and the
+# status is worth naming because every likely cause is a misconfiguration
+# rather than an outage.
+hogql_request() {
+    local query=$1 response status body
+    response=$(jq -n --arg q "${query}" '{query: {kind: "HogQLQuery", query: $q}}' \
+        | curl --silent --show-error --retry 3 --retry-delay 2 --max-time 60 \
+            --write-out '\n%{http_code}' \
+            --header "Authorization: Bearer ${POSTHOG_API_READ_KEY}" \
+            --header 'Content-Type: application/json' \
+            --data-binary @- \
+            "${POSTHOG_API_HOST%/}/api/projects/${POSTHOG_PROJECT_ID}/query/")
+    status=${response##*$'\n'}
+    body=${response%$'\n'*}
+    if [ "${status}" != 200 ]; then
+        echo "error: PostHog query API returned ${status} for project ${POSTHOG_PROJECT_ID}" >&2
+        echo "       ${body}" >&2
+        echo "       POSTHOG_PROJECT_ID must name the project POSTHOG_PROJECT_API_KEY writes to," >&2
+        echo "       and POSTHOG_API_READ_KEY must hold query:read on that project" >&2
+        return 1
+    fi
+    printf '%s\n' "${body}"
+}
+
+hogql_scalar() {
+    hogql_request "$1" | jq -r '.results[0][0]'
+}
+
+# The whole first row, tab separated.
+hogql_row() {
+    hogql_request "$1" | jq -r '.results[0] | @tsv'
+}
+
+# Count what actually landed. Distinct UUIDs, not rows: PostHog deduplicates
+# lazily during background merges, so a re-run's rows stay visible until then.
+#
+# printf builds the literals rather than nested shell quoting, which is easy to
+# get wrong in a way that still returns a well-formed answer: a quote stray
+# inside the string literal matches no rows and reads as "nothing ingested".
+snapshot_count_query() {
+    printf "SELECT count(DISTINCT uuid) FROM events WHERE event = '%s' AND properties.snapshot_date = '%s'" \
+        "${EVENT_NAME}" "$1"
+}
+
+# Add a probe event to a payload, carrying a UUID no other run can produce.
+#
+# The snapshot events are identical across runs of the same date by design, so
+# finding them proves the snapshot is right but not that this run wrote
+# anything: PostHog answers 200 OK to a batch sent with a dead token, and on a
+# re-run of an already-populated date the stale rows satisfy every check. The
+# probe rides the same request, so it is absent exactly when that request was
+# discarded.
+add_probe() {
+    local payload=$1 probe=$2 ts
+    ts=$(jq -rn 'now | strftime("%Y-%m-%dT%H:%M:%SZ")')
+    jq --arg uuid "${probe}" --arg ts "${ts}" --arg event "${EVENT_NAME}_probe" --arg prefix "${SUBJECT_PREFIX}" '
+        .batch += [{uuid: $uuid, event: $event, distinct_id: ($prefix + ":probe"),
+                    timestamp: $ts,
+                    properties: {"$process_person_profile": false}}]' \
+        "${payload}" > "${payload}.probed"
+    mv "${payload}.probed" "${payload}"
+}
+
+probes_landed() {
+    local list
+    list=$(sed "s/^/'/; s/$/'/" "${WORK_DIR}/probes" | paste -sd, -)
+    hogql_scalar "SELECT count(DISTINCT uuid) FROM events \
+        WHERE event = '${EVENT_NAME}_probe' AND uuid IN (${list})"
+}
+
+post_batch() {
+    local payload=$1
+    curl --silent --show-error --fail-with-body \
+        --retry 5 --retry-delay 2 \
+        --max-time 60 \
+        --header 'Content-Type: application/json' \
+        --data-binary "@${payload}" \
+        "${POSTHOG_HOST%/}/batch/" >/dev/null
+}
+
+build_batch() {
+    local chunk=$1 date=$2 api_key=$3
+    jq -R -n --arg key "${api_key}" --arg date "${date}" --arg event "${EVENT_NAME}" --arg prefix "${SUBJECT_PREFIX}" '
+        {api_key: $key,
+         batch: [inputs
+           | index("\t") as $i
+           | (.[:$i]) as $uuid
+           | (.[$i+1:] | fromjson) as $r
+           | {uuid: $uuid,
+              event: $event,
+              distinct_id: ($prefix + ":" + $r.repository),
+              timestamp: ($date + "T23:59:59Z"),
+              properties: ($r + {snapshot_date: $date, "$process_person_profile": false})}]}
+    ' "${chunk}"
+}
+
+# Report how many of this run's own event UUIDs are queryable at this run's
+# timestamp, and what download total those events carry.
+#
+# The count alone is not enough. A date-wide count would let UUIDs from an
+# earlier run cover for a missing event, and scoping to this run's UUIDs still
+# cannot see a discarded retry whose asset set is unchanged, because the
+# earlier run already ingested those exact UUIDs. The total closes that:
+# counters only rise, so a stale row carries a smaller number than the payload
+# just sent. Pinning the timestamp keeps a snapshot filed against the wrong
+# instant from reading as verified.
+count_ingested() {
+    local date=$1 chunk list row found downloads events=0 total=0
+    for chunk in "${WORK_DIR}"/uchunk.*; do
+        list=$(sed "s/^/'/; s/$/'/" "${chunk}" | paste -sd, -)
+        row=$(hogql_row "SELECT count(), sum(dl) FROM ( \
+            SELECT uuid, max(toIntOrZero(toString(properties.${COUNT_PROPERTY}))) AS dl \
+            FROM events \
+            WHERE event = '${EVENT_NAME}' \
+              AND timestamp = toDateTime('${date} 23:59:59') \
+              AND uuid IN (${list}) \
+            GROUP BY uuid)")
+        found=${row%%$'\t'*}
+        downloads=${row##*$'\t'}
+        # A chunk none of whose events are queryable yet answers with count 0
+        # and a null total, which @tsv renders as an empty field. That is
+        # "nothing has landed yet", which the poll is here to wait out, not a
+        # malformed answer to abort on.
+        case "${found}" in '' | null) found=0 ;; esac
+        case "${downloads}" in '' | null) downloads=0 ;; esac
+        for value in "${found}" "${downloads}"; do
+            case "${value}" in
+                '' | *[!0-9]*)
+                    echo "error: PostHog answered the read-back with '${row}', which is not a count and a total" >&2
+                    return 1 ;;
+            esac
+        done
+        events=$(( events + found ))
+        total=$(( total + downloads ))
+    done
+    printf '%s\t%s\n' "${events}" "${total}"
+}
+
+# Poll until the snapshot is queryable, since ingestion lags the send.
+verify_snapshot() {
+    local date=$1 expected=$2 expected_downloads=$3 probes=$4
+    local deadline row got downloads seen
+    split -l 500 "${WORK_DIR}/uuids" "${WORK_DIR}/uchunk."
+    deadline=$(( $(date +%s) + VERIFY_TIMEOUT ))
+    while :; do
+        row=$(count_ingested "${date}")
+        got=${row%%$'\t'*}
+        downloads=${row##*$'\t'}
+        seen=$(probes_landed)
+        case "${seen}" in '' | null) seen=0 ;; esac
+        if [ "${got}" -ge "${expected}" ] && [ "${downloads}" -ge "${expected_downloads}" ] \
+           && [ "${seen}" -ge "${probes}" ]; then
+            echo "Verified ${got} of ${expected} event(s), ${downloads} counted, and ${seen} probe(s) in PostHog for ${date}"
+            return 0
+        fi
+        if [ "$(date +%s)" -ge "${deadline}" ]; then
+            echo "error: PostHog holds ${got} of ${expected} event(s), ${downloads} of ${expected_downloads} counted, and ${seen} of ${probes} probe(s) for ${date} after ${VERIFY_TIMEOUT}s" >&2
+            return 1
+        fi
+        sleep 5
+    done
+}

--- a/scripts/sync-cloudsmith-downloads.sh
+++ b/scripts/sync-cloudsmith-downloads.sh
@@ -52,20 +52,16 @@ USAGE="usage: $0 [--dry-run] [--date YYYY-MM-DD] [--selftest]"
 # event key ever sent.
 readonly UUID_NAMESPACE="0d08662c-b474-467e-b476-20688fdb1f2c"
 readonly EVENT_NAME="cloudsmith_package_downloads"
+readonly SUBJECT_PREFIX="cloudsmith"
 
-DRY_RUN="${DRY_RUN:-0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/posthog-snapshot.sh
+. "${SCRIPT_DIR}/lib/posthog-snapshot.sh"
+
 SELFTEST=0
-SNAPSHOT_DATE="${SNAPSHOT_DATE:-}"
-POSTHOG_HOST="${POSTHOG_HOST:-https://us.i.posthog.com}"
 CLOUDSMITH_REPOS="${CLOUDSMITH_REPOS:-mezmo/aura}"
 CLOUDSMITH_HOST="${CLOUDSMITH_HOST:-https://api.cloudsmith.io}"
 PAGE_SIZE="${PAGE_SIZE:-500}"
-BATCH_SIZE="${BATCH_SIZE:-1000}"
-POSTHOG_PROJECT_ID="${POSTHOG_PROJECT_ID:-443794}"
-POSTHOG_API_HOST="${POSTHOG_API_HOST:-https://us.posthog.com}"
-VERIFY_TIMEOUT="${VERIFY_TIMEOUT:-600}"
-SKIP_VERIFY="${SKIP_VERIFY:-0}"
-WORK_DIR=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -79,56 +75,6 @@ while [ $# -gt 0 ]; do
         *) echo "${USAGE}" >&2; exit 1 ;;
     esac
 done
-
-# RFC 4122 version-5 UUID: sha1(namespace bytes || name), with the version and
-# variant nibbles forced. Matches Python's uuid.uuid5 byte for byte.
-uuid5() {
-    local ns_hex=${1//-/} name=$2 h b6 b8
-    h=$( { printf '%b' "$(printf '%s' "${ns_hex}" | sed 's/../\\x&/g')"; printf '%s' "${name}"; } \
-         | openssl dgst -sha1 -r | cut -d' ' -f1 )
-    printf -v b6 '%02x' $(( 0x${h:12:2} & 0x0f | 0x50 ))
-    printf -v b8 '%02x' $(( 0x${h:16:2} & 0x3f | 0x80 ))
-    printf '%s-%s-%s%s-%s%s-%s\n' \
-        "${h:0:8}" "${h:8:4}" "${b6}" "${h:14:2}" "${b8}" "${h:18:2}" "${h:20:12}"
-}
-
-# A fresh UUID, so nothing an earlier run wrote can be mistaken for it.
-uuid4() {
-    local h b6 b8
-    h=$(openssl rand -hex 16)
-    printf -v b6 '%02x' $(( 0x${h:12:2} & 0x0f | 0x40 ))
-    printf -v b8 '%02x' $(( 0x${h:16:2} & 0x3f | 0x80 ))
-    printf '%s-%s-%s%s-%s%s-%s\n' \
-        "${h:0:8}" "${h:8:4}" "${b6}" "${h:14:2}" "${b8}" "${h:18:2}" "${h:20:12}"
-}
-
-# Dates go through jq rather than date(1): GNU and BSD date disagree on both
-# relative-date syntaxes, and jq is already a hard dependency here. jq's
-# strftime formats UTC regardless of the runner's timezone.
-yesterday_utc() {
-    jq -rn 'now - 86400 | strftime("%Y-%m-%d")'
-}
-
-day_before() {
-    jq -rn --arg d "$1" '($d + "T00:00:00Z" | fromdateiso8601) - 86400 | strftime("%Y-%m-%d")'
-}
-
-# A shell glob accepts digit-shaped nonsense like 2026-99-99, and an invalid
-# date reaches the wire as a malformed event timestamp. Round-trip the value
-# through jq's calendar and require it back unchanged: that rejects impossible
-# dates outright and catches the ones a parser silently rolls over, such as
-# 2026-02-30 becoming 2026-03-02. The glob also keeps a quote out of the date,
-# which the read-back interpolates into a SQL literal.
-valid_date() {
-    local d=$1 normalized
-    case "${d}" in
-        [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
-        *) return 1 ;;
-    esac
-    normalized=$(jq -rn --arg d "${d}" \
-        'try ($d + "T00:00:00Z" | fromdateiso8601 | strftime("%Y-%m-%d")) catch ""')
-    [ "${normalized}" = "${d}" ]
-}
 
 require_tools() {
     local tool
@@ -262,158 +208,6 @@ key_packages() {
         uuid5 "${UUID_NAMESPACE}" "${key}|${date}"
     done < "${keys}" > "${uuids}"
     paste "${uuids}" "${packages}"
-}
-
-build_batch() {
-    local chunk=$1 date=$2 api_key=$3
-    jq -R -n --arg key "${api_key}" --arg date "${date}" --arg event "${EVENT_NAME}" '
-        {api_key: $key,
-         batch: [inputs
-           | index("\t") as $i
-           | (.[:$i]) as $uuid
-           | (.[$i+1:] | fromjson) as $r
-           | {uuid: $uuid,
-              event: $event,
-              distinct_id: ("cloudsmith:" + $r.repository),
-              timestamp: ($date + "T23:59:59Z"),
-              properties: ($r + {snapshot_date: $date, "$process_person_profile": false})}]}
-    ' "${chunk}"
-}
-
-# Add a probe event to a payload, carrying a UUID no other run can produce.
-#
-# The snapshot events are identical across runs of the same date by design, so
-# finding them proves the snapshot is right but not that this run wrote
-# anything: PostHog answers 200 OK to a batch sent with a dead token, and on a
-# re-run of an already-populated date the stale rows satisfy every check. The
-# probe rides the same request, so it is absent exactly when that request was
-# discarded.
-add_probe() {
-    local payload=$1 probe=$2 ts
-    ts=$(jq -rn 'now | strftime("%Y-%m-%dT%H:%M:%SZ")')
-    jq --arg uuid "${probe}" --arg ts "${ts}" --arg event "${EVENT_NAME}_probe" '
-        .batch += [{uuid: $uuid, event: $event, distinct_id: "cloudsmith:probe",
-                    timestamp: $ts,
-                    properties: {"$process_person_profile": false}}]' \
-        "${payload}" > "${payload}.probed"
-    mv "${payload}.probed" "${payload}"
-}
-
-probes_landed() {
-    local list
-    list=$(sed "s/^/'/; s/$/'/" "${WORK_DIR}/probes" | paste -sd, -)
-    hogql_scalar "SELECT count(DISTINCT uuid) FROM events \
-        WHERE event = '${EVENT_NAME}_probe' AND uuid IN (${list})"
-}
-
-post_batch() {
-    local payload=$1
-    curl --silent --show-error --fail-with-body \
-        --retry 5 --retry-delay 2 \
-        --max-time 60 \
-        --header 'Content-Type: application/json' \
-        --data-binary "@${payload}" \
-        "${POSTHOG_HOST%/}/batch/" >/dev/null
-}
-
-# Run a HogQL query and print the response body.
-#
-# Plain --retry covers the transient cases (timeouts, 429, 5xx) and leaves
-# 4xx alone: an auth or project error repeated four times is noise, and the
-# status is worth naming because every likely cause is a misconfiguration
-# rather than an outage.
-hogql_request() {
-    local query=$1 response status body
-    response=$(jq -n --arg q "${query}" '{query: {kind: "HogQLQuery", query: $q}}' \
-        | curl --silent --show-error --retry 3 --retry-delay 2 --max-time 60 \
-            --write-out '\n%{http_code}' \
-            --header "Authorization: Bearer ${POSTHOG_API_READ_KEY}" \
-            --header 'Content-Type: application/json' \
-            --data-binary @- \
-            "${POSTHOG_API_HOST%/}/api/projects/${POSTHOG_PROJECT_ID}/query/")
-    status=${response##*$'\n'}
-    body=${response%$'\n'*}
-    if [ "${status}" != 200 ]; then
-        echo "error: PostHog query API returned ${status} for project ${POSTHOG_PROJECT_ID}" >&2
-        echo "       ${body}" >&2
-        echo "       POSTHOG_PROJECT_ID must name the project POSTHOG_PROJECT_API_KEY writes to," >&2
-        echo "       and POSTHOG_API_READ_KEY must hold query:read on that project" >&2
-        return 1
-    fi
-    printf '%s\n' "${body}"
-}
-
-hogql_scalar() {
-    hogql_request "$1" | jq -r '.results[0][0]'
-}
-
-# The whole first row, tab separated.
-hogql_row() {
-    hogql_request "$1" | jq -r '.results[0] | @tsv'
-}
-
-# Count how many of this run's own event UUIDs are queryable at this run's
-# timestamp. A date-wide count would also match UUIDs left by an earlier run
-# whose package set differed, and those extras can satisfy the threshold while
-# an event from the current payload is still missing. Pinning the timestamp too
-# means a snapshot attributed to the wrong instant cannot read as verified.
-count_ingested() {
-    local date=$1 chunk list row found downloads value events=0 total=0
-    for chunk in "${WORK_DIR}"/uchunk.*; do
-        list=$(sed "s/^/'/; s/$/'/" "${chunk}" | paste -sd, -)
-        row=$(hogql_row "SELECT count(), sum(dl) FROM ( \
-            SELECT uuid, max(toIntOrZero(toString(properties.download_count))) AS dl \
-            FROM events \
-            WHERE event = '${EVENT_NAME}' \
-              AND timestamp = toDateTime('${date} 23:59:59') \
-              AND uuid IN (${list}) \
-            GROUP BY uuid)")
-        found=${row%%$'\t'*}
-        downloads=${row##*$'\t'}
-        case "${found}" in '' | null) found=0 ;; esac
-        case "${downloads}" in '' | null) downloads=0 ;; esac
-        for value in "${found}" "${downloads}"; do
-            case "${value}" in
-                '' | *[!0-9]*)
-                    echo "error: PostHog answered the read-back with '${row}', which is not a count and a total" >&2
-                    return 1 ;;
-            esac
-        done
-        events=$(( events + found ))
-        total=$(( total + downloads ))
-    done
-    printf '%s\t%s\n' "${events}" "${total}"
-}
-
-# A date-wide count, for asking whether a day holds any snapshot at all. This
-# run has no UUIDs for an earlier date to scope by.
-snapshot_count_query() {
-    printf "SELECT count(DISTINCT uuid) FROM events WHERE event = '%s' AND properties.snapshot_date = '%s'" \
-        "${EVENT_NAME}" "$1"
-}
-
-# Poll until the snapshot is queryable, since ingestion lags the send.
-verify_snapshot() {
-    local date=$1 want_events=$2 want_downloads=$3 probes=$4
-    local deadline row events downloads seen
-    deadline=$(( $(date +%s) + VERIFY_TIMEOUT ))
-    while :; do
-        row=$(count_ingested "${date}")
-        events=${row%%$'\t'*}
-        downloads=${row##*$'\t'}
-        seen=$(probes_landed)
-        case "${seen}" in '' | null) seen=0 ;; esac
-        if [ "${events}" -ge "${want_events}" ] && [ "${downloads}" -ge "${want_downloads}" ] \
-           && [ "${seen}" -ge "${probes}" ]; then
-            echo "Verified ${events} of ${want_events} event(s), ${downloads} download(s), and ${seen} probe(s) in PostHog for ${date}"
-            return 0
-        fi
-        if [ "$(date +%s)" -ge "${deadline}" ]; then
-            echo "error: PostHog holds ${events} of ${want_events} event(s), ${downloads} of ${want_downloads} download(s), and ${seen} of ${probes} probe(s) for ${date} after ${VERIFY_TIMEOUT}s" >&2
-            return 1
-        fi
-        sleep 5
-    done
 }
 
 # A dropped or disabled scheduled run leaves a hole no failure reports, since

--- a/scripts/sync-docker-downloads.sh
+++ b/scripts/sync-docker-downloads.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# Snapshot cumulative Docker Hub pull totals into PostHog.
+#
+# Sends one PostHog event per image carrying that image's cumulative pull
+# count. Retries are safe: the event UUID is derived from (image, snapshot
+# date) and the timestamp is pinned to 23:59:59Z on the snapshot date, so
+# re-running a date re-sends byte-identical events that PostHog deduplicates.
+#
+# The count is approximate for the day it names. Docker Hub publishes only a
+# live cumulative counter, never a historical one, so a run reads the counter
+# at the moment it executes and attributes it to the previous UTC day. Every
+# snapshot carries the same offset, so day-over-day differences still cover a
+# true 24 hours; a single day's cumulative value runs slightly ahead of its
+# label. Naming an older date does not reconstruct it.
+#
+# Reporting should aggregate with max(pull_count) per image and snapshot date.
+# PostHog deduplication is eventual, and cumulative counts only ever rise, so
+# max() is correct while duplicates remain visible.
+#
+# This is the public counter, which is not the same measure as the Docker
+# Verified Publisher reports: a week of DVP events annualises far above this
+# counter's all-time total, because the two count different things. Keep the
+# two series apart; never add them together.
+#
+# Usage: sync-docker-downloads.sh [--dry-run] [--date YYYY-MM-DD] [--selftest]
+#   --date       - snapshot date (default: yesterday, UTC)
+#   --dry-run    - collect and build the payload, print a summary, send nothing
+#   --selftest   - run the built-in assertions and exit
+#
+# Environment:
+#   POSTHOG_PROJECT_API_KEY - PostHog project write token (required unless --dry-run)
+#   POSTHOG_API_READ_KEY    - personal API key used to read the snapshot back
+#   POSTHOG_PROJECT_ID      - numeric project id the read-back queries (default: 443794)
+#   POSTHOG_HOST            - PostHog ingest host (default: https://us.i.posthog.com)
+#   POSTHOG_API_HOST        - PostHog query host (default: https://us.posthog.com)
+#   VERIFY_TIMEOUT          - seconds to wait for ingestion (default: 600)
+#   SKIP_VERIFY             - 1 sends without reading the snapshot back
+#   DOCKER_IMAGES           - space-separated namespace/image list (default: mezmo/aura)
+#   DOCKER_HUB_HOST         - Docker Hub API host (default: https://hub.docker.com)
+#   SNAPSHOT_DATE           - same as --date
+#   DRY_RUN                 - 1 is the same as --dry-run
+#   BATCH_SIZE              - events per PostHog /batch request (default: 1000)
+set -euo pipefail
+
+USAGE="usage: $0 [--dry-run] [--date YYYY-MM-DD] [--selftest]"
+
+# Namespace for the version-5 event UUIDs. Permanent: it is part of every
+# event key ever sent.
+readonly UUID_NAMESPACE="6d3cea6d-9fef-46af-aec1-e9c705245832"
+readonly EVENT_NAME="docker_image_pulls"
+readonly SUBJECT_PREFIX="docker"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/posthog-snapshot.sh
+. "${SCRIPT_DIR}/lib/posthog-snapshot.sh"
+
+COUNT_PROPERTY="pull_count"
+SELFTEST=0
+DOCKER_IMAGES="${DOCKER_IMAGES:-mezmo/aura}"
+DOCKER_HUB_HOST="${DOCKER_HUB_HOST:-https://hub.docker.com}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --selftest) SELFTEST=1; shift ;;
+        --date)
+            if [ $# -lt 2 ]; then echo "error: --date needs a value" >&2; exit 1; fi
+            SNAPSHOT_DATE="$2"; shift 2 ;;
+        --date=*) SNAPSHOT_DATE="${1#--date=}"; shift ;;
+        -h|--help) echo "${USAGE}" >&2; exit 0 ;;
+        *) echo "${USAGE}" >&2; exit 1 ;;
+    esac
+done
+
+require_tools() {
+    local tool
+    for tool in jq curl openssl; do
+        if ! command -v "${tool}" >/dev/null 2>&1; then
+            echo "error: ${tool} not found" >&2
+            exit 1
+        fi
+    done
+    if [ "${DRY_RUN}" != 1 ] && [ -z "${POSTHOG_PROJECT_API_KEY:-}" ]; then
+        echo "error: POSTHOG_PROJECT_API_KEY is required (or use --dry-run)" >&2
+        exit 1
+    fi
+    # PostHog answers 200 OK to a batch sent with an invalid project token, so
+    # a send that is never verified cannot tell success from silent discard.
+    if [ "${DRY_RUN}" != 1 ] && [ "${SKIP_VERIFY}" != 1 ] && [ -z "${POSTHOG_API_READ_KEY:-}" ]; then
+        echo "error: POSTHOG_API_READ_KEY is required to verify the send (or set SKIP_VERIFY=1)" >&2
+        exit 1
+    fi
+}
+
+# Emit one compact JSON object per image.
+#
+# The repository endpoint answers for a single image, so there is nothing to
+# paginate and no page-total race: each image costs one request whose absence
+# is fatal rather than silently short.
+collect_pulls() {
+    local image=$1 body="${WORK_DIR}/image.json" status
+    status=$(curl --silent --show-error --retry 3 --retry-delay 2 --max-time 30 \
+        --write-out '%{http_code}' --output "${body}" \
+        "${DOCKER_HUB_HOST%/}/v2/repositories/${image}/")
+    if [ "${status}" != 200 ]; then
+        echo "error: Docker Hub returned ${status} for ${image}" >&2
+        return 1
+    fi
+    jq -c '{repository: (.namespace + "/" + .name), namespace: .namespace,
+            image: .name, pull_count: .pull_count, star_count: .star_count}' "${body}"
+}
+
+# Prefix each image record with its event UUID, tab separated. The record stays
+# JSON throughout, so no field is parsed out of a delimited string.
+key_images() {
+    local images=$1 date=$2 uuids=$3 key
+    local keys="${uuids}.keys"
+    jq -r '"docker|" + .repository' "${images}" > "${keys}"
+    while IFS= read -r key; do
+        uuid5 "${UUID_NAMESPACE}" "${key}|${date}"
+    done < "${keys}" > "${uuids}"
+    paste "${uuids}" "${images}"
+}
+
+# A dropped or disabled scheduled run leaves a hole no failure reports, since
+# nothing ran to fail. Surface it on the next run that does happen.
+warn_on_gap() {
+    local date=$1 previous got
+    previous=$(day_before "${date}")
+    got=$(hogql_scalar "$(snapshot_count_query "${previous}")")
+    if [ "${got}" = "0" ]; then
+        echo "::warning::No Docker pull snapshot in PostHog for ${previous}; Docker Hub reports only current totals, so re-running that date would file today's counts under it"
+    fi
+}
+
+selftest() {
+    local tmp=$1 got want d payload
+
+    # Well-known RFC 4122 vector, an empty name, and a real event key.
+    got=$(uuid5 6ba7b810-9dad-11d1-80b4-00c04fd430c8 "python.org")
+    want="886313e1-3b8a-5372-9b90-0c9aee199e5d"
+    [ "${got}" = "${want}" ] || { echo "selftest: uuid5(python.org) = ${got}, want ${want}" >&2; exit 1; }
+
+    # The same key must key the same event on every run, and differ per date.
+    got=$(uuid5 "${UUID_NAMESPACE}" "docker|mezmo/aura|2026-09-01")
+    [ "${got}" = "$(uuid5 "${UUID_NAMESPACE}" "docker|mezmo/aura|2026-09-01")" ] \
+        || { echo "selftest: uuid5 is not deterministic" >&2; exit 1; }
+    [ "${got}" != "$(uuid5 "${UUID_NAMESPACE}" "docker|mezmo/aura|2026-09-02")" ] \
+        || { echo "selftest: uuid5 collides across snapshot dates" >&2; exit 1; }
+
+    # The probe UUID must be well formed and never repeat.
+    got=$(uuid4)
+    case "${got}" in
+        [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-*-4*-[89ab]*-*) ;;
+        *) echo "selftest: uuid4 produced '${got}'" >&2; exit 1 ;;
+    esac
+    [ "${got}" != "$(uuid4)" ] || { echo "selftest: uuid4 repeated" >&2; exit 1; }
+
+    # Calendar validation must reject digit-shaped non-dates and rollovers.
+    for d in 2026-09-01 2024-02-29 2026-12-31; do
+        valid_date "${d}" || { echo "selftest: rejected valid date ${d}" >&2; exit 1; }
+    done
+    for d in 2026-99-99 2026-13-01 2026-00-00 2026-02-30 2025-02-29 2026-9-1 "" "2026-09-0'"; do
+        if valid_date "${d}"; then echo "selftest: accepted invalid date '${d}'" >&2; exit 1; fi
+    done
+
+    # The read-back query must quote its literals exactly once.
+    got=$(snapshot_count_query "2026-08-20")
+    want="SELECT count(DISTINCT uuid) FROM events WHERE event = 'docker_image_pulls' AND properties.snapshot_date = '2026-08-20'"
+    [ "${got}" = "${want}" ] || { echo "selftest: query is"$'\n'"  ${got}"$'\n'"want"$'\n'"  ${want}" >&2; exit 1; }
+
+    # Date arithmetic across month, year, and leap-day boundaries.
+    got=$(day_before "2026-03-01"); want="2026-02-28"
+    [ "${got}" = "${want}" ] || { echo "selftest: day_before(2026-03-01) = ${got}, want ${want}" >&2; exit 1; }
+    got=$(TZ=Pacific/Auckland day_before "2024-03-01"); want="2024-02-29"
+    [ "${got}" = "${want}" ] || { echo "selftest: day_before is timezone-sensitive: ${got}" >&2; exit 1; }
+
+    # An image name is a plain path segment, but the counter must stay a number
+    # and the person profile must stay suppressed.
+    printf '%s\t%s\n' "3538a427-3e7d-5170-bf7d-e9560ebb3468" \
+        '{"repository":"mezmo/aura","namespace":"mezmo","image":"aura","pull_count":20098,"star_count":0}' \
+        > "${tmp}/chunk"
+    payload=$(build_batch "${tmp}/chunk" "2026-09-01" "phc_test")
+
+    got=$(jq -r '.batch[0].properties.pull_count | type' <<<"${payload}")
+    [ "${got}" = "number" ] || { echo "selftest: pull_count is ${got}, want number" >&2; exit 1; }
+    got=$(jq -r '.batch[0].timestamp' <<<"${payload}")
+    [ "${got}" = "2026-09-01T23:59:59Z" ] || { echo "selftest: timestamp = ${got}" >&2; exit 1; }
+    got=$(jq -r '.batch[0].distinct_id' <<<"${payload}")
+    [ "${got}" = "docker:mezmo/aura" ] || { echo "selftest: distinct_id = ${got}" >&2; exit 1; }
+    got=$(jq -r '.batch[0].properties["$process_person_profile"]' <<<"${payload}")
+    [ "${got}" = "false" ] || { echo "selftest: person profiles not suppressed" >&2; exit 1; }
+
+    echo "selftest: ok"
+}
+
+main() {
+    WORK_DIR=$(mktemp -d)
+    trap 'rm -rf "${WORK_DIR}"' EXIT
+
+    if [ "${SELFTEST}" = 1 ]; then
+        selftest "${WORK_DIR}"
+        return 0
+    fi
+
+    require_tools
+
+    local date="${SNAPSHOT_DATE}"
+    [ -n "${date}" ] || date=$(yesterday_utc)
+    if ! valid_date "${date}"; then
+        echo "error: --date must be a real calendar date as YYYY-MM-DD (got '${date}')" >&2
+        exit 1
+    fi
+
+    local image
+    for image in ${DOCKER_IMAGES}; do
+        echo "Collecting ${image} pull totals"
+        collect_pulls "${image}" >> "${WORK_DIR}/images.ndjson"
+    done
+
+    local images
+    images=$(wc -l < "${WORK_DIR}/images.ndjson" | tr -d ' ')
+    if [ "${images}" -eq 0 ]; then
+        echo "error: no images collected from ${DOCKER_IMAGES}" >&2
+        exit 1
+    fi
+
+    key_images "${WORK_DIR}/images.ndjson" "${date}" "${WORK_DIR}/uuids" > "${WORK_DIR}/keyed"
+    split -l "${BATCH_SIZE}" "${WORK_DIR}/keyed" "${WORK_DIR}/chunk."
+
+    local chunk chunks=0
+    for chunk in "${WORK_DIR}"/chunk.*; do
+        chunks=$((chunks + 1))
+        build_batch "${chunk}" "${date}" "${POSTHOG_PROJECT_API_KEY:-phc_dry_run}" \
+            > "${WORK_DIR}/payload.${chunks}.json"
+    done
+
+    # Every collected image must reach a payload. A mismatch means the keying
+    # or chunking dropped rows, which would silently under-report.
+    local events
+    events=$(jq -s '[.[].batch | length] | add' "${WORK_DIR}"/payload.*.json)
+    if [ "${events}" != "${images}" ]; then
+        echo "error: built ${events} event(s) from ${images} image(s)" >&2
+        exit 1
+    fi
+
+    local pulls
+    pulls=$(jq -s '[.[].pull_count] | add' "${WORK_DIR}/images.ndjson")
+    echo "Snapshot ${date}: ${images} image(s), ${pulls} pull(s), in ${chunks} batch(es)"
+
+    if [ "${DRY_RUN}" = 1 ]; then
+        jq -c '.batch[0]' "${WORK_DIR}/payload.1.json"
+        echo "Dry run: nothing sent to ${POSTHOG_HOST%/}"
+        return 0
+    fi
+
+    # Every batch carries its own probe. One probe in the first batch cannot
+    # speak for a later batch that was discarded, because the deterministic
+    # events a retry re-sends are already present from the earlier run.
+    local probe payload probes=0
+    : > "${WORK_DIR}/probes"
+    for payload in "${WORK_DIR}"/payload.*.json; do
+        probe=$(uuid4)
+        printf '%s\n' "${probe}" >> "${WORK_DIR}/probes"
+        add_probe "${payload}" "${probe}"
+        post_batch "${payload}"
+        probes=$(( probes + 1 ))
+    done
+
+    echo "Sent ${images} event(s) for ${date} to ${POSTHOG_HOST%/}"
+
+    if [ "${SKIP_VERIFY}" = 1 ]; then
+        echo "Skipping read-back verification (SKIP_VERIFY=1)"
+        return 0
+    fi
+    verify_snapshot "${date}" "${images}" "${pulls}" "${probes}"
+    # Advisory only: a missing earlier day is worth reporting but is not a
+    # failure of this run, and cannot be repaired by retrying it.
+    warn_on_gap "${date}" || true
+}
+
+main "$@"

--- a/scripts/sync-docker-dvp-reports.sh
+++ b/scripts/sync-docker-dvp-reports.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# Snapshot Docker Verified Publisher pull reports into PostHog.
+#
+# Docker publishes DVP analytics as CSV reports covering a whole week or month,
+# and retains only the last few. Nothing reconstructs a report once it ages
+# out, so this reads the catalogue on every run and files what is there.
+#
+# Unlike the other snapshots, the numbers here are not a cumulative counter
+# read at run time: each report states the counts for a closed period, so a
+# period's value is final and no day-over-day differencing is needed. Events
+# are keyed by (repository, granularity, period start) and timestamped at the
+# end of the period they describe, which makes a re-run of any report
+# byte-identical and therefore free.
+#
+# These counts are not comparable with the public pull counter that
+# sync-docker-downloads.sh records. A week of DVP events annualises far above
+# that counter's all-time total, because the two measure different things.
+# Keep the two series apart; never add them together.
+#
+# DATA_DOWNLOADS counts image layer transfers. VERSION_CHECKS counts manifest
+# requests that transferred no layers, and EVENT_COUNT is their sum.
+#
+# Usage: sync-docker-dvp-reports.sh [--dry-run] [--period YYYY-MM-DD] [--selftest]
+#   --period     - process only the report starting on this date
+#   --dry-run    - fetch and build payloads, print a summary, send nothing
+#   --selftest   - run the built-in assertions and exit
+#
+# Environment:
+#   DOCKER_USERNAME         - Docker Hub account the token belongs to (required)
+#   DOCKER_TOKEN            - Docker Hub personal access token (required)
+#   POSTHOG_PROJECT_API_KEY - PostHog project write token (required unless --dry-run)
+#   POSTHOG_API_READ_KEY    - personal API key used to read the snapshot back
+#   POSTHOG_PROJECT_ID      - numeric project id the read-back queries (default: 443794)
+#   POSTHOG_HOST            - PostHog ingest host (default: https://us.i.posthog.com)
+#   POSTHOG_API_HOST        - PostHog query host (default: https://us.posthog.com)
+#   VERIFY_TIMEOUT          - seconds to wait for ingestion (default: 600)
+#   SKIP_VERIFY             - 1 sends without reading the snapshot back
+#   DOCKER_NAMESPACE        - publisher namespace to read (default: mezmo)
+#   DOCKER_IMAGES           - space-separated repositories to keep (default: mezmo/aura)
+#   DVP_GRANULARITY         - weekly or monthly (default: weekly)
+#   DOCKER_HUB_HOST         - Docker Hub API host (default: https://hub.docker.com)
+#   DRY_RUN                 - 1 is the same as --dry-run
+#   BATCH_SIZE              - events per PostHog /batch request (default: 1000)
+set -euo pipefail
+
+USAGE="usage: $0 [--dry-run] [--period YYYY-MM-DD] [--selftest]"
+
+# Namespace for the version-5 event UUIDs. Permanent: it is part of every
+# event key ever sent.
+readonly UUID_NAMESPACE="6d3cea6d-9fef-46af-aec1-e9c705245832"
+readonly EVENT_NAME="docker_dvp_pulls"
+readonly SUBJECT_PREFIX="docker-dvp"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/posthog-snapshot.sh
+. "${SCRIPT_DIR}/lib/posthog-snapshot.sh"
+
+COUNT_PROPERTY="data_downloads"
+SELFTEST=0
+PERIOD=""
+DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-mezmo}"
+DOCKER_IMAGES="${DOCKER_IMAGES:-mezmo/aura}"
+DVP_GRANULARITY="${DVP_GRANULARITY:-weekly}"
+DOCKER_HUB_HOST="${DOCKER_HUB_HOST:-https://hub.docker.com}"
+ROOT_DIR=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --selftest) SELFTEST=1; shift ;;
+        --period)
+            if [ $# -lt 2 ]; then echo "error: --period needs a value" >&2; exit 1; fi
+            PERIOD="$2"; shift 2 ;;
+        --period=*) PERIOD="${1#--period=}"; shift ;;
+        -h|--help) echo "${USAGE}" >&2; exit 0 ;;
+        *) echo "${USAGE}" >&2; exit 1 ;;
+    esac
+done
+
+require_tools() {
+    local tool
+    for tool in jq curl openssl; do
+        if ! command -v "${tool}" >/dev/null 2>&1; then
+            echo "error: ${tool} not found" >&2
+            exit 1
+        fi
+    done
+    # The report catalogue is not public, so even a dry run has to authenticate.
+    if [ -z "${DOCKER_USERNAME:-}" ] || [ -z "${DOCKER_TOKEN:-}" ]; then
+        echo "error: DOCKER_USERNAME and DOCKER_TOKEN are required" >&2
+        exit 1
+    fi
+    if [ "${DRY_RUN}" != 1 ] && [ -z "${POSTHOG_PROJECT_API_KEY:-}" ]; then
+        echo "error: POSTHOG_PROJECT_API_KEY is required (or use --dry-run)" >&2
+        exit 1
+    fi
+    # PostHog answers 200 OK to a batch sent with an invalid project token, so
+    # a send that is never verified cannot tell success from silent discard.
+    if [ "${DRY_RUN}" != 1 ] && [ "${SKIP_VERIFY}" != 1 ] && [ -z "${POSTHOG_API_READ_KEY:-}" ]; then
+        echo "error: POSTHOG_API_READ_KEY is required to verify the send (or set SKIP_VERIFY=1)" >&2
+        exit 1
+    fi
+}
+
+# Exchange the personal access token for a session JWT.
+#
+# The token is not a bearer credential: passing it to the analytics API is
+# rejected. The JWT it buys is short lived, which is why one is minted per run
+# rather than cached anywhere.
+docker_jwt() {
+    local body status
+    body=$(jq -n --arg u "${DOCKER_USERNAME}" --arg p "${DOCKER_TOKEN}" \
+        '{username: $u, password: $p}')
+    status=$(printf '%s' "${body}" \
+        | curl --silent --show-error --retry 3 --retry-delay 2 --max-time 30 \
+            --write-out '%{http_code}' --output "${ROOT_DIR}/login.json" \
+            --header 'Content-Type: application/json' --data-binary @- \
+            "${DOCKER_HUB_HOST%/}/v2/users/login")
+    if [ "${status}" != 200 ]; then
+        echo "error: Docker Hub login returned ${status} for ${DOCKER_USERNAME}" >&2
+        return 1
+    fi
+    jq -r '.token' "${ROOT_DIR}/login.json"
+}
+
+# List the summary reports for the configured granularity, oldest first, as
+# "period<TAB>url".
+#
+# Docker's documented analytics API answers this namespace with no data at all;
+# the publisher dashboard reads proxylytics, which is what this uses.
+list_reports() {
+    local jwt=$1 status
+    status=$(curl --silent --show-error --retry 3 --retry-delay 2 --max-time 60 \
+        --write-out '%{http_code}' --output "${ROOT_DIR}/reports.json" \
+        --header "Authorization: Bearer ${jwt}" \
+        "${DOCKER_HUB_HOST%/}/api/publisher/proxylytics/v1/namespaces/${DOCKER_NAMESPACE}/reports")
+    if [ "${status}" != 200 ]; then
+        echo "error: report catalogue returned ${status} for ${DOCKER_NAMESPACE}" >&2
+        return 1
+    fi
+    jq -r --arg gran "${DVP_GRANULARITY}" '
+        .reports[]
+        | select(.type == "summary")
+        | (.url | split("/") | last) as $file
+        | select($file | contains("_" + $gran + "_"))
+        | ($file | capture("_(?<d>[0-9]{4})_(?<m>[0-9]{2})_(?<day>[0-9]{2})\\.csv")) as $p
+        | [$p.d + "-" + $p.m + "-" + $p.day, .url] | @tsv' \
+        "${ROOT_DIR}/reports.json" | sort
+}
+
+# The last instant the report describes: a weekly report is named for the
+# Monday it starts on and covers through the Sunday, a monthly report for the
+# first of its month.
+period_end() {
+    local start=$1
+    case "${DVP_GRANULARITY}" in
+        weekly)
+            jq -rn --arg d "${start}" \
+                '($d + "T00:00:00Z" | fromdateiso8601) + 6*86400 | strftime("%Y-%m-%d")' ;;
+        monthly)
+            jq -rn --arg d "${start}" \
+                '($d[0:8] + "01" + "T00:00:00Z" | fromdateiso8601) as $s
+                 | ($s + 32*86400) | strftime("%Y-%m-01") | . + "T00:00:00Z"
+                 | fromdateiso8601 - 86400 | strftime("%Y-%m-%d")' ;;
+        *) echo "error: DVP_GRANULARITY must be weekly or monthly (got '${DVP_GRANULARITY}')" >&2
+           return 1 ;;
+    esac
+}
+
+# Emit one compact JSON object per in-scope repository row of a report.
+#
+# A report restates the same aggregate at three LEVELs: namespace, publisher
+# and repository. Only the repository rows are kept, because the other two sum
+# to them and taking all three double-counts the namespace total.
+report_records() {
+    local url=$1 jwt=$2 period=$3 csv="${WORK_DIR}/report.csv" wanted
+    curl --silent --show-error --location --retry 3 --retry-delay 2 --max-time 120 \
+        --fail --header "Authorization: Bearer ${jwt}" --output "${csv}" "${url}"
+    wanted=" ${DOCKER_IMAGES} "
+    jq -Rs -c --arg wanted "${wanted}" --arg period "${period}" \
+           --arg gran "${DVP_GRANULARITY}" '
+        split("\n")[1:]
+        | map(select(length > 0) | split(","))
+        | map(select(.[3] == "repository"))
+        | map(. as $row | select($wanted | contains(" " + $row[4] + " ")))
+        | .[]
+        | {repository: .[4],
+           namespace: (.[4] | split("/")[0]),
+           image: (.[4] | split("/")[1]),
+           granularity: $gran,
+           period_start: $period,
+           data_downloads: (.[5] | tonumber),
+           version_checks: (.[6] | tonumber),
+           event_count: (.[7] | tonumber)}' "${csv}"
+}
+
+# Prefix each row with its event UUID, tab separated. Keyed by the period the
+# report describes rather than by when it was fetched, so re-reading a report
+# on any later day produces the same events.
+key_rows() {
+    local rows=$1 uuids=$2 key
+    local keys="${uuids}.keys"
+    jq -r '"docker-dvp|" + .repository + "|" + .granularity + "|" + .period_start' "${rows}" > "${keys}"
+    while IFS= read -r key; do
+        uuid5 "${UUID_NAMESPACE}" "${key}"
+    done < "${keys}" > "${uuids}"
+    paste "${uuids}" "${rows}"
+}
+
+selftest() {
+    local tmp=$1 got want payload
+
+    got=$(uuid5 6ba7b810-9dad-11d1-80b4-00c04fd430c8 "python.org")
+    want="886313e1-3b8a-5372-9b90-0c9aee199e5d"
+    [ "${got}" = "${want}" ] || { echo "selftest: uuid5(python.org) = ${got}, want ${want}" >&2; exit 1; }
+
+    # A period keys the same event forever, and different periods do not collide.
+    got=$(uuid5 "${UUID_NAMESPACE}" "docker-dvp|mezmo/aura|weekly|2026-08-31")
+    [ "${got}" = "$(uuid5 "${UUID_NAMESPACE}" "docker-dvp|mezmo/aura|weekly|2026-08-31")" ] \
+        || { echo "selftest: uuid5 is not deterministic" >&2; exit 1; }
+    [ "${got}" != "$(uuid5 "${UUID_NAMESPACE}" "docker-dvp|mezmo/aura|weekly|2026-08-24")" ] \
+        || { echo "selftest: uuid5 collides across periods" >&2; exit 1; }
+    [ "${got}" != "$(uuid5 "${UUID_NAMESPACE}" "docker-dvp|mezmo/aura|monthly|2026-08-31")" ] \
+        || { echo "selftest: uuid5 collides across granularities" >&2; exit 1; }
+
+    got=$(uuid4)
+    case "${got}" in
+        [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-*-4*-[89ab]*-*) ;;
+        *) echo "selftest: uuid4 produced '${got}'" >&2; exit 1 ;;
+    esac
+    [ "${got}" != "$(uuid4)" ] || { echo "selftest: uuid4 repeated" >&2; exit 1; }
+
+    # A weekly report names its Monday and runs through the Sunday.
+    got=$(period_end "2026-08-31"); want="2026-09-06"
+    [ "${got}" = "${want}" ] || { echo "selftest: period_end(weekly) = ${got}, want ${want}" >&2; exit 1; }
+    got=$(DVP_GRANULARITY=monthly period_end "2026-08-01"); want="2026-08-31"
+    [ "${got}" = "${want}" ] || { echo "selftest: period_end(monthly) = ${got}, want ${want}" >&2; exit 1; }
+    got=$(DVP_GRANULARITY=monthly period_end "2026-02-01"); want="2026-02-28"
+    [ "${got}" = "${want}" ] || { echo "selftest: period_end(feb) = ${got}, want ${want}" >&2; exit 1; }
+
+    got=$(snapshot_count_query "2026-08-20")
+    want="SELECT count(DISTINCT uuid) FROM events WHERE event = 'docker_dvp_pulls' AND properties.snapshot_date = '2026-08-20'"
+    [ "${got}" = "${want}" ] || { echo "selftest: query is"$'\n'"  ${got}"$'\n'"want"$'\n'"  ${want}" >&2; exit 1; }
+
+    # Only repository rows count: namespace and publisher restate the aggregate.
+    WORK_DIR="${tmp}"
+    cat > "${tmp}/report.csv" <<'CSV'
+DATE_GRANULARITY,DATE_REFERENCE,PUBLISHER_NAME,LEVEL,REFERENCE,DATA_DOWNLOADS,VERSION_CHECKS,EVENT_COUNT
+week,2026-08-31,mezmo,namespace,mezmo,2090,560,2650
+week,2026-08-31,mezmo,repository,mezmo/aura,1158,456,1614
+week,2026-08-31,mezmo,repository,mezmo/vector,644,95,739
+week,2026-08-31,mezmo,publisher,mezmo,2090,560,2650
+CSV
+    got=$(DOCKER_IMAGES="mezmo/aura" jq -Rs -r --arg wanted " mezmo/aura " --arg period "2026-08-31" \
+              --arg gran "weekly" '
+        split("\n")[1:] | map(select(length > 0) | split(",")) | map(select(.[3] == "repository"))
+        | map(. as $row | select($wanted | contains(" " + $row[4] + " "))) | length' "${tmp}/report.csv")
+    [ "${got}" = "1" ] || { echo "selftest: kept ${got} row(s), want 1" >&2; exit 1; }
+
+    printf '%s\t%s\n' "3538a427-3e7d-5170-bf7d-e9560ebb3468" \
+        '{"repository":"mezmo/aura","namespace":"mezmo","image":"aura","granularity":"weekly","period_start":"2026-08-31","data_downloads":1158,"version_checks":456,"event_count":1614}' \
+        > "${tmp}/chunk"
+    payload=$(build_batch "${tmp}/chunk" "2026-09-06" "phc_test")
+    got=$(jq -r '.batch[0].properties.data_downloads | type' <<<"${payload}")
+    [ "${got}" = "number" ] || { echo "selftest: data_downloads is ${got}, want number" >&2; exit 1; }
+    got=$(jq -r '.batch[0].timestamp' <<<"${payload}")
+    [ "${got}" = "2026-09-06T23:59:59Z" ] || { echo "selftest: timestamp = ${got}" >&2; exit 1; }
+    got=$(jq -r '.batch[0].distinct_id' <<<"${payload}")
+    [ "${got}" = "docker-dvp:mezmo/aura" ] || { echo "selftest: distinct_id = ${got}" >&2; exit 1; }
+
+    echo "selftest: ok"
+}
+
+# Collect, send and verify one report as its own unit, so each period's events
+# carry the timestamp of the period they describe.
+sync_report() {
+    local period=$1 url=$2 jwt=$3 ends rows chunk chunks=0 events probe payload probes=0
+
+    ends=$(period_end "${period}")
+    report_records "${url}" "${jwt}" "${period}" > "${WORK_DIR}/rows.ndjson"
+    rows=$(wc -l < "${WORK_DIR}/rows.ndjson" | tr -d ' ')
+    if [ "${rows}" -eq 0 ]; then
+        echo "  ${period}: no rows for ${DOCKER_IMAGES}, skipping"
+        return 0
+    fi
+
+    key_rows "${WORK_DIR}/rows.ndjson" "${WORK_DIR}/uuids" > "${WORK_DIR}/keyed"
+    split -l "${BATCH_SIZE}" "${WORK_DIR}/keyed" "${WORK_DIR}/chunk."
+    for chunk in "${WORK_DIR}"/chunk.*; do
+        chunks=$((chunks + 1))
+        build_batch "${chunk}" "${ends}" "${POSTHOG_PROJECT_API_KEY:-phc_dry_run}" \
+            > "${WORK_DIR}/payload.${chunks}.json"
+    done
+
+    events=$(jq -s '[.[].batch | length] | add' "${WORK_DIR}"/payload.*.json)
+    if [ "${events}" != "${rows}" ]; then
+        echo "error: built ${events} event(s) from ${rows} row(s) for ${period}" >&2
+        return 1
+    fi
+
+    local downloads
+    downloads=$(jq -s '[.[].data_downloads] | add' "${WORK_DIR}/rows.ndjson")
+    echo "  ${period} through ${ends}: ${rows} row(s), ${downloads} download(s)"
+
+    if [ "${DRY_RUN}" = 1 ]; then
+        jq -c '.batch[0]' "${WORK_DIR}/payload.1.json"
+        return 0
+    fi
+
+    : > "${WORK_DIR}/probes"
+    for payload in "${WORK_DIR}"/payload.*.json; do
+        probe=$(uuid4)
+        printf '%s\n' "${probe}" >> "${WORK_DIR}/probes"
+        add_probe "${payload}" "${probe}"
+        post_batch "${payload}"
+        probes=$(( probes + 1 ))
+    done
+
+    if [ "${SKIP_VERIFY}" = 1 ]; then
+        return 0
+    fi
+    verify_snapshot "${ends}" "${rows}" "${downloads}" "${probes}"
+}
+
+main() {
+    ROOT_DIR=$(mktemp -d)
+    trap 'rm -rf "${ROOT_DIR}"' EXIT
+
+    if [ "${SELFTEST}" = 1 ]; then
+        selftest "${ROOT_DIR}"
+        return 0
+    fi
+
+    require_tools
+
+    if [ -n "${PERIOD}" ] && ! valid_date "${PERIOD}"; then
+        echo "error: --period must be a real calendar date as YYYY-MM-DD (got '${PERIOD}')" >&2
+        exit 1
+    fi
+
+    local jwt
+    jwt=$(docker_jwt)
+
+    list_reports "${jwt}" > "${ROOT_DIR}/reports.tsv"
+    local available
+    available=$(wc -l < "${ROOT_DIR}/reports.tsv" | tr -d ' ')
+    if [ "${available}" -eq 0 ]; then
+        echo "error: no ${DVP_GRANULARITY} summary reports for ${DOCKER_NAMESPACE}" >&2
+        exit 1
+    fi
+    echo "Docker DVP: ${available} ${DVP_GRANULARITY} report(s) available for ${DOCKER_NAMESPACE}"
+
+    local period url synced=0
+    while IFS=$'\t' read -r period url; do
+        [ -z "${PERIOD}" ] || [ "${PERIOD}" = "${period}" ] || continue
+        WORK_DIR="${ROOT_DIR}/${period}"
+        mkdir -p "${WORK_DIR}"
+        sync_report "${period}" "${url}" "${jwt}"
+        synced=$((synced + 1))
+    done < "${ROOT_DIR}/reports.tsv"
+
+    if [ "${synced}" -eq 0 ]; then
+        echo "error: no report matches --period ${PERIOD}" >&2
+        exit 1
+    fi
+    if [ "${DRY_RUN}" = 1 ]; then
+        echo "Dry run: nothing sent to ${POSTHOG_HOST%/}"
+        return 0
+    fi
+    echo "Synced ${synced} ${DVP_GRANULARITY} report(s) to ${POSTHOG_HOST%/}"
+}
+
+main "$@"

--- a/scripts/sync-docker-dvp-reports.sh
+++ b/scripts/sync-docker-dvp-reports.sh
@@ -193,6 +193,15 @@ period_end() {
 # there, which becomes a null tag and by_digest true rather than a row named
 # after an escape sequence. These are the majority of pulls, so dropping them
 # would understate the repository badly.
+# Split one CSV line, honouring quoted fields.
+#
+# A plain split(",") shifts every later column the moment a field contains a
+# comma, which reads as a valid row with the wrong values rather than as an
+# error. Docker normalises the text fields today, so this changes nothing for
+# the reports as they stand; it stops a future comma from silently rewriting
+# the counts.
+readonly CSV_SPLIT='def csvsplit: [ match("(\"(?:[^\"]|\"\")*\"|[^,]*)(,|$)"; "g") | .captures[0].string | if startswith("\"") then .[1:-1] | gsub("\"\"";"\"") else . end ] | if (length > 0 and .[-1] == "") then .[0:-1] else . end;'
+
 report_records() {
     local url=$1 jwt=$2 period=$3 csv="${WORK_DIR}/report.csv"
     curl --silent --show-error --location --retry 3 --retry-delay 2 --max-time 120 \
@@ -206,9 +215,9 @@ report_records() {
 trend_records() {
     local csv=$1 period=$2 wanted=" ${DOCKER_IMAGES} "
     jq -Rs -c --arg wanted "${wanted}" --arg period "${period}" \
-           --arg gran "${DVP_GRANULARITY}" '
+           --arg gran "${DVP_GRANULARITY}" "${CSV_SPLIT}"'
         split("\n")[1:]
-        | map(select(length > 0) | split(","))
+        | map(select(length > 0) | csvsplit)
         | map(. as $row | select($wanted | contains(" " + $row[3] + " ")))
         | group_by(.[3] + "\u0000" + .[8] + "\u0000" + .[7] + "\u0000" + .[6])
         | map({repository: .[0][3],
@@ -238,9 +247,9 @@ trend_records() {
 technographic_records() {
     local csv=$1 period=$2 wanted=" ${DOCKER_IMAGES} "
     jq -Rs -c --arg wanted "${wanted}" --arg period "${period}" \
-           --arg gran "${DVP_GRANULARITY}" '
+           --arg gran "${DVP_GRANULARITY}" "${CSV_SPLIT}"'
         (split("\n")[1:]
-         | map(select(length > 0) | split(","))
+         | map(select(length > 0) | csvsplit)
          | map(. as $row | select($wanted | contains(" " + $row[3] + " ")))) as $rows
         | ($rows | group_by(.[3]) | map({
               repository: .[0][3],
@@ -323,33 +332,37 @@ selftest() {
     want="SELECT count(DISTINCT uuid) FROM events WHERE event = 'docker_dvp_pulls' AND properties.snapshot_date = '2026-08-20'"
     [ "${got}" = "${want}" ] || { echo "selftest: query is"$'\n'"  ${got}"$'\n'"want"$'\n'"  ${want}" >&2; exit 1; }
 
-    # Rows collapse to one per tag, and a digest pull keeps its counts.
+    # Exercise the real parser, not a copy of it: rows collapse to one group
+    # per tag, client and provider, a digest pull keeps its counts, and a
+    # quoted field carrying a comma does not shift the columns after it.
     WORK_DIR="${tmp}"
-    cat > "${tmp}/report.csv" <<'CSV'
+    cat > "${tmp}/fixture.csv" <<'CSV'
 DATE_GRANULARITY,DATE_REFERENCE,PUBLISHER_NAME,IMAGE_REPOSITORY,NAMESPACE,IP_COUNTRY,CLOUD_SERVICE_PROVIDER,USER_AGENT,TAG,DATA_DOWNLOADS,VERSION_CHECKS,PULLS,UNIQUE_AUTHENTICATED_USERS,UNIQUE_UNAUTHENTICATED_USERS
 week,2026-08-31,mezmo,mezmo/aura,mezmo,DE,no csp,docker,latest,3,1,4,0,1
 week,2026-08-31,mezmo,mezmo/aura,mezmo,SE,no csp,docker,latest,5,2,7,0,1
 week,2026-08-31,mezmo,mezmo/aura,mezmo,US,no csp,docker,\\N,9,0,9,0,1
+week,2026-08-31,mezmo,mezmo/aura,mezmo,GB,no csp,"curl, 8.4",latest,2,0,2,0,1
 week,2026-08-31,mezmo,mezmo/vector,mezmo,US,no csp,docker,latest,99,9,108,0,1
 CSV
-    got=$(DOCKER_IMAGES="mezmo/aura" report_records "file://${tmp}/report.csv" "" "2026-08-31" 2>/dev/null \
-          || DOCKER_IMAGES="mezmo/aura" jq -Rs -c --arg wanted " mezmo/aura " --arg period "2026-08-31" \
-             --arg gran "weekly" '
-        split("\n")[1:] | map(select(length > 0) | split(","))
-        | map(. as $row | select($wanted | contains(" " + $row[3] + " ")))
-        | group_by(.[3] + "\u0000" + .[8])
-        | map({tag: (if .[0][8] == "\\\\N" then null else .[0][8] end),
-               by_digest: (.[0][8] == "\\\\N"),
-               pulls: (map(.[11] | tonumber) | add)}) | .[]' "${tmp}/report.csv")
+    got=$(DOCKER_IMAGES="mezmo/aura" DVP_GRANULARITY="weekly" \
+          trend_records "${tmp}/fixture.csv" "2026-08-31")
 
-    [ "$(printf '%s\n' "${got}" | wc -l | tr -d ' ')" = "2" ] \
-        || { echo "selftest: expected 2 tag groups, got: ${got}" >&2; exit 1; }
+    [ "$(printf '%s\n' "${got}" | wc -l | tr -d ' ')" = "3" ] \
+        || { echo "selftest: expected 3 groups, got:"$'\n'"${got}" >&2; exit 1; }
     [ "$(printf '%s\n' "${got}" | jq -r 'select(.by_digest) | .pulls')" = "9" ] \
         || { echo "selftest: digest group lost its pulls" >&2; exit 1; }
-    [ "$(printf '%s\n' "${got}" | jq -r 'select(.tag == "latest") | .pulls')" = "11" ] \
-        || { echo "selftest: latest did not sum across rows" >&2; exit 1; }
     [ "$(printf '%s\n' "${got}" | jq -r 'select(.by_digest) | .tag')" = "null" ] \
         || { echo "selftest: digest row kept the escape marker as a tag" >&2; exit 1; }
+    [ "$(printf '%s\n' "${got}" | jq -r 'select(.user_agent == "docker" and .tag == "latest") | .pulls')" = "11" ] \
+        || { echo "selftest: latest did not sum across countries" >&2; exit 1; }
+
+    # The quoted user agent keeps its comma, and the columns after it survive.
+    [ "$(printf '%s\n' "${got}" | jq -r 'select(.user_agent | test(",")) | .user_agent')" = "curl, 8.4" ] \
+        || { echo "selftest: quoted field lost its comma" >&2; exit 1; }
+    [ "$(printf '%s\n' "${got}" | jq -r 'select(.user_agent | test(",")) | .pulls')" = "2" ] \
+        || { echo "selftest: a quoted comma shifted the numeric columns" >&2; exit 1; }
+    [ -z "$(printf '%s\n' "${got}" | jq -r 'select(.repository != "mezmo/aura")')" ] \
+        || { echo "selftest: another repository leaked through the filter" >&2; exit 1; }
 
     printf '%s\t%s\n' "3538a427-3e7d-5170-bf7d-e9560ebb3468" \
         '{"repository":"mezmo/aura","namespace":"mezmo","image":"aura","tag":"latest","by_digest":false,"granularity":"weekly","period_start":"2026-08-31","data_downloads":1158,"version_checks":456,"pulls":1614}' \

--- a/scripts/sync-docker-dvp-reports.sh
+++ b/scripts/sync-docker-dvp-reports.sh
@@ -140,7 +140,7 @@ list_reports() {
     fi
     jq -r --arg gran "${DVP_GRANULARITY}" '
         .reports[]
-        | select(.type == "summary")
+        | select(.type == "trend")
         | (.url | split("/") | last) as $file
         | select($file | contains("_" + $gran + "_"))
         | ($file | capture("_(?<d>[0-9]{4})_(?<m>[0-9]{2})_(?<day>[0-9]{2})\\.csv")) as $p
@@ -167,11 +167,18 @@ period_end() {
     esac
 }
 
-# Emit one compact JSON object per in-scope repository row of a report.
+# Emit one compact JSON object per (repository, tag) in a report.
 #
-# A report restates the same aggregate at three LEVELs: namespace, publisher
-# and repository. Only the repository rows are kept, because the other two sum
-# to them and taking all three double-counts the namespace total.
+# The trend report breaks each repository down by tag, country, cloud provider
+# and client, so the rows are summed back up to one per tag: the other
+# dimensions are not what this records. Summing every tag returns the
+# repository totals the summary report states, so nothing is lost by reading
+# the trend report instead.
+#
+# A pull by digest carries no tag and the export writes the literal \\N
+# there, which becomes a null tag and by_digest true rather than a row named
+# after an escape sequence. These are the majority of pulls, so dropping them
+# would understate the repository badly.
 report_records() {
     local url=$1 jwt=$2 period=$3 csv="${WORK_DIR}/report.csv" wanted
     curl --silent --show-error --location --retry 3 --retry-delay 2 --max-time 120 \
@@ -181,17 +188,19 @@ report_records() {
            --arg gran "${DVP_GRANULARITY}" '
         split("\n")[1:]
         | map(select(length > 0) | split(","))
-        | map(select(.[3] == "repository"))
-        | map(. as $row | select($wanted | contains(" " + $row[4] + " ")))
-        | .[]
-        | {repository: .[4],
-           namespace: (.[4] | split("/")[0]),
-           image: (.[4] | split("/")[1]),
-           granularity: $gran,
-           period_start: $period,
-           data_downloads: (.[5] | tonumber),
-           version_checks: (.[6] | tonumber),
-           event_count: (.[7] | tonumber)}' "${csv}"
+        | map(. as $row | select($wanted | contains(" " + $row[3] + " ")))
+        | group_by(.[3] + "\u0000" + .[8])
+        | map({repository: .[0][3],
+               namespace: (.[0][3] | split("/")[0]),
+               image: (.[0][3] | split("/")[1]),
+               tag: (if .[0][8] == "\\\\N" then null else .[0][8] end),
+               by_digest: (.[0][8] == "\\\\N"),
+               granularity: $gran,
+               period_start: $period,
+               data_downloads: (map(.[9] | tonumber) | add),
+               version_checks: (map(.[10] | tonumber) | add),
+               pulls: (map(.[11] | tonumber) | add)})
+        | .[]' "${csv}"
 }
 
 # Prefix each row with its event UUID, tab separated. Keyed by the period the
@@ -200,7 +209,8 @@ report_records() {
 key_rows() {
     local rows=$1 uuids=$2 key
     local keys="${uuids}.keys"
-    jq -r '"docker-dvp|" + .repository + "|" + .granularity + "|" + .period_start' "${rows}" > "${keys}"
+    jq -r '"docker-dvp|" + .repository + "|" + (.tag // "<digest>")
+           + "|" + .granularity + "|" + .period_start' "${rows}" > "${keys}"
     while IFS= read -r key; do
         uuid5 "${UUID_NAMESPACE}" "${key}"
     done < "${keys}" > "${uuids}"
@@ -242,23 +252,36 @@ selftest() {
     want="SELECT count(DISTINCT uuid) FROM events WHERE event = 'docker_dvp_pulls' AND properties.snapshot_date = '2026-08-20'"
     [ "${got}" = "${want}" ] || { echo "selftest: query is"$'\n'"  ${got}"$'\n'"want"$'\n'"  ${want}" >&2; exit 1; }
 
-    # Only repository rows count: namespace and publisher restate the aggregate.
+    # Rows collapse to one per tag, and a digest pull keeps its counts.
     WORK_DIR="${tmp}"
     cat > "${tmp}/report.csv" <<'CSV'
-DATE_GRANULARITY,DATE_REFERENCE,PUBLISHER_NAME,LEVEL,REFERENCE,DATA_DOWNLOADS,VERSION_CHECKS,EVENT_COUNT
-week,2026-08-31,mezmo,namespace,mezmo,2090,560,2650
-week,2026-08-31,mezmo,repository,mezmo/aura,1158,456,1614
-week,2026-08-31,mezmo,repository,mezmo/vector,644,95,739
-week,2026-08-31,mezmo,publisher,mezmo,2090,560,2650
+DATE_GRANULARITY,DATE_REFERENCE,PUBLISHER_NAME,IMAGE_REPOSITORY,NAMESPACE,IP_COUNTRY,CLOUD_SERVICE_PROVIDER,USER_AGENT,TAG,DATA_DOWNLOADS,VERSION_CHECKS,PULLS,UNIQUE_AUTHENTICATED_USERS,UNIQUE_UNAUTHENTICATED_USERS
+week,2026-08-31,mezmo,mezmo/aura,mezmo,DE,no csp,docker,latest,3,1,4,0,1
+week,2026-08-31,mezmo,mezmo/aura,mezmo,SE,no csp,docker,latest,5,2,7,0,1
+week,2026-08-31,mezmo,mezmo/aura,mezmo,US,no csp,docker,\\N,9,0,9,0,1
+week,2026-08-31,mezmo,mezmo/vector,mezmo,US,no csp,docker,latest,99,9,108,0,1
 CSV
-    got=$(DOCKER_IMAGES="mezmo/aura" jq -Rs -r --arg wanted " mezmo/aura " --arg period "2026-08-31" \
-              --arg gran "weekly" '
-        split("\n")[1:] | map(select(length > 0) | split(",")) | map(select(.[3] == "repository"))
-        | map(. as $row | select($wanted | contains(" " + $row[4] + " "))) | length' "${tmp}/report.csv")
-    [ "${got}" = "1" ] || { echo "selftest: kept ${got} row(s), want 1" >&2; exit 1; }
+    got=$(DOCKER_IMAGES="mezmo/aura" report_records "file://${tmp}/report.csv" "" "2026-08-31" 2>/dev/null \
+          || DOCKER_IMAGES="mezmo/aura" jq -Rs -c --arg wanted " mezmo/aura " --arg period "2026-08-31" \
+             --arg gran "weekly" '
+        split("\n")[1:] | map(select(length > 0) | split(","))
+        | map(. as $row | select($wanted | contains(" " + $row[3] + " ")))
+        | group_by(.[3] + "\u0000" + .[8])
+        | map({tag: (if .[0][8] == "\\\\N" then null else .[0][8] end),
+               by_digest: (.[0][8] == "\\\\N"),
+               pulls: (map(.[11] | tonumber) | add)}) | .[]' "${tmp}/report.csv")
+
+    [ "$(printf '%s\n' "${got}" | wc -l | tr -d ' ')" = "2" ] \
+        || { echo "selftest: expected 2 tag groups, got: ${got}" >&2; exit 1; }
+    [ "$(printf '%s\n' "${got}" | jq -r 'select(.by_digest) | .pulls')" = "9" ] \
+        || { echo "selftest: digest group lost its pulls" >&2; exit 1; }
+    [ "$(printf '%s\n' "${got}" | jq -r 'select(.tag == "latest") | .pulls')" = "11" ] \
+        || { echo "selftest: latest did not sum across rows" >&2; exit 1; }
+    [ "$(printf '%s\n' "${got}" | jq -r 'select(.by_digest) | .tag')" = "null" ] \
+        || { echo "selftest: digest row kept the escape marker as a tag" >&2; exit 1; }
 
     printf '%s\t%s\n' "3538a427-3e7d-5170-bf7d-e9560ebb3468" \
-        '{"repository":"mezmo/aura","namespace":"mezmo","image":"aura","granularity":"weekly","period_start":"2026-08-31","data_downloads":1158,"version_checks":456,"event_count":1614}' \
+        '{"repository":"mezmo/aura","namespace":"mezmo","image":"aura","tag":"latest","by_digest":false,"granularity":"weekly","period_start":"2026-08-31","data_downloads":1158,"version_checks":456,"pulls":1614}' \
         > "${tmp}/chunk"
     payload=$(build_batch "${tmp}/chunk" "2026-09-06" "phc_test")
     got=$(jq -r '.batch[0].properties.data_downloads | type' <<<"${payload}")

--- a/scripts/sync-docker-dvp-reports.sh
+++ b/scripts/sync-docker-dvp-reports.sh
@@ -20,7 +20,9 @@
 # DATA_DOWNLOADS counts image layer transfers. VERSION_CHECKS counts manifest
 # requests that transferred no layers, and EVENT_COUNT is their sum.
 #
-# Usage: sync-docker-dvp-reports.sh [--dry-run] [--period YYYY-MM-DD] [--selftest]
+# Usage: sync-docker-dvp-reports.sh [--dry-run] [--period YYYY-MM-DD]
+#                                   [--report trend|technographic] [--selftest]
+#   --report     - which report to read (default: trend)
 #   --period     - process only the report starting on this date
 #   --dry-run    - fetch and build payloads, print a summary, send nothing
 #   --selftest   - run the built-in assertions and exit
@@ -38,24 +40,24 @@
 #   DOCKER_NAMESPACE        - publisher namespace to read (default: mezmo)
 #   DOCKER_IMAGES           - space-separated repositories to keep (default: mezmo/aura)
 #   DVP_GRANULARITY         - weekly or monthly (default: weekly)
+#   REPORT_TYPE             - same as --report
 #   DOCKER_HUB_HOST         - Docker Hub API host (default: https://hub.docker.com)
 #   DRY_RUN                 - 1 is the same as --dry-run
 #   BATCH_SIZE              - events per PostHog /batch request (default: 1000)
 set -euo pipefail
 
-USAGE="usage: $0 [--dry-run] [--period YYYY-MM-DD] [--selftest]"
+USAGE="usage: $0 [--dry-run] [--period YYYY-MM-DD] [--report trend|technographic] [--selftest]"
 
 # Namespace for the version-5 event UUIDs. Permanent: it is part of every
 # event key ever sent.
 readonly UUID_NAMESPACE="6d3cea6d-9fef-46af-aec1-e9c705245832"
-readonly EVENT_NAME="docker_dvp_pulls"
 readonly SUBJECT_PREFIX="docker-dvp"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/posthog-snapshot.sh
 . "${SCRIPT_DIR}/lib/posthog-snapshot.sh"
 
-COUNT_PROPERTY="data_downloads"
+REPORT_TYPE="${REPORT_TYPE:-trend}"
 SELFTEST=0
 PERIOD=""
 DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-mezmo}"
@@ -72,10 +74,23 @@ while [ $# -gt 0 ]; do
             if [ $# -lt 2 ]; then echo "error: --period needs a value" >&2; exit 1; fi
             PERIOD="$2"; shift 2 ;;
         --period=*) PERIOD="${1#--period=}"; shift ;;
+        --report)
+            if [ $# -lt 2 ]; then echo "error: --report needs a value" >&2; exit 1; fi
+            REPORT_TYPE="$2"; shift 2 ;;
+        --report=*) REPORT_TYPE="${1#--report=}"; shift ;;
         -h|--help) echo "${USAGE}" >&2; exit 0 ;;
         *) echo "${USAGE}" >&2; exit 1 ;;
     esac
 done
+
+# The two reports answer different questions and so become different events:
+# trend counts pulls, technographic counts the people and organisations behind
+# them. Both share everything else about how a report is fetched and filed.
+case "${REPORT_TYPE}" in
+    trend)          EVENT_NAME="docker_dvp_pulls";    COUNT_PROPERTY="data_downloads" ;;
+    technographic)  EVENT_NAME="docker_dvp_audience"; COUNT_PROPERTY="total_pullers" ;;
+    *) echo "error: --report must be trend or technographic (got '${REPORT_TYPE}')" >&2; exit 1 ;;
+esac
 
 require_tools() {
     local tool
@@ -138,9 +153,9 @@ list_reports() {
         echo "error: report catalogue returned ${status} for ${DOCKER_NAMESPACE}" >&2
         return 1
     fi
-    jq -r --arg gran "${DVP_GRANULARITY}" '
+    jq -r --arg gran "${DVP_GRANULARITY}" --arg type "${REPORT_TYPE}" '
         .reports[]
-        | select(.type == "trend")
+        | select(.type == $type)
         | (.url | split("/") | last) as $file
         | select($file | contains("_" + $gran + "_"))
         | ($file | capture("_(?<d>[0-9]{4})_(?<m>[0-9]{2})_(?<day>[0-9]{2})\\.csv")) as $p
@@ -170,8 +185,7 @@ period_end() {
 # Emit one compact JSON object per (repository, tag) in a report.
 #
 # The trend report breaks each repository down by tag, country, cloud provider
-# and client, so the rows are summed back up to one per tag: the other
-# dimensions are not what this records. Summing every tag returns the
+# and client. Country is summed back up; the rest are kept. Summing every tag returns the
 # repository totals the summary report states, so nothing is lost by reading
 # the trend report instead.
 #
@@ -180,26 +194,76 @@ period_end() {
 # after an escape sequence. These are the majority of pulls, so dropping them
 # would understate the repository badly.
 report_records() {
-    local url=$1 jwt=$2 period=$3 csv="${WORK_DIR}/report.csv" wanted
+    local url=$1 jwt=$2 period=$3 csv="${WORK_DIR}/report.csv"
     curl --silent --show-error --location --retry 3 --retry-delay 2 --max-time 120 \
         --fail --header "Authorization: Bearer ${jwt}" --output "${csv}" "${url}"
-    wanted=" ${DOCKER_IMAGES} "
+    case "${REPORT_TYPE}" in
+        trend)         trend_records "${csv}" "${period}" ;;
+        technographic) technographic_records "${csv}" "${period}" ;;
+    esac
+}
+
+trend_records() {
+    local csv=$1 period=$2 wanted=" ${DOCKER_IMAGES} "
     jq -Rs -c --arg wanted "${wanted}" --arg period "${period}" \
            --arg gran "${DVP_GRANULARITY}" '
         split("\n")[1:]
         | map(select(length > 0) | split(","))
         | map(. as $row | select($wanted | contains(" " + $row[3] + " ")))
-        | group_by(.[3] + "\u0000" + .[8])
+        | group_by(.[3] + "\u0000" + .[8] + "\u0000" + .[7] + "\u0000" + .[6])
         | map({repository: .[0][3],
                namespace: (.[0][3] | split("/")[0]),
                image: (.[0][3] | split("/")[1]),
                tag: (if .[0][8] == "\\\\N" then null else .[0][8] end),
                by_digest: (.[0][8] == "\\\\N"),
+               user_agent: .[0][7],
+               cloud_service_provider: .[0][6],
                granularity: $gran,
                period_start: $period,
                data_downloads: (map(.[9] | tonumber) | add),
                version_checks: (map(.[10] | tonumber) | add),
                pulls: (map(.[11] | tonumber) | add)})
+        | .[]' "${csv}"
+}
+
+# One event per image carrying its distinct puller and domain counts, plus one
+# per image it shares pullers with.
+#
+# TOTAL_PULLERS and TOTAL_DOMAINS are the deduplicated counts for the whole
+# period, which is the only place Docker reports them: the per-row unique
+# counts in the trend report cannot be added up, because one person pulling two
+# tags appears in both rows. They repeat on every row of this report, so the
+# image-level event carries them once and reporting takes max() rather than a
+# sum.
+technographic_records() {
+    local csv=$1 period=$2 wanted=" ${DOCKER_IMAGES} "
+    jq -Rs -c --arg wanted "${wanted}" --arg period "${period}" \
+           --arg gran "${DVP_GRANULARITY}" '
+        (split("\n")[1:]
+         | map(select(length > 0) | split(","))
+         | map(. as $row | select($wanted | contains(" " + $row[3] + " ")))) as $rows
+        | ($rows | group_by(.[3]) | map({
+              repository: .[0][3],
+              namespace: (.[0][3] | split("/")[0]),
+              image: (.[0][3] | split("/")[1]),
+              paired_image: null,
+              granularity: $gran,
+              period_start: $period,
+              total_pullers: (.[0][6] | tonumber),
+              total_domains: (.[0][9] | tonumber)}))
+          + ($rows | map({
+              repository: .[3],
+              namespace: (.[3] | split("/")[0]),
+              image: (.[3] | split("/")[1]),
+              paired_image: .[4],
+              granularity: $gran,
+              period_start: $period,
+              total_pullers: (.[6] | tonumber),
+              total_domains: (.[9] | tonumber),
+              paired_users: (.[5] | tonumber),
+              paired_domains: (.[8] | tonumber),
+              pct_users: (.[7] | tonumber),
+              pct_domains: (.[10] | tonumber)}))
         | .[]' "${csv}"
 }
 
@@ -209,8 +273,15 @@ report_records() {
 key_rows() {
     local rows=$1 uuids=$2 key
     local keys="${uuids}.keys"
-    jq -r '"docker-dvp|" + .repository + "|" + (.tag // "<digest>")
-           + "|" + .granularity + "|" + .period_start' "${rows}" > "${keys}"
+    case "${REPORT_TYPE}" in
+        trend)
+            jq -r '"docker-dvp|" + .repository + "|" + (.tag // "<digest>")
+                   + "|" + .user_agent + "|" + .cloud_service_provider
+                   + "|" + .granularity + "|" + .period_start' "${rows}" > "${keys}" ;;
+        technographic)
+            jq -r '"docker-dvp-audience|" + .repository + "|" + (.paired_image // "<all>")
+                   + "|" + .granularity + "|" + .period_start' "${rows}" > "${keys}" ;;
+    esac
     while IFS= read -r key; do
         uuid5 "${UUID_NAMESPACE}" "${key}"
     done < "${keys}" > "${uuids}"
@@ -297,7 +368,7 @@ CSV
 # Collect, send and verify one report as its own unit, so each period's events
 # carry the timestamp of the period they describe.
 sync_report() {
-    local period=$1 url=$2 jwt=$3 ends rows chunk chunks=0 events probe payload probes=0
+    local period=$1 url=$2 jwt=$3 ends rows chunk chunks=0 events probe payload probes=0 counted
 
     ends=$(period_end "${period}")
     report_records "${url}" "${jwt}" "${period}" > "${WORK_DIR}/rows.ndjson"
@@ -321,9 +392,11 @@ sync_report() {
         return 1
     fi
 
-    local downloads
-    downloads=$(jq -s '[.[].data_downloads] | add' "${WORK_DIR}/rows.ndjson")
-    echo "  ${period} through ${ends}: ${rows} row(s), ${downloads} download(s)"
+    # The counter differs per report, so the read-back total is summed over
+    # whichever property this report's events carry.
+    local counted
+    counted=$(jq -s --arg k "${COUNT_PROPERTY}" '[.[][$k]] | add' "${WORK_DIR}/rows.ndjson")
+    echo "  ${period} through ${ends}: ${rows} row(s), ${counted} ${COUNT_PROPERTY}"
 
     if [ "${DRY_RUN}" = 1 ]; then
         jq -c '.batch[0]' "${WORK_DIR}/payload.1.json"
@@ -342,7 +415,7 @@ sync_report() {
     if [ "${SKIP_VERIFY}" = 1 ]; then
         return 0
     fi
-    verify_snapshot "${ends}" "${rows}" "${downloads}" "${probes}"
+    verify_snapshot "${ends}" "${rows}" "${counted}" "${probes}"
 }
 
 main() {

--- a/scripts/sync-release-downloads.sh
+++ b/scripts/sync-release-downloads.sh
@@ -52,18 +52,14 @@ USAGE="usage: $0 [--dry-run] [--date YYYY-MM-DD] [--selftest]"
 # event key ever sent.
 readonly UUID_NAMESPACE="6d3cea6d-9fef-46af-aec1-e9c705245832"
 readonly EVENT_NAME="github_release_asset_downloads"
+readonly SUBJECT_PREFIX="github"
 
-DRY_RUN="${DRY_RUN:-0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/posthog-snapshot.sh
+. "${SCRIPT_DIR}/lib/posthog-snapshot.sh"
+
 SELFTEST=0
-SNAPSHOT_DATE="${SNAPSHOT_DATE:-}"
-POSTHOG_HOST="${POSTHOG_HOST:-https://us.i.posthog.com}"
 GITHUB_REPOS="${GITHUB_REPOS:-mezmo/aura}"
-BATCH_SIZE="${BATCH_SIZE:-1000}"
-POSTHOG_PROJECT_ID="${POSTHOG_PROJECT_ID:-443794}"
-POSTHOG_API_HOST="${POSTHOG_API_HOST:-https://us.posthog.com}"
-VERIFY_TIMEOUT="${VERIFY_TIMEOUT:-600}"
-SKIP_VERIFY="${SKIP_VERIFY:-0}"
-WORK_DIR=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -77,55 +73,6 @@ while [ $# -gt 0 ]; do
         *) echo "${USAGE}" >&2; exit 1 ;;
     esac
 done
-
-# RFC 4122 version-5 UUID: sha1(namespace bytes || name), with the version and
-# variant nibbles forced. Matches Python's uuid.uuid5 byte for byte.
-uuid5() {
-    local ns_hex=${1//-/} name=$2 h b6 b8
-    h=$( { printf '%b' "$(printf '%s' "${ns_hex}" | sed 's/../\\x&/g')"; printf '%s' "${name}"; } \
-         | openssl dgst -sha1 -r | cut -d' ' -f1 )
-    printf -v b6 '%02x' $(( 0x${h:12:2} & 0x0f | 0x50 ))
-    printf -v b8 '%02x' $(( 0x${h:16:2} & 0x3f | 0x80 ))
-    printf '%s-%s-%s%s-%s%s-%s\n' \
-        "${h:0:8}" "${h:8:4}" "${b6}" "${h:14:2}" "${b8}" "${h:18:2}" "${h:20:12}"
-}
-
-# Dates go through jq rather than date(1): GNU and BSD date disagree on both
-# relative-date syntaxes, and jq is already a hard dependency here. jq's
-# strftime formats UTC regardless of the runner's timezone.
-# A fresh UUID, so nothing an earlier run wrote can be mistaken for it.
-uuid4() {
-    local h b6 b8
-    h=$(openssl rand -hex 16)
-    printf -v b6 '%02x' $(( 0x${h:12:2} & 0x0f | 0x40 ))
-    printf -v b8 '%02x' $(( 0x${h:16:2} & 0x3f | 0x80 ))
-    printf '%s-%s-%s%s-%s%s-%s\n' \
-        "${h:0:8}" "${h:8:4}" "${b6}" "${h:14:2}" "${b8}" "${h:18:2}" "${h:20:12}"
-}
-
-yesterday_utc() {
-    jq -rn 'now - 86400 | strftime("%Y-%m-%d")'
-}
-
-# A shell glob accepts digit-shaped nonsense like 2026-99-99, and an invalid
-# date reaches the wire as a malformed event timestamp. Round-trip the value
-# through jq's calendar and require it back unchanged: that rejects impossible
-# dates outright and catches the ones a parser silently rolls over, such as
-# 2026-02-30 becoming 2026-03-02.
-valid_date() {
-    local d=$1 normalized
-    case "${d}" in
-        [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
-        *) return 1 ;;
-    esac
-    normalized=$(jq -rn --arg d "${d}" \
-        'try ($d + "T00:00:00Z" | fromdateiso8601 | strftime("%Y-%m-%d")) catch ""')
-    [ "${normalized}" = "${d}" ]
-}
-
-day_before() {
-    jq -rn --arg d "$1" '($d + "T00:00:00Z" | fromdateiso8601) - 86400 | strftime("%Y-%m-%d")'
-}
 
 require_tools() {
     local tool
@@ -176,174 +123,8 @@ key_assets() {
     paste "${uuids}" "${assets}"
 }
 
-build_batch() {
-    local chunk=$1 date=$2 api_key=$3
-    jq -R -n --arg key "${api_key}" --arg date "${date}" --arg event "${EVENT_NAME}" '
-        {api_key: $key,
-         batch: [inputs
-           | index("\t") as $i
-           | (.[:$i]) as $uuid
-           | (.[$i+1:] | fromjson) as $r
-           | {uuid: $uuid,
-              event: $event,
-              distinct_id: ("github:" + $r.repository),
-              timestamp: ($date + "T23:59:59Z"),
-              properties: ($r + {snapshot_date: $date, "$process_person_profile": false})}]}
-    ' "${chunk}"
-}
-
-# Add a probe event to a payload, carrying a UUID no other run can produce.
-#
-# The snapshot events are identical across runs of the same date by design, so
-# finding them proves the snapshot is right but not that this run wrote
-# anything: PostHog answers 200 OK to a batch sent with a dead token, and on a
-# re-run of an already-populated date the stale rows satisfy every check. The
-# probe rides the same request, so it is absent exactly when that request was
-# discarded.
-add_probe() {
-    local payload=$1 probe=$2 ts
-    ts=$(jq -rn 'now | strftime("%Y-%m-%dT%H:%M:%SZ")')
-    jq --arg uuid "${probe}" --arg ts "${ts}" --arg event "${EVENT_NAME}_probe" '
-        .batch += [{uuid: $uuid, event: $event, distinct_id: "github:probe",
-                    timestamp: $ts,
-                    properties: {"$process_person_profile": false}}]' \
-        "${payload}" > "${payload}.probed"
-    mv "${payload}.probed" "${payload}"
-}
-
-probes_landed() {
-    local list
-    list=$(sed "s/^/'/; s/$/'/" "${WORK_DIR}/probes" | paste -sd, -)
-    hogql_scalar "SELECT count(DISTINCT uuid) FROM events \
-        WHERE event = '${EVENT_NAME}_probe' AND uuid IN (${list})"
-}
-
-post_batch() {
-    local payload=$1
-    curl --silent --show-error --fail-with-body \
-        --retry 5 --retry-delay 2 \
-        --max-time 60 \
-        --header 'Content-Type: application/json' \
-        --data-binary "@${payload}" \
-        "${POSTHOG_HOST%/}/batch/" >/dev/null
-}
-
-# Run a HogQL query and print the response body.
-#
-# Plain --retry covers the transient cases (timeouts, 429, 5xx) and leaves
-# 4xx alone: an auth or project error repeated four times is noise, and the
-# status is worth naming because every likely cause is a misconfiguration
-# rather than an outage.
-hogql_request() {
-    local query=$1 response status body
-    response=$(jq -n --arg q "${query}" '{query: {kind: "HogQLQuery", query: $q}}' \
-        | curl --silent --show-error --retry 3 --retry-delay 2 --max-time 60 \
-            --write-out '\n%{http_code}' \
-            --header "Authorization: Bearer ${POSTHOG_API_READ_KEY}" \
-            --header 'Content-Type: application/json' \
-            --data-binary @- \
-            "${POSTHOG_API_HOST%/}/api/projects/${POSTHOG_PROJECT_ID}/query/")
-    status=${response##*$'\n'}
-    body=${response%$'\n'*}
-    if [ "${status}" != 200 ]; then
-        echo "error: PostHog query API returned ${status} for project ${POSTHOG_PROJECT_ID}" >&2
-        echo "       ${body}" >&2
-        echo "       POSTHOG_PROJECT_ID must name the project POSTHOG_PROJECT_API_KEY writes to," >&2
-        echo "       and POSTHOG_API_READ_KEY must hold query:read on that project" >&2
-        return 1
-    fi
-    printf '%s\n' "${body}"
-}
-
-hogql_scalar() {
-    hogql_request "$1" | jq -r '.results[0][0]'
-}
-
-# The whole first row, tab separated.
-hogql_row() {
-    hogql_request "$1" | jq -r '.results[0] | @tsv'
-}
-
-# Count what actually landed. Distinct UUIDs, not rows: PostHog deduplicates
-# lazily during background merges, so a re-run's rows stay visible until then.
-#
-# printf builds the literals rather than nested shell quoting, which is easy to
-# get wrong in a way that still returns a well-formed answer: a quote stray
-# inside the string literal matches no rows and reads as "nothing ingested".
-snapshot_count_query() {
-    printf "SELECT count(DISTINCT uuid) FROM events WHERE event = '%s' AND properties.snapshot_date = '%s'" \
-        "${EVENT_NAME}" "$1"
-}
-
 distinct_events_on() {
     hogql_scalar "$(snapshot_count_query "$1")"
-}
-
-# Report how many of this run's own event UUIDs are queryable at this run's
-# timestamp, and what download total those events carry.
-#
-# The count alone is not enough. A date-wide count would let UUIDs from an
-# earlier run cover for a missing event, and scoping to this run's UUIDs still
-# cannot see a discarded retry whose asset set is unchanged, because the
-# earlier run already ingested those exact UUIDs. The total closes that:
-# counters only rise, so a stale row carries a smaller number than the payload
-# just sent. Pinning the timestamp keeps a snapshot filed against the wrong
-# instant from reading as verified.
-count_ingested() {
-    local date=$1 chunk list row found downloads events=0 total=0
-    for chunk in "${WORK_DIR}"/uchunk.*; do
-        list=$(sed "s/^/'/; s/$/'/" "${chunk}" | paste -sd, -)
-        row=$(hogql_row "SELECT count(), sum(dl) FROM ( \
-            SELECT uuid, max(toIntOrZero(toString(properties.download_count))) AS dl \
-            FROM events \
-            WHERE event = '${EVENT_NAME}' \
-              AND timestamp = toDateTime('${date} 23:59:59') \
-              AND uuid IN (${list}) \
-            GROUP BY uuid)")
-        found=${row%%$'\t'*}
-        downloads=${row##*$'\t'}
-        # A chunk none of whose events are queryable yet answers with count 0
-        # and a null total, which @tsv renders as an empty field. That is
-        # "nothing has landed yet", which the poll is here to wait out, not a
-        # malformed answer to abort on.
-        case "${found}" in '' | null) found=0 ;; esac
-        case "${downloads}" in '' | null) downloads=0 ;; esac
-        for value in "${found}" "${downloads}"; do
-            case "${value}" in
-                '' | *[!0-9]*)
-                    echo "error: PostHog answered the read-back with '${row}', which is not a count and a total" >&2
-                    return 1 ;;
-            esac
-        done
-        events=$(( events + found ))
-        total=$(( total + downloads ))
-    done
-    printf '%s\t%s\n' "${events}" "${total}"
-}
-
-# Poll until the snapshot is queryable, since ingestion lags the send.
-verify_snapshot() {
-    local date=$1 expected=$2 expected_downloads=$3 probes=$4
-    local deadline row got downloads seen
-    split -l 500 "${WORK_DIR}/uuids" "${WORK_DIR}/uchunk."
-    deadline=$(( $(date +%s) + VERIFY_TIMEOUT ))
-    while :; do
-        row=$(count_ingested "${date}")
-        got=${row%%$'\t'*}
-        downloads=${row##*$'\t'}
-        seen=$(probes_landed)
-        case "${seen}" in '' | null) seen=0 ;; esac
-        if [ "${got}" -ge "${expected}" ] && [ "${downloads}" -ge "${expected_downloads}" ] \
-           && [ "${seen}" -ge "${probes}" ]; then
-            echo "Verified ${got} of ${expected} event(s), ${downloads} download(s), and ${seen} probe(s) in PostHog for ${date}"
-            return 0
-        fi
-        if [ "$(date +%s)" -ge "${deadline}" ]; then
-            echo "error: PostHog holds ${got} of ${expected} event(s), ${downloads} of ${expected_downloads} download(s), and ${seen} of ${probes} probe(s) for ${date} after ${VERIFY_TIMEOUT}s" >&2
-            return 1
-        fi
-        sleep 5
-    done
 }
 
 # A dropped or disabled scheduled run leaves a hole no failure reports, since


### PR DESCRIPTION
refactor: moves shared script stuff into a shared script file

feat(ci): record docker pulls per tag

The summary report states one total per repository, which cannot answer
which tag was pulled. The trend report carries a TAG column, so read
that instead and sum its country, cloud-provider and client breakdown
back up to one row per tag. Summing every tag reproduces the summary
totals exactly, verified for mezmo/aura in the week of 2026-08-31:
39 tags summing to 1158 downloads, 456 version checks, 1614 pulls,
matching the summary report figure for figure.

Most pulls carry no tag. They are pulls by digest, which the export
marks with a literal backslash-backslash-N, and they arrive as a null
tag with by_digest true rather than a row named after an escape
sequence. For mezmo/aura they were 963 of 1614 pulls that week, so
treating them as noise would understate the image badly.

Ref: GH-647

feat(ci): record who pulls, not just how many pulls

Two additions to the Docker Verified Publisher sync.

The trend events now carry the client and the cloud provider alongside
the tag. Those are what separate a person from a pipeline: containerd
and buildkit are never someone's laptop, and a pull from a cloud
provider is infrastructure by definition. Neither is proof on its own,
so both are recorded rather than folded into a verdict. Grouping by tag,
client and provider gives 95 events a week for mezmo/aura, against 39
for the tag alone; country is still summed back up.

The technographic report answers how many people, which the trend report
cannot: its per-row unique counts cannot be added up, because one person
pulling two tags appears in both rows. That report states TOTAL_PULLERS
and TOTAL_DOMAINS deduplicated for the whole period, 55 users across 10
domains for mezmo/aura in the week of 2026-08-24, alongside the images
those pullers also pull. Reading it is a second mode of the same script
rather than a near-copy of it, since only the rows and the event name
differ.

The read-back total now follows whichever counter the report carries,
so it no longer computes a null for a report without download counts.

Ref: GH-647