### PR TITLE
ci: restrict pull requests into main and back-merge it to channels

### DIFF
--- a/.github/workflows/pr-target-branch.yml
+++ b/.github/workflows/pr-target-branch.yml
@@ -1,0 +1,118 @@
+name: "PR target branch"
+
+on:
+  # pull_request_target so the job can comment on pull requests from forks,
+  # which a fork-triggered pull_request token cannot do.
+  #
+  # DANGER: this runs with a repository token against pull requests from
+  # untrusted forks. It is safe only because nothing from the head revision is
+  # checked out or executed, and no pull-request-controlled string reaches a
+  # `run:` block. Do not add actions/checkout, and keep permissions scoped to
+  # pull-requests: write.
+  #
+  # GitHub reads this file from the pull request's base branch, so it must
+  # exist on main to guard pull requests into main, and on nightly to clear
+  # the comment once one is retargeted there.
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: pr-target-branch-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: "Reject pull requests targeting main"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Runs for every base branch rather than filtering on main, so
+      # retargeting a rejected pull request to nightly re-runs the check and
+      # clears both the failure and the comment.
+      #
+      # Pinned to a commit SHA because the tag is mutable and this step holds
+      # a write-scoped token.
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const action = context.payload.action;
+            const base = pr.base.ref;
+            const head = pr.head.ref;
+            const marker = '<!-- pr-target-branch -->';
+            const {owner, repo} = context.repo;
+
+            // Retargeting and reopening are the only ways a comment written
+            // on a previous run can survive onto a passing pull request, so
+            // every other event skips the comment lookup entirely.
+            const mayHaveStaleComment =
+              action === 'reopened' ||
+              (action === 'edited' && Boolean(context.payload.changes?.base));
+
+            if (base !== 'main' && !mayHaveStaleComment) {
+              core.info(`Base branch is ${base}; nothing to check.`);
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+
+            // Author match as well as marker match. The marker is public, and
+            // matching it alone would let a contributor's comment be selected
+            // and then overwritten with this workflow's text.
+            const existing = comments.find(
+              (c) => c.user?.login === 'github-actions[bot]' && (c.body || '').includes(marker),
+            );
+
+            // One marker comment per pull request, rewritten in place, so a
+            // retarget leaves no stale instruction behind and a retarget back
+            // to main restates them.
+            const upsert = async (lines) => {
+              const body = [marker, ...lines].join('\n');
+              if (!existing) {
+                await github.rest.issues.createComment({owner, repo, issue_number: pr.number, body});
+              } else if (existing.body !== body) {
+                await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body});
+              }
+            };
+
+            const accept = async (reason) => {
+              core.info(reason);
+              if (existing) {
+                await upsert([`Resolved — this pull request targets \`${base}\`.`]);
+              }
+            };
+
+            if (base !== 'main') {
+              return accept(`Base branch is ${base}; nothing to check.`);
+            }
+
+            // A promotion merge from nightly or beta, and a hotfix release,
+            // may land on main directly. Each comes from a branch in this
+            // repository, so a fork branch of the same name does not qualify.
+            // head.repo is null once a fork is deleted, which is not internal.
+            const internal = pr.head.repo?.full_name === context.payload.repository.full_name;
+            const promotion = head === 'nightly' || head === 'beta' || head.startsWith('hotfix/');
+            if (internal && promotion) {
+              return accept(`${head} is allowed to target main.`);
+            }
+
+            await upsert([
+              '**This pull request targets `main`. Please retarget it to `nightly`.**',
+              '',
+              '`main` carries the stable release line. It only takes promotion merges from',
+              '`nightly` or `beta` and hotfix branches, so day-to-day changes branch from and',
+              'merge into `nightly`. See [docs/design/release-channels.md](https://github.com/mezmo/aura/blob/main/docs/design/release-channels.md).',
+              '',
+              'Use **Edit** next to the pull request title to change the base branch, then',
+              'rebase onto `nightly` if the diff picked up unrelated commits.',
+            ]);
+
+            core.setFailed(`Pull requests may not target main (head: ${head}). Retarget to nightly.`);

--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -1,0 +1,157 @@
+name: "Sync main to channel branches"
+
+on:
+  schedule:
+    # Every six hours at :41. Off the hour because GitHub drops queued
+    # scheduled jobs when load peaks there, and out of the 01:00 hour the
+    # metrics snapshots occupy.
+    #
+    # GitHub runs schedule and workflow_dispatch only from the default
+    # branch, so this file has no effect until it is on main.
+    - cron: "41 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Branch to sync into"
+        required: false
+        default: "all"
+        type: choice
+        options: [all, nightly, beta]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # Stable is the only channel that commits back — release.config.js drops the
+  # changelog and git plugins on nightly and beta — so every stable release
+  # leaves a CHANGELOG and version-bump commit on main alone. Hotfixes land
+  # there first as well. Both have to reach the channel branches.
+  sync:
+    name: "Sync main into ${{ matrix.target }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [nightly, beta]
+    concurrency:
+      group: sync-main-${{ matrix.target }}
+      cancel-in-progress: false
+    steps:
+      # No checkout. Every question here is one API call, and the common case
+      # is a no-op.
+      - name: "Open the sync pull request"
+        env:
+          # A pull request opened with GITHUB_TOKEN does not start workflows,
+          # so neither the CLA check nor pr-target-branch runs on it. Jenkins
+          # runs off webhooks and is unaffected.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TARGET: ${{ matrix.target }}
+          REQUESTED: ${{ github.event.inputs.target || 'all' }}
+          DESIGN_DOC: "https://github.com/mezmo/aura/blob/main/docs/design/release-channels.md"
+        run: |
+          set -euo pipefail
+
+          if [ "$REQUESTED" != "all" ] && [ "$REQUESTED" != "$TARGET" ]; then
+            echo "Run requested $REQUESTED; skipping $TARGET."
+            exit 0
+          fi
+
+          # Assigned first so an API failure fails the job. Testing the call
+          # inline would read a network or auth error as a missing branch and
+          # report a green no-op. Exact name match, because a ref pattern also
+          # matches refs/heads/hotfix/$TARGET.
+          branches="$(gh api "repos/${REPO}/branches?per_page=100" --paginate --jq '.[].name')"
+          if ! printf '%s\n' "$branches" | grep -Fxq "$TARGET"; then
+            echo "No $TARGET branch on the remote; nothing to sync."
+            exit 0
+          fi
+
+          # compare/{base}...{head} reports head's position relative to base.
+          compare() { gh api "repos/${REPO}/compare/${1}...${2}" --jq .status; }
+
+          position="$(compare "$TARGET" main)"
+          if [ "$position" = "identical" ] || [ "$position" = "behind" ]; then
+            echo "$TARGET already contains main."
+            exit 0
+          fi
+
+          # Between promotion and deletion, beta is contained in main and its
+          # candidate is already shipped. Merging main into it there would
+          # mutate a released candidate.
+          if [ "$TARGET" = "beta" ]; then
+            promoted="$(compare main beta)"
+            if [ "$promoted" = "identical" ] || [ "$promoted" = "behind" ]; then
+              echo "beta is contained in main; it is promoted and awaiting deletion."
+              exit 0
+            fi
+          fi
+
+          sync_branch="sync/main-to-${TARGET}"
+          MAIN_SHA="$(gh api "repos/${REPO}/commits/main" --jq .sha)"
+          export MAIN_SHA
+
+          # An open pull request may carry conflict resolutions pushed by a
+          # maintainer, so the branch is left exactly as it is.
+          open_pr="$(gh pr list --head "$sync_branch" --base "$TARGET" \
+            --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$open_pr" ]; then
+            echo "Pull request #${open_pr} is open; leaving ${sync_branch} untouched."
+            exit 0
+          fi
+
+          # A closed pull request at this exact tip was already answered,
+          # whether declined or squash-merged. Reopening it every six hours
+          # would argue with the person who closed it.
+          settled="$(gh pr list --head "$sync_branch" --base "$TARGET" --state all \
+            --json number,headRefOid \
+            --jq '[.[] | select(.headRefOid == env.MAIN_SHA)] | .[0].number // empty')"
+          if [ -n "$settled" ]; then
+            echo "Pull request #${settled} already covered main at ${MAIN_SHA}; not reopening."
+            exit 0
+          fi
+
+          # The branch should be nothing but a pointer at main. Commits main
+          # does not have are someone's reconciliation work, which outranks
+          # any conclusion drawn from pull request state above.
+          if printf '%s\n' "$branches" | grep -Fxq "$sync_branch"; then
+            drift="$(compare main "$sync_branch")"
+            if [ "$drift" = "ahead" ] || [ "$drift" = "diverged" ]; then
+              echo "${sync_branch} carries commits main does not; leaving it alone."
+              exit 0
+            fi
+            gh api -X PATCH "repos/${REPO}/git/refs/heads/${sync_branch}" \
+              -f "sha=${MAIN_SHA}" -F force=true --silent
+          else
+            gh api -X POST "repos/${REPO}/git/refs" \
+              -f "ref=refs/heads/${sync_branch}" -f "sha=${MAIN_SHA}" --silent
+          fi
+
+          # shellcheck disable=SC2016  # backticks are markdown, not expansions
+          printf '%s\n' \
+            "Automated back-merge of \`main\` into \`${TARGET}\`." \
+            '' \
+            '`main` carries commits the channel branches never produce — the stable' \
+            '`CHANGELOG.md` and version bump from `semantic-release`, and any hotfix' \
+            'released from `main`. This pull request carries them back.' \
+            '' \
+            '**Merge with a merge commit.** Do not squash or rebase. Published history is' \
+            'never rewritten, and the merge commit is what keeps the `[skip ci]` version' \
+            "commit off the branch tip, where it would suppress the channel's release build." \
+            '' \
+            'Merging into `beta` changes the release candidate, so a new beta has to be' \
+            'validated before promotion.' \
+            '' \
+            'Opened by a workflow, so GitHub Actions checks do not start on it. Closing' \
+            'this pull request is respected — it is not reopened unless `main` advances.' \
+            '' \
+            "See [docs/design/release-channels.md](${DESIGN_DOC})." \
+            > "${RUNNER_TEMP}/sync-body.md"
+
+          gh pr create \
+            --base "$TARGET" \
+            --head "$sync_branch" \
+            --title "chore: sync main into ${TARGET}" \
+            --body-file "${RUNNER_TEMP}/sync-body.md"

--- a/docs/design/release-channels.md
+++ b/docs/design/release-channels.md
@@ -184,6 +184,17 @@ exists, so Cut creates `beta` on the remote and Sync deletes it there.
 The Cut commit must descend from the latest `main` tag; do not re-merge
 `nightly → beta` during a cycle (it would pull in features landed after the cut).
 
+`.github/workflows/sync-main.yml` proposes the `main →` back-merges as pull
+requests. It leaves an open one alone, respects a closed one, never overwrites
+a sync branch carrying commits `main` lacks, and skips `beta` once that branch
+is contained in `main`. Deleting `beta` and the Stabilize `beta → nightly`
+back-merge stay manual.
+
+`.github/workflows/pr-target-branch.yml` fails a pull request into `main` whose
+head is not `nightly`, `beta`, or `hotfix/*`. Both files have to exist on
+`main`, because GitHub runs a schedule only from the default branch and reads
+a `pull_request_target` workflow from the pull request's base branch.
+
 **Promotion invariants.** Channel branches are merged, not cherry-picked, so `main`
 retains the exact candidate history; published history is never squashed or rebased.
 Promotion freezes `beta` at the blessed commit. The merge into `main` must
@@ -285,6 +296,10 @@ Recovery rules:
 - `.dockerignore` — excludes `CHANGELOG.md` from the image build context (§4).
 - Repository ruleset — persistent name-matched protection for `nightly`, `beta`,
   `main` (§9).
+- `.github/workflows/pr-target-branch.yml` — fails pull requests into `main`
+  from outside the promotion and hotfix branches (§5).
+- `.github/workflows/sync-main.yml` — proposes the `main →` channel back-merges
+  as pull requests (§5).
 
 ## 11. Related docs
 


### PR DESCRIPTION
Pull requests targeting main now fail a check and get a comment directing them to nightly. Only nightly, beta, and hotfix/* branches in this repository may target main directly.

A scheduled job opens a pull request back-merging main into nightly and beta whenever they are behind. Stable is the only channel that commits back, so the changelog and version-bump commits exist on main alone until they are merged forward.