### PR TITLE
feat(docker): add cargo_features build arg to the release image

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -87,6 +87,17 @@ Make targets are composed from modular includes under `.makefiles/` (rust, docke
 | `make docker-test`     | Run the Docker build's lint/test stage         |
 | `make start` / `make stop` | Start/stop the Docker Compose setup        |
 
+### Docker image features
+
+The release image compiles `aura` and `aura-web-server` with no optional
+cargo features. The `CARGO_FEATURES` build arg (a comma-separated cargo
+feature list) enables them for both binaries, for example the Redis/Valkey
+session store a multi-instance deployment needs:
+
+```bash
+docker build --build-arg CARGO_FEATURES=session-store-redis --target release -t aura:redis .
+```
+
 ## Testing
 
 ### Unit Tests

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -90,9 +90,11 @@ Make targets are composed from modular includes under `.makefiles/` (rust, docke
 ### Docker image features
 
 The release image compiles `aura` and `aura-web-server` with no optional
-cargo features. The `CARGO_FEATURES` build arg (a comma-separated cargo
-feature list) enables them for both binaries, for example the Redis/Valkey
-session store a multi-instance deployment needs:
+cargo features. The `CARGO_FEATURES` build arg accepts a comma-separated list
+of features shared by both packages (`aura-cli` and `aura-web-server`) and
+enables them for both binaries; a feature only one package defines fails the
+build. For example, the Redis/Valkey session store a multi-instance deployment
+needs:
 
 ```bash
 docker build --build-arg CARGO_FEATURES=session-store-redis --target release -t aura:redis .

--- a/Dockerfile
+++ b/Dockerfile
@@ -288,16 +288,19 @@ COPY crates/ ./crates/
 RUN cargo build --workspace --bin aura
 
 ### 010 Cook-release
-# CARGO_FEATURES is a comma-separated cargo feature list for the release
-# binaries (e.g. session-store-redis). Empty by default; the cook and the
-# build both apply it so the dependency cache is keyed on the same set.
+# CARGO_FEATURES is a comma-separated cargo feature list applied to both
+# release binaries, so every name must exist in aura-cli and aura-web-server
+# (e.g. session-store-redis). Empty by default; the cook and the build both
+# apply it so the dependency cache is keyed on the same set. Each RUN
+# expands it once into the positional parameters.
 FROM core AS cook-release
 ARG CARGO_FEATURES=""
 WORKDIR /usr/src/app
 COPY --from=planner /usr/src/app/recipe.json recipe.json
 ENV CARGO_TARGET_DIR=/usr/src/app/target
-RUN cargo chef cook --release -p aura-cli --bin aura ${CARGO_FEATURES:+--features "$CARGO_FEATURES"} --recipe-path recipe.json \
- && cargo chef cook --release --bin aura-web-server ${CARGO_FEATURES:+--features "$CARGO_FEATURES"} --recipe-path recipe.json
+RUN set -- ${CARGO_FEATURES:+--features "$CARGO_FEATURES"} \
+ && cargo chef cook --release -p aura-cli --bin aura "$@" --recipe-path recipe.json \
+ && cargo chef cook --release --bin aura-web-server "$@" --recipe-path recipe.json
 
 ### 011 Release-build
 # Source changes only recompile workspace crates.
@@ -309,8 +312,9 @@ COPY crates/ ./crates/
 
 RUN <<EOR
   set -e
-  cargo build --release -p aura-cli --bin aura ${CARGO_FEATURES:+--features "$CARGO_FEATURES"}
-  cargo build --release --bin aura-web-server ${CARGO_FEATURES:+--features "$CARGO_FEATURES"}
+  set -- ${CARGO_FEATURES:+--features "$CARGO_FEATURES"}
+  cargo build --release -p aura-cli --bin aura "$@"
+  cargo build --release --bin aura-web-server "$@"
 EOR
 
 ### 012 Runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -288,24 +288,29 @@ COPY crates/ ./crates/
 RUN cargo build --workspace --bin aura
 
 ### 010 Cook-release
+# CARGO_FEATURES is a comma-separated cargo feature list for the release
+# binaries (e.g. session-store-redis). Empty by default; the cook and the
+# build both apply it so the dependency cache is keyed on the same set.
 FROM core AS cook-release
+ARG CARGO_FEATURES=""
 WORKDIR /usr/src/app
 COPY --from=planner /usr/src/app/recipe.json recipe.json
 ENV CARGO_TARGET_DIR=/usr/src/app/target
-RUN cargo chef cook --release -p aura-cli --bin aura --recipe-path recipe.json \
- && cargo chef cook --release --bin aura-web-server --recipe-path recipe.json
+RUN cargo chef cook --release -p aura-cli --bin aura ${CARGO_FEATURES:+--features "$CARGO_FEATURES"} --recipe-path recipe.json \
+ && cargo chef cook --release --bin aura-web-server ${CARGO_FEATURES:+--features "$CARGO_FEATURES"} --recipe-path recipe.json
 
 ### 011 Release-build
 # Source changes only recompile workspace crates.
 FROM cook-release AS release-build
+ARG CARGO_FEATURES=""
 WORKDIR /usr/src/app
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ ./crates/
 
 RUN <<EOR
   set -e
-  cargo build --release -p aura-cli --bin aura
-  cargo build --release --bin aura-web-server
+  cargo build --release -p aura-cli --bin aura ${CARGO_FEATURES:+--features "$CARGO_FEATURES"}
+  cargo build --release --bin aura-web-server ${CARGO_FEATURES:+--features "$CARGO_FEATURES"}
 EOR
 
 ### 012 Runtime


### PR DESCRIPTION
## What

Adds a `CARGO_FEATURES` build arg to the Dockerfile's `cook-release` and `release-build` stages, applied to both the `aura` and `aura-web-server` builds, plus a short DEVELOPMENT.md note with the example:

```bash
docker build --build-arg CARGO_FEATURES=session-store-redis --target release -t aura:redis .
```

## Why

The release image compiles with no optional cargo features, so the published image cannot run with `AURA_SESSION_STORE=redis`: startup fails with `session store backend 'redis' requires the 'session-store-redis' cargo feature`. A multi-instance deployment built from this Dockerfile had no way to enable that feature short of editing the file. The aura-sandbox HA rig works around it today by compiling its own binary inside a runner container; moving that rig to Kubernetes needs an image that carries the feature. Context: the shared `memory_dir` / VFS work in #579.

## Design notes

- Empty by default, so the default build renders exactly the commands it did before (`${CARGO_FEATURES:+...}` expands to nothing when unset).
- Applied on the cook stage as well as the build stage so the cargo-chef dependency cache is keyed on the same feature set.
- Redeclared in `release-build` because an `ARG` does not cross a stage boundary without it.

## Verification

- `docker build --target release` with no arg: builds, and a container started with `AURA_SESSION_STORE=redis` exits 1 with the feature message above (negative control).
- `docker build --build-arg CARGO_FEATURES=session-store-redis --target release`: builds, and against a Valkey container `/health` reports `"session_store":{"backend":"redis","ping":{"latency_ms":0,"ok":true}}` with `Session store backend: redis` in the log.
- `make lint`, `make lint-commits`, hadolint (with the file's existing `DL3008` ignore), and shellcheck on the RUN bodies are clean.

Not in scope, possible follow-ups: a `make docker-build` passthrough for the arg, and the chart's `sessionStore.*` values from `docs/design/session-storage.md` section 10 (the chart's existing `extraEnv` covers it in the meantime).

Refs: #579
