### PR TITLE
Webhook poll delivery (1/4): config surface, pending-approval scan, owner-only store files

### DIFF
--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -409,6 +409,35 @@ impl Config {
         // Scratchpad validation
         self.validate_scratchpad()?;
 
+        if let Some(hitl) = &self.hitl
+            && let DecisionRouteConfig::Webhook {
+                delivery: WebhookDelivery::Poll,
+                headers_from_request,
+                ..
+            } = &hitl.route
+        {
+            if !hitl.park.enabled {
+                return Err(crate::ConfigError::Validation(
+                    "`hitl.route.delivery = \"poll\"` requires `hitl.park.enabled = true`: \
+                     poll approvals may be long-lived and requests are never held open"
+                        .to_string(),
+                ));
+            }
+            if !headers_from_request.is_empty() {
+                return Err(crate::ConfigError::Validation(
+                    "`hitl.route.headers_from_request` is unsupported with \
+                     `hitl.route.delivery = \"poll\"`: request-derived headers cannot be \
+                     reconstructed by the background reconciler after a restart"
+                        .to_string(),
+                ));
+            }
+            return Err(crate::ConfigError::Validation(
+                "`hitl.route.delivery = \"poll\"` is not enabled in this build; use \
+                 `delivery = \"sync\"`"
+                    .to_string(),
+            ));
+        }
+
         if let (Some(hitl), Some(orch)) = (
             &self.hitl,
             self.orchestration.as_ref().filter(|o| o.enabled),
@@ -1112,6 +1141,10 @@ mod tests {
                 headers: HashMap::new(),
                 headers_from_request: HashMap::new(),
                 tool_headers_from_response: ToolHeaderMappings::default(),
+                delivery: WebhookDelivery::default(),
+                poll_url: None,
+                poll_interval_secs: default_poll_interval_secs(),
+                poll_request_timeout_secs: default_poll_request_timeout_secs(),
             },
         };
         assert!(hitl_timeout_conflict_warning(&hitl, 0).is_none());
@@ -1145,6 +1178,10 @@ mod tests {
                 headers: HashMap::new(),
                 headers_from_request: HashMap::new(),
                 tool_headers_from_response: ToolHeaderMappings::default(),
+                delivery: WebhookDelivery::default(),
+                poll_url: None,
+                poll_interval_secs: default_poll_interval_secs(),
+                poll_request_timeout_secs: default_poll_request_timeout_secs(),
             },
         };
         assert!(hitl_timeout_conflict_warning(&hitl, 60).is_none());
@@ -1161,6 +1198,10 @@ mod tests {
                 headers: HashMap::new(),
                 headers_from_request: HashMap::new(),
                 tool_headers_from_response: ToolHeaderMappings::default(),
+                delivery: WebhookDelivery::default(),
+                poll_url: None,
+                poll_interval_secs: default_poll_interval_secs(),
+                poll_request_timeout_secs: default_poll_request_timeout_secs(),
             },
         };
         let msg = hitl_timeout_conflict_warning(&hitl, 60).unwrap();
@@ -1179,6 +1220,10 @@ mod tests {
                 headers: HashMap::new(),
                 headers_from_request: HashMap::new(),
                 tool_headers_from_response: ToolHeaderMappings::default(),
+                delivery: WebhookDelivery::default(),
+                poll_url: None,
+                poll_interval_secs: default_poll_interval_secs(),
+                poll_request_timeout_secs: default_poll_request_timeout_secs(),
             },
         };
         let msg = hitl_timeout_conflict_warning(&hitl, 60).unwrap();
@@ -1242,6 +1287,138 @@ mode = "conversational"
 "#;
         let hitl: HitlConfig = toml::from_str(toml).unwrap();
         assert!(!hitl.park.enabled);
+    }
+
+    /// A `[hitl]` config TOML with a webhook route carrying `route_lines`.
+    fn hitl_toml(route_lines: &str) -> String {
+        format!(
+            "require_approval = [\"kubectl_*\"]\n\n\
+             [route]\nmode = \"webhook\"\nurl = \"https://approvals.example.com/decide\"\n\
+             {route_lines}\n"
+        )
+    }
+
+    /// A full config TOML with a webhook route carrying `route_lines`;
+    /// `park` controls the `[hitl.park]` table.
+    fn poll_config_toml(park: bool, route_lines: &str) -> String {
+        let park_table = if park {
+            "[hitl.park]\nenabled = true\n\n"
+        } else {
+            ""
+        };
+        format!(
+            "[agent]\nname = \"Test\"\nsystem_prompt = \"test\"\n\n\
+             [agent.llm]\nprovider = \"openai\"\napi_key = \"test\"\nmodel = \"gpt-4o\"\n\n\
+             [hitl]\nrequire_approval = [\"kubectl_*\"]\n\n\
+             {park_table}\
+             [hitl.route]\nmode = \"webhook\"\nurl = \"https://approvals.example.com/decide\"\n\
+             {route_lines}\n"
+        )
+    }
+
+    fn poll_fields(route: &DecisionRouteConfig) -> (WebhookDelivery, Option<String>, u64, u64) {
+        let DecisionRouteConfig::Webhook {
+            delivery,
+            poll_url,
+            poll_interval_secs,
+            poll_request_timeout_secs,
+            ..
+        } = route
+        else {
+            panic!("expected Webhook route, got {route:?}");
+        };
+        (
+            *delivery,
+            poll_url.as_ref().map(|u| u.as_str().to_owned()),
+            *poll_interval_secs,
+            *poll_request_timeout_secs,
+        )
+    }
+
+    #[test]
+    fn hitl_webhook_delivery_defaults_to_sync() {
+        let hitl: HitlConfig = toml::from_str(&hitl_toml("")).unwrap();
+        assert_eq!(poll_fields(&hitl.route).0, WebhookDelivery::Sync);
+    }
+
+    #[test]
+    fn hitl_webhook_poll_delivery_parses_with_defaults() {
+        let hitl: HitlConfig = toml::from_str(&hitl_toml("delivery = \"poll\"")).unwrap();
+        assert_eq!(
+            poll_fields(&hitl.route),
+            (WebhookDelivery::Poll, None, 10, 30)
+        );
+    }
+
+    #[test]
+    fn hitl_webhook_poll_fields_round_trip() {
+        let lines = "delivery = \"poll\"\n\
+                     poll_url = \"https://status.example.com/decisions\"\n\
+                     poll_interval_secs = 5\n\
+                     poll_request_timeout_secs = 45";
+        let hitl: HitlConfig = toml::from_str(&hitl_toml(lines)).unwrap();
+        let expected = (
+            WebhookDelivery::Poll,
+            Some("https://status.example.com/decisions".to_owned()),
+            5,
+            45,
+        );
+        assert_eq!(poll_fields(&hitl.route), expected);
+
+        let round_tripped: HitlConfig = toml::from_str(&toml::to_string(&hitl).unwrap()).unwrap();
+        assert_eq!(
+            poll_fields(&round_tripped.route),
+            expected,
+            "explicit poll fields must survive a round trip"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_poll_delivery_without_park() {
+        let err = crate::load_config_from_str(&poll_config_toml(false, "delivery = \"poll\""))
+            .expect_err("poll delivery without park mode must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("hitl.route.delivery") && msg.contains("hitl.park.enabled"),
+            "error must name both keys: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_poll_delivery_with_headers_from_request() {
+        let err = crate::load_config_from_str(&poll_config_toml(
+            true,
+            "delivery = \"poll\"\nheaders_from_request = { \"authorization\" = \"authorization\" }",
+        ))
+        .expect_err("headers_from_request with poll delivery must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("hitl.route.headers_from_request"),
+            "error must name the key: {msg}"
+        );
+    }
+
+    /// Until the poll path lands, an otherwise valid poll route is refused at
+    /// boot, naming the knob and the way out.
+    #[test]
+    fn validate_refuses_poll_delivery_until_the_poll_path_lands() {
+        let err = crate::load_config_from_str(&poll_config_toml(
+            true,
+            "delivery = \"poll\"\n\
+             tool_headers_from_response = { \"X-Forwarded-User\" = \"X-Approver-Id\" }",
+        ))
+        .expect_err("poll delivery is refused until the poll path lands");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not enabled") && msg.contains("delivery = \"sync\""),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_sync_delivery_without_park() {
+        crate::load_config_from_str(&poll_config_toml(false, ""))
+            .expect("sync webhook without park mode must stay valid");
     }
 
     #[test]
@@ -1464,6 +1641,9 @@ pub struct ParkConfig {
 /// URL, so the "url required, never empty" invariant holds structurally.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "mode", rename_all = "snake_case")]
+// Parsed once at startup and never moved in a hot path; shrinking the webhook
+// variant with boxes is not worth the serde and call-site churn.
+#[allow(clippy::large_enum_variant)]
 pub enum DecisionRouteConfig {
     /// Attended: the approver is already at the client (default timeout 60s).
     Conversational {
@@ -1485,7 +1665,43 @@ pub enum DecisionRouteConfig {
         /// Outbound MCP header name → webhook approval-response header name.
         #[serde(default, skip_serializing_if = "ToolHeaderMappings::is_empty")]
         tool_headers_from_response: ToolHeaderMappings,
+        #[serde(default, skip_serializing_if = "WebhookDelivery::is_sync")]
+        delivery: WebhookDelivery,
+        /// Status endpoint for the decision poll.
+        #[serde(default)]
+        poll_url: Option<WebhookUrl>,
+        /// Seconds between reconciler polls of the status endpoint.
+        #[serde(
+            default = "default_poll_interval_secs",
+            skip_serializing_if = "is_default_poll_interval_secs"
+        )]
+        poll_interval_secs: u64,
+        /// Per-attempt HTTP timeout for each notify/poll request.
+        #[serde(
+            default = "default_poll_request_timeout_secs",
+            skip_serializing_if = "is_default_poll_request_timeout_secs"
+        )]
+        poll_request_timeout_secs: u64,
     },
+}
+
+/// How the webhook route delivers an approval decision.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebhookDelivery {
+    /// Synchronous: the POST response carries the decision.
+    #[default]
+    Sync,
+    /// Asynchronous decision delivery.
+    Poll,
+}
+
+impl WebhookDelivery {
+    /// True for the synchronous delivery mode (the serde skip condition).
+    #[must_use]
+    pub fn is_sync(&self) -> bool {
+        matches!(self, Self::Sync)
+    }
 }
 
 /// Transport-owned header names a `tool_headers_from_response` mapping may
@@ -1580,6 +1796,22 @@ fn default_conversational_timeout_secs() -> u64 {
 
 fn default_webhook_timeout_secs() -> u64 {
     300
+}
+
+fn default_poll_interval_secs() -> u64 {
+    10
+}
+
+fn is_default_poll_interval_secs(value: &u64) -> bool {
+    *value == default_poll_interval_secs()
+}
+
+fn default_poll_request_timeout_secs() -> u64 {
+    30
+}
+
+fn is_default_poll_request_timeout_secs(value: &u64) -> bool {
+    *value == default_poll_request_timeout_secs()
 }
 
 /// A validated webhook URL.

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1431,6 +1431,10 @@ mod tests {
             headers: std::collections::HashMap::new(),
             headers_from_request: std::collections::HashMap::new(),
             tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
+            delivery: aura_config::WebhookDelivery::Sync,
+            poll_url: None,
+            poll_interval_secs: 10,
+            poll_request_timeout_secs: 30,
         });
         let req = chat_request_with_stream(None);
 

--- a/crates/aura-web-server/src/session_store/redis/approval_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/approval_store.rs
@@ -18,6 +18,10 @@
 //! the record TTL and pruned best-effort on resolve/remove. The cancel sweep
 //! prunes per id, never the whole index key; `SWEEP_TAKE_SCRIPT` states what
 //! each id yields.
+//! `list_pending` SCANs the parked-record keys in batches (never KEYS),
+//! skipping decision and index keys by segment and wrong-typed or
+//! undecodable records per key; the native TTL is the primary expiry, with
+//! a post-decode filter as defense in depth.
 
 use std::sync::LazyLock;
 
@@ -36,6 +40,25 @@ const MIN_TTL_SECS: u64 = 1;
 const REQ_INDEX_TTL_MARGIN_SECS: u64 = 60;
 /// Decision TTL margin over the parked record's remaining TTL.
 const DECISION_TTL_MARGIN_MS: u64 = 60_000;
+const SCAN_BATCH_SIZE: usize = 200;
+/// Type-guarded GET for the `list_pending` scan: a string key's value,
+/// integer 0 for a wrong-typed key (the caller warns and skips), nil for a
+/// key that expired or resolved between SCAN and here. A bare GET maps the
+/// server's WRONGTYPE to an extension error that would fail the whole scan.
+static TYPED_GET_SCRIPT: &str = r#"
+if redis.call('TYPE', KEYS[1]).ok == 'string' then
+    return redis.call('GET', KEYS[1])
+end
+if redis.call('EXISTS', KEYS[1]) == 1 then
+    return 0
+end
+return nil
+"#;
+/// Key prefixes under `{p}:approval:` that are not parked records: the
+/// recorded decisions and the `cancel_request` index sets. Matched against
+/// the key remainder after the `{p}:approval:` prefix is stripped.
+const DECISION_KEY_SEGMENT: &str = "decision:";
+const REQ_KEY_SEGMENT: &str = "req:";
 
 /// Sweep one approval key (KEYS[1]) out of its request index (KEYS[2]):
 /// a string key is GETDEL'd and its id SREM'd; a wrong-typed key returns 0
@@ -253,6 +276,92 @@ impl ApprovalStore for RedisApprovalStore {
             }
         }
         Ok(cleared)
+    }
+
+    async fn list_pending(&self) -> Result<Vec<ParkedApproval>, SessionStoreError> {
+        let mut conn = self.conn.clone();
+        let pattern = format!("{}:approval:*", self.key_prefix);
+
+        // SCAN in batches, never KEYS: a scan must not block the server.
+        // A mutating keyspace can hand a key back twice; dedupe before GET.
+        let mut cursor: u64 = 0;
+        let mut keys = std::collections::HashSet::new();
+        loop {
+            let (next, batch): (u64, Vec<String>) = redis::cmd("SCAN")
+                .cursor_arg(cursor)
+                .arg("MATCH")
+                .arg(&pattern)
+                .arg("COUNT")
+                .arg(SCAN_BATCH_SIZE)
+                .query_async(&mut conn)
+                .await
+                .map_err(request_err)?;
+            keys.extend(batch);
+            cursor = next;
+            if cursor == 0 {
+                break;
+            }
+        }
+
+        let now = chrono::Utc::now();
+        let mut pending = Vec::new();
+        for key in keys {
+            // Strip the configured prefix before the subspace test: a prefix
+            // containing ":decision:" or ":req:" must not exclude every key.
+            let Some(rest) = key.strip_prefix(format!("{}:approval:", self.key_prefix).as_str())
+            else {
+                continue;
+            };
+            if rest.starts_with(DECISION_KEY_SEGMENT) || rest.starts_with(REQ_KEY_SEGMENT) {
+                continue;
+            }
+            let value = redis::cmd("EVAL")
+                .arg(TYPED_GET_SCRIPT)
+                .arg(1)
+                .arg(&key)
+                .query_async::<redis::Value>(&mut conn)
+                .await
+                .map_err(request_err)?;
+            let json = match value {
+                // Expired or resolved between SCAN and GET: nothing to list.
+                redis::Value::Nil => continue,
+                redis::Value::Int(0) => {
+                    tracing::warn!(key = %key, "wrong-typed approval key skipped by list_pending");
+                    continue;
+                }
+                redis::Value::BulkString(bytes) => match String::from_utf8(bytes) {
+                    Ok(json) => json,
+                    Err(err) => {
+                        tracing::warn!(
+                            key = %key, error = %err,
+                            "non-UTF8 approval record skipped by list_pending"
+                        );
+                        continue;
+                    }
+                },
+                _ => {
+                    tracing::warn!(key = %key, "unexpected approval key value skipped by list_pending");
+                    continue;
+                }
+            };
+            let parked = match decode(&json) {
+                Ok(parked) => parked,
+                Err(err) => {
+                    tracing::warn!(
+                        key = %key, error = %err,
+                        "undecodable approval record skipped by list_pending"
+                    );
+                    continue;
+                }
+            };
+            // Native TTL is the primary expiry; the contract filter repeats
+            // here so a record inside its MIN_TTL_SECS floor past
+            // `expires_at` is never listed.
+            if parked.expires_at > now {
+                pending.push(parked);
+            }
+        }
+        Ok(pending)
     }
 }
 

--- a/crates/aura-web-server/tests/common/mod.rs
+++ b/crates/aura-web-server/tests/common/mod.rs
@@ -7,9 +7,18 @@
 //! store. For networked backends they are separate connections to the same
 //! server; for single-process backends they are two handles to the same
 //! store, which is that backend's deployment shape.
+//!
+//! Each test binary includes a subset of this module, so unused items here
+//! are normal; `dead_code` is allowed for that reason.
 
-use std::sync::Arc;
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
+use tokio::process::{Child, Command};
 
 use aura::hitl::{
     AgentScope, ApprovalDecision, ApprovalItem, ApprovalOrigin, ApprovalRequest, DecisionId,
@@ -163,4 +172,209 @@ pub async fn cancel_request_removes_only_matching(instance: &Arc<dyn ApprovalSto
     assert_eq!(cleared[0].request.decision_id, cancel_id);
     assert!(instance.get(&cancel_id).await.unwrap().is_none());
     assert!(instance.get(&keep_id).await.unwrap().is_some());
+}
+
+/// The poll reconciler's scan source: `list_pending` returns exactly the
+/// parked, undecided tickets — a resolved sibling is never listed.
+pub async fn list_pending_returns_only_live_undecided(
+    instance_a: &Arc<dyn ApprovalStore>,
+    instance_b: &Arc<dyn ApprovalStore>,
+) {
+    let resolved = make_parked("req-poll-resolved", Duration::from_secs(60));
+    let resolved_id = resolved.request.decision_id;
+    let live = make_parked("req-poll-live", Duration::from_secs(60));
+    let live_id = live.request.decision_id;
+    instance_a.register(resolved).await.unwrap();
+    instance_a.register(live).await.unwrap();
+    instance_b
+        .resolve(&resolved_id, ApprovalDecision::Approved)
+        .await
+        .unwrap();
+
+    let pending = instance_a.list_pending().await.unwrap();
+
+    let ids: Vec<DecisionId> = pending.iter().map(|p| p.request.decision_id).collect();
+    assert_eq!(ids, [live_id], "exactly the undecided ticket is listed");
+}
+
+pub async fn list_pending_empty_store_returns_empty(instance: &Arc<dyn ApprovalStore>) {
+    assert!(instance.list_pending().await.unwrap().is_empty());
+}
+
+/// Expired tickets are never listed, even where the backend retains them
+/// (the file store keeps them until remove; Redis floors the record TTL).
+pub async fn list_pending_excludes_expired(
+    instance_a: &Arc<dyn ApprovalStore>,
+    instance_b: &Arc<dyn ApprovalStore>,
+) {
+    let mut expired = make_parked("req-poll-expired", Duration::from_secs(60));
+    expired.expires_at = chrono::Utc::now() - chrono::Duration::seconds(1);
+    let live = make_parked("req-poll-live", Duration::from_secs(60));
+    let live_id = live.request.decision_id;
+    instance_a.register(expired).await.unwrap();
+    instance_a.register(live).await.unwrap();
+
+    let pending = instance_b.list_pending().await.unwrap();
+
+    let ids: Vec<DecisionId> = pending.iter().map(|p| p.request.decision_id).collect();
+    assert_eq!(ids, [live_id], "the expired ticket must not be listed");
+}
+
+// ---------------------------------------------------------------------------
+// A spawned aura-web-server for integration suites
+// ---------------------------------------------------------------------------
+
+/// How long a spawned server has to answer `/health` before the spawn
+/// retries once on a fresh port.
+pub const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// A freshly spawned `aura-web-server`, bound to its own port and reading a
+/// config generated for exactly one test case. Killed and its config file
+/// removed on drop.
+pub struct AuraServer {
+    port: u16,
+    child: Child,
+    config_path: PathBuf,
+    /// Accumulated stderr, drained continuously so the child's pipe never
+    /// blocks; read back to explain a health-check timeout.
+    stderr_log: Arc<Mutex<String>>,
+}
+
+impl AuraServer {
+    pub fn base_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+
+    /// Spawn `aura-web-server` against `config_toml` (config file named
+    /// `{config_prefix}{uuid}.toml`) with `extra_env` applied to the child,
+    /// waiting until it answers `/health`. `free_port`'s bind-then-drop
+    /// leaves a window for another process to grab the port; one retry on a
+    /// fresh port covers that.
+    pub async fn start(
+        config_toml: &str,
+        config_prefix: &str,
+        extra_env: &[(&str, String)],
+    ) -> Self {
+        match Self::try_start(config_toml, config_prefix, extra_env).await {
+            Ok(server) => server,
+            Err(failed) => {
+                let log = failed.stderr_log.lock().expect("stderr log mutex").clone();
+                eprintln!(
+                    "aura-web-server on port {} never answered /health within {HEALTH_TIMEOUT:?}; \
+                     retrying once on a fresh port. stderr:\n{log}",
+                    failed.port
+                );
+                failed.stop().await;
+                match Self::try_start(config_toml, config_prefix, extra_env).await {
+                    Ok(server) => server,
+                    Err(failed) => {
+                        let log = failed.stderr_log.lock().expect("stderr log mutex").clone();
+                        let port = failed.port;
+                        failed.stop().await;
+                        panic!(
+                            "aura-web-server never answered /health, on a fresh port either; \
+                             last tried port {port}; stderr:\n{log}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// One spawn-and-wait attempt. `Err` carries the (still-running) server
+    /// so the caller can log its stderr and stop it before retrying.
+    async fn try_start(
+        config_toml: &str,
+        config_prefix: &str,
+        extra_env: &[(&str, String)],
+    ) -> Result<Self, Self> {
+        let port = free_port();
+        let config_path =
+            std::env::temp_dir().join(format!("{config_prefix}{}.toml", uuid::Uuid::new_v4()));
+        std::fs::write(&config_path, config_toml).expect("write generated test config");
+
+        let mut child = Command::new(env!("CARGO_BIN_EXE_aura-web-server"))
+            .env("CONFIG_PATH", &config_path)
+            .env("HOST", "127.0.0.1")
+            .env("PORT", port.to_string())
+            .env("RUST_LOG", "warn")
+            .envs(extra_env.iter().map(|(k, v)| (*k, v.clone())))
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn aura-web-server (did `cargo build -p aura-web-server` succeed?)");
+
+        let stderr_log = Arc::new(Mutex::new(String::new()));
+        let stderr = child.stderr.take().expect("stderr was piped");
+        let log_sink = Arc::clone(&stderr_log);
+        tokio::spawn(async move {
+            let mut reader = tokio::io::BufReader::new(stderr);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                use tokio::io::AsyncBufReadExt;
+                if reader.read_line(&mut line).await.unwrap_or(0) == 0 {
+                    break;
+                }
+                let mut log = log_sink.lock().expect("stderr log mutex");
+                log.push_str(line.trim_end_matches('\n'));
+                log.push('\n');
+            }
+        });
+
+        let server = Self {
+            port,
+            child,
+            config_path,
+            stderr_log,
+        };
+        if server.is_healthy_within(HEALTH_TIMEOUT).await {
+            Ok(server)
+        } else {
+            Err(server)
+        }
+    }
+
+    async fn is_healthy_within(&self, timeout: Duration) -> bool {
+        let client = reqwest::Client::new();
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Ok(resp) = client
+                .get(format!("{}/health", self.base_url()))
+                .send()
+                .await
+                && resp.status().is_success()
+            {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+
+    /// Kill the child and await its exit, reaping the process, then remove its generated config file. Call this explicitly at test end; `Drop`'s `start_kill` is only the fallback for a test that panics.
+    pub async fn stop(mut self) {
+        let _ = self.child.kill().await;
+        let _ = std::fs::remove_file(&self.config_path);
+    }
+}
+
+impl Drop for AuraServer {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+        let _ = std::fs::remove_file(&self.config_path);
+    }
+}
+
+/// An OS-assigned free port, read and released before the caller uses it.
+/// The bind-then-drop race is the standard tolerance for test-local ports.
+pub fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
 }

--- a/crates/aura-web-server/tests/file_session_store_test.rs
+++ b/crates/aura-web-server/tests/file_session_store_test.rs
@@ -79,6 +79,27 @@ async fn file_battery_cancel_request_removes_only_matching() {
     common::cancel_request_removes_only_matching(&instance_a).await;
 }
 
+#[tokio::test]
+async fn file_battery_list_pending_returns_only_live_undecided() {
+    let dir = tempfile::tempdir().unwrap();
+    let (instance_a, instance_b) = file_pair(&dir);
+    common::list_pending_returns_only_live_undecided(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn file_battery_list_pending_empty_store_returns_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let (instance_a, _) = file_pair(&dir);
+    common::list_pending_empty_store_returns_empty(&instance_a).await;
+}
+
+#[tokio::test]
+async fn file_battery_list_pending_excludes_expired() {
+    let dir = tempfile::tempdir().unwrap();
+    let (instance_a, instance_b) = file_pair(&dir);
+    common::list_pending_excludes_expired(&instance_a, &instance_b).await;
+}
+
 // ---------------------------------------------------------------------------
 // Shared battery vs the memory backend (uniform contract, no Docker)
 // ---------------------------------------------------------------------------
@@ -117,6 +138,24 @@ async fn memory_battery_remove_makes_resolve_not_found() {
 async fn memory_battery_cancel_request_removes_only_matching() {
     let (instance_a, _) = memory_pair();
     common::cancel_request_removes_only_matching(&instance_a).await;
+}
+
+#[tokio::test]
+async fn memory_battery_list_pending_returns_only_live_undecided() {
+    let (instance_a, instance_b) = memory_pair();
+    common::list_pending_returns_only_live_undecided(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn memory_battery_list_pending_empty_store_returns_empty() {
+    let (instance_a, _) = memory_pair();
+    common::list_pending_empty_store_returns_empty(&instance_a).await;
+}
+
+#[tokio::test]
+async fn memory_battery_list_pending_excludes_expired() {
+    let (instance_a, instance_b) = memory_pair();
+    common::list_pending_excludes_expired(&instance_a, &instance_b).await;
 }
 
 // ---------------------------------------------------------------------------
@@ -234,6 +273,148 @@ async fn resolve_moves_the_approval_into_the_decision_file() {
     assert_eq!(on_disk["decision"]["reason"], serde_json::Value::Null);
 }
 
+/// An expired undecided approval leaves the store on the scan that finds
+/// it, so no credential outlives the decision window.
+#[tokio::test]
+async fn list_pending_unlinks_expired_approval_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let mut expired = make_parked("req-expired", Duration::from_secs(60));
+    expired.expires_at = chrono::Utc::now() - chrono::Duration::seconds(1);
+    let id = expired.request.decision_id;
+    store.register(expired).await.unwrap();
+
+    assert!(store.list_pending().await.unwrap().is_empty());
+    assert!(
+        !dir.path()
+            .join("approvals")
+            .join(format!("{id}.json"))
+            .exists(),
+        "the expired approval file was unlinked"
+    );
+}
+
+/// Rows hold credentials, so the store's directories and files are
+/// readable by the owner only.
+#[cfg(unix)]
+#[tokio::test]
+async fn store_directories_and_files_are_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let parked = make_parked("req-mode", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    store.register(parked).await.unwrap();
+    let mode =
+        |path: std::path::PathBuf| std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
+
+    assert_eq!(mode(dir.path().join("approvals")), 0o700);
+    assert_eq!(mode(dir.path().join("decisions")), 0o700);
+    assert_eq!(
+        mode(dir.path().join("approvals").join(format!("{id}.json"))),
+        0o600
+    );
+
+    store
+        .resolve(&id, ApprovalDecision::Approved)
+        .await
+        .unwrap();
+    assert_eq!(
+        mode(dir.path().join("decisions").join(format!("{id}.json"))),
+        0o600
+    );
+}
+
+/// An approval file left behind after its decision was written (the unlink
+/// in `resolve` is best-effort) is neither returned nor kept: the pending
+/// scan removes it, so the row's credentials do not outlive the decision.
+#[tokio::test]
+async fn list_pending_removes_an_approval_file_that_already_has_a_decision() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let parked = make_parked("req-residue", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    store.register(parked).await.unwrap();
+    let approval_path = dir.path().join("approvals").join(format!("{id}.json"));
+    let approval_bytes = std::fs::read(&approval_path).unwrap();
+
+    store
+        .resolve(&id, ApprovalDecision::Approved)
+        .await
+        .unwrap();
+    assert!(!approval_path.exists(), "resolve unlinks the approval file");
+    std::fs::write(&approval_path, &approval_bytes).unwrap();
+
+    let pending = store.list_pending().await.unwrap();
+
+    assert_eq!(pending.len(), 0, "a decided id is never pending");
+    assert!(
+        !approval_path.exists(),
+        "the scan removes the decided approval residue"
+    );
+    assert!(
+        dir.path()
+            .join("decisions")
+            .join(format!("{id}.json"))
+            .exists(),
+        "the decision record is untouched"
+    );
+}
+
+/// A decision file that does not decode (a write interrupted before its
+/// sync) marks the id as claimed but not recoverable from that file: the
+/// scan neither returns the row nor removes the approval file, which stays
+/// the only intact record and still answers `get`.
+#[tokio::test]
+async fn list_pending_keeps_the_approval_file_behind_an_incomplete_decision() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let parked = make_parked("req-torn", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    store.register(parked).await.unwrap();
+    let approval_path = dir.path().join("approvals").join(format!("{id}.json"));
+    let decision_path = dir.path().join("decisions").join(format!("{id}.json"));
+    std::fs::write(&decision_path, b"{\"approval\":").unwrap();
+
+    let pending = store.list_pending().await.unwrap();
+
+    assert_eq!(pending.len(), 0, "a claimed id is never pending");
+    assert!(approval_path.exists(), "the intact approval file is kept");
+    let got = store
+        .get(&id)
+        .await
+        .unwrap()
+        .expect("the approval still reads");
+    assert_eq!(got.request.decision_id, id);
+    assert!(
+        matches!(
+            store.decision(&id).await,
+            Err(SessionStoreError::Decode { .. })
+        ),
+        "the torn decision file reads as a decode error"
+    );
+    assert_eq!(
+        store.resolve(&id, ApprovalDecision::Approved).await,
+        Err(ResolveError::NotFound),
+        "the torn file still holds the at-most-once claim"
+    );
+    assert!(
+        approval_path.exists(),
+        "a refused resolve leaves the approval"
+    );
+
+    // Recovery: clearing the torn file returns the row to the pending set
+    // and lets a fresh resolve land.
+    std::fs::remove_file(&decision_path).unwrap();
+    let pending = store.list_pending().await.unwrap();
+    assert_eq!(pending.len(), 1, "the row is pending again");
+    store
+        .resolve(&id, ApprovalDecision::Approved)
+        .await
+        .expect("a fresh resolve lands");
+    assert!(!approval_path.exists(), "resolve unlinks the approval file");
+}
+
 /// §2.5: `cancel_request` removes undecided approvals by owner id and
 /// returns exactly the cleared set; a decided approval of the same owner and
 /// an undecided approval of another owner survive.
@@ -349,6 +530,57 @@ async fn cancel_request_skips_an_undecodable_approval_file() {
     assert!(corrupt.exists(), "the undecodable file is left in place");
 }
 
+#[tokio::test]
+async fn list_pending_skips_an_undecodable_approval_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let parked = make_parked("req-poll-corrupt", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    store.register(parked).await.unwrap();
+    let corrupt = dir.path().join("approvals").join("corrupt.json");
+    std::fs::write(&corrupt, b"not json").unwrap();
+
+    let pending = store.list_pending().await.unwrap();
+
+    let ids: Vec<_> = pending.iter().map(|p| p.request.decision_id).collect();
+    assert_eq!(ids, [id], "the corrupt file must not fail the scan");
+    assert!(corrupt.exists(), "the undecodable file is left in place");
+}
+
+/// The residue of resolve's best-effort approval unlink — a stale approval
+/// file whose decision file exists — never re-enters the reconciler's scan:
+/// the recorded decision owns the outcome.
+#[tokio::test]
+async fn list_pending_skips_a_stale_decided_approval() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FileApprovalStore::open(dir.path()).unwrap();
+    let live = make_parked("req-poll-live", Duration::from_secs(60));
+    let live_id = live.request.decision_id;
+    store.register(live).await.unwrap();
+    let decided = make_parked("req-poll-residue", Duration::from_secs(60));
+    let decided_id = decided.request.decision_id;
+    let residue = serde_json::to_vec(&ParkedApprovalRecord::from(&decided)).unwrap();
+    store.register(decided).await.unwrap();
+    store
+        .resolve(&decided_id, ApprovalDecision::Approved)
+        .await
+        .unwrap();
+
+    // Resolve's approval unlink failed: put the residue back.
+    std::fs::write(
+        dir.path()
+            .join("approvals")
+            .join(format!("{decided_id}.json")),
+        residue,
+    )
+    .unwrap();
+
+    let pending = store.list_pending().await.unwrap();
+
+    let ids: Vec<_> = pending.iter().map(|p| p.request.decision_id).collect();
+    assert_eq!(ids, [live_id], "the decided residue must not be listed");
+}
+
 /// A read-only `approvals/` directory must not fail `resolve`: the decision
 /// write and its sync are the commit, and the approval removal past them is
 /// best-effort — the stale approval remains, `get` still returns the record,
@@ -437,29 +669,19 @@ impl Drop for Restore<'_> {
     }
 }
 
-/// A read-only store directory must fail `open`, not the first approval:
-/// readiness keys on construction and ping, so an unwritable path rejects
-/// the server at startup.
-#[cfg(unix)]
+/// A regular file where a store directory belongs must fail `open`, so an
+/// unusable path rejects the server at startup rather than the first
+/// approval.
 #[tokio::test]
-async fn open_fails_when_a_store_directory_is_not_writable() {
-    use std::os::unix::fs::PermissionsExt;
-
+async fn open_fails_when_a_store_directory_is_obstructed() {
     let dir = tempfile::tempdir().unwrap();
     drop(FileApprovalStore::open(dir.path()).unwrap());
     let approvals = dir.path().join("approvals");
-    std::fs::set_permissions(&approvals, std::fs::Permissions::from_mode(0o500)).unwrap();
-    let _restore = Restore(&approvals);
-
-    let probe = approvals.join(".write-probe");
-    if std::fs::write(&probe, b"x").is_ok() {
-        let _ = std::fs::remove_file(&probe);
-        eprintln!("skipping: process bypasses directory permissions (running as root?)");
-        return;
-    }
+    std::fs::remove_dir_all(&approvals).unwrap();
+    std::fs::write(&approvals, b"obstruction").unwrap();
 
     let err = match FileApprovalStore::open(dir.path()) {
-        Ok(_) => panic!("open must refuse an unwritable store directory"),
+        Ok(_) => panic!("open must refuse an obstructed store directory"),
         Err(err) => err,
     };
     assert!(

--- a/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
+++ b/crates/aura-web-server/tests/hitl_header_forwarding_tests.rs
@@ -19,156 +19,21 @@
 //! this suite. Each test spawns its server fresh, waits on `/health`, drives
 //! one chat completion, and kills it on drop.
 
-use std::path::PathBuf;
-use std::process::Stdio;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use serde_json::{Value, json};
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
-use tokio::process::{Child, Command};
+mod common;
+
+use common::AuraServer;
 
 const CHAT_TIMEOUT: Duration = Duration::from_secs(90);
-const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// The prompt that has the model call `echo_headers` and relay its output.
 const ECHO_PROMPT: &str = "Call the echo_headers tool now and reply with only its raw JSON output.";
-
-// ---------------------------------------------------------------------------
-// A dedicated aura-web-server, spawned fresh per test case
-// ---------------------------------------------------------------------------
-
-/// A freshly spawned `aura-web-server`, bound to its own port and reading a config generated for exactly one test case. Killed and its config file removed on drop.
-struct AuraServer {
-    port: u16,
-    child: Child,
-    config_path: PathBuf,
-    /// Accumulated stderr, drained continuously so the child's pipe never
-    /// blocks; read back to explain a health-check timeout.
-    stderr_log: Arc<Mutex<String>>,
-}
-
-impl AuraServer {
-    fn base_url(&self) -> String {
-        format!("http://127.0.0.1:{}", self.port)
-    }
-
-    /// Spawn `aura-web-server` against `config_toml`, wait until it answers `/health`. `free_port`'s bind-then-drop leaves a window for another process to grab the port; one retry on a fresh port covers that.
-    async fn start(config_toml: &str) -> Self {
-        match Self::try_start(config_toml).await {
-            Ok(server) => server,
-            Err(failed) => {
-                let log = failed.stderr_log.lock().expect("stderr log mutex").clone();
-                eprintln!(
-                    "aura-web-server on port {} never answered /health within {HEALTH_TIMEOUT:?}; \
-                     retrying once on a fresh port. stderr:\n{log}",
-                    failed.port
-                );
-                failed.stop().await;
-                match Self::try_start(config_toml).await {
-                    Ok(server) => server,
-                    Err(failed) => {
-                        let log = failed.stderr_log.lock().expect("stderr log mutex").clone();
-                        let port = failed.port;
-                        failed.stop().await;
-                        panic!(
-                            "aura-web-server never answered /health, on a fresh port either; \
-                             last tried port {port}; stderr:\n{log}"
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    /// One spawn-and-wait attempt. `Err` carries the (still-running) server
-    /// so the caller can log its stderr and stop it before retrying.
-    async fn try_start(config_toml: &str) -> Result<Self, Self> {
-        let port = free_port();
-        let config_path =
-            std::env::temp_dir().join(format!("aura-hitl-test-{}.toml", uuid::Uuid::new_v4()));
-        std::fs::write(&config_path, config_toml).expect("write generated test config");
-
-        let mut child = Command::new(env!("CARGO_BIN_EXE_aura-web-server"))
-            .env("CONFIG_PATH", &config_path)
-            .env("HOST", "127.0.0.1")
-            .env("PORT", port.to_string())
-            .env("RUST_LOG", "warn")
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .expect("spawn aura-web-server (did `cargo build -p aura-web-server` succeed?)");
-
-        let stderr_log = Arc::new(Mutex::new(String::new()));
-        let stderr = child.stderr.take().expect("stderr was piped");
-        let log_sink = Arc::clone(&stderr_log);
-        tokio::spawn(async move {
-            let mut lines = tokio::io::BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                let mut log = log_sink.lock().expect("stderr log mutex");
-                log.push_str(&line);
-                log.push('\n');
-            }
-        });
-
-        let server = Self {
-            port,
-            child,
-            config_path,
-            stderr_log,
-        };
-        if server.is_healthy_within(HEALTH_TIMEOUT).await {
-            Ok(server)
-        } else {
-            Err(server)
-        }
-    }
-
-    async fn is_healthy_within(&self, timeout: Duration) -> bool {
-        let client = reqwest::Client::new();
-        let deadline = tokio::time::Instant::now() + timeout;
-        loop {
-            if let Ok(resp) = client
-                .get(format!("{}/health", self.base_url()))
-                .send()
-                .await
-                && resp.status().is_success()
-            {
-                return true;
-            }
-            if tokio::time::Instant::now() >= deadline {
-                return false;
-            }
-            tokio::time::sleep(Duration::from_millis(200)).await;
-        }
-    }
-
-    /// Kill the child and await its exit, reaping the process, then remove its generated config file. Call this explicitly at test end; `Drop`'s `start_kill` is only the fallback for a test that panics.
-    async fn stop(mut self) {
-        let _ = self.child.kill().await;
-        let _ = std::fs::remove_file(&self.config_path);
-    }
-}
-
-impl Drop for AuraServer {
-    fn drop(&mut self) {
-        let _ = self.child.start_kill();
-        let _ = std::fs::remove_file(&self.config_path);
-    }
-}
-
-/// An OS-assigned free port, read and released before the caller uses it.
-/// The bind-then-drop race is the standard tolerance for test-local ports.
-fn free_port() -> u16 {
-    std::net::TcpListener::bind("127.0.0.1:0")
-        .expect("bind ephemeral port")
-        .local_addr()
-        .expect("local addr")
-        .port()
-}
 
 // ---------------------------------------------------------------------------
 // A hand-rolled mock webhook approver
@@ -436,11 +301,15 @@ fn extract_json_object(text: &str) -> Option<Value> {
 /// `[hitl]` route points at it and whose client carries the frozen identity.
 async fn gated_server(reply: ApproverReply) -> (MockApprover, AuraServer) {
     let approver = MockApprover::start(reply).await;
-    let server = AuraServer::start(&config_toml(
-        &mcp_url(),
-        "Bearer legacy-frozen-identity",
-        &gated_hitl_toml(&approver.url),
-    ))
+    let server = AuraServer::start(
+        &config_toml(
+            &mcp_url(),
+            "Bearer legacy-frozen-identity",
+            &gated_hitl_toml(&approver.url),
+        ),
+        "aura-hitl-test-",
+        &[],
+    )
     .await;
     (approver, server)
 }
@@ -514,11 +383,15 @@ async fn missing_mapped_header_fails_the_call_by_name_only() {
 #[tokio::test]
 async fn a_tool_the_glob_does_not_match_is_unaffected() {
     let approver = MockApprover::start(ApproverReply::Deny).await;
-    let server = AuraServer::start(&config_toml(
-        &mcp_url(),
-        "Bearer legacy-frozen-identity",
-        &ungated_hitl_toml(&approver.url),
-    ))
+    let server = AuraServer::start(
+        &config_toml(
+            &mcp_url(),
+            "Bearer legacy-frozen-identity",
+            &ungated_hitl_toml(&approver.url),
+        ),
+        "aura-hitl-test-",
+        &[],
+    )
     .await;
 
     let response = send_chat(&server, ECHO_PROMPT).await;

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -422,6 +422,62 @@ async fn approval_cancel_request_removes_only_matching() {
     common::cancel_request_removes_only_matching(&approvals).await;
 }
 
+#[tokio::test]
+async fn approval_list_pending_returns_only_live_undecided() {
+    let config = test_config(60);
+    let instance_a = connect(&config).await.approvals();
+    let instance_b = connect(&config).await.approvals();
+    common::list_pending_returns_only_live_undecided(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn approval_list_pending_empty_store_returns_empty() {
+    let approvals = connect(&test_config(60)).await.approvals();
+    common::list_pending_empty_store_returns_empty(&approvals).await;
+}
+
+/// An expired record still inside its MIN_TTL_SECS floor must not be
+/// listed: the post-decode filter backs the native TTL.
+#[tokio::test]
+async fn approval_list_pending_excludes_expired() {
+    let config = test_config(60);
+    let instance_a = connect(&config).await.approvals();
+    let instance_b = connect(&config).await.approvals();
+    common::list_pending_excludes_expired(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn approval_list_pending_skips_wrong_typed_and_undecodable_keys() {
+    let config = test_config(60);
+    let approvals = connect(&config).await.approvals();
+    let parked = make_parked("req-list-skips", std::time::Duration::from_secs(60));
+    let live_id = parked.request.decision_id;
+    approvals.register(parked).await.unwrap();
+
+    let client = redis::Client::open(redis_url()).unwrap();
+    let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+    let prefix = &config.key_prefix;
+    let wrong_typed = format!("{prefix}:approval:{}", uuid::Uuid::new_v4());
+    redis::cmd("SADD")
+        .arg(&wrong_typed)
+        .arg("x")
+        .query_async::<()>(&mut conn)
+        .await
+        .unwrap();
+    let undecodable = format!("{prefix}:approval:{}", uuid::Uuid::new_v4());
+    redis::cmd("SET")
+        .arg(&undecodable)
+        .arg("not a parked approval")
+        .query_async::<()>(&mut conn)
+        .await
+        .unwrap();
+
+    let pending = approvals.list_pending().await.unwrap();
+
+    let ids: Vec<_> = pending.iter().map(|p| p.request.decision_id).collect();
+    assert_eq!(ids, [live_id], "only the genuine record is listed");
+}
+
 /// `cancel_request` returns exactly the records it cleared; a decided
 /// sibling of the same owner is absent, and a cleared ticket refuses a later
 /// resolve.
@@ -694,6 +750,19 @@ async fn approval_expires_with_its_record_ttl() {
         approvals.resolve(&id, ApprovalDecision::Approved).await,
         Err(ResolveError::NotFound)
     );
+}
+
+/// Native TTL expiry removes the record outright: the `list_pending` scan
+/// sees neither the key nor a residue.
+#[tokio::test]
+async fn approval_list_pending_excludes_a_natively_expired_record() {
+    let approvals = connect(&test_config(60)).await.approvals();
+    let parked = make_parked("req-poll-ttl", Duration::from_secs(1));
+    approvals.register(parked).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(1600)).await;
+
+    assert!(approvals.list_pending().await.unwrap().is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -57,6 +57,16 @@ impl HitlRuntime {
         hmac: Option<&WebhookHmac>,
         req_headers: Option<&HashMap<String, String>>,
     ) -> Self {
+        assert!(
+            !matches!(
+                &config.route,
+                DecisionRouteConfig::Webhook {
+                    delivery: aura_config::WebhookDelivery::Poll,
+                    ..
+                }
+            ),
+            "`hitl.route.delivery = \"poll\"` is not enabled in this build; use `delivery = \"sync\"`"
+        );
         let route = match &config.route {
             DecisionRouteConfig::Webhook {
                 url,
@@ -64,6 +74,7 @@ impl HitlRuntime {
                 headers,
                 headers_from_request,
                 tool_headers_from_response,
+                ..
             } => {
                 let signing = match hmac {
                     None => EgressSigning::Disabled,
@@ -695,10 +706,11 @@ pub struct PlaintextWebhookUrlError {
 }
 
 /// Boot-time guard: with an HMAC secret configured, a plaintext `http://`
-/// webhook URL must fail startup, not the first approval request. Call this
-/// for every `[hitl]` config once the secret has been loaded; the request-time
-/// `Misconfigured` rejection inside [`WebhookClient`] acts as defense in
-/// depth for paths that skip startup validation.
+/// webhook URL must fail startup, not the first approval request — and the
+/// poll status endpoint (`poll_url`, when configured) is held to the same
+/// rule. Call this for every `[hitl]` config once the secret has been loaded;
+/// the request-time `Misconfigured` rejection inside [`WebhookClient`] acts
+/// as defense in depth for paths that skip startup validation.
 pub fn validate_webhook_signing_config(
     config: &HitlConfig,
     hmac: Option<&WebhookHmac>,
@@ -712,6 +724,13 @@ pub fn validate_webhook_signing_config(
                 url: url.as_str().to_string(),
             })
         }
+        // A None poll_url resolves to `url`, already checked above.
+        DecisionRouteConfig::Webhook {
+            poll_url: Some(poll_url),
+            ..
+        } if poll_url.as_str().starts_with("http://") => Err(PlaintextWebhookUrlError {
+            url: poll_url.as_str().to_string(),
+        }),
         DecisionRouteConfig::Webhook { .. } | DecisionRouteConfig::Conversational { .. } => Ok(()),
     }
 }
@@ -1618,6 +1637,67 @@ mod tests {
             validate_webhook_signing_config(&conversational, Some(&hmac)).unwrap();
         }
 
+        #[test]
+        fn boot_validation_rejects_plaintext_poll_url_only_with_secret() {
+            use super::super::validate_webhook_signing_config;
+
+            let poll_route = |url: &str, poll_url: Option<&str>| aura_config::HitlConfig {
+                require_approval: vec![],
+                park: aura_config::ParkConfig::default(),
+                route: aura_config::DecisionRouteConfig::Webhook {
+                    url: aura_config::WebhookUrl::new(url).unwrap(),
+                    timeout_secs: 300,
+                    headers: HashMap::new(),
+                    headers_from_request: HashMap::new(),
+                    tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
+                    delivery: aura_config::WebhookDelivery::Poll,
+                    poll_url: poll_url.map(|u| aura_config::WebhookUrl::new(u).unwrap()),
+                    poll_interval_secs: 10,
+                    poll_request_timeout_secs: 30,
+                },
+            };
+            let hmac = test_hmac();
+
+            let err = validate_webhook_signing_config(
+                &poll_route(
+                    "https://approvals.example.com/aura",
+                    Some("http://status.example.com/aura"),
+                ),
+                Some(&hmac),
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains("plaintext http://"));
+            assert!(err.to_string().contains("http://status.example.com/aura"));
+
+            let err = validate_webhook_signing_config(
+                &poll_route(
+                    "http://approvals.example.com/aura",
+                    Some("https://status.example.com/aura"),
+                ),
+                Some(&hmac),
+            )
+            .unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("http://approvals.example.com/aura")
+            );
+
+            validate_webhook_signing_config(
+                &poll_route(
+                    "https://approvals.example.com/aura",
+                    Some("http://status.example.com/aura"),
+                ),
+                None,
+            )
+            .unwrap();
+
+            validate_webhook_signing_config(
+                &poll_route("https://approvals.example.com/aura", None),
+                Some(&hmac),
+            )
+            .unwrap();
+        }
+
         fn webhook_config(
             url: &str,
             tool_headers_from_response: aura_config::ToolHeaderMappings,
@@ -1631,6 +1711,10 @@ mod tests {
                     headers: HashMap::new(),
                     headers_from_request: HashMap::new(),
                     tool_headers_from_response,
+                    delivery: aura_config::WebhookDelivery::Sync,
+                    poll_url: None,
+                    poll_interval_secs: 10,
+                    poll_request_timeout_secs: 30,
                 },
             }
         }

--- a/crates/aura/src/orchestration/park/commit.rs
+++ b/crates/aura/src/orchestration/park/commit.rs
@@ -183,10 +183,10 @@ pub(crate) async fn publish(
     let parked_dir = parked_dir.to_path_buf();
     let run_id = run_id.to_string();
     tokio::task::spawn_blocking(move || {
-        std::fs::create_dir_all(&parked_dir)?;
+        crate::session_store::private_dir(&parked_dir)?;
 
         let tmp = parked_dir.join(format!(".{run_id}.tmp"));
-        std::fs::write(&tmp, &bytes)?;
+        crate::session_store::write_private(&tmp, &bytes)?;
         let dest = parked_dir.join(format!("{run_id}{PARKED_DOCUMENT_SUFFIX}"));
         std::fs::rename(&tmp, &dest)?;
 
@@ -390,10 +390,15 @@ mod tests {
 
         let reloaded = load_parked_run(&dest).await.unwrap();
         assert_eq!(reloaded.run_id, run_id);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&dest).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "the checkpoint is owner-only");
+        }
     }
 
-    /// A read-only parked directory fails the temp write, publishes nothing,
-    /// and leaves no partial document.
+    /// An obstructed temp-file path fails the write and publishes nothing.
     #[tokio::test]
     async fn failing_temp_write_publishes_nothing() {
         let dir = tempfile::tempdir().unwrap();
@@ -422,24 +427,9 @@ mod tests {
             config_fingerprint: "f".to_string(),
         };
 
-        let mut perms = tokio::fs::metadata(&parked_dir)
-            .await
-            .unwrap()
-            .permissions();
-        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o555);
-        tokio::fs::set_permissions(&parked_dir, perms)
-            .await
-            .unwrap();
+        let tmp = parked_dir.join(format!(".{run_id}.tmp"));
+        tokio::fs::create_dir(&tmp).await.unwrap();
         let result = publish(&document, &parked_dir, run_id).await;
-        // Restore writability so the tempdir can clean itself up.
-        let mut perms = tokio::fs::metadata(&parked_dir)
-            .await
-            .unwrap()
-            .permissions();
-        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
-        tokio::fs::set_permissions(&parked_dir, perms)
-            .await
-            .unwrap();
 
         assert!(result.is_err(), "the temp write must fail");
         assert!(
@@ -449,6 +439,7 @@ mod tests {
                 .unwrap(),
             "no document is published on a failed temp write"
         );
+        assert!(tmp.is_dir(), "the obstruction is left in place");
     }
 
     /// Refresh drops decided and removed approvals, keeps the undecided

--- a/crates/aura/src/orchestration/park/continuation.rs
+++ b/crates/aura/src/orchestration/park/continuation.rs
@@ -166,7 +166,10 @@ impl ResumingDocumentHandle {
                 .unwrap_or_default()
         ));
         tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            std::fs::write(&tmp, &bytes)?;
+            if let Some(parent) = non_empty_parent(&publish_path) {
+                crate::session_store::private_dir(parent)?;
+            }
+            crate::session_store::write_private(&tmp, &bytes)?;
             std::fs::rename(&tmp, &publish_path)
         })
         .await
@@ -223,6 +226,9 @@ pub(crate) async fn load_recorded_decisions(
                 .await
                 .map_err(|e| RehydrateError::Store(e.to_string()))?;
             let Some(parked) = parked else {
+                if chrono::Utc::now() > expires_at {
+                    return Err(RehydrateError::Expired);
+                }
                 return Err(RehydrateError::Mismatch(format!(
                     "store approval {} is missing",
                     call.decision_id
@@ -324,8 +330,25 @@ pub(crate) fn replace_tool_result(current_prompt: &mut Message, call_id: &str, w
     replaced
 }
 
+/// The directory a document lives in, or `None` for a bare file name whose
+/// parent is the empty path.
+fn non_empty_parent(path: &std::path::Path) -> Option<&std::path::Path> {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+}
+
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn non_empty_parent_skips_a_bare_file_name() {
+        use std::path::Path;
+        assert_eq!(super::non_empty_parent(Path::new("run.json")), None);
+        assert_eq!(
+            super::non_empty_parent(Path::new("parked/run.json")),
+            Some(Path::new("parked"))
+        );
+    }
+
     use super::*;
     use crate::hitl::{
         AgentScope, ApprovalDecision, ApprovalItem, ApprovalOrigin, ApprovalRequest,
@@ -510,10 +533,16 @@ mod tests {
 
         // The same undecided call past the document's expiry is the expired
         // row.
-        let mut doc = parked_run(vec![pending_call(undecided, args)]);
+        let mut doc = parked_run(vec![pending_call(undecided, args.clone())]);
         doc.expires_at = (chrono::Utc::now() - chrono::Duration::seconds(1)).to_rfc3339();
         let err = load_recorded_decisions(&registry, &doc).await.unwrap_err();
         assert!(err.to_string().contains("expired"), "got: {err}");
+
+        // A row the store already swept past the window is expired, not a
+        // mismatch.
+        doc.plan.tasks[0].pending = Some(vec![pending_call(vanished, args)]);
+        let err = load_recorded_decisions(&registry, &doc).await.unwrap_err();
+        assert!(matches!(err, RehydrateError::Expired), "got: {err}");
     }
 
     /// The stored approval's scope must name this run and this checkpoint
@@ -666,6 +695,12 @@ mod tests {
         )
         .unwrap();
 
+        #[cfg(unix)]
+        std::fs::set_permissions(
+            dir.path(),
+            <std::fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(0o755),
+        )
+        .unwrap();
         let handle = Arc::new(ResumingDocumentHandle::open(&parked_path).await.unwrap());
         let h1 = Arc::clone(&handle);
         let h2 = Arc::clone(&handle);
@@ -698,6 +733,21 @@ mod tests {
             .filter_map(|e| e.ok())
             .any(|e| e.file_name().to_string_lossy().ends_with(".tmp"));
         assert!(!residue, "no temp file residue");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(handle.publish_path())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600, "the resuming document is owner-only");
+            let dir_mode = std::fs::metadata(dir.path()).unwrap().permissions().mode() & 0o777;
+            assert_eq!(
+                dir_mode, 0o700,
+                "the parked directory is tightened on append"
+            );
+        }
     }
 
     /// A missing document opens as NotFound — the section 2.6 "not found"

--- a/crates/aura/src/session_store/fault_store.rs
+++ b/crates/aura/src/session_store/fault_store.rs
@@ -77,4 +77,8 @@ impl ApprovalStore for FaultInjectingStore {
     ) -> Result<Vec<ParkedApproval>, SessionStoreError> {
         self.inner.cancel_request(request_id).await
     }
+
+    async fn list_pending(&self) -> Result<Vec<ParkedApproval>, SessionStoreError> {
+        self.inner.list_pending().await
+    }
 }

--- a/crates/aura/src/session_store/file.rs
+++ b/crates/aura/src/session_store/file.rs
@@ -11,7 +11,7 @@
 //! Store contract (park/reify §2.5):
 //!
 //! - `resolve` refuses past the approval's `expires_at`, uniformly with an
-//!   unknown id; expiry is enforced only by `resolve`.
+//!   unknown id.
 //! - `resolve` *moves* the approval into the decision file rather than deleting
 //!   it: `get` returns the approval before and after the decision, `decision`
 //!   returns the recorded decision, and both are retained until `remove`.
@@ -20,6 +20,11 @@
 //! - `cancel_request` removes undecided approvals by owner (request) id and
 //!   returns them; decided entries are retained until their consumer removes
 //!   them.
+//! - `list_pending` scans the undecided approvals for the poll reconciler:
+//!   corrupt files are warn-and-skipped per id, expired records are
+//!   unlinked, and an approval file left behind a complete decision file
+//!   is unlinked (one behind an undecodable decision file is kept, as the
+//!   only intact record).
 //!
 //! Decision ids are validated as UUIDs before path building, so none address
 //! outside the root.
@@ -83,8 +88,8 @@ impl FileApprovalStore {
     /// cannot hold files must fail at startup, not on the first approval.
     pub fn open(root: impl AsRef<Path>) -> Result<Self, SessionStoreError> {
         let root = root.as_ref();
-        fs::create_dir_all(root.join(APPROVALS_DIR)).map_err(connect_err)?;
-        fs::create_dir_all(root.join(DECISIONS_DIR)).map_err(connect_err)?;
+        private_dir(&root.join(APPROVALS_DIR)).map_err(connect_err)?;
+        private_dir(&root.join(DECISIONS_DIR)).map_err(connect_err)?;
         let inner = Arc::new(Inner {
             root: root.to_path_buf(),
             lock: Mutex::new(()),
@@ -128,7 +133,7 @@ impl Inner {
     fn probe_writable_sync(&self) -> io::Result<()> {
         for dir in [self.approvals_dir(), self.decisions_dir()] {
             let probe = dir.join(format!(".{}.probe", uuid::Uuid::new_v4()));
-            fs::write(&probe, b"")
+            write_private(&probe, b"")
                 .and_then(|()| fs::remove_file(&probe))
                 .map_err(|err| {
                     io::Error::new(err.kind(), format!("{} not writable: {err}", dir.display()))
@@ -191,7 +196,11 @@ impl Inner {
         .expect("resolved entry serializes to JSON");
 
         let decision_path = self.decision_path(&id);
-        let mut file = match fs::File::create_new(&decision_path) {
+        let mut file = match private_file()
+            .write(true)
+            .create_new(true)
+            .open(&decision_path)
+        {
             Ok(file) => file,
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                 return Err(ResolveError::NotFound);
@@ -325,6 +334,81 @@ impl Inner {
         }
         Ok(cleared)
     }
+
+    fn list_pending_sync(&self) -> Result<Vec<ParkedApproval>, SessionStoreError> {
+        let _guard = self.lock();
+        let entries = match fs::read_dir(self.approvals_dir()) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => return Err(request_err(err)),
+        };
+        let now = chrono::Utc::now();
+
+        let mut pending = Vec::new();
+        for entry in entries {
+            let entry = entry.map_err(request_err)?;
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                // A mid-publish temp file, never a stored approval.
+                continue;
+            }
+            let bytes = match fs::read(&path) {
+                Ok(bytes) => bytes,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(request_err(err)),
+            };
+            let parked = match decode_approval(&bytes) {
+                Ok(parked) => parked,
+                Err(err) => {
+                    tracing::warn!(
+                        path = %path.display(), error = %err,
+                        "undecodable approval file skipped by list_pending"
+                    );
+                    continue;
+                }
+            };
+            // resolve writes the decision before its best-effort approval
+            // unlink, so a decision file here marks an already-decided id:
+            // the reconciler must not re-poll it. A decision file that
+            // decodes as a complete entry makes the approval file residue
+            // (which carries the row's credentials), retried for removal on
+            // every scan until it is gone; a decision file that does not
+            // decode (a write interrupted before its sync) leaves the
+            // approval file in place as the only intact record.
+            let decision_path = self.decision_path(&parked.request.decision_id.to_string());
+            match fs::read(&decision_path) {
+                Ok(bytes) => {
+                    if serde_json::from_slice::<ResolvedEntry>(&bytes).is_ok() {
+                        if let Err(err) = fs::remove_file(&path)
+                            && err.kind() != io::ErrorKind::NotFound
+                        {
+                            tracing::warn!(
+                                path = %path.display(), error = %err,
+                                "decided approval file not removed by list_pending"
+                            );
+                        }
+                    } else {
+                        tracing::warn!(
+                            path = %decision_path.display(),
+                            "incomplete decision file; approval file kept for recovery"
+                        );
+                    }
+                    continue;
+                }
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+                Err(err) => return Err(request_err(err)),
+            }
+            if parked.expires_at > now {
+                pending.push(parked);
+            } else if let Err(err) = fs::remove_file(&path) {
+                tracing::warn!(
+                    path = %path.display(), error = %err,
+                    "expired approval file not removed by list_pending"
+                );
+            }
+        }
+        Ok(pending)
+    }
 }
 
 #[async_trait]
@@ -385,6 +469,13 @@ impl ApprovalStore for FileApprovalStore {
             .await
             .map_err(join_err)?
     }
+
+    async fn list_pending(&self) -> Result<Vec<ParkedApproval>, SessionStoreError> {
+        let inner = Arc::clone(&self.inner);
+        spawn_blocking(move || inner.list_pending_sync())
+            .await
+            .map_err(join_err)?
+    }
 }
 
 /// Validate decision id as canonical UUID for path safety.
@@ -408,11 +499,53 @@ fn publish(path: &Path, payload: &[u8]) -> Result<(), SessionStoreError> {
         name.to_string_lossy(),
         uuid::Uuid::new_v4()
     ));
-    let written = fs::write(&tmp, payload).and_then(|()| fs::rename(&tmp, path));
+    let written = write_private(&tmp, payload).and_then(|()| fs::rename(&tmp, path));
     if let Err(err) = written {
         let _ = fs::remove_file(&tmp);
         return Err(request_err(err));
     }
+    Ok(())
+}
+
+/// Open options that create files readable by the owner only.
+fn private_file() -> fs::OpenOptions {
+    let mut options = fs::OpenOptions::new();
+    #[cfg(unix)]
+    std::os::unix::fs::OpenOptionsExt::mode(&mut options, 0o600);
+    options
+}
+
+/// Write `payload` to a new or truncated owner-only file. A file that
+/// already exists at `path` is tightened to owner-only after truncation
+/// and before the payload is written, so a permissive leftover never
+/// holds new content.
+pub(crate) fn write_private(path: &Path, payload: &[u8]) -> io::Result<()> {
+    #[cfg_attr(not(unix), allow(unused_mut))]
+    let mut file = private_file()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)?;
+    #[cfg(unix)]
+    file.set_permissions(<fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(0o600))?;
+    file.write_all(payload)
+}
+
+/// Create `path` and any missing parents as owner-only directories. A
+/// `path` that already exists is tightened to owner-only, so a directory
+/// created under a permissive umask by an earlier version stops exposing
+/// the records inside it the next time the store or park path opens.
+pub(crate) fn private_dir(path: &Path) -> io::Result<()> {
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    std::os::unix::fs::DirBuilderExt::mode(&mut builder, 0o700);
+    builder.create(path)?;
+    #[cfg(unix)]
+    fs::set_permissions(
+        path,
+        <fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(0o700),
+    )?;
     Ok(())
 }
 
@@ -449,5 +582,43 @@ fn decode_err(reason: impl std::fmt::Display) -> SessionStoreError {
 fn join_err(err: JoinError) -> SessionStoreError {
     SessionStoreError::Request {
         reason: format!("file store task failed: {err}"),
+    }
+}
+
+#[cfg(all(test, unix))]
+mod private_mode_tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::{private_dir, write_private};
+
+    fn mode_of(path: &std::path::Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[test]
+    fn private_dir_tightens_an_existing_permissive_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("approvals");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert_eq!(mode_of(&target), 0o755, "fixture is permissive");
+
+        private_dir(&target).unwrap();
+
+        assert_eq!(mode_of(&target), 0o700);
+    }
+
+    #[test]
+    fn write_private_tightens_a_permissive_leftover_before_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join(".leftover.tmp");
+        std::fs::write(&target, b"stale").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(mode_of(&target), 0o644, "fixture is permissive");
+
+        write_private(&target, b"fresh").unwrap();
+
+        assert_eq!(mode_of(&target), 0o600);
+        assert_eq!(std::fs::read(&target).unwrap(), b"fresh");
     }
 }

--- a/crates/aura/src/session_store/memory.rs
+++ b/crates/aura/src/session_store/memory.rs
@@ -113,6 +113,19 @@ impl ApprovalStore for InMemoryApprovalStore {
             .collect();
         Ok(cleared)
     }
+
+    async fn list_pending(&self) -> Result<Vec<ParkedApproval>, SessionStoreError> {
+        // The map self-prunes only decided entries; expired tickets stay
+        // until resolve/remove, so the contract filter repeats here.
+        let now = chrono::Utc::now();
+        let entries = self.lock();
+        let pending = entries
+            .values()
+            .filter(|parked| parked.expires_at > now)
+            .cloned()
+            .collect();
+        Ok(pending)
+    }
 }
 
 /// A local `tokio::broadcast` registry keyed by topic. Single-instance pub/sub:
@@ -313,24 +326,6 @@ mod tests {
         assert!(store.get(&id).await.unwrap().is_some());
         store.remove(&id).await.unwrap();
         assert!(store.get(&id).await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn approval_store_cancel_request_removes_only_matching() {
-        let store = InMemoryApprovalStore::new();
-        let cancel = parked("req-cancel");
-        let cancel_id = cancel.request.decision_id;
-        let keep = parked("req-keep");
-        let keep_id = keep.request.decision_id;
-        store.register(cancel).await.unwrap();
-        store.register(keep).await.unwrap();
-
-        let cleared = store.cancel_request("req-cancel").await.unwrap();
-
-        assert_eq!(cleared.len(), 1, "only the matching ticket is cleared");
-        assert_eq!(cleared[0].request.decision_id, cancel_id);
-        assert!(store.get(&keep_id).await.unwrap().is_some());
-        assert_eq!(store.lock().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/aura/src/session_store/mod.rs
+++ b/crates/aura/src/session_store/mod.rs
@@ -27,6 +27,7 @@ use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
 #[cfg(test)]
 pub(crate) use fault_store::FaultInjectingStore;
 pub use file::FileApprovalStore;
+pub(crate) use file::{private_dir, write_private};
 pub use memory::{InMemoryApprovalStore, InMemoryEventBus};
 pub use record::{DecisionRecord, InvalidRecord, OriginRecord, ParkedApprovalRecord, ScopeRecord};
 
@@ -60,7 +61,7 @@ pub enum SessionStoreError {
 pub trait ApprovalStore: Send + Sync {
     /// Persist a parked approval, keyed by its `DecisionId`. Backends with
     /// native expiry set the entry's TTL from `expires_at`; the file store
-    /// keeps it until `remove`.
+    /// unlinks an expired entry on its next poll scan.
     async fn register(&self, parked: ParkedApproval) -> Result<(), SessionStoreError>;
 
     /// Look up a parked approval.
@@ -92,6 +93,10 @@ pub trait ApprovalStore: Send + Sync {
         &self,
         request_id: &str,
     ) -> Result<Vec<ParkedApproval>, SessionStoreError>;
+
+    /// List every parked approval that is undecided and non-expired
+    /// (`expires_at > now`). No ordering guarantee.
+    async fn list_pending(&self) -> Result<Vec<ParkedApproval>, SessionStoreError>;
 }
 
 /// The payload stream returned by [`EventBus::subscribe`].


### PR DESCRIPTION
First of four PRs that add an asynchronous "poll" delivery mode to the HITL webhook route. This one adds the config keys and the store method the later PRs build on, and keeps the mode switched off.

What changes:

- `[hitl.route]` gains `delivery` (`sync`, the default, or `poll`), `poll_url`, `poll_interval_secs`, and `poll_request_timeout_secs`. Config validation rejects `delivery = "poll"` outright in this PR, since the code that serves it lands in the next two. It also requires `[hitl.park].enabled` for poll and refuses a plaintext `poll_url` when an HMAC secret is set.
- `ApprovalStore` gains `list_pending`, implemented for the memory, file, and Redis backends (the fault-injecting test store delegates to its inner store). Nothing calls it yet; the reconciler in the next PR does. It is a required trait method with no default, so an out-of-tree backend has to implement it. That is deliberate: a default that returns an error would show up as a failure on every reconciler tick instead of at compile time.
- Approval files and parked-run checkpoints hold credentials and tool output, so they are created 0600 in 0700 directories instead of inheriting the umask. A directory left permissive by an earlier build is tightened when the store opens or a checkpoint is written. The file store's pending scan also unlinks two kinds of leftover approval file: one that has expired, and one whose decision is already fully recorded. Redis rows already expire by TTL.
- On the existing park resume path, a checkpointed call whose store approval has vanished past the checkpoint's expiry is now an expiry error rather than a store-mismatch error. Nothing in the merged tree calls that path yet; the resume endpoint is separate work.
- The spawned-server fixture from the header-forwarding integration tests moves into the shared test module so later suites can reuse it.

Not in this PR: the reconciler and its wire format. Those come next; the park-path activation and credential persistence follow, and the last PR turns the mode on.

Testing: unit tests for the new config fields and each validation error; backend-contract tests for `list_pending` on the memory, file, and Redis stores (live rows only, empty store, expired excluded); file-store tests for unlinking an expired file and skipping an undecodable one; Redis tests for wrong-typed and undecodable keys; unit tests for the file modes. `cargo test --workspace`, clippy, and fmt are clean, and the Redis tests ran against a local Valkey.

Stack: based on `nightly`. Next: `mshearer/271-poll-protocol`.
