### PR TITLE
Webhook poll delivery (2/4): notify and status-poll legs, reconciler

### DIFF
--- a/crates/aura-config/src/config.rs
+++ b/crates/aura-config/src/config.rs
@@ -413,6 +413,7 @@ impl Config {
             && let DecisionRouteConfig::Webhook {
                 delivery: WebhookDelivery::Poll,
                 headers_from_request,
+                poll_interval_secs,
                 ..
             } = &hitl.route
         {
@@ -428,6 +429,13 @@ impl Config {
                     "`hitl.route.headers_from_request` is unsupported with \
                      `hitl.route.delivery = \"poll\"`: request-derived headers cannot be \
                      reconstructed by the background reconciler after a restart"
+                        .to_string(),
+                ));
+            }
+            if *poll_interval_secs == 0 {
+                return Err(crate::ConfigError::Validation(
+                    "`hitl.route.poll_interval_secs` must be greater than zero: \
+                     the poll reconciler ticks on this interval"
                         .to_string(),
                 ));
             }
@@ -1394,6 +1402,20 @@ mode = "conversational"
         let msg = err.to_string();
         assert!(
             msg.contains("hitl.route.headers_from_request"),
+            "error must name the key: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_zero_poll_interval() {
+        let err = crate::load_config_from_str(&poll_config_toml(
+            true,
+            "delivery = \"poll\"\npoll_interval_secs = 0",
+        ))
+        .expect_err("a zero poll interval must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("hitl.route.poll_interval_secs"),
             "error must name the key: {msg}"
         );
     }

--- a/crates/aura-web-server/src/server.rs
+++ b/crates/aura-web-server/src/server.rs
@@ -429,7 +429,7 @@ async fn run(args: ServerArgs) -> std::io::Result<()> {
     }
 
     let app_state = Arc::new(AppState {
-        configs: configs_arc,
+        configs: Arc::clone(&configs_arc),
         tool_result_mode: args.tool_result_mode,
         tool_result_max_length: args.tool_result_max_length,
         streaming_buffer_size: args.streaming_buffer_size,
@@ -456,6 +456,57 @@ async fn run(args: ServerArgs) -> std::io::Result<()> {
         "Starting server on {}:{} (shutdown_timeout={}s)",
         args.host, args.port, shutdown_timeout_secs
     );
+
+    // Poll delivery: one reconciler per poll-mode agent config, holding its
+    // own webhook client built from the same route config the per-request
+    // routes use, and the ingress registry's store. Each loop stops when the
+    // shutdown token cancels (phase 1).
+    //
+    // Boot guard: two poll-mode configs whose agent settings produce the
+    // same effective instance id would each spawn a reconciler claiming
+    // the same pending rows in one process, breaking the single-writer
+    // posture the poller documents — refuse at boot, the same loud config
+    // error as the plaintext-http-with-secret refusal. In-process only: a
+    // cross-process same-id deployment (active/standby) must fence
+    // reconciler leadership externally.
+    let mut reconcilers = Vec::new();
+    let mut claims = Vec::new();
+    for config in configs_arc.iter() {
+        let Some(hitl) = &config.hitl else {
+            continue;
+        };
+        let instance_id = compute_instance_id(&config.agent).to_string();
+        let Some(reconciler) = aura::hitl::PollReconciler::from_config(
+            hitl,
+            ingress_hmac.as_ref(),
+            instance_id.clone(),
+            session_store.approvals(),
+            &app_state.pending_approvals,
+        ) else {
+            continue;
+        };
+        let label = config.agent.alias.as_deref().unwrap_or(&config.agent.name);
+        claims.push((label.to_string(), instance_id));
+        reconcilers.push(reconciler);
+    }
+    if let Some(((first, second), id)) = reconciler_id_conflicts(&claims) {
+        error!(
+            "poll-delivery conflict: agents '{first}' and '{second}' resolve to the same \
+             effective instance id {id}"
+        );
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "poll-delivery conflict: agents '{first}' and '{second}' resolve to the same \
+                 effective instance id {id}; two reconcilers in one process would claim the \
+                 same pending approvals. give each poll-mode agent a distinct instance_seed \
+                 (or a distinct name)"
+            ),
+        ));
+    }
+    for reconciler in reconcilers {
+        reconciler.spawn(&shutdown_token);
+    }
 
     let app = Router::new()
         .route("/health", get(handlers::health))
@@ -561,6 +612,52 @@ async fn run(args: ServerArgs) -> std::io::Result<()> {
             shutdown_rx.await.ok();
         })
         .await
+}
+
+/// The reconciler boot guard's conflict scan: the first duplicate
+/// effective instance id among the configs that would spawn a reconciler,
+/// as `((first agent label, second agent label), shared id)`.
+fn reconciler_id_conflicts(claims: &[(String, String)]) -> Option<((String, String), String)> {
+    let mut seen = std::collections::HashMap::new();
+    for (label, id) in claims {
+        if let Some(first) = seen.insert(id, label) {
+            return Some(((first.clone(), label.clone()), id.clone()));
+        }
+    }
+    None
+}
+
+/// The scan sees only configs `PollReconciler::from_config` arms (the
+/// spawn loop claims no others), so a non-poll config sharing an id never
+/// reaches it; that gating is pinned by the poller's
+/// `from_config_gates_on_poll_delivery`.
+#[cfg(test)]
+mod reconciler_boot_guard_tests {
+    use super::reconciler_id_conflicts;
+
+    fn claim(label: &str, id: &str) -> (String, String) {
+        (label.to_string(), id.to_string())
+    }
+
+    #[test]
+    fn duplicate_id_reports_both_labels_and_the_id() {
+        let ((first, second), id) = reconciler_id_conflicts(&[
+            claim("alpha", "id-1"),
+            claim("beta", "id-2"),
+            claim("gamma", "id-1"),
+        ])
+        .expect("the shared id must conflict");
+        assert_eq!(first, "alpha");
+        assert_eq!(second, "gamma");
+        assert_eq!(id, "id-1");
+    }
+
+    #[test]
+    fn distinct_ids_do_not_conflict() {
+        assert!(
+            reconciler_id_conflicts(&[claim("alpha", "id-1"), claim("beta", "id-2")]).is_none()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/aura/src/hitl/mod.rs
+++ b/crates/aura/src/hitl/mod.rs
@@ -31,6 +31,7 @@
 mod decision;
 mod events;
 mod gate;
+mod poller;
 mod protocol;
 mod registry;
 mod route;
@@ -42,7 +43,48 @@ pub use decision::{
     DecisionId, Timestamp,
 };
 pub(crate) use events::completed_cancelled;
+/// Read one full HTTP/1.1 request (head plus content-length body) off a
+/// test socket, returning the raw text. Shared by the scripted receivers in
+/// the route and poller test modules.
+#[cfg(test)]
+pub(crate) async fn read_full_request(socket: &mut tokio::net::TcpStream) -> String {
+    use tokio::io::AsyncReadExt;
+
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    // Read until we have the complete header section (\r\n\r\n).
+    loop {
+        let n = socket.read(&mut chunk).await.unwrap();
+        assert!(n > 0, "peer closed before request completed");
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    // Parse Content-Length so the request body is consumed before
+    // responding — otherwise reqwest may see a connection reset while
+    // still sending the POST body.
+    let header_end = buf.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
+    let header_section = String::from_utf8_lossy(&buf[..header_end]).to_string();
+    let content_length: usize = header_section
+        .lines()
+        .find(|line| line.to_lowercase().starts_with("content-length:"))
+        .and_then(|line| line.split(':').nth(1))
+        .and_then(|val| val.trim().parse().ok())
+        .unwrap_or(0);
+    let body_already_read = buf.len() - header_end;
+    let remaining = content_length.saturating_sub(body_already_read);
+    if remaining > 0 {
+        let mut body_buf = vec![0u8; remaining];
+        socket.read_exact(&mut body_buf).await.unwrap();
+        buf.extend_from_slice(&body_buf);
+    }
+    String::from_utf8_lossy(&buf).to_string()
+}
+
 pub use gate::HitlApprovalWrapper;
+pub use poller::{PollReconciler, PollerHandle};
 pub use protocol::{ApprovalDecisionWire, ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
 pub use registry::{ParkedApproval, PendingApprovals, ResolveError};
 pub use route::{

--- a/crates/aura/src/hitl/poller.rs
+++ b/crates/aura/src/hitl/poller.rs
@@ -1,0 +1,692 @@
+//! The poll-delivery reconciler: drives a parked webhook-poll approval from
+//! notification to durable resolution.
+//!
+//! Each tick the reconciler lists the undecided, non-expired approvals
+//! from the shared [`ApprovalStore`], keeps its own `instance_id`'s rows,
+//! and per id — one row at a time — reads the status endpoint before
+//! attempting the ack-only notification POST: a receiver that holds the
+//! POST open costs at most one request timeout per tick before the row
+//! and the rows queued behind it move on, and a decided 200 resolves
+//! durably through the same [`PendingApprovals::resolve`] path the
+//! ingress handler uses without re-posting the request. The reconciler
+//! never terminalizes an approval — expiry stays fail-closed at resolve
+//! time — and its notified markers are in-memory only, self-pruning when
+//! an id leaves `list_pending`.
+//!
+//! HA posture: single-writer — parked documents are pod-local, so two
+//! instances' reconcilers never see each other's runs. Notify delivery is
+//! at-least-once: a crash between a 2xx ack and the marker being observed
+//! produces one duplicate, idempotent by `decision_id` at the receiver.
+//! Poll-claim is exactly-once within an instance; a shared-store,
+//! multi-instance deployment has no cross-instance claim guarantee.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use aura_config::{DecisionRouteConfig, HitlConfig, WebhookDelivery};
+
+use super::decision::DecisionId;
+use super::registry::{PendingApprovals, ResolveError};
+use super::route::{PollOutcome, WebhookClient, webhook_client_from_config};
+use super::signing::WebhookHmac;
+use crate::session_store::ApprovalStore;
+
+/// The poll-delivery reconciler for one process: a private webhook client,
+/// the shared approval store it scans, and the ingress registry it resolves
+/// through. Built once at startup from the `[hitl.route]` config; [`Self::spawn`]
+/// runs the tick loop until its shutdown token cancels.
+pub struct PollReconciler {
+    client: WebhookClient,
+    store: Arc<dyn ApprovalStore>,
+    registry: PendingApprovals,
+    instance_id: String,
+    interval: Duration,
+}
+
+impl PollReconciler {
+    /// Build the reconciler for a `[hitl]` config, or `None` for every
+    /// configuration the reconciler does not drive: the conversational arm,
+    /// and the webhook arm under sync delivery. The client is built by the
+    /// same construction [`super::route::HitlRuntime::from_config`] uses, so
+    /// the reconciler's notify/poll legs carry the exact wire shape of the
+    /// per-request routes (static operator headers only — poll delivery
+    /// refuses `headers_from_request` at config validation).
+    #[must_use]
+    pub fn from_config(
+        config: &HitlConfig,
+        hmac: Option<&WebhookHmac>,
+        instance_id: String,
+        store: Arc<dyn ApprovalStore>,
+        registry: &PendingApprovals,
+    ) -> Option<Self> {
+        let DecisionRouteConfig::Webhook {
+            delivery: WebhookDelivery::Poll,
+            poll_interval_secs,
+            ..
+        } = &config.route
+        else {
+            return None;
+        };
+        Some(Self {
+            client: webhook_client_from_config(&config.route, hmac, None)?,
+            store,
+            registry: registry.clone(),
+            instance_id,
+            interval: Duration::from_secs(*poll_interval_secs),
+        })
+    }
+
+    /// Spawn the tick loop on the current runtime. The loop stops when
+    /// `shutdown` cancels (the web server registers its shutdown token
+    /// here) or when the returned handle's [`Self::stop`] runs.
+    /// Dropping the handle detaches the loop — the cancel-sweep task's
+    /// caller convention (`park::cancel_run_approvals`): await it for
+    /// ordered teardown, or drop it and let the loop keep running until
+    /// shutdown.
+    pub fn spawn(self, shutdown: &CancellationToken) -> PollerHandle {
+        let token = shutdown.child_token();
+        let task = tokio::spawn(self.run(token.clone()));
+        PollerHandle { token, task }
+    }
+
+    async fn run(self, token: CancellationToken) {
+        let mut tick = tokio::time::interval(self.interval);
+        tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let mut notified = HashSet::new();
+        loop {
+            tokio::select! {
+                () = token.cancelled() => break,
+                _ = tick.tick() => self.tick(&mut notified).await,
+            }
+        }
+    }
+
+    /// One reconcile pass. The notified set self-prunes first: an id that
+    /// left `list_pending` (resolved, cancelled, expired) needs no marker.
+    async fn tick(&self, notified: &mut HashSet<DecisionId>) {
+        let pending = match self.store.list_pending().await {
+            Ok(pending) => pending,
+            Err(err) => {
+                warn!(error = %err, "approval list_pending failed; retrying next tick");
+                return;
+            }
+        };
+        notified.retain(|id| {
+            pending
+                .iter()
+                .any(|parked| parked.request.decision_id == *id)
+        });
+
+        for parked in pending {
+            if parked.request.instance_id != self.instance_id {
+                continue;
+            }
+            let id = parked.request.decision_id;
+            // The status read runs before the notify attempt, so a
+            // receiver that holds the POST open delays its own row's
+            // acknowledgment, never that row's status read, and a decided
+            // row never re-posts its request.
+            match self.client.poll_decision(id).await {
+                Ok(PollOutcome::NotYet) => {}
+                Ok(PollOutcome::Decided {
+                    decision,
+                    response_headers,
+                }) => {
+                    // The response headers are not consumed here; the
+                    // reconciler resolves on the decision alone.
+                    drop(response_headers);
+                    match self.registry.resolve(&id, decision).await {
+                        Ok(()) => {}
+                        // The ticket expired or was swept between
+                        // list_pending and resolve; the decision is
+                        // discarded with it, as the ingress 404 would.
+                        Err(ResolveError::NotFound) => debug!(
+                            decision_id = %id,
+                            "polled decision arrived after the approval left the store"
+                        ),
+                        Err(ResolveError::Store(err)) => warn!(
+                            decision_id = %id,
+                            error = %err,
+                            "polled decision could not be recorded; it may be re-polled"
+                        ),
+                    }
+                    continue;
+                }
+                Err(err) => warn!(
+                    decision_id = %id,
+                    error = %err,
+                    "approval poll failed; retrying next tick"
+                ),
+            }
+            if !notified.contains(&id) {
+                match self.client.notify(&parked.request).await {
+                    Ok(()) => {
+                        notified.insert(id);
+                    }
+                    Err(err) => {
+                        warn!(
+                            decision_id = %id,
+                            error = %err,
+                            "approval notify failed; retrying next tick"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Stop/join handle for a spawned [`PollReconciler`].
+pub struct PollerHandle {
+    token: CancellationToken,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl PollerHandle {
+    /// Cancel the loop and await its exit. The in-flight tick completes
+    /// first — a notify or poll request already under way is never cut.
+    pub async fn stop(self) {
+        self.token.cancel();
+        let _ = self.task.await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+    use tokio::sync::mpsc;
+
+    use super::super::decision::{AgentScope, ApprovalDecision, ApprovalOrigin};
+    use super::super::protocol::{ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
+    use super::super::read_full_request;
+    use super::super::registry::ParkedApproval;
+    use super::*;
+    use crate::session_store::{FileApprovalStore, InMemoryApprovalStore};
+
+    const INSTANCE_ID: &str = "poll-instance";
+
+    fn poll_config() -> aura_config::HitlConfig {
+        aura_config::HitlConfig {
+            require_approval: vec![],
+            park: aura_config::ParkConfig::default(),
+            route: aura_config::DecisionRouteConfig::Webhook {
+                url: aura_config::WebhookUrl::new("http://127.0.0.1:1").unwrap(),
+                timeout_secs: 300,
+                headers: std::collections::HashMap::new(),
+                headers_from_request: std::collections::HashMap::new(),
+                tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
+                delivery: aura_config::WebhookDelivery::Poll,
+                poll_url: None,
+                poll_interval_secs: 1,
+                poll_request_timeout_secs: 30,
+            },
+        }
+    }
+
+    fn parked_request(decision_id: DecisionId, instance_id: &str) -> ApprovalRequest {
+        ApprovalRequest {
+            version: PROTOCOL_VERSION,
+            instance_id: instance_id.to_string(),
+            decision_id,
+            request_id: format!("req_{decision_id}"),
+            scope: AgentScope::Single { session_id: None },
+            origin: ApprovalOrigin::ConfigGate {
+                matched_pattern: "kubectl_*".to_string(),
+                agent_name: "test-agent".to_string(),
+            },
+            items: vec![ApprovalItem {
+                tool_name: "kubectl_apply".to_string(),
+                arguments: serde_json::json!({ "namespace": "prod" }),
+                tool_call_intent: None,
+            }],
+        }
+    }
+
+    fn reconciler_with(store: Arc<dyn ApprovalStore>, url: &str) -> PollReconciler {
+        let mut config = poll_config();
+        let aura_config::DecisionRouteConfig::Webhook { url: route_url, .. } = &mut config.route
+        else {
+            unreachable!("poll_config builds a webhook route");
+        };
+        *route_url = aura_config::WebhookUrl::new(url).unwrap();
+        let registry = PendingApprovals::with_backend(
+            store.clone(),
+            Arc::new(crate::session_store::InMemoryEventBus::new()),
+        );
+        PollReconciler::from_config(&config, None, INSTANCE_ID.to_string(), store, &registry)
+            .expect("poll config builds a reconciler")
+    }
+
+    /// A pending approval parked directly in the store, expiring far out.
+    async fn park_pending(store: &Arc<dyn ApprovalStore>, instance_id: &str) -> DecisionId {
+        let request = parked_request(DecisionId::generate(), instance_id);
+        let id = request.decision_id;
+        store
+            .register(ParkedApproval {
+                request,
+                registered_at: chrono::Utc::now(),
+                expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+            })
+            .await
+            .expect("pending approval registers");
+        id
+    }
+
+    /// Sequential-connection mock receiver: connection `i` gets
+    /// `responses[i]`, every captured request text lands on the channel.
+    /// Each response closes the connection, so every request is its own.
+    async fn scripted_receiver(
+        responses: Vec<(&'static str, String)>,
+    ) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let (tx, rx) = mpsc::channel(responses.len());
+        tokio::spawn(async move {
+            for (status, body) in responses {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let captured = read_full_request(&mut socket).await;
+                let response = format!(
+                    "HTTP/1.1 {status}\r\ncontent-type: application/json\r\n\
+                     content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.ok();
+                socket.shutdown().await.ok();
+                tx.send(captured).await.expect("capture channel open");
+            }
+        });
+        (url, rx)
+    }
+
+    fn ack_ok() -> (&'static str, String) {
+        ("200 OK", String::new())
+    }
+
+    fn poll_pending() -> (&'static str, String) {
+        ("204 No Content", String::new())
+    }
+
+    fn poll_decided(decision: &str) -> (&'static str, String) {
+        ("200 OK", decision.to_string())
+    }
+
+    async fn store_decision(
+        store: &Arc<dyn ApprovalStore>,
+        id: &DecisionId,
+    ) -> Option<ApprovalDecision> {
+        store.decision(id).await.unwrap()
+    }
+
+    /// The tick loop against a scripted receiver: the status read runs
+    /// before the notify attempt, a failed notify retries the POST next
+    /// tick, an acked id skips the POST (the marker short-circuits it)
+    /// and keeps polling, and the decided 200 resolves durably through
+    /// the ingress registry.
+    #[tokio::test]
+    async fn tick_polls_while_unacked_and_the_marker_skips_the_post() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let id = park_pending(&store, INSTANCE_ID).await;
+        let (url, mut rx) = scripted_receiver(vec![
+            poll_pending(),
+            ("503 Service Unavailable", String::new()),
+            poll_pending(),
+            ack_ok(),
+            poll_decided(r#"{"status":"approved"}"#),
+        ])
+        .await;
+        let reconciler = reconciler_with(store.clone(), &url);
+        let mut notified = HashSet::new();
+
+        reconciler.tick(&mut notified).await;
+        let first = rx.recv().await.unwrap();
+        assert!(
+            first.starts_with("GET "),
+            "first tick reads status: {first}"
+        );
+        assert!(
+            first.contains(&format!("decision_id={id}")),
+            "the poll query carries the decision id: {first}"
+        );
+        let same_tick = rx.recv().await.unwrap();
+        assert!(
+            same_tick.starts_with("POST "),
+            "the notify attempt follows the read: {same_tick}"
+        );
+
+        reconciler.tick(&mut notified).await;
+        assert!(rx.recv().await.unwrap().starts_with("GET "));
+        let retried = rx.recv().await.unwrap();
+        assert!(
+            retried.starts_with("POST "),
+            "an unacked id retries the POST: {retried}"
+        );
+
+        reconciler.tick(&mut notified).await;
+        let marked = rx.recv().await.unwrap();
+        assert!(
+            marked.starts_with("GET "),
+            "the notified marker must skip the POST: {marked}"
+        );
+
+        assert_eq!(
+            store_decision(&store, &id).await,
+            Some(ApprovalDecision::Approved),
+            "the decided 200 resolves durably"
+        );
+        assert!(
+            store.get(&id).await.unwrap().is_none(),
+            "resolve removed the pending ticket"
+        );
+    }
+
+    /// A receiver whose POSTs never succeed cannot starve the status read:
+    /// the approval still resolves through the GET alone, which also never
+    /// re-posts the request once the decision is visible.
+    #[tokio::test]
+    async fn tick_resolves_via_the_status_get_while_notify_never_acks() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let id = park_pending(&store, INSTANCE_ID).await;
+        let (url, mut rx) = scripted_receiver(vec![
+            poll_pending(),
+            ("503 Service Unavailable", String::new()),
+            poll_decided(r#"{"status":"approved"}"#),
+        ])
+        .await;
+        let reconciler = reconciler_with(store.clone(), &url);
+        let mut notified = HashSet::new();
+
+        reconciler.tick(&mut notified).await;
+        assert!(rx.recv().await.unwrap().starts_with("GET "));
+        assert!(rx.recv().await.unwrap().starts_with("POST "));
+
+        reconciler.tick(&mut notified).await;
+        assert!(rx.recv().await.unwrap().starts_with("GET "));
+
+        assert_eq!(
+            store_decision(&store, &id).await,
+            Some(ApprovalDecision::Approved),
+            "the status GET alone must carry the resolution"
+        );
+    }
+
+    /// A 200 whose body is outside the status envelope keeps the approval
+    /// pending: nothing is recorded and the row survives for the next tick.
+    #[tokio::test]
+    async fn tick_unparsable_poll_200_records_no_decision() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let id = park_pending(&store, INSTANCE_ID).await;
+        let (url, mut rx) = scripted_receiver(vec![
+            poll_decided("<html>upstream error page</html>"),
+            ack_ok(),
+        ])
+        .await;
+        let reconciler = reconciler_with(store.clone(), &url);
+        let mut notified = HashSet::new();
+
+        reconciler.tick(&mut notified).await;
+        let out_of_envelope = rx.recv().await.unwrap();
+        assert!(out_of_envelope.starts_with("GET "));
+        assert!(rx.recv().await.unwrap().starts_with("POST "));
+
+        assert_eq!(
+            store_decision(&store, &id).await,
+            None,
+            "an out-of-envelope body must never become a decision"
+        );
+        assert!(store.get(&id).await.unwrap().is_some());
+    }
+
+    /// A policy-instant approval on the notify POST is never read as a
+    /// decision: the ack body is dropped, and only the status GET resolves.
+    #[tokio::test]
+    async fn policy_instant_approve_on_the_notify_ack_waits_for_the_status_get() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let id = park_pending(&store, INSTANCE_ID).await;
+        let (url, mut rx) = scripted_receiver(vec![
+            poll_pending(),
+            poll_decided(r#"{"status":"approved"}"#), // the approving ack body
+            poll_decided(r#"{"status":"approved"}"#),
+        ])
+        .await;
+        let reconciler = reconciler_with(store.clone(), &url);
+        let mut notified = HashSet::new();
+
+        reconciler.tick(&mut notified).await;
+        let first_read = rx.recv().await.unwrap();
+        assert!(
+            first_read.starts_with("GET "),
+            "the status read runs before the notify: {first_read}"
+        );
+        assert!(rx.recv().await.unwrap().starts_with("POST "));
+
+        assert!(
+            store_decision(&store, &id).await.is_none(),
+            "an approving ack body must never mint a decision"
+        );
+
+        reconciler.tick(&mut notified).await;
+        assert!(rx.recv().await.unwrap().starts_with("GET "));
+        assert_eq!(
+            store_decision(&store, &id).await,
+            Some(ApprovalDecision::Approved),
+            "the decided status GET resolves durably"
+        );
+    }
+
+    /// A pending row belonging to another instance is never notified,
+    /// polled, or resolved: the own-instance filter keeps a shared
+    /// backend's reconcilers to their own approvals.
+    #[tokio::test]
+    async fn tick_skips_pending_approvals_of_other_instances() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let own = park_pending(&store, INSTANCE_ID).await;
+        let other = park_pending(&store, "another-instance").await;
+        let (url, mut rx) = scripted_receiver(vec![
+            poll_pending(),
+            ack_ok(),
+            poll_decided(r#"{"status":"approved"}"#),
+        ])
+        .await;
+        let reconciler = reconciler_with(store.clone(), &url);
+        let mut notified = HashSet::new();
+
+        reconciler.tick(&mut notified).await;
+        let first = rx.recv().await.unwrap();
+        assert!(first.starts_with("GET "));
+        assert!(
+            first.contains(&format!("decision_id={own}")) && !first.contains(&other.to_string()),
+            "the status read targets the own-instance row only"
+        );
+        let second = rx.recv().await.unwrap();
+        assert!(second.starts_with("POST "));
+        assert!(
+            second.contains(&own.to_string()) && !second.contains(&other.to_string()),
+            "the notify belongs to the own-instance row only"
+        );
+
+        reconciler.tick(&mut notified).await;
+        assert!(rx.recv().await.unwrap().starts_with("GET "));
+
+        assert_eq!(
+            store_decision(&store, &own).await,
+            Some(ApprovalDecision::Approved),
+        );
+        assert!(
+            store.get(&other).await.unwrap().is_some(),
+            "the other instance's row stays untouched"
+        );
+    }
+
+    /// `from_config` gates the production spawn on webhook poll delivery.
+    #[test]
+    fn from_config_gates_on_poll_delivery() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let registry = PendingApprovals::new();
+        let build = |config| {
+            PollReconciler::from_config(
+                &config,
+                None,
+                INSTANCE_ID.to_string(),
+                store.clone(),
+                &registry,
+            )
+        };
+
+        assert!(build(poll_config()).is_some());
+
+        let mut sync = poll_config();
+        if let aura_config::DecisionRouteConfig::Webhook { delivery, .. } = &mut sync.route {
+            *delivery = aura_config::WebhookDelivery::Sync;
+        }
+        assert!(build(sync).is_none(), "sync delivery has no reconciler");
+
+        let conversational = aura_config::HitlConfig {
+            require_approval: vec![],
+            park: aura_config::ParkConfig::default(),
+            route: aura_config::DecisionRouteConfig::Conversational { timeout_secs: 60 },
+        };
+        assert!(build(conversational).is_none());
+    }
+
+    /// The restart path through the real production wiring (from_config +
+    /// spawn over a persistent file-backed store): boot one reads status
+    /// and notifies; stop the runtime; the reboot's fresh markers
+    /// re-notify the still-undecided row (idempotent by decision id), and
+    /// the next tick's decided poll resolves durably.
+    #[tokio::test]
+    async fn restart_renotifies_the_undecided_row_and_resolves_after_reboot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        let (url, mut rx) = scripted_receiver(vec![
+            poll_pending(),
+            ack_ok(),
+            poll_pending(),
+            ack_ok(),
+            poll_decided(r#"{"status":"approved"}"#),
+        ])
+        .await;
+
+        let shutdown = CancellationToken::new();
+
+        // Boot one.
+        let store_a: Arc<dyn ApprovalStore> = Arc::new(FileApprovalStore::open(&path).unwrap());
+        let registry_a = PendingApprovals::with_backend(
+            store_a.clone(),
+            Arc::new(crate::session_store::InMemoryEventBus::new()),
+        );
+        let id = {
+            let request = parked_request(DecisionId::generate(), INSTANCE_ID);
+            let id = request.decision_id;
+            registry_a
+                .register_durable(ParkedApproval {
+                    request,
+                    registered_at: chrono::Utc::now(),
+                    expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+                })
+                .await
+                .expect("pending approval parks durably");
+            id
+        };
+        let handle_a = reconciler_with(store_a.clone(), &url).spawn(&shutdown);
+        let read = rx.recv().await.unwrap();
+        assert!(read.starts_with("GET "), "boot one reads status: {read}");
+        let notify = rx.recv().await.unwrap();
+        assert!(notify.starts_with("POST "), "boot one notifies: {notify}");
+        handle_a.stop().await;
+
+        // Boot two: a fresh reconciler over the same store root — notified
+        // markers are gone, so the reboot re-notifies the undecided row and
+        // the next tick's poll picks up the decision. Its registry resolves
+        // over the same store, as the ingress handler's would.
+        let store_b: Arc<dyn ApprovalStore> = Arc::new(FileApprovalStore::open(&path).unwrap());
+        let _handle_b = reconciler_with(store_b.clone(), &url).spawn(&shutdown);
+        let reread = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("boot two reads status")
+            .unwrap();
+        assert!(
+            reread.starts_with("GET "),
+            "the reboot reads status: {reread}"
+        );
+        let renotify = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("boot two re-notifies")
+            .unwrap();
+        assert!(
+            renotify.starts_with("POST "),
+            "the reboot re-notifies: {renotify}"
+        );
+
+        let recorded = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(decision) = store_decision(&store_b, &id).await {
+                    break decision;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the reboot's decided tick resolves");
+        assert_eq!(recorded, ApprovalDecision::Approved);
+        // The file backend retains the record behind `get` (resolve moves
+        // the ticket into the decision file); the pending scan is what the
+        // reconciler consumes, so that is what must be empty now.
+        let still_pending = store_b
+            .list_pending()
+            .await
+            .unwrap()
+            .into_iter()
+            .any(|parked| parked.request.decision_id == id);
+        assert!(
+            !still_pending,
+            "the resolved ticket leaves the pending scan"
+        );
+
+        shutdown.cancel();
+    }
+
+    /// The handle stops the loop cleanly: no tick is cut mid-request and
+    /// the joined task ends without hanging.
+    #[tokio::test]
+    async fn stop_stops_the_loop_and_joins_without_hanging() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let (url, _rx) = scripted_receiver(vec![ack_ok()]).await;
+        let reconciler = reconciler_with(store, &url);
+        let handle = reconciler.spawn(&CancellationToken::new());
+
+        let started = std::time::Instant::now();
+        tokio::time::timeout(Duration::from_secs(5), handle.stop())
+            .await
+            .expect("stop must not hang");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "stop returned promptly"
+        );
+    }
+
+    /// Cancelling the token the loop was spawned under — the web server's
+    /// shutdown path — ends the loop.
+    #[tokio::test]
+    async fn shutdown_token_cancel_ends_the_loop() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let (url, _rx) = scripted_receiver(vec![ack_ok()]).await;
+        let shutdown = CancellationToken::new();
+        let reconciler = reconciler_with(store, &url);
+        let handle = reconciler.spawn(&shutdown);
+
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !handle.task.is_finished() {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the loop must end when the shutdown token cancels");
+    }
+}

--- a/crates/aura/src/hitl/protocol.rs
+++ b/crates/aura/src/hitl/protocol.rs
@@ -77,6 +77,27 @@ impl From<ApprovalDecisionWire> for ApprovalDecision {
     }
 }
 
+/// Wire form of one status-poll answer: the `{ "status": ..., "reason": ... }`
+/// envelope a governance receiver returns on the poll-delivery status GET.
+/// `pending` parses here like any other status (the envelope is
+/// self-describing), unknown fields are tolerated, and an unknown status
+/// value fails the parse — which the poll leg treats as not-yet.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct PollDecisionWire {
+    pub status: PollStatusWire,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// The status discriminant of [`PollDecisionWire`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum PollStatusWire {
+    Pending,
+    Approved,
+    Denied,
+}
+
 /// The webhook request projected to its wire form: the flat, rename-stable JSON
 /// AURA POSTs to an approval webhook (Route A).
 ///

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -9,14 +9,18 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use aura_config::{DecisionRouteConfig, GlobPattern, HitlConfig, ToolHeaderMappings, WebhookUrl};
+use aura_config::{
+    DecisionRouteConfig, GlobPattern, HitlConfig, ToolHeaderMappings, WebhookDelivery, WebhookUrl,
+};
 use reqwest::header::HeaderMap;
 
 use super::decision::{ApprovalDecision, ApprovalOutcome, DecisionId};
 use super::events;
-use super::protocol::{ApprovalDecisionWire, ApprovalRequest, ApprovalRequestWire};
+use super::protocol::{
+    ApprovalDecisionWire, ApprovalRequest, ApprovalRequestWire, PollDecisionWire, PollStatusWire,
+};
 use super::registry::PendingApprovals;
-use super::signing::{SigningContext, WebhookHmac, authorize_ingress};
+use super::signing::{SigningContext, VerifiedBody, WebhookHmac, authorize_ingress};
 use crate::approval_event_broker::{self, ApprovalLifecycleEvent};
 
 /// Maximum time to wait for a TCP connection to the approval webhook before
@@ -57,44 +61,12 @@ impl HitlRuntime {
         hmac: Option<&WebhookHmac>,
         req_headers: Option<&HashMap<String, String>>,
     ) -> Self {
-        assert!(
-            !matches!(
-                &config.route,
-                DecisionRouteConfig::Webhook {
-                    delivery: aura_config::WebhookDelivery::Poll,
-                    ..
-                }
-            ),
-            "`hitl.route.delivery = \"poll\"` is not enabled in this build; use `delivery = \"sync\"`"
-        );
         let route = match &config.route {
-            DecisionRouteConfig::Webhook {
-                url,
-                timeout_secs,
-                headers,
-                headers_from_request,
-                tool_headers_from_response,
-                ..
-            } => {
-                let signing = match hmac {
-                    None => EgressSigning::Disabled,
-                    Some(hmac) => EgressSigning::Enabled(hmac.clone()),
-                };
-                DecisionRoute::Webhook {
-                    client: WebhookClient::with_headers_and_signing(
-                        build_webhook_client(),
-                        url.clone(),
-                        crate::webhook_utils::resolve_headers(
-                            headers,
-                            headers_from_request,
-                            req_headers,
-                        ),
-                        signing,
-                        tool_headers_from_response.clone(),
-                    ),
-                    timeout: Duration::from_secs(*timeout_secs),
-                }
-            }
+            DecisionRouteConfig::Webhook { timeout_secs, .. } => DecisionRoute::Webhook {
+                client: webhook_client_from_config(&config.route, hmac, req_headers)
+                    .expect("the webhook arm of the route config builds a client"),
+                timeout: Duration::from_secs(*timeout_secs),
+            },
             DecisionRouteConfig::Conversational { timeout_secs } => DecisionRoute::Conversational {
                 registry: pending_approvals.clone(),
                 timeout: Duration::from_secs(*timeout_secs),
@@ -106,6 +78,55 @@ impl HitlRuntime {
             park_enabled: config.park.enabled,
         }
     }
+}
+
+/// Build the webhook route's client for a `[hitl.route]` config: the one
+/// construction every webhook arm shares (per-request [`HitlRuntime`]s and
+/// the poll reconciler's own client alike), so both see one wire shape.
+/// `None` for the conversational arm.
+///
+/// Poll settings exist only for poll delivery; `None` is the sync marker.
+/// `poll_interval_secs` stays unread here: the client carries no cadence,
+/// the reconciler owns it.
+pub(crate) fn webhook_client_from_config(
+    route: &DecisionRouteConfig,
+    hmac: Option<&WebhookHmac>,
+    req_headers: Option<&HashMap<String, String>>,
+) -> Option<WebhookClient> {
+    let DecisionRouteConfig::Webhook {
+        url,
+        headers,
+        headers_from_request,
+        tool_headers_from_response,
+        delivery,
+        poll_url,
+        poll_request_timeout_secs,
+        ..
+    } = route
+    else {
+        return None;
+    };
+    let signing = match hmac {
+        None => EgressSigning::Disabled,
+        Some(hmac) => EgressSigning::Enabled(hmac.clone()),
+    };
+    let poll = match delivery {
+        WebhookDelivery::Poll => Some(PollSettings {
+            // An unconfigured status endpoint polls the route url itself;
+            // resolution happens here, once.
+            poll_url: poll_url.clone().unwrap_or_else(|| url.clone()),
+            request_timeout: Duration::from_secs(*poll_request_timeout_secs),
+        }),
+        WebhookDelivery::Sync => None,
+    };
+    Some(WebhookClient::with_headers_and_signing(
+        build_webhook_client(),
+        url.clone(),
+        crate::webhook_utils::resolve_headers(headers, headers_from_request, req_headers),
+        signing,
+        tool_headers_from_response.clone(),
+        poll,
+    ))
 }
 
 /// Errors that can occur while asking a webhook for an approval decision.
@@ -138,6 +159,12 @@ pub enum ApprovalError {
     /// application-time failures cannot be mislabeled as capture failures.
     #[error("{0}")]
     CaptureFailed(#[from] crate::approver_headers::CaptureError),
+}
+
+impl From<reqwest::Error> for ApprovalError {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Transport(err.without_url().to_string())
+    }
 }
 
 /// A decision as seen by the config gate.
@@ -272,6 +299,21 @@ async fn webhook_round_trip<T>(
     result
 }
 
+/// The live-path guard for poll delivery: a poll-mode client's synchronous
+/// decision legs must not fire the sync POST, whose ack would be misread as
+/// a decision. Every decision on a poll route fails closed here until the
+/// park arm takes config-gated calls; the agent-callable `request_approval`
+/// tool path always lands here.
+fn poll_delivery_guard(client: &WebhookClient) -> Result<(), ApprovalError> {
+    if client.poll.is_some() {
+        Err(ApprovalError::Misconfigured(
+            "poll delivery has no live decision path".to_string(),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 impl DecisionRoute {
     /// Obtain a decision for a config-gated call, carrying any captured
     /// approver header overrides on the approved arm.
@@ -293,6 +335,7 @@ impl DecisionRoute {
                 Ok(GateDecision::without_overrides(outcome))
             }
             Self::Webhook { client, timeout } => {
+                poll_delivery_guard(client)?;
                 webhook_round_trip(
                     &request,
                     cancel,
@@ -377,6 +420,7 @@ impl DecisionRoute {
                 Ok(outcome)
             }
             Self::Webhook { client, timeout } => {
+                poll_delivery_guard(client)?;
                 webhook_round_trip(
                     &request,
                     cancel,
@@ -415,6 +459,17 @@ enum EgressSigning {
     Misconfigured(String),
 }
 
+/// Per-attempt settings for the poll-delivery legs ([`WebhookClient::notify`]
+/// and [`WebhookClient::poll_decision`]): where to poll and how long one
+/// attempt may take.
+struct PollSettings {
+    /// Status endpoint to GET: the configured `poll_url`, or the route `url`
+    /// when unconfigured.
+    poll_url: WebhookUrl,
+    /// Per-attempt HTTP timeout for both poll legs.
+    request_timeout: Duration,
+}
+
 /// HTTP client for the webhook route.
 pub struct WebhookClient {
     client: reqwest::Client,
@@ -424,6 +479,9 @@ pub struct WebhookClient {
     signing: EgressSigning,
     /// Validated `tool_headers_from_response` mappings.
     tool_header_mappings: ToolHeaderMappings,
+    /// Poll delivery, or `None` for sync delivery (the POST response itself
+    /// carries the decision, and the live decision paths are available).
+    poll: Option<PollSettings>,
 }
 
 /// One webhook round trip's answer, with the HTTP response headers it
@@ -448,6 +506,24 @@ impl WebhookReply {
     }
 }
 
+/// One poll attempt's answer ([`WebhookClient::poll_decision`]).
+///
+/// Pending is an outcome, not an error: a 404/204 or an unrecognized 200
+/// body only means "keep polling", so the caller can loop without catching.
+#[derive(Debug)]
+pub(crate) enum PollOutcome {
+    /// 200 with a strictly-parsed, signature-verified decision; response
+    /// headers ride along for approver-identity capture by the caller.
+    Decided {
+        decision: ApprovalDecision,
+        response_headers: HeaderMap,
+    },
+    /// 404, 204, or a 200 whose body does not parse as
+    /// [`ApprovalDecisionWire`] (a pending-shaped body we don't
+    /// recognize): keep polling.
+    NotYet,
+}
+
 impl WebhookClient {
     /// Builds an unsigned client. Deliberately does NOT read the environment
     /// (so constructing one in a test never races env-mutating tests):
@@ -461,6 +537,7 @@ impl WebhookClient {
             HeaderMap::new(),
             EgressSigning::Disabled,
             ToolHeaderMappings::default(),
+            None,
         )
     }
 
@@ -474,6 +551,7 @@ impl WebhookClient {
             headers,
             EgressSigning::Disabled,
             ToolHeaderMappings::default(),
+            None,
         )
     }
 
@@ -483,6 +561,7 @@ impl WebhookClient {
         headers: HeaderMap,
         signing: EgressSigning,
         tool_header_mappings: ToolHeaderMappings,
+        poll: Option<PollSettings>,
     ) -> Self {
         // A plaintext response channel would defeat response-leg verification,
         // so http:// with a secret configured is itself a misconfiguration
@@ -510,6 +589,7 @@ impl WebhookClient {
             headers,
             signing,
             tool_header_mappings,
+            poll,
         }
     }
 
@@ -565,34 +645,59 @@ impl WebhookClient {
             .into_outcome())
     }
 
-    /// POST the request and resolve a decision, failing closed on timeout or
-    /// transport/parse error. With a secret configured the POST carries the
-    /// `X-Aura-*` signature headers (context `approval-request:{decision_id}`)
-    /// and the HTTP response must verify under
-    /// `approval-decision:{decision_id}` before its body is parsed.
-    ///
-    /// The reply carries the response headers, cloned off the response
-    /// before its body is consumed. On the signed path they reach a caller
-    /// only inside a [`WebhookReply::Decided`], which is built after
-    /// verification and parse both succeed.
-    async fn request_approval_with_headers(
+    /// Resolve the signing state for one webhook leg. A misconfigured signing
+    /// setup fails closed here, before any request is built.
+    fn egress_hmac(&self) -> Result<Option<&WebhookHmac>, ApprovalError> {
+        match &self.signing {
+            EgressSigning::Misconfigured(reason) => {
+                Err(ApprovalError::Misconfigured(reason.clone()))
+            }
+            EgressSigning::Disabled => Ok(None),
+            EgressSigning::Enabled(hmac) => Ok(Some(hmac)),
+        }
+    }
+
+    /// Verify a decision-bearing response under `approval-decision:{decision_id}`
+    /// — the same primitive the ingress handler runs — before any parse.
+    fn verify_decision_response(
+        hmac: &WebhookHmac,
+        headers: &HeaderMap,
+        body: bytes::Bytes,
+        decision_id: DecisionId,
+    ) -> Result<VerifiedBody, ApprovalError> {
+        let signature = header_value(headers, super::signing::SIGNATURE_HEADER);
+        let timestamp = header_value(headers, super::signing::TIMESTAMP_HEADER);
+        let response_context = SigningContext::new(&format!("approval-decision:{decision_id}"))
+            .expect("decision id renders as dot-free ASCII");
+        authorize_ingress(
+            Some(hmac),
+            &response_context,
+            signature.as_deref(),
+            timestamp.as_deref(),
+            body,
+        )
+        .map_err(|e| ApprovalError::ResponseUnverified(e.to_string()))
+    }
+
+    /// Build the approval-request POST: the serialized wire view — HMAC-signed
+    /// with the `X-Aura-*` headers under context `approval-request:{decision_id}`
+    /// when a secret is configured — with operator headers and the per-attempt
+    /// `timeout` applied. The caller owns `send()` and the response, which the
+    /// legs read differently: the sync decision leg parses a decision off it,
+    /// while the poll ack leg ([`Self::notify`]) never reads the body.
+    fn build_approval_post(
         &self,
         request: &ApprovalRequest,
         timeout: Duration,
-    ) -> Result<WebhookReply, ApprovalError> {
-        let hmac = match &self.signing {
-            EgressSigning::Misconfigured(reason) => {
-                return Err(ApprovalError::Misconfigured(reason.clone()));
-            }
-            EgressSigning::Disabled => None,
-            EgressSigning::Enabled(hmac) => Some(hmac),
-        };
+    ) -> Result<reqwest::RequestBuilder, ApprovalError> {
         // Serialize the wire view, not the domain request: it keeps `scope` /
         // `origin` as the flat `aura_events` DTOs instead of leaking Rust enum
         // variant names onto the webhook contract.
         let wire = ApprovalRequestWire::from(request);
-        let Some(hmac) = hmac else {
-            return self.request_approval_unsigned(&wire, timeout).await;
+        let Some(hmac) = self.egress_hmac()? else {
+            return Ok(self
+                .apply_operator_headers(self.client.post(self.url.as_str()).json(&wire))
+                .timeout(timeout));
         };
 
         // Signing requires the exact bytes that go on the wire, so serialize
@@ -612,9 +717,28 @@ impl WebhookClient {
         for (name, value) in headers.into_pairs() {
             post = post.header(name, value);
         }
-        match post.body(body).timeout(timeout).send().await {
+        Ok(post.body(body).timeout(timeout))
+    }
+
+    /// POST the request and resolve a decision, failing closed on timeout or
+    /// transport/parse error. With a secret configured the POST carries the
+    /// `X-Aura-*` signature headers (context `approval-request:{decision_id}`)
+    /// and the HTTP response must verify under
+    /// `approval-decision:{decision_id}` before its body is parsed.
+    ///
+    /// The reply carries the response headers, cloned off the response
+    /// before its body is consumed. On the signed path they reach a caller
+    /// only inside a [`WebhookReply::Decided`], which is built after
+    /// verification and parse both succeed.
+    async fn request_approval_with_headers(
+        &self,
+        request: &ApprovalRequest,
+        timeout: Duration,
+    ) -> Result<WebhookReply, ApprovalError> {
+        let post = self.build_approval_post(request, timeout)?;
+        match post.send().await {
             Err(e) if e.is_timeout() => Ok(WebhookReply::TimedOut { waited: timeout }),
-            Err(e) => Err(ApprovalError::Transport(e.to_string())),
+            Err(e) => Err(e.into()),
             Ok(resp) => {
                 let status = resp.status();
                 if !status.is_success() {
@@ -622,75 +746,186 @@ impl WebhookClient {
                         status: status.as_u16(),
                     });
                 }
-                // Route A response leg: the decision arrives as this HTTP
-                // response, so it is verified with the same primitive as
-                // ingress before any parse.
-                let signature = header_value(resp.headers(), super::signing::SIGNATURE_HEADER);
-                let timestamp = header_value(resp.headers(), super::signing::TIMESTAMP_HEADER);
-                // Cloned here because `bytes()` consumes the response.
+                // Cloned here because `bytes()`/`json()` consume the response.
                 let response_headers = resp.headers().clone();
-                let body = match resp.bytes().await {
-                    Ok(body) => body,
-                    // A timeout firing mid-body download is still a timeout, not
-                    // a transport fault — keep the classification honest.
-                    Err(e) if e.is_timeout() => {
-                        return Ok(WebhookReply::TimedOut { waited: timeout });
+                match self.egress_hmac()? {
+                    Some(hmac) => {
+                        let body = match resp.bytes().await {
+                            Ok(body) => body,
+                            // A timeout firing mid-body download is still a
+                            // timeout, not a transport fault — keep the
+                            // classification honest.
+                            Err(e) if e.is_timeout() => {
+                                return Ok(WebhookReply::TimedOut { waited: timeout });
+                            }
+                            Err(e) => return Err(e.into()),
+                        };
+                        let verified = Self::verify_decision_response(
+                            hmac,
+                            &response_headers,
+                            body,
+                            request.decision_id,
+                        )?;
+                        match serde_json::from_slice::<ApprovalDecisionWire>(verified.as_ref()) {
+                            Ok(wire) => Ok(WebhookReply::Decided {
+                                decision: ApprovalDecision::from(wire),
+                                response_headers,
+                            }),
+                            Err(e) => Err(ApprovalError::Parse(e.to_string())),
+                        }
                     }
-                    Err(e) => return Err(ApprovalError::Transport(e.to_string())),
-                };
-                let response_context =
-                    SigningContext::new(&format!("approval-decision:{}", request.decision_id))
-                        .expect("decision id renders as dot-free ASCII");
-                let verified = authorize_ingress(
-                    Some(hmac),
-                    &response_context,
-                    signature.as_deref(),
-                    timestamp.as_deref(),
-                    body,
-                )
-                .map_err(|e| ApprovalError::ResponseUnverified(e.to_string()))?;
-                match serde_json::from_slice::<ApprovalDecisionWire>(verified.as_ref()) {
-                    Ok(wire) => Ok(WebhookReply::Decided {
-                        decision: ApprovalDecision::from(wire),
-                        response_headers,
-                    }),
-                    Err(e) => Err(ApprovalError::Parse(e.to_string())),
+                    // Unsigned egress: trust the response and parse it.
+                    None => match resp.json::<ApprovalDecisionWire>().await {
+                        Ok(wire) => Ok(WebhookReply::Decided {
+                            decision: ApprovalDecision::from(wire),
+                            response_headers,
+                        }),
+                        // A timeout firing mid-body download is still a timeout,
+                        // not a parse fault — keep the error-vs-decision
+                        // classification honest.
+                        Err(e) if e.is_timeout() => Ok(WebhookReply::TimedOut { waited: timeout }),
+                        Err(e) => Err(ApprovalError::Parse(e.to_string())),
+                    },
                 }
             }
         }
     }
 
-    /// Send the approval POST unsigned and trust the response.
-    async fn request_approval_unsigned(
-        &self,
-        wire: &ApprovalRequestWire<'_>,
-        timeout: Duration,
-    ) -> Result<WebhookReply, ApprovalError> {
-        let builder = self
-            .apply_operator_headers(self.client.post(self.url.as_str()).json(wire))
-            .timeout(timeout);
-        match builder.send().await {
-            Err(e) if e.is_timeout() => Ok(WebhookReply::TimedOut { waited: timeout }),
-            Err(e) => Err(ApprovalError::Transport(e.to_string())),
+    /// Fire the approval request as an ack-only notification (poll delivery):
+    /// 2xx means delivered; the response body is never read as a decision.
+    /// A 409 means delivered too: the receiver answers 409 only for a
+    /// decision id it already holds, so the conflict itself proves an
+    /// earlier POST landed. Without this arm, a torn notify — the receiver
+    /// recorded the row but the 2xx never came back — faults on every
+    /// tick until the human decides.
+    ///
+    /// A timeout is a transport fault, not a decision-shaped outcome — the
+    /// reconciler simply retries on the next tick. The response body is
+    /// dropped unread, so each attempt is its own connection.
+    pub(crate) async fn notify(&self, request: &ApprovalRequest) -> Result<(), ApprovalError> {
+        let Some(poll) = &self.poll else {
+            return Err(ApprovalError::Misconfigured(
+                "notify is the poll-delivery ack leg, but this client has no poll settings"
+                    .to_string(),
+            ));
+        };
+        let post = self.build_approval_post(request, poll.request_timeout)?;
+        match post.send().await {
+            Err(e) => Err(e.into()),
             Ok(resp) => {
                 let status = resp.status();
-                if !status.is_success() {
-                    return Err(ApprovalError::BadStatus {
+                if status.is_success() || status == reqwest::StatusCode::CONFLICT {
+                    Ok(())
+                } else {
+                    Err(ApprovalError::BadStatus {
                         status: status.as_u16(),
-                    });
+                    })
                 }
-                // Cloned here because `json()` consumes the response.
-                let response_headers = resp.headers().clone();
-                match resp.json::<ApprovalDecisionWire>().await {
-                    Ok(wire) => Ok(WebhookReply::Decided {
-                        decision: ApprovalDecision::from(wire),
+            }
+        }
+    }
+
+    /// One poll of the status endpoint: `GET {poll_url}?decision_id=<id>`.
+    ///
+    /// With a secret configured the GET is signed over its empty body under
+    /// context `approval-request:{decision_id}` (the receiver recomputes with
+    /// the id from the query param), and a 200 response must verify under
+    /// `approval-decision:{decision_id}` with the same ingress primitive the
+    /// sync response leg uses. A decided 200 carries the receiver's
+    /// `{ "status": ... }` envelope; `pending` and any body outside the
+    /// envelope keep the caller polling (the latter logs a warn).
+    pub(crate) async fn poll_decision(
+        &self,
+        decision_id: DecisionId,
+    ) -> Result<PollOutcome, ApprovalError> {
+        let Some(poll) = &self.poll else {
+            return Err(ApprovalError::Misconfigured(
+                "poll_decision is the poll-delivery status leg, but this client has no poll \
+                 settings"
+                    .to_string(),
+            ));
+        };
+        let mut get = self.apply_operator_headers(self.client.get(poll.poll_url.as_str()));
+        if let Some(hmac) = self.egress_hmac()? {
+            let egress_context = SigningContext::new(&format!("approval-request:{}", decision_id))
+                .expect("decision id renders as dot-free ASCII");
+            let headers = hmac
+                .sign(&egress_context, &[])
+                .map_err(|e| ApprovalError::Signing(e.to_string()))?;
+            for (name, value) in headers.into_pairs() {
+                get = get.header(name, value);
+            }
+        }
+        let resp = get
+            .query(&[("decision_id", decision_id.to_string())])
+            .timeout(poll.request_timeout)
+            .send()
+            .await?;
+
+        // The status contract is exact: 200 carries (or withholds) a
+        // decision, 404/204 mean pending. Any other status, including other
+        // 2xx codes, is a channel fault rather than an invented pending.
+        match resp.status() {
+            reqwest::StatusCode::OK => {}
+            reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::NO_CONTENT => {
+                return Ok(PollOutcome::NotYet);
+            }
+            other => {
+                return Err(ApprovalError::BadStatus {
+                    status: other.as_u16(),
+                });
+            }
+        }
+
+        // Cloned before `bytes()` consumes the response; they ride along on
+        // `Decided` for approver-identity capture by the caller.
+        let response_headers = resp.headers().clone();
+        // Unlike the sync leg there is no decision-shaped timeout outcome to
+        // preserve, so a timeout firing mid-body download is a plain
+        // transport fault.
+        let body = resp.bytes().await?;
+        let verified = match self.egress_hmac()? {
+            Some(hmac) => {
+                Self::verify_decision_response(hmac, &response_headers, body, decision_id)?
+                    .into_inner()
+            }
+            None => body,
+        };
+        match serde_json::from_slice::<PollDecisionWire>(&verified) {
+            Ok(wire) => match wire.status {
+                PollStatusWire::Pending => Ok(PollOutcome::NotYet),
+                PollStatusWire::Approved => {
+                    if let Some(reason) = wire.reason.as_deref() {
+                        tracing::debug!(
+                            decision_id = %decision_id,
+                            reason,
+                            "approve-side reason discarded; the decision model carries none"
+                        );
+                    }
+                    Ok(PollOutcome::Decided {
+                        decision: ApprovalDecision::Approved,
                         response_headers,
-                    }),
-                    // A timeout firing mid-body download is still a timeout, not a
-                    // parse fault — keep the error-vs-decision classification honest.
-                    Err(e) if e.is_timeout() => Ok(WebhookReply::TimedOut { waited: timeout }),
-                    Err(e) => Err(ApprovalError::Parse(e.to_string())),
+                    })
                 }
+                PollStatusWire::Denied => Ok(PollOutcome::Decided {
+                    decision: ApprovalDecision::Denied {
+                        reason: wire.reason,
+                    },
+                    response_headers,
+                }),
+            },
+            Err(e) => {
+                // A body outside the status envelope keeps the poll alive —
+                // a pending read must never become a terminal denial — but
+                // with the envelope typed it now implies receiver schema
+                // drift or a proxy answering in the path, so it warns.
+                tracing::warn!(
+                    decision_id = %decision_id,
+                    error = %e,
+                    "poll 200 body is not a valid decision envelope: \
+                     receiver schema drift or a proxy in the path"
+                );
+                Ok(PollOutcome::NotYet)
             }
         }
     }
@@ -796,6 +1031,7 @@ mod tests {
     use super::super::protocol::{
         ApprovalDecisionWire, ApprovalItem, ApprovalRequest, ApprovalRequestWire, PROTOCOL_VERSION,
     };
+    use super::super::read_full_request;
     use super::super::registry::PendingApprovals;
     use super::DecisionRoute;
     use std::time::Duration;
@@ -1289,8 +1525,8 @@ mod tests {
             WebhookHmac, authorize_ingress,
         };
         use super::super::{
-            ApprovalError, ApprovalOutcome, EgressSigning, GateDecision, WebhookClient,
-            build_webhook_client,
+            ApprovalError, ApprovalOutcome, EgressSigning, GateDecision, PollOutcome, PollSettings,
+            WebhookClient, build_webhook_client,
         };
         use crate::approver_headers::CaptureError;
 
@@ -1319,6 +1555,7 @@ mod tests {
         }
 
         struct ReceivedRequest {
+            request_line: String,
             headers: Vec<(String, String)>,
             body: Vec<u8>,
         }
@@ -1390,6 +1627,7 @@ mod tests {
                     }
                 };
                 let header_text = String::from_utf8(buf[..header_end].to_vec()).unwrap();
+                let request_line = header_text.lines().next().unwrap_or_default().to_string();
                 let headers: Vec<(String, String)> = header_text
                     .lines()
                     .skip(1)
@@ -1426,7 +1664,12 @@ mod tests {
                 // A cancelling caller may already have dropped the connection, so a failed reply is not a test failure; every test that cares asserts on what the client resolved to.
                 socket.write_all(response.as_bytes()).await.ok();
                 socket.shutdown().await.ok();
-                tx.send(ReceivedRequest { headers, body }).ok();
+                tx.send(ReceivedRequest {
+                    request_line,
+                    headers,
+                    body,
+                })
+                .ok();
             });
             (url, rx)
         }
@@ -1456,6 +1699,28 @@ mod tests {
                 headers: HeaderMap::new(),
                 signing,
                 tool_header_mappings,
+                poll: None,
+            }
+        }
+
+        /// [`loopback_client`] with poll delivery: the ack/status legs run
+        /// against `poll_url`, which may differ from the POST `url`.
+        fn loopback_poll_client(
+            url: &str,
+            signing: EgressSigning,
+            poll_url: &str,
+            request_timeout: Duration,
+        ) -> WebhookClient {
+            WebhookClient {
+                client: build_webhook_client(),
+                url: aura_config::WebhookUrl::new(url).unwrap(),
+                headers: HeaderMap::new(),
+                signing,
+                tool_header_mappings: aura_config::ToolHeaderMappings::default(),
+                poll: Some(PollSettings {
+                    poll_url: aura_config::WebhookUrl::new(poll_url).unwrap(),
+                    request_timeout,
+                }),
             }
         }
 
@@ -1587,6 +1852,7 @@ mod tests {
                 HeaderMap::new(),
                 EgressSigning::Enabled(test_hmac()),
                 aura_config::ToolHeaderMappings::default(),
+                None,
             );
             let err = client
                 .request_approval(
@@ -1960,6 +2226,7 @@ mod tests {
                 HeaderMap::new(),
                 EgressSigning::Disabled,
                 aura_config::ToolHeaderMappings::default(),
+                None,
             );
             let outcome = client
                 .request_approval(&test_request(decision_id), Duration::from_secs(5))
@@ -2286,6 +2553,463 @@ mod tests {
                 "expected Cancelled to win over the ready approval, got {decision:?}"
             );
         }
+
+        // ---------------------------------------------------------
+        // poll delivery: notify (ack-only POST) and poll_decision (status GET)
+        // ---------------------------------------------------------
+
+        /// `[hitl.route]` with `delivery = "poll"`: `poll_url` override and
+        /// per-attempt timeout plumbed straight through.
+        fn poll_config(url: &str, poll_url: Option<&str>) -> aura_config::HitlConfig {
+            aura_config::HitlConfig {
+                require_approval: vec![],
+                park: aura_config::ParkConfig::default(),
+                route: aura_config::DecisionRouteConfig::Webhook {
+                    url: aura_config::WebhookUrl::new(url).unwrap(),
+                    timeout_secs: 300,
+                    headers: HashMap::new(),
+                    headers_from_request: HashMap::new(),
+                    tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
+                    delivery: aura_config::WebhookDelivery::Poll,
+                    poll_url: poll_url.map(|u| aura_config::WebhookUrl::new(u).unwrap()),
+                    poll_interval_secs: 10,
+                    poll_request_timeout_secs: 30,
+                },
+            }
+        }
+
+        fn webhook_client_of(runtime: &super::super::HitlRuntime) -> &WebhookClient {
+            match &*runtime.route {
+                super::super::DecisionRoute::Webhook { client, .. } => client,
+                super::super::DecisionRoute::Conversational { .. } => {
+                    panic!("expected webhook route")
+                }
+            }
+        }
+
+        /// The ack-only POST must succeed on a 2xx even when the body looks
+        /// exactly like a decision: poll delivery never reads the notify
+        /// response body, so a chatty receiver cannot mint a decision.
+        #[tokio::test]
+        async fn notify_2xx_with_decision_shaped_body_is_just_an_ack() {
+            let decision_id = DecisionId::generate();
+            let (url, received) =
+                one_shot_receiver(vec![], r#"{"approved":true}"#.to_string()).await;
+
+            let client =
+                loopback_poll_client(&url, EgressSigning::Disabled, &url, Duration::from_secs(5));
+            client
+                .notify(&test_request(decision_id))
+                .await
+                .expect("a 2xx ack must resolve Ok");
+
+            let received = received.await.unwrap();
+            assert!(
+                received.request_line.starts_with("POST "),
+                "notify must POST, got: {}",
+                received.request_line
+            );
+            assert!(
+                String::from_utf8_lossy(&received.body).contains(&decision_id.to_string()),
+                "the ack POST must carry the approval-request wire body"
+            );
+        }
+
+        #[tokio::test]
+        async fn notify_non_2xx_is_bad_status() {
+            let (url, _received) =
+                one_shot_receiver_with_status("503 Service Unavailable", vec![], String::new())
+                    .await;
+
+            let client =
+                loopback_poll_client(&url, EgressSigning::Disabled, &url, Duration::from_secs(5));
+            let err = client
+                .notify(&test_request(DecisionId::generate()))
+                .await
+                .expect_err("a 503 ack must fault");
+            assert!(
+                matches!(err, ApprovalError::BadStatus { status: 503 }),
+                "expected BadStatus(503), got {err:?}"
+            );
+        }
+
+        /// A 409 ack means the receiver already holds this decision id —
+        /// the retry after a torn 2xx — so it acks instead of faulting the
+        /// reconciler's every tick.
+        #[tokio::test]
+        async fn notify_duplicate_409_is_delivered() {
+            let (url, _received) =
+                one_shot_receiver_with_status("409 Conflict", vec![], String::new()).await;
+
+            let client =
+                loopback_poll_client(&url, EgressSigning::Disabled, &url, Duration::from_secs(5));
+            client
+                .notify(&test_request(DecisionId::generate()))
+                .await
+                .expect("a 409 ack must resolve Ok: the receiver holding the row is the ack");
+        }
+
+        /// A timed-out notify is not a decision-shaped outcome (there is no
+        /// TimedOut reply on the ack leg): it must surface as a transport
+        /// fault so the reconciler simply retries next tick.
+        #[tokio::test]
+        async fn notify_timeout_is_a_transport_fault() {
+            let (url, _accepted) = stalled_receiver().await;
+
+            let client = loopback_poll_client(
+                &url,
+                EgressSigning::Disabled,
+                &url,
+                Duration::from_millis(200),
+            );
+            let err = client
+                .notify(&test_request(DecisionId::generate()))
+                .await
+                .expect_err("a stalled ack must fault");
+            assert!(
+                matches!(err, ApprovalError::Transport(_)),
+                "expected Transport, got {err:?}"
+            );
+        }
+
+        /// A transport fault renders without its URL: a token embedded in
+        /// the webhook URL must not reach the reconciler's warn log.
+        #[tokio::test]
+        async fn transport_fault_omits_the_url() {
+            let url = "http://127.0.0.1:1/hook?token=SECRET";
+            let client =
+                loopback_poll_client(url, EgressSigning::Disabled, url, Duration::from_secs(1));
+            let err = client
+                .notify(&test_request(DecisionId::generate()))
+                .await
+                .expect_err("a refused connection must fault");
+            let rendered = err.to_string();
+            assert!(
+                !rendered.contains("SECRET") && !rendered.contains("127.0.0.1"),
+                "transport error leaked the url: {rendered}"
+            );
+        }
+
+        #[tokio::test]
+        async fn signed_notify_verifies_receiver_side_over_request_body() {
+            let hmac = test_hmac();
+            let decision_id = DecisionId::generate();
+            let (url, received) =
+                one_shot_receiver(vec![], r#"{"approved":true}"#.to_string()).await;
+
+            let client = loopback_poll_client(
+                &url,
+                EgressSigning::Enabled(hmac.clone()),
+                &url,
+                Duration::from_secs(5),
+            );
+            client
+                .notify(&test_request(decision_id))
+                .await
+                .expect("a signed ack must resolve Ok");
+
+            let received = received.await.unwrap();
+            let signature = received.header(SIGNATURE_HEADER).map(str::to_owned);
+            let timestamp = received.header(TIMESTAMP_HEADER).map(str::to_owned);
+            assert!(signature.is_some(), "notify must carry the signature");
+            assert!(timestamp.is_some(), "notify must carry the timestamp");
+            let egress_context =
+                SigningContext::new(&format!("approval-request:{decision_id}")).unwrap();
+            authorize_ingress(
+                Some(&hmac),
+                &egress_context,
+                signature.as_deref(),
+                timestamp.as_deref(),
+                Bytes::from(received.body),
+            )
+            .expect("receiver must verify the notify signature over the request body");
+        }
+
+        #[tokio::test]
+        async fn poll_decision_404_and_204_are_pending() {
+            for status in ["404 Not Found", "204 No Content"] {
+                let (url, _received) =
+                    one_shot_receiver_with_status(status, vec![], String::new()).await;
+
+                let client = loopback_poll_client(
+                    &url,
+                    EgressSigning::Disabled,
+                    &url,
+                    Duration::from_secs(5),
+                );
+                let outcome = client
+                    .poll_decision(DecisionId::generate())
+                    .await
+                    .unwrap_or_else(|err| {
+                        panic!("{status}: a pending status must not fault: {err:?}")
+                    });
+                assert!(
+                    matches!(outcome, PollOutcome::NotYet),
+                    "{status}: expected NotYet, got {outcome:?}"
+                );
+            }
+        }
+
+        /// The full signed round trip: the GET is signed over its empty body
+        /// under the approval-request context (receiver-side verified), the
+        /// query string carries the decision id, and a 200 signed under the
+        /// approval-decision context resolves — with the response headers
+        /// riding along for approver-identity capture.
+        #[tokio::test]
+        async fn poll_decision_200_signed_decision_resolves_and_get_signature_verifies() {
+            let hmac = test_hmac();
+            let decision_id = DecisionId::generate();
+            let response_body = r#"{"status":"approved"}"#.to_string();
+            let mut response_headers = signed_response_headers(&hmac, decision_id, &response_body);
+            response_headers.push(("x-approver-id".to_owned(), "alice".to_owned()));
+            let (url, received) = one_shot_receiver(response_headers, response_body).await;
+
+            let client = loopback_poll_client(
+                &url,
+                EgressSigning::Enabled(hmac.clone()),
+                &url,
+                Duration::from_secs(5),
+            );
+            let outcome = client
+                .poll_decision(decision_id)
+                .await
+                .expect("a signed poll of a decided approval must resolve");
+            match outcome {
+                PollOutcome::Decided {
+                    decision,
+                    response_headers,
+                } => {
+                    assert_eq!(decision, ApprovalDecision::Approved);
+                    assert_eq!(
+                        response_headers
+                            .get("x-approver-id")
+                            .map(|v| v.to_str().unwrap()),
+                        Some("alice"),
+                        "response headers must ride along for identity capture"
+                    );
+                }
+                other => panic!("expected Decided, got {other:?}"),
+            }
+
+            let received = received.await.unwrap();
+            assert!(
+                received.request_line.starts_with("GET "),
+                "poll must GET, got: {}",
+                received.request_line
+            );
+            assert!(
+                received
+                    .request_line
+                    .contains(&format!("decision_id={decision_id}")),
+                "the query string must carry the decision id, got: {}",
+                received.request_line
+            );
+            assert!(received.body.is_empty(), "the poll GET must carry no body");
+            let signature = received.header(SIGNATURE_HEADER).map(str::to_owned);
+            let timestamp = received.header(TIMESTAMP_HEADER).map(str::to_owned);
+            assert!(signature.is_some(), "the GET must carry the signature");
+            assert!(timestamp.is_some(), "the GET must carry the timestamp");
+            let egress_context =
+                SigningContext::new(&format!("approval-request:{decision_id}")).unwrap();
+            authorize_ingress(
+                Some(&hmac),
+                &egress_context,
+                signature.as_deref(),
+                timestamp.as_deref(),
+                Bytes::from(received.body),
+            )
+            .expect("receiver must verify the GET signature over the empty body");
+        }
+
+        /// A 200 body that verifies but is not the receiver's status
+        /// envelope keeps the approval alive: warn and keep polling.
+        #[tokio::test]
+        async fn poll_decision_200_unparsable_body_is_pending_not_an_error() {
+            let hmac = test_hmac();
+            let decision_id = DecisionId::generate();
+            let garbage = "<html>upstream error page</html>".to_string();
+            let response_headers = signed_response_headers(&hmac, decision_id, &garbage);
+            let (url, _received) = one_shot_receiver(response_headers, garbage).await;
+
+            let client = loopback_poll_client(
+                &url,
+                EgressSigning::Enabled(hmac),
+                &url,
+                Duration::from_secs(5),
+            );
+            let outcome = client
+                .poll_decision(decision_id)
+                .await
+                .expect("a pending-shaped body must not fault");
+            assert!(
+                matches!(outcome, PollOutcome::NotYet),
+                "expected NotYet, got {outcome:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn poll_decision_unverified_200_fails_closed() {
+            let (url, _received) =
+                one_shot_receiver(vec![], r#"{"status":"approved"}"#.to_string()).await;
+
+            let client = loopback_poll_client(
+                &url,
+                EgressSigning::Enabled(test_hmac()),
+                &url,
+                Duration::from_secs(5),
+            );
+            let err = client
+                .poll_decision(DecisionId::generate())
+                .await
+                .expect_err("an unsigned 200 decision must not be trusted");
+            assert!(
+                matches!(err, ApprovalError::ResponseUnverified(_)),
+                "expected ResponseUnverified, got {err:?}"
+            );
+        }
+
+        /// Unsigned mode mirrors the sync route's unsigned posture: no
+        /// signature headers on the GET, response body trusted, and a
+        /// garbage body still only means pending.
+        #[tokio::test]
+        async fn poll_decision_unsigned_mode_resolves_decision_and_garbage_stays_pending() {
+            let (url, _received) =
+                one_shot_receiver(vec![], r#"{"status":"denied","reason":"no"}"#.to_string()).await;
+            let client =
+                loopback_poll_client(&url, EgressSigning::Disabled, &url, Duration::from_secs(5));
+            match client
+                .poll_decision(DecisionId::generate())
+                .await
+                .expect("an unsigned poll of a decided approval must resolve")
+            {
+                PollOutcome::Decided {
+                    decision: ApprovalDecision::Denied { reason },
+                    ..
+                } => assert_eq!(reason.as_deref(), Some("no")),
+                other => panic!("expected Decided(Denied), got {other:?}"),
+            }
+
+            let (garbage_url, _garbage_received) =
+                one_shot_receiver(vec![], "not json".to_string()).await;
+            let garbage_client = loopback_poll_client(
+                &garbage_url,
+                EgressSigning::Disabled,
+                &garbage_url,
+                Duration::from_secs(5),
+            );
+            let outcome = garbage_client
+                .poll_decision(DecisionId::generate())
+                .await
+                .expect("a garbage body must not fault in unsigned mode");
+            assert!(
+                matches!(outcome, PollOutcome::NotYet),
+                "expected NotYet, got {outcome:?}"
+            );
+        }
+
+        /// Poll delivery must fail closed on the live synchronous decision
+        /// paths — `decide` and `decide_for_gate` — without touching the
+        /// webhook: the ack a sync POST receives is not a decision.
+        #[tokio::test]
+        async fn poll_delivery_live_decision_paths_fail_closed_without_http() {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let url = format!("http://{}", listener.local_addr().unwrap());
+            let route = super::super::DecisionRoute::Webhook {
+                client: loopback_poll_client(
+                    &url,
+                    EgressSigning::Disabled,
+                    &url,
+                    Duration::from_secs(5),
+                ),
+                timeout: Duration::from_secs(300),
+            };
+            let cancel = crate::request_cancellation::RequestCancelToken::unbound();
+
+            for (route_wide, decision) in [
+                (
+                    false,
+                    route
+                        .decide_for_gate(test_request(DecisionId::generate()), &cancel)
+                        .await
+                        .expect_err("the live gate path must fail closed"),
+                ),
+                (
+                    true,
+                    route
+                        .decide(test_request(DecisionId::generate()), &cancel)
+                        .await
+                        .expect_err("the live route-wide path must fail closed"),
+                ),
+            ] {
+                assert!(
+                    matches!(decision, ApprovalError::Misconfigured(_)),
+                    "route_wide={route_wide}: expected Misconfigured, got {decision:?}"
+                );
+            }
+
+            let rogue = tokio::time::timeout(Duration::from_millis(200), listener.accept()).await;
+            assert!(
+                rogue.is_err(),
+                "the live decision paths must not touch the webhook server"
+            );
+        }
+
+        /// Poll delivery resolves the status endpoint once, at route
+        /// construction — asserted via behavior: the poll GET must land on
+        /// the configured override, or on the route url itself when unset.
+        #[tokio::test]
+        async fn from_config_poll_delivery_resolves_the_status_url() {
+            use super::super::HitlRuntime;
+
+            // Explicit poll_url override wins over the route url.
+            let (post_url, post_rx) = one_shot_receiver(vec![], String::new()).await;
+            let (override_url, override_rx) =
+                one_shot_receiver_with_status("204 No Content", vec![], String::new()).await;
+            let runtime = HitlRuntime::from_config(
+                &poll_config(&post_url, Some(&override_url)),
+                &crate::hitl::PendingApprovals::new(),
+                None,
+                None,
+            );
+            let outcome = webhook_client_of(&runtime)
+                .poll_decision(DecisionId::generate())
+                .await
+                .expect("the resolved client must poll the override url");
+            assert!(matches!(outcome, PollOutcome::NotYet), "got {outcome:?}");
+            let received = override_rx.await.unwrap();
+            assert!(
+                received.request_line.starts_with("GET "),
+                "got: {}",
+                received.request_line
+            );
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), post_rx)
+                    .await
+                    .is_err(),
+                "the POST url must not receive the poll GET"
+            );
+
+            // A None poll_url polls the route url itself.
+            let (url, rx) =
+                one_shot_receiver_with_status("204 No Content", vec![], String::new()).await;
+            let runtime = HitlRuntime::from_config(
+                &poll_config(&url, None),
+                &crate::hitl::PendingApprovals::new(),
+                None,
+                None,
+            );
+            let outcome = webhook_client_of(&runtime)
+                .poll_decision(DecisionId::generate())
+                .await
+                .expect("the resolved client must poll the route url");
+            assert!(matches!(outcome, PollOutcome::NotYet), "got {outcome:?}");
+            let received = rx.await.unwrap();
+            assert!(
+                received.request_line.starts_with("GET "),
+                "got: {}",
+                received.request_line
+            );
+        }
     }
 
     #[tokio::test]
@@ -2604,49 +3328,6 @@ mod tests {
         });
 
         (port, rx)
-    }
-
-    /// Read one complete HTTP request (request line + headers + the
-    /// Content-Length-declared body) from `socket` and return it as a
-    /// lossy-UTF-8 string. Reading the body before responding prevents reqwest
-    /// from seeing a connection reset while it is still sending the POST body.
-    async fn read_full_request(socket: &mut tokio::net::TcpStream) -> String {
-        use tokio::io::AsyncReadExt;
-
-        let mut buf = Vec::new();
-        let mut chunk = [0u8; 4096];
-        // Read until we have the complete header section (\r\n\r\n).
-        loop {
-            let n = socket.read(&mut chunk).await.unwrap();
-            if n == 0 {
-                break;
-            }
-            buf.extend_from_slice(&chunk[..n]);
-            if buf.windows(4).any(|w| w == b"\r\n\r\n") {
-                break;
-            }
-        }
-
-        // Parse Content-Length so we can consume the request body before
-        // responding — otherwise reqwest may get a connection reset while
-        // still sending the POST body.
-        let header_end = buf.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
-        let header_section = String::from_utf8_lossy(&buf[..header_end]).to_string();
-        let content_length: usize = header_section
-            .lines()
-            .find(|line| line.to_lowercase().starts_with("content-length:"))
-            .and_then(|line| line.split(':').nth(1))
-            .and_then(|val| val.trim().parse().ok())
-            .unwrap_or(0);
-        let body_already_read = buf.len() - header_end;
-        let remaining = content_length.saturating_sub(body_already_read);
-        if remaining > 0 {
-            let mut body_buf = vec![0u8; remaining];
-            socket.read_exact(&mut body_buf).await.unwrap();
-            buf.extend_from_slice(&body_buf);
-        }
-
-        String::from_utf8_lossy(&buf).to_string()
     }
 
     fn make_approval_request() -> ApprovalRequest {


### PR DESCRIPTION
Second of four. Adds the outbound protocol for poll delivery and the background loop that drives it. Config validation still rejects the mode, so none of this runs in a deployment yet; the defensive assert the first PR put in the runtime constructor goes away here, since the runtime now handles poll routes.

What changes:

- Two new legs on the webhook client. `notify` POSTs the approval request and treats any 2xx as delivered; the response body is never read as a decision. `poll_decision` GETs `{poll_url}?decision_id=<id>` with the same HMAC signing and response verification as the sync route. The receiver answers a status envelope: `{"status": "pending"}` while undecided, then `{"status": "approved"}` or `{"status": "denied", "reason": "..."}`, where `reason` is an optional string. A 404 or 204 also means keep polling. Unknown fields on a decided body are tolerated, an unknown status value fails the parse, and a 200 whose body is not the envelope is logged at warn and treated as pending.
- In poll mode the live decide paths fail closed, so the approval tool cannot mistake an ack for a decision. A unit test pins the case where the notify ack body itself looks like an approval: nothing resolves until the status GET says so.
- A per-process reconciler ticks over `ApprovalStore::list_pending`. It reads each row's status endpoint first, then notifies rows the read left undecided, retrying until a 2xx; a decided row resolves through the existing ingress path without re-posting its request, so a receiver that holds the POST open costs its row one request timeout per tick and never delays the status read. The web server spawns one per poll-mode agent config and stops it on shutdown. `poll_interval_secs` must be greater than zero.
- Webhook transport errors are rendered without the URL, on the existing sync route as well as the new legs, because a URL may embed a token and the reconciler logs every failed attempt. Sync deployments will see the changed error text in their logs.
- Parked documents are instance-local, so the reconciler is single-writer by construction. Notify is at-least-once; a cross-instance poll claim is not part of this design.

Not yet: the park path does not route through the reconciler, and captured request headers are not persisted. Both are in the next PR.

Tested with scripted-receiver unit tests for both legs and the status-envelope parse, the fail-closed paths, and multi-tick reconciler sequences including a receiver that never acks.

Stack: based on `mshearer/271-poll-foundation`. Next: `mshearer/271-poll-at-rest`.
