### PR TITLE
fix(logging): cut long console lines on a char boundary

### DIFF
--- a/crates/aura/src/logging.rs
+++ b/crates/aura/src/logging.rs
@@ -257,14 +257,11 @@ where
         ctx.field_format()
             .format_fields(field_writer.by_ref(), event)?;
 
-        // Check length and truncate if needed
-        if buf.len() > self.max_length {
-            writeln!(
-                writer,
-                "{}... ({} chars)",
-                &buf[..self.max_length],
-                buf.len()
-            )?;
+        // Check length and truncate if needed, on a char boundary: slicing at
+        // the raw byte limit panics when a multibyte character straddles it.
+        let (shown, truncated) = crate::string_utils::truncate_for_log(&buf, self.max_length);
+        if truncated {
+            writeln!(writer, "{shown}... ({} chars)", buf.len())?;
         } else {
             writeln!(writer, "{buf}")?;
         }
@@ -920,6 +917,39 @@ mod tests {
             !log.contains("info noise stays filtered"),
             "the directive is warn-level, not a blanket enable, got log: {log}"
         );
+    }
+
+    /// Console lines longer than the formatter's limit are cut on a char
+    /// boundary, including when a multibyte character straddles the byte
+    /// limit, so the output stays valid UTF-8.
+    #[test]
+    fn truncating_formatter_cuts_long_lines_on_char_boundaries() {
+        use std::sync::Arc;
+
+        // `—` is 3 bytes, so of any three consecutive limits that land inside
+        // the message, at least two fall mid-character.
+        for max_length in 60..63 {
+            let buf = Arc::new(CapturedLog(std::sync::Mutex::new(Vec::new())));
+            let subscriber = tracing_subscriber::fmt()
+                .event_format(TruncatingFormatter { max_length })
+                .with_writer(buf.clone())
+                .finish();
+
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::info!(target: "aura::logging", "{}", "—".repeat(100));
+            });
+
+            let log = String::from_utf8(buf.0.lock().unwrap().clone())
+                .expect("a truncated line must still be valid UTF-8");
+            let (shown, _) = log
+                .split_once("... (")
+                .unwrap_or_else(|| panic!("line was not truncated: {log}"));
+            assert!(
+                shown.len() <= max_length && shown.len() + 3 > max_length,
+                "expected a cut within one char of {max_length} bytes, got {} bytes",
+                shown.len()
+            );
+        }
     }
 
     /// A prompt longer than `OTEL_CONTENT_MAX_LENGTH` must still serialize to


### PR DESCRIPTION
## What

Fixes a panic in `TruncatingFormatter`, the console formatter used in verbose mode. Long log lines are now cut on a UTF-8 char boundary instead of at a raw byte offset.

## Why

The formatter shortened lines over `max_length` (500 bytes in verbose mode) with `&buf[..self.max_length]`. When a multibyte character straddled that byte, the slice panicked the tokio worker handling the event, and the tool call being logged failed with it.

It happened in a deployed sre-agent (`mezmo/aura:0.2.13-nightly.9`) while logging the arguments of a PagerDuty `add_note` whose text had an em dash at bytes 498..501:

```
thread 'tokio-rt-worker' panicked at crates/aura/src/logging.rs:265:21:
end byte index 500 is not a char boundary; it is inside '—' (bytes 498..501) of `2026-09-10T18:59:14.359Z INFO  aura::mcp::execution:    Arguments: {"request":{"action":"add_note",…
```

The agent retried and the note landed, but any log line longer than the limit with a multibyte character at the cut hits this. Agent-written text (incident notes, file contents, PR bodies) is full of em dashes. #609 fixed the same panic in tool-result previews (#610); this formatter wasn't covered.

## How

Truncate with `string_utils::truncate_for_log`, the `floor_char_boundary` helper the other truncation sites already share. The `... (N chars)` suffix is unchanged: it still reports `buf.len()`, which is bytes.

## Testing

- **New test.** `logging::tests::truncating_formatter_cuts_long_lines_on_char_boundaries` drives a real subscriber through `TruncatingFormatter` with a line of `—` at three consecutive limits. At least two of them cut mid-character. It checks the output is valid UTF-8 and cut within one character of the limit. Against the unfixed code it fails with the same panic at `logging.rs:265:21`.
- **Checks:**
  - `cargo test --workspace` passes.
  - `cargo fmt --all -- --check` is clean.
  - `cargo clippy -p aura --all-targets --all-features -- -D warnings` is clean. The change is confined to the `aura` crate.
  - `npm run commitlint` passes on the commit.

Refs: #609
