### PR TITLE
Webhook poll delivery (3/4): park-path activation and credentials at rest

### DIFF
--- a/crates/aura-cli/src/repl/loop.rs
+++ b/crates/aura-cli/src/repl/loop.rs
@@ -3620,7 +3620,7 @@ impl StreamHandler for ReplStreamHandler {
                     let resolve = tracing::Instrument::instrument(
                         async move {
                             if let Err(aura::hitl::ResolveError::NotFound) =
-                                registry.resolve(&id, decision).await
+                                registry.resolve(&id, decision.into()).await
                             {
                                 eprintln!(
                                     "warning: approval decision was not found \

--- a/crates/aura-web-server/src/handlers.rs
+++ b/crates/aura-web-server/src/handlers.rs
@@ -1206,9 +1206,11 @@ pub async fn resolve_approval(
         }
     };
     let decision = aura::hitl::ApprovalDecision::from(body);
+    // The conversational ingress has no identity source: the decision
+    // resolves uncaptured.
     match state
         .pending_approvals
-        .resolve(&decision_id, decision)
+        .resolve(&decision_id, aura::hitl::ResolvedDecision::from(decision))
         .await
     {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),

--- a/crates/aura-web-server/src/session_store/redis/approval_store.rs
+++ b/crates/aura-web-server/src/session_store/redis/approval_store.rs
@@ -26,7 +26,7 @@
 use std::sync::LazyLock;
 
 use async_trait::async_trait;
-use aura::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
+use aura::hitl::{DecisionId, ParkedApproval, ResolveError, ResolvedDecision};
 use aura::session_store::{ApprovalStore, DecisionRecord, ParkedApprovalRecord, SessionStoreError};
 use redis::AsyncCommands;
 use redis::aio::ConnectionManager;
@@ -176,12 +176,13 @@ impl ApprovalStore for RedisApprovalStore {
     async fn resolve(
         &self,
         id: &DecisionId,
-        decision: ApprovalDecision,
+        decision: ResolvedDecision,
     ) -> Result<(), ResolveError> {
         // The script's atomic take is the at-most-once guarantee: exactly one
         // resolver gets the record; everyone else (and every later attempt)
-        // sees `NotFound`. The same step writes the decision record, so a
-        // consumed parked entry always leaves a recoverable decision.
+        // sees `NotFound`. The same step writes the decision record — the
+        // serialized record carries the decision AND any captured identity,
+        // so one atomic SET keeps the pair together under concurrency.
         let payload = serde_json::to_string(&DecisionRecord::from(&decision))
             .expect("decision record serializes to JSON");
         let mut conn = self.conn.clone();
@@ -203,7 +204,7 @@ impl ApprovalStore for RedisApprovalStore {
     async fn decision(
         &self,
         id: &DecisionId,
-    ) -> Result<Option<ApprovalDecision>, SessionStoreError> {
+    ) -> Result<Option<ResolvedDecision>, SessionStoreError> {
         let mut conn = self.conn.clone();
         let payload: Option<String> = conn
             .get(self.decision_key(&id.to_string()))
@@ -212,9 +213,13 @@ impl ApprovalStore for RedisApprovalStore {
         payload
             .map(|json| {
                 serde_json::from_str::<DecisionRecord>(&json)
-                    .map(ApprovalDecision::from)
                     .map_err(|e| SessionStoreError::Decode {
                         reason: e.to_string(),
+                    })
+                    .and_then(|record| {
+                        ResolvedDecision::try_from(record).map_err(|e| SessionStoreError::Decode {
+                            reason: e.to_string(),
+                        })
                     })
             })
             .transpose()

--- a/crates/aura-web-server/tests/common/mod.rs
+++ b/crates/aura-web-server/tests/common/mod.rs
@@ -22,7 +22,7 @@ use tokio::process::{Child, Command};
 
 use aura::hitl::{
     AgentScope, ApprovalDecision, ApprovalItem, ApprovalOrigin, ApprovalRequest, DecisionId,
-    PROTOCOL_VERSION, ParkedApproval, ResolveError,
+    PROTOCOL_VERSION, ParkedApproval, ResolveError, ResolvedDecision,
 };
 use aura::session_store::{ApprovalStore, ParkedApprovalRecord};
 
@@ -48,6 +48,7 @@ pub fn make_parked(request_id: &str, ttl: Duration) -> ParkedApproval {
         },
         registered_at: now,
         expires_at: now + chrono::Duration::from_std(ttl).unwrap(),
+        egress_headers: None,
     }
 }
 
@@ -80,11 +81,13 @@ pub async fn resolve_is_at_most_once(
     instance_a.register(parked).await.unwrap();
 
     instance_b
-        .resolve(&id, ApprovalDecision::Approved)
+        .resolve(&id, ApprovalDecision::Approved.into())
         .await
         .expect("first resolve wins");
     assert_eq!(
-        instance_a.resolve(&id, ApprovalDecision::Approved).await,
+        instance_a
+            .resolve(&id, ApprovalDecision::Approved.into())
+            .await,
         Err(ResolveError::NotFound)
     );
 }
@@ -99,8 +102,8 @@ pub async fn concurrent_resolves_have_exactly_one_winner(
     instance_a.register(parked).await.unwrap();
 
     let (a, b) = tokio::join!(
-        instance_a.resolve(&id, ApprovalDecision::Approved),
-        instance_b.resolve(&id, ApprovalDecision::Approved),
+        instance_a.resolve(&id, ApprovalDecision::Approved.into()),
+        instance_b.resolve(&id, ApprovalDecision::Approved.into()),
     );
     let winners = usize::from(a.is_ok()) + usize::from(b.is_ok());
     assert_eq!(winners, 1, "exactly one resolver must win: {a:?} / {b:?}");
@@ -119,21 +122,81 @@ pub async fn resolve_records_readable_decision(
     let denied = ApprovalDecision::Denied {
         reason: Some("not now".to_string()),
     };
-    instance_b.resolve(&id, denied.clone()).await.unwrap();
+    instance_b
+        .resolve(&id, denied.clone().into())
+        .await
+        .unwrap();
 
     assert_eq!(
         instance_a.decision(&id).await.unwrap(),
-        Some(denied.clone())
+        Some(ResolvedDecision::from(denied.clone()))
     );
     assert_eq!(
-        instance_a.resolve(&id, ApprovalDecision::Approved).await,
+        instance_a
+            .resolve(&id, ApprovalDecision::Approved.into())
+            .await,
         Err(ResolveError::NotFound)
     );
-    assert_eq!(instance_a.decision(&id).await.unwrap(), Some(denied));
+    assert_eq!(
+        instance_a.decision(&id).await.unwrap(),
+        Some(ResolvedDecision::from(denied))
+    );
     assert_eq!(
         instance_a.decision(&DecisionId::generate()).await.unwrap(),
         None
     );
+}
+
+/// Identity captured at resolve time persists in the SAME decision record:
+/// the read-back carries the decision AND the identity together, from any
+/// instance.
+pub async fn resolve_records_identity_with_the_decision(
+    instance_a: &Arc<dyn ApprovalStore>,
+    instance_b: &Arc<dyn ApprovalStore>,
+) {
+    let parked = make_parked("req-identity", Duration::from_secs(60));
+    let id = parked.request.decision_id;
+    instance_a.register(parked).await.unwrap();
+
+    let identity =
+        aura::hitl::ResolvedDecision::approved(Some(unidentity(&[("x-forwarded-user", "alice")])));
+    instance_b.resolve(&id, identity).await.unwrap();
+
+    match instance_a.decision(&id).await.unwrap().expect("recorded") {
+        aura::hitl::ResolvedDecision::Approved {
+            identity: Some(got),
+        } => {
+            assert_eq!(
+                got.captured_names().collect::<Vec<_>>(),
+                ["x-forwarded-user"],
+                "the identity reads back with the decision, from the other instance",
+            );
+        }
+        other => panic!("expected Approved with identity, got {other:?}"),
+    }
+}
+
+fn unidentity(pairs: &[(&str, &str)]) -> aura::approver_headers::ApproverHeaders {
+    // The carrier's constructor is crate-private; build through the record's
+    // storage projection instead, the path any resolver's identity takes.
+    let map: std::collections::BTreeMap<String, String> = pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+    let record_json = serde_json::json!({
+        "approved": true,
+        "reason": null,
+        "decided_at": chrono::Utc::now(),
+        "identity": map,
+    });
+    let record: aura::session_store::DecisionRecord =
+        serde_json::from_value(record_json).expect("a decision record with identity");
+    match aura::hitl::ResolvedDecision::try_from(record).expect("the record restores") {
+        aura::hitl::ResolvedDecision::Approved { identity } => {
+            identity.expect("the restored approval carries the identity")
+        }
+        other => panic!("expected an approval, got {other:?}"),
+    }
 }
 
 /// A removed ticket no longer resolves.
@@ -145,7 +208,9 @@ pub async fn remove_makes_resolve_not_found(instance: &Arc<dyn ApprovalStore>) {
     instance.remove(&id).await.unwrap();
 
     assert_eq!(
-        instance.resolve(&id, ApprovalDecision::Approved).await,
+        instance
+            .resolve(&id, ApprovalDecision::Approved.into())
+            .await,
         Err(ResolveError::NotFound)
     );
 }
@@ -187,7 +252,7 @@ pub async fn list_pending_returns_only_live_undecided(
     instance_a.register(resolved).await.unwrap();
     instance_a.register(live).await.unwrap();
     instance_b
-        .resolve(&resolved_id, ApprovalDecision::Approved)
+        .resolve(&resolved_id, ApprovalDecision::Approved.into())
         .await
         .unwrap();
 

--- a/crates/aura-web-server/tests/file_session_store_test.rs
+++ b/crates/aura-web-server/tests/file_session_store_test.rs
@@ -11,7 +11,7 @@ mod common;
 use std::sync::Arc;
 use std::time::Duration;
 
-use aura::hitl::{ApprovalDecision, ResolveError};
+use aura::hitl::{ApprovalDecision, ResolveError, ResolvedDecision};
 use aura::session_store::{
     ApprovalStore, FileApprovalStore, InMemoryApprovalStore, ParkedApprovalRecord,
     SessionStoreError,
@@ -63,6 +63,21 @@ async fn file_battery_resolve_records_readable_decision() {
     let dir = tempfile::tempdir().unwrap();
     let (instance_a, instance_b) = file_pair(&dir);
     common::resolve_records_readable_decision(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn file_battery_resolve_records_identity_with_the_decision() {
+    let dir = tempfile::tempdir().unwrap();
+    let (instance_a, instance_b) = file_pair(&dir);
+    common::resolve_records_identity_with_the_decision(&instance_a, &instance_b).await;
+}
+
+#[tokio::test]
+async fn memory_battery_resolve_records_identity_with_the_decision() {
+    let instance_a: std::sync::Arc<dyn aura::session_store::ApprovalStore> =
+        std::sync::Arc::new(aura::session_store::InMemoryApprovalStore::new());
+    let instance_b = std::sync::Arc::clone(&instance_a);
+    common::resolve_records_identity_with_the_decision(&instance_a, &instance_b).await;
 }
 
 #[tokio::test]
@@ -184,7 +199,7 @@ async fn expired_resolve_is_not_found_and_approval_is_retained() {
     store.register(parked).await.unwrap();
 
     assert_eq!(
-        store.resolve(&id, ApprovalDecision::Approved).await,
+        store.resolve(&id, ApprovalDecision::Approved.into()).await,
         Err(ResolveError::NotFound)
     );
     assert_eq!(store.decision(&id).await.unwrap(), None);
@@ -214,7 +229,7 @@ async fn approval_and_decision_are_retained_until_remove() {
     );
 
     store
-        .resolve(&id, ApprovalDecision::Approved)
+        .resolve(&id, ApprovalDecision::Approved.into())
         .await
         .unwrap();
 
@@ -230,31 +245,34 @@ async fn approval_and_decision_are_retained_until_remove() {
     );
     assert_eq!(
         store.decision(&id).await.unwrap(),
-        Some(ApprovalDecision::Approved)
+        Some(ResolvedDecision::from(ApprovalDecision::Approved))
     );
 
     store.remove(&id).await.unwrap();
     assert!(store.get(&id).await.unwrap().is_none());
     assert_eq!(store.decision(&id).await.unwrap(), None);
     assert_eq!(
-        store.resolve(&id, ApprovalDecision::Approved).await,
+        store.resolve(&id, ApprovalDecision::Approved.into()).await,
         Err(ResolveError::NotFound)
     );
 }
 
 /// §2.5: `resolve` moves the approval into the decision file rather than
 /// deleting it — on disk the approval file is gone and the decision file
-/// carries both the approval record and the decision.
+/// carries the approval record, minus its egress headers, and the decision.
 #[tokio::test]
 async fn resolve_moves_the_approval_into_the_decision_file() {
     let dir = tempfile::tempdir().unwrap();
     let store = FileApprovalStore::open(dir.path()).unwrap();
-    let parked = make_parked("req-move", Duration::from_secs(60));
+    let mut parked = make_parked("req-move", Duration::from_secs(60));
+    let mut egress = reqwest::header::HeaderMap::new();
+    egress.insert("x-tenant-egress", "tenant-secret".parse().unwrap());
+    parked.egress_headers = Some(egress);
     let id = parked.request.decision_id;
     store.register(parked).await.unwrap();
 
     store
-        .resolve(&id, ApprovalDecision::Approved)
+        .resolve(&id, ApprovalDecision::Approved.into())
         .await
         .unwrap();
 
@@ -265,12 +283,16 @@ async fn resolve_moves_the_approval_into_the_decision_file() {
             .exists()
     );
     let decision_path = dir.path().join("decisions").join(format!("{id}.json"));
-    let on_disk: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(decision_path).unwrap()).unwrap();
+    let raw = std::fs::read_to_string(decision_path).unwrap();
+    let on_disk: serde_json::Value = serde_json::from_str(&raw).unwrap();
     assert_eq!(on_disk["approval"]["decision_id"], id.to_string());
     assert_eq!(on_disk["approval"]["request_id"], "req-move");
     assert_eq!(on_disk["decision"]["approved"], true);
     assert_eq!(on_disk["decision"]["reason"], serde_json::Value::Null);
+    assert!(
+        !raw.contains("tenant-secret"),
+        "egress credential survived resolve"
+    );
 }
 
 /// An expired undecided approval leaves the store on the scan that finds
@@ -316,7 +338,7 @@ async fn store_directories_and_files_are_owner_only() {
     );
 
     store
-        .resolve(&id, ApprovalDecision::Approved)
+        .resolve(&id, ApprovalDecision::Approved.into())
         .await
         .unwrap();
     assert_eq!(
@@ -339,7 +361,7 @@ async fn list_pending_removes_an_approval_file_that_already_has_a_decision() {
     let approval_bytes = std::fs::read(&approval_path).unwrap();
 
     store
-        .resolve(&id, ApprovalDecision::Approved)
+        .resolve(&id, ApprovalDecision::Approved.into())
         .await
         .unwrap();
     assert!(!approval_path.exists(), "resolve unlinks the approval file");
@@ -394,7 +416,7 @@ async fn list_pending_keeps_the_approval_file_behind_an_incomplete_decision() {
         "the torn decision file reads as a decode error"
     );
     assert_eq!(
-        store.resolve(&id, ApprovalDecision::Approved).await,
+        store.resolve(&id, ApprovalDecision::Approved.into()).await,
         Err(ResolveError::NotFound),
         "the torn file still holds the at-most-once claim"
     );
@@ -409,7 +431,7 @@ async fn list_pending_keeps_the_approval_file_behind_an_incomplete_decision() {
     let pending = store.list_pending().await.unwrap();
     assert_eq!(pending.len(), 1, "the row is pending again");
     store
-        .resolve(&id, ApprovalDecision::Approved)
+        .resolve(&id, ApprovalDecision::Approved.into())
         .await
         .expect("a fresh resolve lands");
     assert!(!approval_path.exists(), "resolve unlinks the approval file");
@@ -429,7 +451,7 @@ async fn cancel_request_removes_only_undecided_matching_approvals() {
     let decided_id = decided.request.decision_id;
     store.register(decided).await.unwrap();
     store
-        .resolve(&decided_id, ApprovalDecision::Approved)
+        .resolve(&decided_id, ApprovalDecision::Approved.into())
         .await
         .unwrap();
     let other = make_parked("req-other", Duration::from_secs(60));
@@ -447,7 +469,7 @@ async fn cancel_request_removes_only_undecided_matching_approvals() {
     );
     assert_eq!(
         store.decision(&decided_id).await.unwrap(),
-        Some(ApprovalDecision::Approved)
+        Some(ResolvedDecision::from(ApprovalDecision::Approved))
     );
     assert!(store.get(&other_id).await.unwrap().is_some());
 }
@@ -467,7 +489,7 @@ async fn cancel_request_sweeps_a_stale_decided_approval_without_returning_it() {
     let residue = serde_json::to_vec(&ParkedApprovalRecord::from(&decided)).unwrap();
     store.register(decided).await.unwrap();
     store
-        .resolve(&decided_id, ApprovalDecision::Approved)
+        .resolve(&decided_id, ApprovalDecision::Approved.into())
         .await
         .unwrap();
 
@@ -499,7 +521,7 @@ async fn cancel_request_sweeps_a_stale_decided_approval_without_returning_it() {
     );
     assert_eq!(
         store.decision(&decided_id).await.unwrap(),
-        Some(ApprovalDecision::Approved),
+        Some(ResolvedDecision::from(ApprovalDecision::Approved)),
         "the recorded decision is retained"
     );
 }
@@ -562,7 +584,7 @@ async fn list_pending_skips_a_stale_decided_approval() {
     let residue = serde_json::to_vec(&ParkedApprovalRecord::from(&decided)).unwrap();
     store.register(decided).await.unwrap();
     store
-        .resolve(&decided_id, ApprovalDecision::Approved)
+        .resolve(&decided_id, ApprovalDecision::Approved.into())
         .await
         .unwrap();
 
@@ -610,12 +632,12 @@ async fn resolve_succeeds_when_the_approval_file_cannot_be_removed() {
     }
 
     store
-        .resolve(&id, ApprovalDecision::Approved)
+        .resolve(&id, ApprovalDecision::Approved.into())
         .await
         .expect("resolve commits without the approval removal");
     assert_eq!(
         store.decision(&id).await.unwrap(),
-        Some(ApprovalDecision::Approved)
+        Some(ResolvedDecision::from(ApprovalDecision::Approved))
     );
     let restored = store
         .get(&id)
@@ -624,7 +646,7 @@ async fn resolve_succeeds_when_the_approval_file_cannot_be_removed() {
         .expect("approval record survives the failed removal");
     assert_eq!(restored.request.decision_id, id);
     assert_eq!(
-        store.resolve(&id, ApprovalDecision::Approved).await,
+        store.resolve(&id, ApprovalDecision::Approved.into()).await,
         Err(ResolveError::NotFound)
     );
 }
@@ -648,12 +670,12 @@ async fn state_survives_reopening_the_store() {
 
     let reopened = FileApprovalStore::open(dir.path()).unwrap();
     reopened
-        .resolve(&id, ApprovalDecision::Approved)
+        .resolve(&id, ApprovalDecision::Approved.into())
         .await
         .expect("resolve after reopen");
     assert_eq!(
         reopened.decision(&id).await.unwrap(),
-        Some(ApprovalDecision::Approved)
+        Some(ResolvedDecision::from(ApprovalDecision::Approved))
     );
 }
 

--- a/crates/aura-web-server/tests/redis_session_store_test.rs
+++ b/crates/aura-web-server/tests/redis_session_store_test.rs
@@ -366,7 +366,7 @@ async fn approval_resolve_removes_the_parked_record() {
     approvals.register(parked).await.unwrap();
 
     approvals
-        .resolve(&id, ApprovalDecision::Approved)
+        .resolve(&id, ApprovalDecision::Approved.into())
         .await
         .unwrap();
 
@@ -390,6 +390,16 @@ async fn approval_resolve_records_decision_readable_cross_instance() {
     common::resolve_records_readable_decision(&instance_a, &instance_b).await;
 }
 
+/// The decision record keeps identity and decision together across
+/// instances.
+#[tokio::test]
+async fn approval_resolve_records_identity_readable_cross_instance() {
+    let config = test_config(60);
+    let instance_a = connect(&config).await.approvals();
+    let instance_b = connect(&config).await.approvals();
+    common::resolve_records_identity_with_the_decision(&instance_a, &instance_b).await;
+}
+
 /// The decision record's TTL keeps a margin past the parked record's.
 #[tokio::test]
 async fn decision_record_outlives_parked_record_ttl() {
@@ -398,7 +408,7 @@ async fn decision_record_outlives_parked_record_ttl() {
     let id = parked.request.decision_id;
     approvals.register(parked).await.unwrap();
     approvals
-        .resolve(&id, ApprovalDecision::Approved)
+        .resolve(&id, ApprovalDecision::Approved.into())
         .await
         .unwrap();
 
@@ -406,7 +416,7 @@ async fn decision_record_outlives_parked_record_ttl() {
 
     assert_eq!(
         approvals.decision(&id).await.unwrap(),
-        Some(ApprovalDecision::Approved)
+        Some(ApprovalDecision::Approved.into())
     );
 }
 
@@ -496,7 +506,7 @@ async fn approval_cancel_request_returns_cleared_set() {
     approvals.register(decided).await.unwrap();
     approvals.register(keep).await.unwrap();
     approvals
-        .resolve(&decided_id, ApprovalDecision::Approved)
+        .resolve(&decided_id, ApprovalDecision::Approved.into())
         .await
         .unwrap();
 
@@ -511,7 +521,7 @@ async fn approval_cancel_request_returns_cleared_set() {
     assert!(approvals.get(&keep_id).await.unwrap().is_some());
     assert_eq!(
         approvals
-            .resolve(&undecided_id, ApprovalDecision::Approved)
+            .resolve(&undecided_id, ApprovalDecision::Approved.into())
             .await,
         Err(ResolveError::NotFound),
         "a cleared ticket resolves NotFound"
@@ -555,7 +565,7 @@ async fn approval_cancel_request_returns_cleared_set() {
     );
     assert_eq!(
         approvals
-            .resolve(&late_id, ApprovalDecision::Approved)
+            .resolve(&late_id, ApprovalDecision::Approved.into())
             .await,
         Err(ResolveError::NotFound),
         "the second cancel GETDEL'd the late ticket"
@@ -747,7 +757,9 @@ async fn approval_expires_with_its_record_ttl() {
 
     assert!(approvals.get(&id).await.unwrap().is_none());
     assert_eq!(
-        approvals.resolve(&id, ApprovalDecision::Approved).await,
+        approvals
+            .resolve(&id, ApprovalDecision::Approved.into())
+            .await,
         Err(ResolveError::NotFound)
     );
 }
@@ -1127,7 +1139,7 @@ async fn approval_parked_on_one_instance_wakes_when_resolved_on_another() {
     let handle = instance_a.register(request, Duration::from_secs(30)).await;
 
     instance_b
-        .resolve(&id, ApprovalDecision::Approved)
+        .resolve(&id, ApprovalDecision::Approved.into())
         .await
         .expect("resolve through the other instance succeeds");
 
@@ -1157,7 +1169,7 @@ async fn store_only_resolve_wakes_parking_instance_via_poll() {
     // Resolve against the store alone — no registry, no publish.
     store_b
         .approvals()
-        .resolve(&id, ApprovalDecision::Approved)
+        .resolve(&id, ApprovalDecision::Approved.into())
         .await
         .expect("store resolve succeeds");
 

--- a/crates/aura/src/approver_headers.rs
+++ b/crates/aura/src/approver_headers.rs
@@ -14,9 +14,7 @@ use reqwest::header::{HeaderMap, HeaderName};
 ///
 /// A value of this type exists only for an approved webhook decision whose
 /// mapped response headers were all present and valid; a partial capture
-/// is unrepresentable (construction fails closed). Construction is
-/// crate-private: the webhook client's gate-scoped path is the only
-/// producer.
+/// is unrepresentable (construction fails closed, crate-private).
 #[derive(Clone)]
 pub struct ApproverHeaders {
     /// Validated override pairs, keys lowercased. Keys serve as the audit surface (names only); no separate name list exists.
@@ -38,6 +36,15 @@ impl ApproverHeaders {
         for (outbound, response_name) in mapping.iter() {
             match response_headers.get(response_name) {
                 Some(value) => {
+                    // A parsed `HeaderValue` may still carry opaque bytes
+                    // outside visible ASCII; the identity is persisted as
+                    // text, so such a value fails the capture closed rather
+                    // than the later projection.
+                    if value.to_str().is_err() {
+                        return Err(CaptureError::InvalidValue {
+                            name: outbound.to_owned(),
+                        });
+                    }
                     // The outbound name is a validated lowercase header name
                     // by construction of `ToolHeaderMappings`.
                     let name = HeaderName::from_bytes(outbound.as_bytes())
@@ -57,6 +64,27 @@ impl ApproverHeaders {
     /// The captured outbound header names (never values), lowercased.
     pub fn captured_names(&self) -> impl Iterator<Item = &str> {
         self.headers.keys().map(HeaderName::as_str)
+    }
+
+    /// The captured pairs as plain `(lowercased name, value)` strings — the
+    /// storage projection the decision record persists. Values are visible
+    /// ASCII by construction (`from_captured` rejects any other value), so
+    /// `to_str` cannot fail.
+    pub(crate) fn to_pair_map(&self) -> std::collections::BTreeMap<String, String> {
+        crate::webhook_utils::header_map_to_pairs(&self.headers)
+    }
+
+    /// Restore a captured identity from its stored pair map: every name and
+    /// value must be a valid header pair, so a corrupted record fails the
+    /// decode instead of fabricating a partial identity. Keys are stored
+    /// lowercased (the capture convention); a non-lowercase name is still
+    /// valid per HTTP and lands normalized by `HeaderName`.
+    pub(crate) fn from_pairs(
+        pairs: impl IntoIterator<Item = (String, String)>,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            headers: crate::webhook_utils::pairs_to_header_map(pairs)?,
+        })
     }
 
     /// Apply the overrides to an outbound request builder as per-request
@@ -96,18 +124,20 @@ impl Eq for ApproverHeaders {}
 /// Capture-time failures: the approved webhook response could not yield
 /// the configured approver headers (fail closed).
 ///
-/// The `names` payload is diagnostic-only text for the error message and
-/// the event-level audit signal: always non-empty by construction (capture
-/// fails only when at least one name is missing), lowercased outbound
-/// header names, never values, and no domain logic branches on it.
+/// The payload is diagnostic-only text for the error message and the
+/// event-level audit signal: lowercased outbound header names, never
+/// values, and no domain logic branches on it.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum CaptureError {
-    /// Mapped response headers absent from the approved response. Invalid
-    /// values cannot occur here: capture reads a parsed `HeaderMap`, whose
-    /// values are already syntactically valid; invalid outbound names are
-    /// rejected earlier, at config parse.
+    /// Mapped response headers absent from the approved response.
     #[error("approver identity capture failed: response missing mapped headers {names:?}")]
     MissingHeaders { names: Vec<String> },
+    /// A mapped response header whose value is not visible ASCII. The name
+    /// is the outbound header name; the value is never carried.
+    #[error(
+        "approver identity capture failed: header {name} carries a value outside visible ASCII"
+    )]
+    InvalidValue { name: String },
 }
 
 /// Application-time failures at the execution seam (double override,
@@ -288,6 +318,33 @@ pub(crate) mod tests {
         assert_eq!(
             captured.headers.get_all("x-forwarded-user").iter().count(),
             1
+        );
+    }
+
+    /// A mapped response header carrying bytes outside visible ASCII fails
+    /// the capture closed, naming the outbound header and never its value.
+    #[test]
+    fn non_ascii_value_fails_the_capture_closed() {
+        let mut response_headers = HeaderMap::new();
+        response_headers.insert(
+            "x-approver-id",
+            reqwest::header::HeaderValue::from_bytes(b"s3cr\xfft-value").unwrap(),
+        );
+        let err = ApproverHeaders::from_captured(
+            &mappings(&[("x-forwarded-user", "x-approver-id")]),
+            &response_headers,
+        )
+        .expect_err("a value outside visible ASCII must not be captured");
+
+        assert_eq!(
+            err,
+            CaptureError::InvalidValue {
+                name: "x-forwarded-user".to_owned(),
+            }
+        );
+        assert!(
+            !err.to_string().contains("s3cr"),
+            "the value never leaks: {err}"
         );
     }
 

--- a/crates/aura/src/hitl/decision.rs
+++ b/crates/aura/src/hitl/decision.rs
@@ -63,6 +63,67 @@ pub enum ApprovalDecision {
     Denied { reason: Option<String> },
 }
 
+/// A decision plus the approver identity captured alongside it.
+#[derive(Clone, PartialEq, Eq)]
+pub enum ResolvedDecision {
+    Approved {
+        /// Captured approver identity.
+        identity: Option<crate::approver_headers::ApproverHeaders>,
+    },
+    Denied {
+        reason: Option<String>,
+    },
+}
+
+impl ResolvedDecision {
+    /// An approved decision with its captured identity.
+    #[must_use]
+    pub fn approved(identity: Option<crate::approver_headers::ApproverHeaders>) -> Self {
+        Self::Approved { identity }
+    }
+
+    /// The credential-free decision, the only part that reaches the bus, the
+    /// wake, and the events.
+    #[must_use]
+    pub fn decision(&self) -> ApprovalDecision {
+        match self {
+            Self::Approved { .. } => ApprovalDecision::Approved,
+            Self::Denied { reason } => ApprovalDecision::Denied {
+                reason: reason.clone(),
+            },
+        }
+    }
+}
+
+impl From<ApprovalDecision> for ResolvedDecision {
+    fn from(decision: ApprovalDecision) -> Self {
+        match decision {
+            ApprovalDecision::Approved => Self::Approved { identity: None },
+            ApprovalDecision::Denied { reason } => Self::Denied { reason },
+        }
+    }
+}
+
+impl std::fmt::Debug for ResolvedDecision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // Identity values are credentials: names only, the ApproverHeaders
+            // precedent.
+            Self::Approved { identity } => f
+                .debug_struct("Approved")
+                .field(
+                    "identity_names",
+                    &identity
+                        .as_ref()
+                        .map(crate::approver_headers::ApproverHeaders::captured_names)
+                        .map(Iterator::collect::<Vec<_>>),
+                )
+                .finish(),
+            Self::Denied { reason } => f.debug_struct("Denied").field("reason", reason).finish(),
+        }
+    }
+}
+
 /// Why a parked approval was cancelled rather than decided or timed out.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum CancelReason {

--- a/crates/aura/src/hitl/gate.rs
+++ b/crates/aura/src/hitl/gate.rs
@@ -12,7 +12,7 @@ use aura_config::GlobPattern;
 use rig::tool::ToolError;
 use serde_json::Value;
 
-use super::decision::{AgentScope, ApprovalOrigin, ApprovalOutcome, DecisionId};
+use super::decision::{AgentScope, ApprovalOrigin, DecisionId};
 use super::protocol::{ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
 use super::registry::{ParkedApproval, PendingApprovals};
 use super::route::{ApprovalError, DecisionRoute, GateDecision};
@@ -145,17 +145,35 @@ impl HitlApprovalWrapper {
             ));
         };
         // The route timeout bounds the decision window until a park TTL exists.
-        let DecisionRoute::Conversational { timeout, .. } = &*self.route else {
+        let Some((_, timeout)) = self.route.park_registry() else {
             return Err(ToolError::ToolCallError(
-                "tool call blocked: park mode requires the conversational route"
+                "tool call blocked: park mode requires a park-capable route"
                     .to_string()
                     .into(),
             ));
         };
 
+        // Egress capture, resolved where the route was built per request: a
+        // mapped destination with no usable value closes the registration
+        // before anything persists — notify is egress auth with no later
+        // reify checkpoint (deliberately stricter than identity docking).
+        let egress_headers = match self.route.park_egress() {
+            Ok(headers) => (!headers.is_empty()).then(|| headers.into_owned()),
+            Err(err) => {
+                tracing::warn!(
+                    tool_name = %ctx.tool_name,
+                    error = %err,
+                    "park-mode webhook egress capture failed; failing the gated call closed",
+                );
+                return Err(ToolError::ToolCallError(
+                    format!("tool call blocked: {err}").into(),
+                ));
+            }
+        };
+
         let now = chrono::Utc::now();
         let expires_at =
-            now + chrono::Duration::from_std(*timeout).expect("approval timeout fits in chrono");
+            now + chrono::Duration::from_std(timeout).expect("approval timeout fits in chrono");
         let decision_id = DecisionId::generate();
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
@@ -183,6 +201,7 @@ impl HitlApprovalWrapper {
             request,
             registered_at: now,
             expires_at,
+            egress_headers,
         };
         if let Err(err) = park.registry.register_durable(parked.clone()).await {
             tracing::warn!(
@@ -270,11 +289,7 @@ impl ToolWrapper for HitlApprovalWrapper {
                 ));
             };
             match recorded.take(&CallKey::new(task_id, &ctx.tool_name, args)) {
-                Some(decision) => {
-                    return approval_result_to_pre_call(Ok(GateDecision::without_overrides(
-                        ApprovalOutcome::Decided(decision),
-                    )));
-                }
+                Some(resolved) => return recorded_pre_call(&self.route, resolved),
                 // A continuation invocation that misses is a resume fault,
                 // never a fresh park: the recorded call no longer matches what
                 // the chain produced. Fail the call closed and let the resume
@@ -321,12 +336,7 @@ fn approval_result_to_pre_call(
 ) -> Result<PreCallOutcome, ToolError> {
     match result {
         Ok(GateDecision::Approved { overrides }) => Ok(PreCallOutcome::Proceed { overrides }),
-        Ok(GateDecision::Denied { reason }) => Ok(PreCallOutcome::ShortCircuit {
-            output: format!(
-                "Tool call blocked by human approval denial: {}. Do not execute this action.",
-                reason.unwrap_or_else(|| "no reason provided".to_string())
-            ),
-        }),
+        Ok(GateDecision::Denied { reason }) => Ok(denial_outcome(reason)),
         Ok(GateDecision::TimedOut { .. }) => Err(ToolError::ToolCallError(
             "tool call denied: approval timed out".to_string().into(),
         )),
@@ -336,6 +346,45 @@ fn approval_result_to_pre_call(
         Err(e) => Err(ToolError::ToolCallError(
             format!("tool call blocked: approval channel error: {e}").into(),
         )),
+    }
+}
+
+/// The live path's denial feedback: the denial is feedback the model can act
+/// on, so it short-circuits the call rather than erroring it.
+fn denial_outcome(reason: Option<String>) -> PreCallOutcome {
+    PreCallOutcome::ShortCircuit {
+        output: format!(
+            "Tool call blocked by human approval denial: {}. Do not execute this action.",
+            reason.unwrap_or_else(|| "no reason provided".to_string())
+        ),
+    }
+}
+
+/// Map a recorded decision to a pre-call outcome — the same surfaces the live
+/// gate produces. An approved call re-executes under its recorded identity,
+/// riding the same `Proceed.overrides` apply point the sync gate captures
+/// into; when the route's identity mapping demands identity and the recorded
+/// approval carries none (the poll-200 capture failed closed), reify blocks
+/// the approved execution rather than sending it under the requester's
+/// credentials.
+fn recorded_pre_call(
+    route: &DecisionRoute,
+    resolved: super::decision::ResolvedDecision,
+) -> Result<PreCallOutcome, ToolError> {
+    match resolved {
+        super::decision::ResolvedDecision::Approved { identity } => {
+            if identity.is_none() && route.requires_identity() {
+                return Err(ToolError::ToolCallError(
+                    "resume mismatch: approved call is missing required approver identity"
+                        .to_string()
+                        .into(),
+                ));
+            }
+            Ok(PreCallOutcome::Proceed {
+                overrides: identity,
+            })
+        }
+        super::decision::ResolvedDecision::Denied { reason } => Ok(denial_outcome(reason)),
     }
 }
 
@@ -358,7 +407,9 @@ mod tests {
                     build_webhook_client(),
                     WebhookUrl::new("http://localhost:9").unwrap(),
                 ),
+                registry: PendingApprovals::new(),
                 timeout: Duration::from_secs(1),
+                egress_capture: Ok(()),
             }),
             AgentScope::Single { session_id: None },
             "t".into(),
@@ -384,7 +435,9 @@ mod tests {
                     // Discard port: nothing listens, so the POST fails closed.
                     WebhookUrl::new("http://127.0.0.1:9").unwrap(),
                 ),
-                timeout: Duration::from_secs(2),
+                registry: PendingApprovals::new(),
+                timeout: Duration::from_secs(1),
+                egress_capture: Ok(()),
             }),
             AgentScope::Single { session_id: None },
             "req-test".into(),
@@ -457,6 +510,7 @@ mod tests {
         use std::time::Duration;
 
         use super::*;
+        use crate::session_store::ApprovalStore;
 
         fn worker_scope() -> AgentScope {
             AgentScope::Worker {
@@ -725,6 +779,261 @@ mod tests {
             }
             assert!(store.get(&decision_id).await.unwrap().is_none());
         }
+
+        /// A webhook route with poll delivery parks the gated call. The
+        /// route is wired the production way
+        /// ([`crate::hitl::HitlRuntime::from_config`] over a poll config) so
+        /// the client carries the poll marker; the park arm registers into
+        /// the shared registry without consulting the unreachable webhook.
+        /// The reconciler flow itself is the poller's.
+        #[tokio::test]
+        async fn webhook_poll_route_parks_the_gated_call() {
+            let config = aura_config::HitlConfig {
+                require_approval: vec![aura_config::GlobPattern::new("kubectl_*").unwrap()],
+                park: aura_config::ParkConfig { enabled: true },
+                route: aura_config::DecisionRouteConfig::Webhook {
+                    url: WebhookUrl::new("http://127.0.0.1:9").unwrap(),
+                    timeout_secs: 60,
+                    headers: std::collections::HashMap::new(),
+                    headers_from_request: std::collections::HashMap::new(),
+                    tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
+                    delivery: aura_config::WebhookDelivery::Poll,
+                    poll_url: None,
+                    poll_interval_secs: 10,
+                    poll_request_timeout_secs: 30,
+                },
+            };
+            let store: Arc<dyn crate::session_store::ApprovalStore> =
+                Arc::new(crate::session_store::InMemoryApprovalStore::new());
+            let registry = PendingApprovals::with_backend(
+                store.clone(),
+                Arc::new(crate::session_store::InMemoryEventBus::new()),
+            );
+            let runtime = crate::hitl::HitlRuntime::from_config(&config, &registry, None, None);
+            assert!(
+                runtime.route.park_registry().is_some(),
+                "the poll route arms the park arm"
+            );
+
+            let cell = Arc::new(crate::orchestration::BlockedCell::default());
+            cell.set_current_call_id(Some("call_poll".to_string()));
+            let gate = parked_gate(&registry, &runtime.route, "req-poll-park", &cell);
+
+            let args = serde_json::json!({ "namespace": "prod" });
+            let outcome = gate
+                .pre_call(&args, &ToolCallContext::new("kubectl_apply"))
+                .await
+                .unwrap();
+            assert_eq!(
+                outcome,
+                PreCallOutcome::ShortCircuit {
+                    output: super::PARK_SENTINEL.to_string()
+                },
+                "a gated call parks under poll delivery"
+            );
+
+            // The registration landed in the shared store under the
+            // run-scoped owner.
+            cell.snapshot_if_pending(&[], &rig::completion::Message::user("results"));
+            match cell.outcome() {
+                crate::orchestration::CellOutcome::Blocked { pending } => {
+                    assert_eq!(pending.len(), 1);
+                    let parked = store
+                        .get(&pending[0].decision_id)
+                        .await
+                        .unwrap()
+                        .expect("ticket parked in the store");
+                    assert_eq!(
+                        parked.request.request_id,
+                        "run:0191e8c0-1111-7000-8000-000000000042"
+                    );
+                }
+                other => panic!("expected Blocked, got {other:?}"),
+            }
+        }
+
+        /// A poll webhook config with `headers_from_request`, built the
+        /// production way with `req_headers` supplied by the caller.
+        fn poll_route_with_mapping(
+            registry: &PendingApprovals,
+            req_headers: Option<&std::collections::HashMap<String, String>>,
+            static_headers: std::collections::HashMap<String, String>,
+        ) -> (
+            Arc<dyn crate::session_store::ApprovalStore>,
+            Arc<DecisionRoute>,
+        ) {
+            let store: Arc<dyn crate::session_store::ApprovalStore> =
+                Arc::new(crate::session_store::InMemoryApprovalStore::new());
+            let config = aura_config::HitlConfig {
+                require_approval: vec![aura_config::GlobPattern::new("kubectl_*").unwrap()],
+                park: aura_config::ParkConfig { enabled: true },
+                route: aura_config::DecisionRouteConfig::Webhook {
+                    url: WebhookUrl::new("https://approvals.example.com/hook").unwrap(),
+                    timeout_secs: 60,
+                    headers: static_headers,
+                    headers_from_request: std::collections::HashMap::from([(
+                        "authorization".to_string(),
+                        "x-incoming-auth".to_string(),
+                    )]),
+                    tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
+                    delivery: aura_config::WebhookDelivery::Poll,
+                    poll_url: None,
+                    poll_interval_secs: 10,
+                    poll_request_timeout_secs: 30,
+                },
+            };
+            let runtime =
+                crate::hitl::HitlRuntime::from_config(&config, registry, None, req_headers);
+            (store, runtime.route)
+        }
+
+        fn req_headers(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
+            pairs
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect()
+        }
+
+        /// Capture failure fails the REGISTRATION closed: a mapped
+        /// destination with no usable resolved value and no static fallback
+        /// produces no approval row, no pending event, and no blocked-cell
+        /// entry — so there is also nothing for the reconciler to notify.
+        #[tokio::test]
+        async fn egress_capture_failure_fails_the_registration_closed() {
+            let request_id = format!("req_egress_fail_{}", uuid::Uuid::new_v4().simple());
+            let mut events = crate::approval_event_broker::subscribe(&request_id).await;
+            let store = Arc::new(crate::session_store::InMemoryApprovalStore::new());
+            let registry = PendingApprovals::with_backend(
+                store.clone(),
+                Arc::new(crate::session_store::InMemoryEventBus::new()),
+            );
+            let (_, route) = poll_route_with_mapping(&registry, None, Default::default());
+            let cell = Arc::new(crate::orchestration::BlockedCell::default());
+            let gate = parked_gate(&registry, &route, &request_id, &cell);
+
+            let err = gate
+                .pre_call(
+                    &serde_json::json!({ "namespace": "prod" }),
+                    &ToolCallContext::new("kubectl_apply"),
+                )
+                .await
+                .expect_err("an unresolvable mapped destination must fail the call closed");
+
+            let message = err.to_string();
+            assert!(
+                message.contains("egress capture failed") && message.contains("authorization"),
+                "the error names the capture failure and the destination: {message}"
+            );
+            assert!(
+                store.list_pending().await.unwrap().is_empty(),
+                "no approval row may exist"
+            );
+            assert!(cell.is_empty(), "no blocked-cell entry may exist");
+            assert!(
+                tokio::time::timeout(Duration::from_millis(50), events.recv())
+                    .await
+                    .is_err(),
+                "no approval event may be published"
+            );
+            crate::approval_event_broker::unsubscribe(&request_id).await;
+        }
+
+        /// The successful capture copies the request-scoped resolved values
+        /// onto the parked row: the row carries THIS request's credential,
+        /// the input the reconciler will notify with.
+        #[tokio::test]
+        async fn egress_capture_lands_on_the_parked_row() {
+            let store = Arc::new(crate::session_store::InMemoryApprovalStore::new());
+            let registry = PendingApprovals::with_backend(
+                store.clone(),
+                Arc::new(crate::session_store::InMemoryEventBus::new()),
+            );
+            let (_, route) = poll_route_with_mapping(
+                &registry,
+                Some(&req_headers(&[(
+                    "x-incoming-auth",
+                    "Bearer request-scoped",
+                )])),
+                Default::default(),
+            );
+            let cell = Arc::new(crate::orchestration::BlockedCell::default());
+            let gate = parked_gate(&registry, &route, "req-egress-ok", &cell);
+
+            gate.pre_call(
+                &serde_json::json!({ "namespace": "prod" }),
+                &ToolCallContext::new("kubectl_apply"),
+            )
+            .await
+            .expect("a resolvable mapping parks normally");
+
+            cell.snapshot_if_pending(&[], &rig::completion::Message::user("results"));
+            match cell.outcome() {
+                crate::orchestration::CellOutcome::Blocked { pending } => {
+                    let parked = store
+                        .get(&pending[0].decision_id)
+                        .await
+                        .unwrap()
+                        .expect("ticket parked");
+                    let row = parked.egress_headers.as_ref().expect("row egress headers");
+                    assert_eq!(
+                        row.get("authorization").unwrap(),
+                        "Bearer request-scoped",
+                        "the parked row carries this request's resolved credential"
+                    );
+                }
+                other => panic!("expected Blocked, got {other:?}"),
+            }
+        }
+
+        /// An explicit valid static fallback keeps the existing resolution
+        /// semantics: the absent request header resolves to the static value
+        /// and the row parks with it.
+        #[tokio::test]
+        async fn static_fallback_keeps_registration_open() {
+            let store = Arc::new(crate::session_store::InMemoryApprovalStore::new());
+            let registry = PendingApprovals::with_backend(
+                store.clone(),
+                Arc::new(crate::session_store::InMemoryEventBus::new()),
+            );
+            let (_, route) = poll_route_with_mapping(
+                &registry,
+                None,
+                std::collections::HashMap::from([(
+                    "authorization".to_string(),
+                    "Bearer static-fallback".to_string(),
+                )]),
+            );
+            let cell = Arc::new(crate::orchestration::BlockedCell::default());
+            let gate = parked_gate(&registry, &route, "req-egress-fallback", &cell);
+
+            gate.pre_call(
+                &serde_json::json!({}),
+                &ToolCallContext::new("kubectl_apply"),
+            )
+            .await
+            .expect("a static fallback keeps the registration open");
+
+            cell.snapshot_if_pending(&[], &rig::completion::Message::user("results"));
+            match cell.outcome() {
+                crate::orchestration::CellOutcome::Blocked { pending } => {
+                    let parked = store
+                        .get(&pending[0].decision_id)
+                        .await
+                        .unwrap()
+                        .expect("ticket parked");
+                    assert_eq!(
+                        parked
+                            .egress_headers
+                            .as_ref()
+                            .expect("row egress headers")
+                            .get("authorization")
+                            .unwrap(),
+                        "Bearer static-fallback",
+                    );
+                }
+                other => panic!("expected Blocked, got {other:?}"),
+            }
+        }
     }
 
     // ====================================================================
@@ -736,7 +1045,7 @@ mod tests {
         use std::time::Duration;
 
         use super::*;
-        use crate::hitl::ApprovalDecision;
+        use crate::hitl::{ApprovalDecision, ResolvedDecision};
 
         /// A route whose webhook is unreachable, so a fall-through to the
         /// route fails closed rather than hanging. A recorded hit
@@ -748,7 +1057,9 @@ mod tests {
                     // Discard port: nothing listens, so the POST fails closed.
                     WebhookUrl::new("http://127.0.0.1:9").unwrap(),
                 ),
+                registry: PendingApprovals::new(),
                 timeout: Duration::from_secs(2),
+                egress_capture: Ok(()),
             })
         }
 
@@ -776,6 +1087,129 @@ mod tests {
             ctx
         }
 
+        /// A route with `tool_headers_from_response` configured, so the
+        /// reify-side rule "approved calls must carry identity" is armed.
+        fn identity_route() -> Arc<DecisionRoute> {
+            let config = aura_config::HitlConfig {
+                require_approval: vec![],
+                park: aura_config::ParkConfig::default(),
+                route: aura_config::DecisionRouteConfig::Webhook {
+                    url: WebhookUrl::new("https://approvals.example.com/hook").unwrap(),
+                    timeout_secs: 60,
+                    headers: Default::default(),
+                    headers_from_request: Default::default(),
+                    tool_headers_from_response: crate::approver_headers::tests::mappings(&[(
+                        "x-forwarded-user",
+                        "x-approver-id",
+                    )]),
+                    delivery: aura_config::WebhookDelivery::Sync,
+                    poll_url: None,
+                    poll_interval_secs: 10,
+                    poll_request_timeout_secs: 30,
+                },
+            };
+            let client =
+                crate::hitl::webhook_client_from_config(&config.route, None, None).unwrap();
+            Arc::new(DecisionRoute::Webhook {
+                client,
+                registry: PendingApprovals::new(),
+                timeout: Duration::from_secs(2),
+                egress_capture: Ok(()),
+            })
+        }
+
+        fn identity(values: &[(&str, &str)]) -> crate::approver_headers::ApproverHeaders {
+            crate::approver_headers::ApproverHeaders::from_pairs(
+                values
+                    .iter()
+                    .map(|(k, v)| ((*k).to_string(), (*v).to_string())),
+            )
+            .expect("identity test pairs are valid headers")
+        }
+
+        /// A recorded approval WITH captured identity re-executes under it:
+        /// the overrides ride the same `Proceed` apply point the sync gate
+        /// captures into.
+        #[tokio::test]
+        async fn recorded_identity_is_applied_at_reexecution() {
+            let recorded = Arc::new(RecordedDecisions::default());
+            let args = serde_json::json!({"namespace": "prod"});
+            recorded.push(
+                CallKey::new(1, "kubectl_apply", &args),
+                ResolvedDecision::approved(Some(identity(&[(
+                    "x-forwarded-user",
+                    "approver-alice",
+                )]))),
+            );
+
+            let gate = recorded_gate(recorded, identity_route());
+            let outcome = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", Some(1)))
+                .await
+                .expect("a recorded approval with its identity re-executes");
+
+            match outcome {
+                PreCallOutcome::Proceed {
+                    overrides: Some(overrides),
+                } => assert_eq!(
+                    overrides.captured_names().collect::<Vec<_>>(),
+                    ["x-forwarded-user"],
+                ),
+                other => panic!("expected Proceed with overrides, got {other:?}"),
+            }
+        }
+
+        /// Reify blocks an approved call whose identity capture failed
+        /// (recorded without identity) when the route demands identity:
+        /// record-then-block, per the approver identity ADR — the decision
+        /// is not lost, but the call never runs under the requester's
+        /// credentials.
+        #[tokio::test]
+        async fn approved_without_required_identity_fails_the_call_closed() {
+            let recorded = Arc::new(RecordedDecisions::default());
+            let args = serde_json::json!({"namespace": "prod"});
+            recorded.push(
+                CallKey::new(1, "kubectl_apply", &args),
+                ResolvedDecision::approved(None),
+            );
+
+            let gate = recorded_gate(recorded, identity_route());
+            let err = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", Some(1)))
+                .await
+                .expect_err("an approved call missing required identity must fail closed");
+
+            let message = err.to_string();
+            assert!(
+                message.contains("required approver identity"),
+                "the error names the missing identity, got: {message}"
+            );
+            assert!(
+                !message.contains("approval channel"),
+                "this is a reify block, not a route fault: {message}"
+            );
+        }
+
+        /// Without an identity mapping the same uncaptured approval proceeds:
+        /// the block keys off the route's demand, not off identity being
+        /// absent per se.
+        #[tokio::test]
+        async fn approved_without_identity_proceeds_when_route_demands_none() {
+            let recorded = Arc::new(RecordedDecisions::default());
+            let args = serde_json::json!({"namespace": "prod"});
+            recorded.push(
+                CallKey::new(1, "kubectl_apply", &args),
+                ResolvedDecision::approved(None),
+            );
+
+            let gate = recorded_gate(recorded, discard_route());
+            let outcome = gate
+                .pre_call(&args, &ctx_for("kubectl_apply", Some(1)))
+                .await
+                .unwrap();
+            assert_eq!(outcome, PreCallOutcome::Proceed { overrides: None });
+        }
+
         /// A recorded approval proceeds through the same mapping the live
         /// route uses, without ever consulting the (unreachable) route.
         #[tokio::test]
@@ -784,7 +1218,7 @@ mod tests {
             let args = serde_json::json!({"namespace": "prod"});
             recorded.push(
                 CallKey::new(1, "kubectl_apply", &args),
-                ApprovalDecision::Approved,
+                ApprovalDecision::Approved.into(),
             );
 
             let gate = recorded_gate(recorded, discard_route());
@@ -807,7 +1241,8 @@ mod tests {
                 CallKey::new(1, "kubectl_apply", &args),
                 ApprovalDecision::Denied {
                     reason: Some("too risky".to_string()),
-                },
+                }
+                .into(),
             );
 
             let gate = recorded_gate(recorded, discard_route());
@@ -1009,7 +1444,7 @@ mod tests {
 
             let payload_id = payload_decision_id(&mut events).await;
             registry
-                .resolve(&payload_id, ApprovalDecision::Approved)
+                .resolve(&payload_id, ApprovalDecision::Approved.into())
                 .await
                 .expect("parked approval resolves");
             call.await
@@ -1138,7 +1573,7 @@ mod tests {
                 tokio::join!(tool.call(json!({ "namespace": "prod" })), async {
                     let id = payload_decision_id(&mut events).await;
                     registry
-                        .resolve(&id, ApprovalDecision::Approved)
+                        .resolve(&id, ApprovalDecision::Approved.into())
                         .await
                         .expect("parked approval resolves");
                     id
@@ -1205,7 +1640,9 @@ mod tests {
                         // Discard port: nothing listens, so the POST fails closed.
                         WebhookUrl::new("http://127.0.0.1:9").unwrap(),
                     ),
+                    registry: PendingApprovals::new(),
                     timeout: Duration::from_secs(2),
+                    egress_capture: Ok(()),
                 },
                 &request_id,
                 "kubectl_delete",

--- a/crates/aura/src/hitl/mod.rs
+++ b/crates/aura/src/hitl/mod.rs
@@ -40,7 +40,7 @@ mod tool;
 
 pub use decision::{
     AgentScope, ApprovalDecision, ApprovalOrigin, ApprovalOutcome, AwaitingDecision, CancelReason,
-    DecisionId, Timestamp,
+    DecisionId, ResolvedDecision, Timestamp,
 };
 pub(crate) use events::completed_cancelled;
 /// Read one full HTTP/1.1 request (head plus content-length body) off a
@@ -87,6 +87,10 @@ pub use gate::HitlApprovalWrapper;
 pub use poller::{PollReconciler, PollerHandle};
 pub use protocol::{ApprovalDecisionWire, ApprovalItem, ApprovalRequest, PROTOCOL_VERSION};
 pub use registry::{ParkedApproval, PendingApprovals, ResolveError};
+// Re-exported so config-fingerprint tests construct the poll client the
+// production way.
+#[cfg(test)]
+pub(crate) use route::webhook_client_from_config;
 pub use route::{
     ApprovalError, DecisionRoute, HitlRuntime, PlaintextWebhookUrlError, WebhookClient,
     cleartext_capture_warning, validate_webhook_signing_config, warn_on_cleartext_capture,

--- a/crates/aura/src/hitl/poller.rs
+++ b/crates/aura/src/hitl/poller.rs
@@ -28,24 +28,27 @@ use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-use aura_config::{DecisionRouteConfig, HitlConfig, WebhookDelivery};
+use aura_config::{DecisionRouteConfig, HitlConfig, ToolHeaderMappings, WebhookDelivery};
 
-use super::decision::DecisionId;
+use super::decision::{ApprovalDecision, DecisionId, ResolvedDecision};
 use super::registry::{PendingApprovals, ResolveError};
 use super::route::{PollOutcome, WebhookClient, webhook_client_from_config};
 use super::signing::WebhookHmac;
+use crate::approver_headers::ApproverHeaders;
 use crate::session_store::ApprovalStore;
 
 /// The poll-delivery reconciler for one process: a private webhook client,
-/// the shared approval store it scans, and the ingress registry it resolves
-/// through. Built once at startup from the `[hitl.route]` config; [`Self::spawn`]
-/// runs the tick loop until its shutdown token cancels.
+/// the shared approval store it scans, the ingress registry it resolves
+/// through, and the identity mapping its poll-200 captures against. Built
+/// once at startup from the `[hitl.route]` config; [`Self::spawn`] runs the
+/// tick loop until its shutdown token cancels.
 pub struct PollReconciler {
     client: WebhookClient,
     store: Arc<dyn ApprovalStore>,
     registry: PendingApprovals,
     instance_id: String,
     interval: Duration,
+    tool_header_mappings: ToolHeaderMappings,
 }
 
 impl PollReconciler {
@@ -54,8 +57,10 @@ impl PollReconciler {
     /// and the webhook arm under sync delivery. The client is built by the
     /// same construction [`super::route::HitlRuntime::from_config`] uses, so
     /// the reconciler's notify/poll legs carry the exact wire shape of the
-    /// per-request routes (static operator headers only — poll delivery
-    /// refuses `headers_from_request` at config validation).
+    /// per-request routes. Its operator headers are the static set only —
+    /// `headers_from_request` values are per-row: each parked approval
+    /// carries its own request-scoped resolved values, which the notify
+    /// overlays without mutating this client.
     #[must_use]
     pub fn from_config(
         config: &HitlConfig,
@@ -67,6 +72,7 @@ impl PollReconciler {
         let DecisionRouteConfig::Webhook {
             delivery: WebhookDelivery::Poll,
             poll_interval_secs,
+            tool_headers_from_response,
             ..
         } = &config.route
         else {
@@ -78,6 +84,7 @@ impl PollReconciler {
             registry: registry.clone(),
             instance_id,
             interval: Duration::from_secs(*poll_interval_secs),
+            tool_header_mappings: tool_headers_from_response.clone(),
         })
     }
 
@@ -137,10 +144,34 @@ impl PollReconciler {
                     decision,
                     response_headers,
                 }) => {
-                    // The response headers are not consumed here; the
-                    // reconciler resolves on the decision alone.
-                    drop(response_headers);
-                    match self.registry.resolve(&id, decision).await {
+                    let resolved = match decision {
+                        // Approver identity rides these headers: capture
+                        // against the route's mapping the same way the sync
+                        // gate does. A capture failure records the decision
+                        // WITHOUT identity — reify blocks the approved
+                        // execution later if identity is required
+                        // (record-then-block, per the approver identity
+                        // ADR).
+                        ApprovalDecision::Approved if !self.tool_header_mappings.is_empty() => {
+                            match ApproverHeaders::from_captured(
+                                &self.tool_header_mappings,
+                                &response_headers,
+                            ) {
+                                Ok(identity) => ResolvedDecision::approved(Some(identity)),
+                                Err(err) => {
+                                    warn!(
+                                        decision_id = %id,
+                                        error = %err,
+                                        "approver identity capture failed; recording the \
+                                         decision without identity",
+                                    );
+                                    ResolvedDecision::approved(None)
+                                }
+                            }
+                        }
+                        other => ResolvedDecision::from(other),
+                    };
+                    match self.registry.resolve(&id, resolved).await {
                         Ok(()) => {}
                         // The ticket expired or was swept between
                         // list_pending and resolve; the decision is
@@ -164,7 +195,11 @@ impl PollReconciler {
                 ),
             }
             if !notified.contains(&id) {
-                match self.client.notify(&parked.request).await {
+                match self
+                    .client
+                    .notify(&parked.request, parked.egress_headers.as_ref())
+                    .await
+                {
                     Ok(()) => {
                         notified.insert(id);
                     }
@@ -272,6 +307,7 @@ mod tests {
                 request,
                 registered_at: chrono::Utc::now(),
                 expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+                egress_headers: None,
             })
             .await
             .expect("pending approval registers");
@@ -319,7 +355,7 @@ mod tests {
     async fn store_decision(
         store: &Arc<dyn ApprovalStore>,
         id: &DecisionId,
-    ) -> Option<ApprovalDecision> {
+    ) -> Option<ResolvedDecision> {
         store.decision(id).await.unwrap()
     }
 
@@ -376,7 +412,7 @@ mod tests {
 
         assert_eq!(
             store_decision(&store, &id).await,
-            Some(ApprovalDecision::Approved),
+            Some(ResolvedDecision::from(ApprovalDecision::Approved)),
             "the decided 200 resolves durably"
         );
         assert!(
@@ -410,7 +446,7 @@ mod tests {
 
         assert_eq!(
             store_decision(&store, &id).await,
-            Some(ApprovalDecision::Approved),
+            Some(ResolvedDecision::from(ApprovalDecision::Approved)),
             "the status GET alone must carry the resolution"
         );
     }
@@ -474,7 +510,7 @@ mod tests {
         assert!(rx.recv().await.unwrap().starts_with("GET "));
         assert_eq!(
             store_decision(&store, &id).await,
-            Some(ApprovalDecision::Approved),
+            Some(ResolvedDecision::from(ApprovalDecision::Approved)),
             "the decided status GET resolves durably"
         );
     }
@@ -515,7 +551,7 @@ mod tests {
 
         assert_eq!(
             store_decision(&store, &own).await,
-            Some(ApprovalDecision::Approved),
+            Some(ResolvedDecision::from(ApprovalDecision::Approved)),
         );
         assert!(
             store.get(&other).await.unwrap().is_some(),
@@ -588,6 +624,7 @@ mod tests {
                     request,
                     registered_at: chrono::Utc::now(),
                     expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+                    egress_headers: None,
                 })
                 .await
                 .expect("pending approval parks durably");
@@ -633,7 +670,7 @@ mod tests {
         })
         .await
         .expect("the reboot's decided tick resolves");
-        assert_eq!(recorded, ApprovalDecision::Approved);
+        assert_eq!(recorded, ResolvedDecision::from(ApprovalDecision::Approved));
         // The file backend retains the record behind `get` (resolve moves
         // the ticket into the decision file); the pending scan is what the
         // reconciler consumes, so that is what must be empty now.
@@ -688,5 +725,590 @@ mod tests {
         })
         .await
         .expect("the loop must end when the shutdown token cancels");
+    }
+
+    // ====================================================================
+    // Egress headers at rest + identity docking on the decision record
+    // ====================================================================
+
+    mod at_rest {
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        use futures::StreamExt;
+        use reqwest::header::{HeaderMap, HeaderValue};
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+        use tokio::sync::mpsc;
+
+        use super::super::super::decision::ResolvedDecision;
+        use super::super::super::registry::ParkedApproval;
+        use super::*;
+        use crate::session_store::EventBus;
+        use crate::session_store::FileApprovalStore;
+
+        const EGRESS_ALPHA: &str = "Bearer egress-sentinel-alpha";
+        const EGRESS_BETA: &str = "Bearer egress-sentinel-beta";
+        const IDENTITY_SENTINEL: &str = "approver-identity-sentinel";
+
+        /// Minimal tracing-capture buffer, shared as the writer (the
+        /// route.rs `CapturedLog` pattern).
+        struct CaptureLog(std::sync::Mutex<Vec<u8>>);
+
+        impl std::io::Write for &CaptureLog {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        /// A poll config with static client headers and an optional identity
+        /// mapping, built the production way.
+        fn poll_config_with(
+            static_headers: HashMap<String, String>,
+            identity_mapping: bool,
+        ) -> aura_config::HitlConfig {
+            aura_config::HitlConfig {
+                require_approval: vec![],
+                park: aura_config::ParkConfig::default(),
+                route: aura_config::DecisionRouteConfig::Webhook {
+                    url: aura_config::WebhookUrl::new("http://127.0.0.1:1").unwrap(),
+                    timeout_secs: 300,
+                    headers: static_headers,
+                    headers_from_request: HashMap::new(),
+                    tool_headers_from_response: if identity_mapping {
+                        crate::approver_headers::tests::mappings(&[(
+                            "x-forwarded-user",
+                            "x-approver-id",
+                        )])
+                    } else {
+                        aura_config::ToolHeaderMappings::default()
+                    },
+                    delivery: aura_config::WebhookDelivery::Poll,
+                    poll_url: None,
+                    poll_interval_secs: 10,
+                    poll_request_timeout_secs: 30,
+                },
+            }
+        }
+
+        /// A reconciler built from `config`, pointed at `url`, resolving
+        /// through the given registry.
+        fn reconciler_over(
+            config: &aura_config::HitlConfig,
+            store: Arc<dyn ApprovalStore>,
+            url: &str,
+            registry: &PendingApprovals,
+        ) -> PollReconciler {
+            let mut config = config.clone();
+            if let aura_config::DecisionRouteConfig::Webhook { url: route_url, .. } =
+                &mut config.route
+            {
+                *route_url = aura_config::WebhookUrl::new(url).unwrap();
+            }
+            PollReconciler::from_config(&config, None, INSTANCE_ID.to_string(), store, registry)
+                .expect("a poll config builds a reconciler")
+        }
+
+        /// A reconciler over its own registry, the standalone shape.
+        fn reconciler_from(
+            config: &aura_config::HitlConfig,
+            store: Arc<dyn ApprovalStore>,
+            url: &str,
+        ) -> PollReconciler {
+            let registry = PendingApprovals::with_backend(
+                store.clone(),
+                Arc::new(crate::session_store::InMemoryEventBus::new()),
+            );
+            reconciler_over(config, store, url, &registry)
+        }
+
+        /// Park a durable row carrying `egress` as its resolved authorization
+        /// value.
+        async fn park_row(store: &Arc<dyn ApprovalStore>, egress: &str) -> DecisionId {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                "authorization",
+                HeaderValue::from_str(egress).expect("sentinels are valid header values"),
+            );
+            let request = parked_request(DecisionId::generate(), INSTANCE_ID);
+            let id = request.decision_id;
+            store
+                .register(ParkedApproval {
+                    request,
+                    registered_at: chrono::Utc::now(),
+                    expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+                    egress_headers: Some(headers),
+                })
+                .await
+                .expect("pending approval registers");
+            id
+        }
+
+        /// One scripted receiver response: status line, extra headers, body.
+        type ScriptedResponse = (
+            &'static str,
+            Vec<(&'static str, &'static str)>,
+            &'static str,
+        );
+
+        /// Sequential-connection receiver whose responses may carry headers:
+        /// connection `i` gets `responses[i]`, every captured raw request
+        /// lands on the channel in order.
+        async fn scripted_receiver_with_headers(
+            responses: Vec<ScriptedResponse>,
+        ) -> (String, mpsc::Receiver<String>) {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let url = format!("http://{}", listener.local_addr().unwrap());
+            let (tx, rx) = mpsc::channel(responses.len());
+            tokio::spawn(async move {
+                for (status, headers, body) in responses {
+                    let (mut socket, _) = listener.accept().await.unwrap();
+                    let captured = read_full_request(&mut socket).await;
+                    let mut response = format!(
+                        "HTTP/1.1 {status}\r\ncontent-type: application/json\r\n\
+                         content-length: {}\r\nconnection: close\r\n",
+                        body.len()
+                    );
+                    for (name, value) in &headers {
+                        response.push_str(&format!("{name}: {value}\r\n"));
+                    }
+                    response.push_str("\r\n");
+                    response.push_str(body);
+                    socket.write_all(response.as_bytes()).await.ok();
+                    socket.shutdown().await.ok();
+                    tx.send(captured).await.expect("capture channel open");
+                }
+            });
+            (url, rx)
+        }
+
+        /// The `decision_id` a captured notify POST body carries.
+        fn body_decision_id(captured: &str) -> String {
+            let body = captured
+                .split("\r\n\r\n")
+                .nth(1)
+                .expect("the capture carries a body");
+            let json: serde_json::Value = serde_json::from_str(body).expect("wire body is JSON");
+            json["decision_id"]
+                .as_str()
+                .expect("the wire carries the decision id")
+                .to_string()
+        }
+
+        /// Distinct-credential approvals keep their own headers through
+        /// registration, notify retry, and store reopen: each notify POST —
+        /// including the retried one — authenticates with ITS row's value,
+        /// never the sibling's and never the client's static fallback.
+        #[tokio::test]
+        async fn distinct_rows_keep_their_own_headers_through_retry_and_reopen() {
+            let dir = tempfile::tempdir().unwrap();
+            let store_root = dir.path().join("approvals");
+
+            // Registration: both rows land with their own resolved values.
+            let writer: Arc<dyn ApprovalStore> =
+                Arc::new(FileApprovalStore::open(&store_root).unwrap());
+            let alpha = park_row(&writer, EGRESS_ALPHA).await;
+            let beta = park_row(&writer, EGRESS_BETA).await;
+
+            // Store reopen: a second handle over the same root — the
+            // reconciler's view — still sees each row's own headers.
+            let reader: Arc<dyn ApprovalStore> =
+                Arc::new(FileApprovalStore::open(&store_root).unwrap());
+            let pending = reader.list_pending().await.unwrap();
+            let expected: HashMap<String, String> = HashMap::from([
+                (alpha.to_string(), EGRESS_ALPHA.to_string()),
+                (beta.to_string(), EGRESS_BETA.to_string()),
+            ]);
+            assert_eq!(pending.len(), 2);
+            for parked in &pending {
+                let row = parked.egress_headers.as_ref().expect("row headers survive");
+                assert_eq!(
+                    row.get("authorization")
+                        .map(|value| value.to_str().unwrap()),
+                    Some(expected[&parked.request.decision_id.to_string()].as_str()),
+                );
+            }
+
+            // The reconciler's client carries a DIFFERENT static value for
+            // the same header name, so a per-row override failure is visible.
+            let mut static_headers = HashMap::new();
+            static_headers.insert(
+                "authorization".to_string(),
+                "Bearer client-static".to_string(),
+            );
+            let config = poll_config_with(static_headers, false);
+            let (url, mut rx) = scripted_receiver_with_headers(vec![
+                // Tick 1: row A reads status then POSTs 503 (captured);
+                // row B reads status then acks. Four connections.
+                ("204 No Content", vec![], ""),
+                ("503 Service Unavailable", vec![], ""),
+                ("204 No Content", vec![], ""),
+                ("200 OK", vec![], ""),
+                // Tick 2: row A reads status, then its failed notify
+                // retries (captured); row B's marker skips its POST.
+                // Three connections.
+                ("204 No Content", vec![], ""),
+                ("200 OK", vec![], ""),
+                ("204 No Content", vec![], ""),
+                // Tick 3: both rows resolve on the read alone. Two
+                // connections.
+                ("200 OK", vec![], r#"{"status":"approved"}"#),
+                ("200 OK", vec![], r#"{"status":"approved"}"#),
+            ])
+            .await;
+            let reconciler = reconciler_from(&config, Arc::clone(&reader), &url);
+            let mut notified = HashSet::new();
+
+            reconciler.tick(&mut notified).await;
+            let _first = rx.recv().await.unwrap();
+            let second = rx.recv().await.unwrap();
+            let _third = rx.recv().await.unwrap();
+            let fourth = rx.recv().await.unwrap();
+            reconciler.tick(&mut notified).await;
+            let _fifth = rx.recv().await.unwrap();
+            let sixth = rx.recv().await.unwrap();
+            let _seventh = rx.recv().await.unwrap();
+            reconciler.tick(&mut notified).await;
+            let _eighth = rx.recv().await.unwrap();
+            let _ninth = rx.recv().await.unwrap();
+
+            assert!(second.starts_with("POST ") && fourth.starts_with("POST "));
+            assert!(sixth.starts_with("POST "), "the failed notify retries");
+
+            let posts = [second, fourth, sixth];
+            for captured in &posts {
+                let id = body_decision_id(captured);
+                let expected_value = expected[&id].as_str();
+                let header_line = captured
+                    .lines()
+                    .find(|line| line.to_lowercase().starts_with("authorization:"))
+                    .unwrap_or_else(|| {
+                        panic!("every notify POST carries its row header: {captured}")
+                    });
+                assert_eq!(
+                    header_line.split_once(':').expect("header line").1.trim(),
+                    expected_value,
+                    "each notify POST authenticates with its own row's value: {captured}"
+                );
+                assert!(
+                    !captured.contains("Bearer client-static"),
+                    "the client's static value must never leak beside the row's: {captured}"
+                );
+            }
+
+            // Both rows resolved durably, decisions without identity.
+            assert_eq!(
+                store_decision(&reader, &alpha).await,
+                Some(ResolvedDecision::from(ApprovalDecision::Approved)),
+            );
+            assert_eq!(
+                store_decision(&reader, &beta).await,
+                Some(ResolvedDecision::from(ApprovalDecision::Approved)),
+            );
+        }
+
+        /// The poll-200's configured identity headers are captured and
+        /// recorded in the SAME resolve as the decision.
+        #[tokio::test]
+        async fn poll_200_identity_is_captured_into_the_decision_record() {
+            let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+            let id = park_row(&store, EGRESS_ALPHA).await;
+            let config = poll_config_with(HashMap::new(), true);
+            let (url, mut rx) = scripted_receiver_with_headers(vec![(
+                "200 OK",
+                vec![("x-approver-id", IDENTITY_SENTINEL)],
+                r#"{"status":"approved"}"#,
+            )])
+            .await;
+            let reconciler = reconciler_from(&config, store.clone(), &url);
+            let mut notified = HashSet::new();
+
+            reconciler.tick(&mut notified).await;
+            let poll = rx.recv().await.unwrap();
+            assert!(poll.starts_with("GET "), "the status read: {poll}");
+            assert!(
+                !poll.contains(EGRESS_ALPHA) && !poll.contains(IDENTITY_SENTINEL),
+                "the status GET carries no row egress or identity values: {poll}"
+            );
+
+            match store_decision(&store, &id).await.expect("resolved") {
+                ResolvedDecision::Approved {
+                    identity: Some(captured),
+                } => {
+                    assert_eq!(
+                        captured.captured_names().collect::<Vec<_>>(),
+                        ["x-forwarded-user"],
+                        "the identity is stored under the outbound name",
+                    );
+                    assert_eq!(
+                        captured.to_pair_map()["x-forwarded-user"],
+                        IDENTITY_SENTINEL,
+                        "the captured value is the poll-200's, whole",
+                    );
+                }
+                other => panic!("expected Approved with captured identity, got {other:?}"),
+            }
+        }
+
+        /// A poll-200 missing the mapped identity header records the
+        /// decision WITHOUT identity (record-then-block, per the approver
+        /// identity ADR): the
+        /// resolution is not lost, reify blocks later if identity is
+        /// required.
+        #[tokio::test]
+        async fn identity_capture_failure_records_the_decision_without_identity() {
+            let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+            let id = park_row(&store, EGRESS_ALPHA).await;
+            let config = poll_config_with(HashMap::new(), true);
+            let (url, mut rx) = scripted_receiver_with_headers(vec![(
+                "200 OK",
+                vec![],
+                r#"{"status":"approved"}"#,
+            )])
+            .await;
+            let reconciler = reconciler_from(&config, store.clone(), &url);
+            let mut notified = HashSet::new();
+
+            reconciler.tick(&mut notified).await;
+            let _poll = rx.recv().await.unwrap();
+
+            assert_eq!(
+                store_decision(&store, &id).await,
+                Some(ResolvedDecision::approved(None)),
+                "the decision records without identity",
+            );
+        }
+
+        /// The sentinel leak guard. Distinct egress and identity sentinels
+        /// are proven to reach ONLY the allowed store fields (the undecided
+        /// row's `egress_headers`, the decision record's `identity`) and the
+        /// intended HTTP headers (the notify POST's authorization), and to be
+        /// absent from the decision-bus payload, lifecycle/SSE events,
+        /// tracing and error text, and the run's serialized checkpoints (the
+        /// parked document, the `.resuming.json`, and the commit's temp
+        /// write).
+        #[tokio::test]
+        async fn sentinels_reach_only_allowed_store_fields_and_intended_headers() {
+            const EGRESS: &str = "Bearer egress-leakguard-sentinel";
+            const IDENTITY: &str = "identity-leakguard-sentinel";
+
+            let dir = tempfile::tempdir().unwrap();
+            let store_root = dir.path().join("approvals");
+            let memory_dir = dir.path().join("memory");
+            std::fs::create_dir_all(&memory_dir).unwrap();
+
+            let store: Arc<dyn ApprovalStore> =
+                Arc::new(FileApprovalStore::open(&store_root).unwrap());
+            let bus = Arc::new(crate::session_store::InMemoryEventBus::new());
+            let registry = PendingApprovals::with_backend(store.clone(), bus.clone());
+
+            // The parked row: the run-scoped owner a production park arm
+            // writes, with the egress sentinel on the allowed field.
+            let run_id = "0191e8c0-1eak-7000-8000-000000000001";
+            let request = parked_request(DecisionId::generate(), INSTANCE_ID);
+            let id = request.decision_id;
+            let mut request = request;
+            request.request_id = format!("run:{run_id}");
+            let mut egress = HeaderMap::new();
+            egress.insert("authorization", HeaderValue::from_str(EGRESS).unwrap());
+            registry
+                .register_durable(ParkedApproval {
+                    request,
+                    registered_at: chrono::Utc::now(),
+                    expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+                    egress_headers: Some(egress),
+                })
+                .await
+                .unwrap();
+
+            // Watch the decision bus and the lifecycle broker before any
+            // traffic.
+            let mut bus_sub = bus.subscribe(&format!("approval:{id}")).await.unwrap();
+            let mut sse = crate::approval_event_broker::subscribe(&format!("run:{run_id}")).await;
+
+            // Tracing capture around the whole reconcile: strict DEBUG, so
+            // every warn/error/debug line the flow could emit is checked.
+            // The thread-local default reaches the awaited tick on this
+            // single-thread test runtime.
+            let log_buf = Arc::new(CaptureLog(std::sync::Mutex::new(Vec::<u8>::new())));
+
+            let config = poll_config_with(HashMap::new(), true);
+            let (url, mut rx) = scripted_receiver_with_headers(vec![
+                ("204 No Content", vec![], ""),
+                ("200 OK", vec![], ""),
+                (
+                    "200 OK",
+                    vec![("x-approver-id", IDENTITY)],
+                    r#"{"status":"approved"}"#,
+                ),
+            ])
+            .await;
+            let reconciler = reconciler_over(&config, store.clone(), &url, &registry);
+            let mut notified = HashSet::new();
+
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(Arc::clone(&log_buf))
+                .with_max_level(tracing::Level::DEBUG)
+                .with_ansi(false)
+                .finish();
+            let notify = {
+                let _log_guard = tracing::subscriber::set_default(subscriber);
+                reconciler.tick(&mut notified).await;
+                let _read = rx.recv().await.unwrap();
+                let notify = rx.recv().await.unwrap();
+                reconciler.tick(&mut notified).await;
+                let _decided = rx.recv().await.unwrap();
+                notify
+            };
+
+            // ---- POSITIVE: only the allowed store fields and headers. ----
+
+            // The notify POST carried the egress sentinel on authorization,
+            // and nothing else on the wire carried either sentinel.
+            assert!(notify.starts_with("POST "));
+            let header_line = notify
+                .lines()
+                .find(|line| line.to_lowercase().starts_with("authorization:"))
+                .expect("the notify carries the row header");
+            assert_eq!(header_line.split_once(':').unwrap().1.trim(), EGRESS);
+            assert!(
+                !notify.contains(IDENTITY),
+                "identity never rides the notify POST: {notify}"
+            );
+
+            // The store decision file holds the captured identity beside the
+            // decision and nothing of the egress: resolve moves the approval
+            // into `decisions/{id}.json` without its egress headers.
+            let decision_file = store_root.join("decisions").join(format!("{id}.json"));
+            let stored = std::fs::read_to_string(&decision_file).expect("decision file exists");
+            assert!(
+                !stored.contains(EGRESS),
+                "the egress credential outlived resolve: {stored}"
+            );
+            assert!(
+                stored.contains(IDENTITY),
+                "the captured identity persists beside the decision: {stored}"
+            );
+            // And the carrier reads both back together.
+            match store_decision(&store, &id).await.expect("resolved") {
+                ResolvedDecision::Approved {
+                    identity: Some(got),
+                } => {
+                    assert_eq!(got.to_pair_map()["x-forwarded-user"], IDENTITY);
+                }
+                other => panic!("expected the identity to read back, got {other:?}"),
+            }
+
+            // ---- NEGATIVE: everywhere else is sentinel-free. ----
+
+            // Decision-bus payload: the credential-free decision alone.
+            let payload = tokio::time::timeout(Duration::from_secs(1), bus_sub.next())
+                .await
+                .expect("the bus wake arrives")
+                .expect("stream open");
+            let bus_text = String::from_utf8_lossy(&payload).to_string();
+            assert!(
+                !bus_text.contains(EGRESS) && !bus_text.contains(IDENTITY),
+                "the bus payload is credential-free, got: {bus_text}"
+            );
+
+            // Lifecycle/SSE events: the reconciler publishes none for the
+            // run's owner id, so nothing can carry a sentinel.
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), sse.recv())
+                    .await
+                    .is_err(),
+                "no lifecycle event may be published by the reconcile",
+            );
+
+            // Tracing and error text across the whole tick.
+            let log = String::from_utf8_lossy(&log_buf.0.lock().unwrap()).to_string();
+            assert!(
+                !log.contains(EGRESS) && !log.contains(IDENTITY),
+                "no sentinel may reach tracing, got: {log}"
+            );
+
+            // Serialized checkpoints: the same run's parked document, the
+            // resuming document, and the commit's temp write.
+            let mut plan = crate::orchestration::Plan::new("Deploy");
+            plan.add_task(crate::orchestration::Task::new(3, "Gated apply", "r"));
+            plan.tasks[0].state = crate::orchestration::TaskState::AwaitingApproval {
+                pending: vec![crate::orchestration::PendingCall {
+                    decision_id: id,
+                    tool_name: "kubectl_apply".to_string(),
+                    arguments: serde_json::json!({ "namespace": "prod" }),
+                    call_id: "call-1".to_string(),
+                }],
+            };
+            let mut records = std::collections::HashMap::new();
+            records.insert(
+                3,
+                crate::orchestration::ParkedTaskRecord {
+                    attempt: 1,
+                    snapshot: crate::orchestration::ParkSnapshot {
+                        history: vec![rig::completion::Message::user("apply it")],
+                        current_prompt: rig::completion::Message::user("tool results"),
+                    },
+                },
+            );
+            let inputs = crate::orchestration::ParkCommitInputs {
+                state: crate::orchestration::RunStateForPark {
+                    run_id,
+                    session_id: None,
+                    query: "Deploy",
+                    chat_history: &[],
+                    coordinator_conversation: &[],
+                    routing_decision: None,
+                    iteration: 1,
+                    planning_ms: 0,
+                    failure_history: &[],
+                },
+                plan: &plan,
+                records: &records,
+                registry: &registry,
+                memory_dir: memory_dir.to_str().unwrap(),
+                config: &crate::config::AgentRuntimeConfig::default(),
+                decision_window: Duration::from_secs(300),
+            };
+            crate::orchestration::commit_from_run_state(&inputs)
+                .await
+                .expect("the park commit publishes");
+
+            let parked_doc = memory_dir.join("parked").join(format!("{run_id}.json"));
+            let parked_text = std::fs::read_to_string(&parked_doc).expect("parked document");
+            assert!(
+                !parked_text.contains(EGRESS) && !parked_text.contains(IDENTITY),
+                "the parked document must never carry approval credentials, got: {parked_text}"
+            );
+
+            let handle = crate::orchestration::ResumingDocumentHandle::open(&parked_doc)
+                .await
+                .expect("the resuming handle opens");
+            handle
+                .append_executed_and_publish("call-1")
+                .await
+                .expect("the resuming append publishes");
+            let resuming_text = std::fs::read_to_string(
+                memory_dir
+                    .join("parked")
+                    .join(format!("{run_id}.resuming.json")),
+            )
+            .expect("resuming document");
+            assert!(
+                !resuming_text.contains(EGRESS) && !resuming_text.contains(IDENTITY),
+                "the resuming document must never carry approval credentials, got: {resuming_text}"
+            );
+            let tmp_residue = std::fs::read_dir(memory_dir.join("parked"))
+                .unwrap()
+                .filter_map(Result::ok)
+                .any(|e| e.file_name().to_string_lossy().ends_with(".tmp"));
+            assert!(!tmp_residue, "the append's temp write is renamed away");
+
+            crate::approval_event_broker::unsubscribe(&format!("run:{run_id}")).await;
+        }
     }
 }

--- a/crates/aura/src/hitl/registry.rs
+++ b/crates/aura/src/hitl/registry.rs
@@ -33,7 +33,9 @@ use crate::session_store::{
     Subscription,
 };
 
-use super::decision::{ApprovalDecision, AwaitingDecision, DecisionId, Timestamp};
+use super::decision::{
+    ApprovalDecision, AwaitingDecision, DecisionId, ResolvedDecision, Timestamp,
+};
 use super::protocol::ApprovalRequest;
 
 /// Bus topic carrying the decision for one parked approval.
@@ -73,12 +75,17 @@ impl WakeEntry {
 }
 
 /// The serializable record of a parked approval. Carries everything needed to
-/// re-render and re-validate the approval after a restart.
+/// re-render and re-validate the approval after a restart — and, under poll
+/// delivery, the resolved egress headers its notify POST authenticates with.
 #[derive(Clone)]
 pub struct ParkedApproval {
     pub request: ApprovalRequest,
     pub registered_at: Timestamp,
     pub expires_at: Timestamp,
+    /// Resolved egress headers (`headers_from_request` overlaying the static
+    /// headers) for this row's notify POST. Values are credentials at rest:
+    /// the storage projection's Debug prints names only.
+    pub egress_headers: Option<reqwest::header::HeaderMap>,
 }
 
 /// Why a [`PendingApprovals::resolve`] could not complete.
@@ -129,6 +136,7 @@ impl PendingApprovals {
             registered_at: now,
             expires_at: now
                 + chrono::Duration::from_std(timeout).expect("approval timeout fits in chrono"),
+            egress_headers: None,
         };
 
         // Subscribe before the store insert: once `store.register` returns,
@@ -182,16 +190,19 @@ impl PendingApprovals {
         self.0.store.register(parked).await
     }
 
-    /// Resolve a parked approval: durably record the decision in the store
-    /// (at most once per `DecisionId`) and publish it on the bus, waking the
-    /// parked await wherever it lives.
+    /// Resolve a parked approval: durably record the decision — and the
+    /// approver identity captured alongside it, as one carrier — in the store
+    /// (at most once per `DecisionId`), and publish the credential-free
+    /// decision on the bus, waking the parked await wherever it lives.
     pub async fn resolve(
         &self,
         id: &DecisionId,
-        decision: ApprovalDecision,
+        resolved: ResolvedDecision,
     ) -> Result<(), ResolveError> {
-        self.0.store.resolve(id, decision.clone()).await?;
-        let payload = serde_json::to_vec(&decision).expect("ApprovalDecision serializes to JSON");
+        self.0.store.resolve(id, resolved.clone()).await?;
+        // Identity never rides the bus: the payload is the decision alone.
+        let payload =
+            serde_json::to_vec(&resolved.decision()).expect("ApprovalDecision serializes to JSON");
         if let Err(err) = self
             .0
             .bus
@@ -213,10 +224,11 @@ impl PendingApprovals {
         self.0.store.get(id).await
     }
 
-    /// The durably recorded decision for an already-resolved approval, if
-    /// any. A store fault reads as "no recorded decision" (logged), so
-    /// callers keep their fail-closed shape.
-    pub async fn recorded_decision(&self, id: &DecisionId) -> Option<ApprovalDecision> {
+    /// The decision durably recorded for an already-resolved approval —
+    /// decision and captured identity together — if any. A store fault reads
+    /// as "no recorded decision" (logged), so callers keep their fail-closed
+    /// shape.
+    pub async fn recorded_decision(&self, id: &DecisionId) -> Option<ResolvedDecision> {
         match self.0.store.decision(id).await {
             Ok(decision) => decision,
             Err(err) => {
@@ -322,7 +334,7 @@ async fn wake_on_decision(
                     return;
                 };
                 match inner.store.decision(&id).await {
-                    Ok(Some(decision)) => decision,
+                    Ok(Some(resolved)) => resolved.decision(),
                     Ok(None) => continue,
                     Err(err) => {
                         warn!(
@@ -399,7 +411,7 @@ mod tests {
         let cancel = RequestCancelToken::unbound();
 
         registry
-            .resolve(&id, ApprovalDecision::Approved)
+            .resolve(&id, ApprovalDecision::Approved.into())
             .await
             .expect("resolve succeeds");
 
@@ -422,7 +434,8 @@ mod tests {
                 &id,
                 ApprovalDecision::Denied {
                     reason: Some("not safe".into()),
-                },
+                }
+                .into(),
             )
             .await
             .expect("resolve succeeds");
@@ -440,7 +453,9 @@ mod tests {
         let registry = PendingApprovals::new();
         let unknown = DecisionId::generate();
         assert_eq!(
-            registry.resolve(&unknown, ApprovalDecision::Approved).await,
+            registry
+                .resolve(&unknown, ApprovalDecision::Approved.into())
+                .await,
             Err(ResolveError::NotFound)
         );
     }
@@ -453,11 +468,13 @@ mod tests {
         let _handle = registry.register(req, Duration::from_secs(60)).await;
 
         registry
-            .resolve(&id, ApprovalDecision::Approved)
+            .resolve(&id, ApprovalDecision::Approved.into())
             .await
             .expect("first resolve succeeds");
         assert_eq!(
-            registry.resolve(&id, ApprovalDecision::Approved).await,
+            registry
+                .resolve(&id, ApprovalDecision::Approved.into())
+                .await,
             Err(ResolveError::NotFound)
         );
     }
@@ -472,7 +489,9 @@ mod tests {
         registry.remove(&id).await;
 
         assert_eq!(
-            registry.resolve(&id, ApprovalDecision::Approved).await,
+            registry
+                .resolve(&id, ApprovalDecision::Approved.into())
+                .await,
             Err(ResolveError::NotFound)
         );
     }
@@ -488,7 +507,9 @@ mod tests {
         drop(handle);
 
         assert_eq!(
-            registry.resolve(&id, ApprovalDecision::Approved).await,
+            registry
+                .resolve(&id, ApprovalDecision::Approved.into())
+                .await,
             Ok(())
         );
     }
@@ -510,7 +531,7 @@ mod tests {
             .await
             .expect("publish succeeds");
         registry
-            .resolve(&id, ApprovalDecision::Approved)
+            .resolve(&id, ApprovalDecision::Approved.into())
             .await
             .expect("resolve succeeds");
 
@@ -565,13 +586,15 @@ mod tests {
             ApprovalOutcome::Cancelled(CancelReason::SenderDropped)
         );
         assert_eq!(
-            registry.resolve(&id_a, ApprovalDecision::Approved).await,
+            registry
+                .resolve(&id_a, ApprovalDecision::Approved.into())
+                .await,
             Err(ResolveError::NotFound),
             "cancelled approval must be gone from the store too",
         );
 
         registry
-            .resolve(&id_b, ApprovalDecision::Approved)
+            .resolve(&id_b, ApprovalDecision::Approved.into())
             .await
             .expect("unrelated entry survives");
         assert_eq!(
@@ -647,7 +670,7 @@ mod tests {
         let handle = parker.register(req, Duration::from_secs(60)).await;
 
         resolver
-            .resolve(&id, ApprovalDecision::Approved)
+            .resolve(&id, ApprovalDecision::Approved.into())
             .await
             .expect("resolve succeeds");
 
@@ -681,7 +704,8 @@ mod tests {
                 &id,
                 ApprovalDecision::Denied {
                     reason: Some("nope".into()),
-                },
+                }
+                .into(),
             )
             .await
             .expect("resolve succeeds");
@@ -710,13 +734,150 @@ mod tests {
         let handle = instance_a.register(req, Duration::from_secs(60)).await;
 
         instance_b
-            .resolve(&id, ApprovalDecision::Approved)
+            .resolve(&id, ApprovalDecision::Approved.into())
             .await
             .expect("resolve on the other instance succeeds");
 
         assert_eq!(
             handle.outcome(&cancel).await,
             ApprovalOutcome::Decided(ApprovalDecision::Approved)
+        );
+    }
+
+    /// Identity captured at resolve time persists in the SAME resolve: the
+    /// store read-back carries the decision AND the identity together, and
+    /// the wake (the conversational consumer) sees the credential-free
+    /// decision only.
+    #[tokio::test]
+    async fn resolve_persists_identity_with_the_decision() {
+        let registry = PendingApprovals::new();
+        let cancel = RequestCancelToken::unbound();
+        let req = test_request("req-identity");
+        let id = req.decision_id;
+        let handle = registry.register(req, Duration::from_secs(60)).await;
+
+        let identity = crate::approver_headers::ApproverHeaders::from_pairs([(
+            "x-forwarded-user".to_owned(),
+            "alice".to_owned(),
+        )])
+        .unwrap();
+        registry
+            .resolve(&id, ResolvedDecision::approved(Some(identity)))
+            .await
+            .expect("resolve succeeds");
+
+        let recorded = registry
+            .recorded_decision(&id)
+            .await
+            .expect("the decision is recorded");
+        match recorded {
+            ResolvedDecision::Approved {
+                identity: Some(got),
+            } => {
+                assert_eq!(
+                    got.captured_names().collect::<Vec<_>>(),
+                    ["x-forwarded-user"]
+                );
+            }
+            other => panic!("expected Approved with identity, got {other:?}"),
+        }
+        // The wake carries the decision alone.
+        assert_eq!(
+            handle.outcome(&cancel).await,
+            ApprovalOutcome::Decided(ApprovalDecision::Approved)
+        );
+    }
+
+    /// Two competing resolves under concurrency: exactly one wins, and the
+    /// stored pair is the winner's decision AND identity — a losing resolver
+    /// cannot overwrite either half.
+    #[tokio::test]
+    async fn competing_resolves_keep_the_winning_decision_and_identity_together() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let registry = PendingApprovals::with_backend(store, Arc::new(InMemoryEventBus::new()));
+        let req = test_request("req-competing");
+        let id = req.decision_id;
+        registry
+            .register_durable(ParkedApproval {
+                request: req,
+                registered_at: chrono::Utc::now(),
+                expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+                egress_headers: None,
+            })
+            .await
+            .unwrap();
+
+        let alice_pair = |v: &str| {
+            std::collections::BTreeMap::from([("x-forwarded-user".to_owned(), v.to_owned())])
+        };
+        let (a, b) = tokio::join!(
+            registry.resolve(
+                &id,
+                ResolvedDecision::approved(Some(
+                    crate::approver_headers::ApproverHeaders::from_pairs(alice_pair("alice"))
+                        .unwrap(),
+                )),
+            ),
+            registry.resolve(
+                &id,
+                ResolvedDecision::approved(Some(
+                    crate::approver_headers::ApproverHeaders::from_pairs(alice_pair("mallory"))
+                        .unwrap(),
+                )),
+            ),
+        );
+        let winners = usize::from(a.is_ok()) + usize::from(b.is_ok());
+        assert_eq!(winners, 1, "exactly one resolver wins: {a:?} / {b:?}");
+
+        match registry.recorded_decision(&id).await.expect("recorded") {
+            ResolvedDecision::Approved {
+                identity: Some(got),
+            } => {
+                // The surviving identity is exactly one resolver's pair —
+                // decision and identity won their race together.
+                let stored = got.to_pair_map();
+                assert!(
+                    stored == alice_pair("alice") || stored == alice_pair("mallory"),
+                    "the winner's identity is stored whole, got {stored:?}"
+                );
+            }
+            other => panic!("expected Approved with identity, got {other:?}"),
+        }
+    }
+
+    /// The decision bus publishes only the credential-free decision: the
+    /// payload on the approval topic is exactly the serialized
+    /// `ApprovalDecision`, with no identity field or value.
+    #[tokio::test]
+    async fn decision_bus_payload_is_credential_free() {
+        let store: Arc<dyn ApprovalStore> = Arc::new(InMemoryApprovalStore::new());
+        let bus: Arc<dyn EventBus> = Arc::new(InMemoryEventBus::new());
+        let registry = PendingApprovals::with_backend(store, bus.clone());
+        let req = test_request("req-bus");
+        let id = req.decision_id;
+        let _handle = registry.register(req, Duration::from_secs(60)).await;
+        let mut sub = bus.subscribe(&approval_topic(&id)).await.unwrap();
+        let identity = crate::approver_headers::ApproverHeaders::from_pairs([(
+            "x-forwarded-user".to_owned(),
+            "alice-sentinel".to_owned(),
+        )])
+        .unwrap();
+        registry
+            .resolve(&id, ResolvedDecision::approved(Some(identity)))
+            .await
+            .expect("resolve succeeds");
+
+        let payload = tokio::time::timeout(Duration::from_secs(1), sub.next())
+            .await
+            .expect("the bus wake arrives")
+            .expect("stream open");
+        let json: serde_json::Value =
+            serde_json::from_slice(&payload).expect("the payload is the serialized decision");
+        assert_eq!(json, serde_json::json!("Approved"));
+        let text = String::from_utf8_lossy(&payload).to_string();
+        assert!(
+            !text.contains("alice-sentinel") && !text.contains("x-forwarded-user"),
+            "the bus payload must be credential-free, got: {text}"
         );
     }
 }

--- a/crates/aura/src/hitl/route.rs
+++ b/crates/aura/src/hitl/route.rs
@@ -62,11 +62,29 @@ impl HitlRuntime {
         req_headers: Option<&HashMap<String, String>>,
     ) -> Self {
         let route = match &config.route {
-            DecisionRouteConfig::Webhook { timeout_secs, .. } => DecisionRoute::Webhook {
-                client: webhook_client_from_config(&config.route, hmac, req_headers)
-                    .expect("the webhook arm of the route config builds a client"),
-                timeout: Duration::from_secs(*timeout_secs),
-            },
+            DecisionRouteConfig::Webhook {
+                timeout_secs,
+                headers_from_request,
+                ..
+            } => {
+                let client = webhook_client_from_config(&config.route, hmac, req_headers)
+                    .expect("the webhook arm of the route config builds a client");
+                // Request-scoped egress capture: `client.headers` already
+                // carries the resolved values for THIS request; the strict
+                // check turns a mapped destination with no usable value into
+                // the error that closes the park arm's registration. The
+                // parked rows copy the client's map — never re-resolve.
+                let egress_capture = crate::webhook_utils::check_egress_capture(
+                    client.resolved_headers(),
+                    headers_from_request,
+                );
+                DecisionRoute::Webhook {
+                    client,
+                    registry: pending_approvals.clone(),
+                    timeout: Duration::from_secs(*timeout_secs),
+                    egress_capture,
+                }
+            }
             DecisionRouteConfig::Conversational { timeout_secs } => DecisionRoute::Conversational {
                 registry: pending_approvals.clone(),
                 timeout: Duration::from_secs(*timeout_secs),
@@ -235,10 +253,17 @@ pub enum DecisionRoute {
         registry: PendingApprovals,
         timeout: Duration,
     },
-    /// Unattended: one synchronous HTTP round-trip to a webhook.
+    /// Unattended: one synchronous HTTP round-trip to a webhook, or — under
+    /// poll delivery — the park arm registering into `registry`, with the
+    /// reconciler driving the decision.
     Webhook {
         client: WebhookClient,
+        /// The shared approval registry the park arm registers into.
+        registry: PendingApprovals,
         timeout: Duration,
+        /// The request-scoped egress-capture verdict for this client's
+        /// resolved headers.
+        egress_capture: Result<(), crate::webhook_utils::EgressCaptureError>,
     },
 }
 
@@ -301,13 +326,13 @@ async fn webhook_round_trip<T>(
 
 /// The live-path guard for poll delivery: a poll-mode client's synchronous
 /// decision legs must not fire the sync POST, whose ack would be misread as
-/// a decision. Every decision on a poll route fails closed here until the
-/// park arm takes config-gated calls; the agent-callable `request_approval`
-/// tool path always lands here.
+/// a decision. Config-gated calls are intercepted by the park arm before
+/// reaching here; this guards the agent-callable `request_approval` tool
+/// path, which bypasses it.
 fn poll_delivery_guard(client: &WebhookClient) -> Result<(), ApprovalError> {
     if client.poll.is_some() {
         Err(ApprovalError::Misconfigured(
-            "poll delivery has no live decision path".to_string(),
+            "poll delivery parks; the live decision path is unavailable".to_string(),
         ))
     } else {
         Ok(())
@@ -315,6 +340,55 @@ fn poll_delivery_guard(client: &WebhookClient) -> Result<(), ApprovalError> {
 }
 
 impl DecisionRoute {
+    /// The park arm's inputs: the approval registry to register against and
+    /// the decision window the route timeout bounds. `Some` for the
+    /// conversational route and for a webhook route with poll delivery,
+    /// `None` for sync delivery — whose decision returns on the POST
+    /// response itself. The client's poll settings are the one delivery
+    /// marker; this switch must not grow a second one.
+    pub(crate) fn park_registry(&self) -> Option<(&PendingApprovals, Duration)> {
+        match self {
+            Self::Conversational { registry, timeout } => Some((registry, *timeout)),
+            Self::Webhook {
+                client,
+                registry,
+                timeout,
+                ..
+            } => client.poll_delivery().then_some((registry, *timeout)),
+        }
+    }
+
+    /// The park arm's egress headers: the client's request-scoped resolved
+    /// map, which parked rows copy in before `register_durable`. `Err`
+    /// closes the registration — a mapped destination with no usable
+    /// resolved value and no valid static fallback. The conversational arm
+    /// has no webhook egress and always yields an empty map.
+    pub(crate) fn park_egress(
+        &self,
+    ) -> Result<std::borrow::Cow<'_, HeaderMap>, &crate::webhook_utils::EgressCaptureError> {
+        match self {
+            Self::Conversational { .. } => Ok(std::borrow::Cow::Owned(HeaderMap::new())),
+            Self::Webhook {
+                client,
+                egress_capture,
+                ..
+            } => match egress_capture {
+                Ok(()) => Ok(std::borrow::Cow::Borrowed(client.resolved_headers())),
+                Err(err) => Err(err),
+            },
+        }
+    }
+
+    /// Whether the route's identity mapping demands approver identity on an
+    /// approved call — the reify-side rule that blocks a recorded approval
+    /// carrying none. The conversational route has no identity source.
+    pub(crate) fn requires_identity(&self) -> bool {
+        match self {
+            Self::Conversational { .. } => false,
+            Self::Webhook { client, .. } => client.requires_identity(),
+        }
+    }
+
     /// Obtain a decision for a config-gated call, carrying any captured
     /// approver header overrides on the approved arm.
     ///
@@ -334,7 +408,9 @@ impl DecisionRoute {
                 let outcome = self.decide_inner(request, cancel).await?;
                 Ok(GateDecision::without_overrides(outcome))
             }
-            Self::Webhook { client, timeout } => {
+            Self::Webhook {
+                client, timeout, ..
+            } => {
                 poll_delivery_guard(client)?;
                 webhook_round_trip(
                     &request,
@@ -404,9 +480,9 @@ impl DecisionRoute {
                 // Cancellation deliberately does not — a disconnected request
                 // must not execute a buffered approval.
                 if matches!(outcome, ApprovalOutcome::TimedOut { .. })
-                    && let Some(decision) = registry.recorded_decision(&decision_id).await
+                    && let Some(resolved) = registry.recorded_decision(&decision_id).await
                 {
-                    outcome = ApprovalOutcome::Decided(decision);
+                    outcome = ApprovalOutcome::Decided(resolved.decision());
                 }
 
                 let completed_event =
@@ -419,7 +495,9 @@ impl DecisionRoute {
 
                 Ok(outcome)
             }
-            Self::Webhook { client, timeout } => {
+            Self::Webhook {
+                client, timeout, ..
+            } => {
                 poll_delivery_guard(client)?;
                 webhook_round_trip(
                     &request,
@@ -508,9 +586,11 @@ impl WebhookReply {
 
 /// One poll attempt's answer ([`WebhookClient::poll_decision`]).
 ///
-/// Pending is an outcome, not an error: a 404/204 or an unrecognized 200
-/// body only means "keep polling", so the caller can loop without catching.
-#[derive(Debug)]
+/// Pending is an outcome, not an error: the caller can loop without
+/// catching.
+///
+/// Manual `Debug`: the response headers may carry approver identity, so
+/// their values never render — names only.
 pub(crate) enum PollOutcome {
     /// 200 with a strictly-parsed, signature-verified decision; response
     /// headers ride along for approver-identity capture by the caller.
@@ -518,13 +598,53 @@ pub(crate) enum PollOutcome {
         decision: ApprovalDecision,
         response_headers: HeaderMap,
     },
-    /// 404, 204, or a 200 whose body does not parse as
-    /// [`ApprovalDecisionWire`] (a pending-shaped body we don't
-    /// recognize): keep polling.
+    /// Keep polling: 404/204, a pending status, or a 200 body outside
+    /// the status envelope (the full contract sits at the poll match).
     NotYet,
 }
 
+impl std::fmt::Debug for PollOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Decided {
+                decision,
+                response_headers,
+            } => f
+                .debug_struct("Decided")
+                .field("decision", decision)
+                .field(
+                    "response_header_names",
+                    &response_headers
+                        .keys()
+                        .map(reqwest::header::HeaderName::as_str)
+                        .collect::<Vec<_>>(),
+                )
+                .finish(),
+            Self::NotYet => f.write_str("NotYet"),
+        }
+    }
+}
+
 impl WebhookClient {
+    /// The one delivery marker: whether poll settings are present. The park
+    /// switch (`park_registry`) and the config fingerprint's delivery
+    /// projection both read this — no second delivery flag exists.
+    pub(crate) fn poll_delivery(&self) -> bool {
+        self.poll.is_some()
+    }
+
+    /// Whether the configured `tool_headers_from_response` mapping demands
+    /// approver identity on an approved decision.
+    pub(crate) fn requires_identity(&self) -> bool {
+        !self.tool_header_mappings.is_empty()
+    }
+
+    /// The resolved operator headers this client applies to every request —
+    /// for poll delivery, also the at-rest egress values parked rows carry.
+    pub(crate) fn resolved_headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
     /// Builds an unsigned client. Deliberately does NOT read the environment
     /// (so constructing one in a test never races env-mutating tests):
     /// production construction goes through [`HitlRuntime::from_config`],
@@ -632,6 +752,21 @@ impl WebhookClient {
         builder
     }
 
+    /// Overlay one parked row's resolved egress headers onto a request
+    /// builder. `RequestBuilder::headers` replaces per name, so a row value
+    /// supersedes the shared client's fallback for this POST only — the
+    /// client itself is never mutated.
+    fn apply_row_headers(
+        &self,
+        builder: reqwest::RequestBuilder,
+        row_headers: Option<&HeaderMap>,
+    ) -> reqwest::RequestBuilder {
+        match row_headers {
+            Some(row) => builder.headers(row.clone()),
+            None => builder,
+        }
+    }
+
     /// Resolve a decision without its response headers: the route-wide path,
     /// which never captures approver identity.
     async fn request_approval(
@@ -682,22 +817,29 @@ impl WebhookClient {
     /// Build the approval-request POST: the serialized wire view — HMAC-signed
     /// with the `X-Aura-*` headers under context `approval-request:{decision_id}`
     /// when a secret is configured — with operator headers and the per-attempt
-    /// `timeout` applied. The caller owns `send()` and the response, which the
-    /// legs read differently: the sync decision leg parses a decision off it,
-    /// while the poll ack leg ([`Self::notify`]) never reads the body.
+    /// `timeout` applied. `row_headers` (the parked row's own resolved values,
+    /// reconciler path only) overlay the client's per-name AFTER them, so a
+    /// row value replaces the shared client's fallback for that one POST;
+    /// signature headers are applied last and can never be displaced. The
+    /// caller owns `send()` and the response, which the legs read differently:
+    /// the sync decision leg parses a decision off it, while the poll ack leg
+    /// ([`Self::notify`]) never reads the body.
     fn build_approval_post(
         &self,
         request: &ApprovalRequest,
         timeout: Duration,
+        row_headers: Option<&HeaderMap>,
     ) -> Result<reqwest::RequestBuilder, ApprovalError> {
         // Serialize the wire view, not the domain request: it keeps `scope` /
         // `origin` as the flat `aura_events` DTOs instead of leaking Rust enum
         // variant names onto the webhook contract.
         let wire = ApprovalRequestWire::from(request);
         let Some(hmac) = self.egress_hmac()? else {
-            return Ok(self
-                .apply_operator_headers(self.client.post(self.url.as_str()).json(&wire))
-                .timeout(timeout));
+            let builder = self.apply_row_headers(
+                self.apply_operator_headers(self.client.post(self.url.as_str()).json(&wire)),
+                row_headers,
+            );
+            return Ok(builder.timeout(timeout));
         };
 
         // Signing requires the exact bytes that go on the wire, so serialize
@@ -709,10 +851,13 @@ impl WebhookClient {
         let headers = hmac
             .sign(&egress_context, &body)
             .map_err(|e| ApprovalError::Signing(e.to_string()))?;
-        let mut post = self.apply_operator_headers(
-            self.client
-                .post(self.url.as_str())
-                .header(reqwest::header::CONTENT_TYPE, "application/json"),
+        let mut post = self.apply_row_headers(
+            self.apply_operator_headers(
+                self.client
+                    .post(self.url.as_str())
+                    .header(reqwest::header::CONTENT_TYPE, "application/json"),
+            ),
+            row_headers,
         );
         for (name, value) in headers.into_pairs() {
             post = post.header(name, value);
@@ -735,7 +880,7 @@ impl WebhookClient {
         request: &ApprovalRequest,
         timeout: Duration,
     ) -> Result<WebhookReply, ApprovalError> {
-        let post = self.build_approval_post(request, timeout)?;
+        let post = self.build_approval_post(request, timeout, None)?;
         match post.send().await {
             Err(e) if e.is_timeout() => Ok(WebhookReply::TimedOut { waited: timeout }),
             Err(e) => Err(e.into()),
@@ -799,17 +944,24 @@ impl WebhookClient {
     /// recorded the row but the 2xx never came back — faults on every
     /// tick until the human decides.
     ///
-    /// A timeout is a transport fault, not a decision-shaped outcome — the
-    /// reconciler simply retries on the next tick. The response body is
-    /// dropped unread, so each attempt is its own connection.
-    pub(crate) async fn notify(&self, request: &ApprovalRequest) -> Result<(), ApprovalError> {
+    /// `row_headers` are the parked approval's own resolved egress values,
+    /// overlaid per name onto the client's operator headers for this POST —
+    /// per-row override, not client state. A timeout is a transport fault,
+    /// not a decision-shaped outcome — the reconciler simply retries on the
+    /// next tick. The response body is dropped unread, so each attempt is
+    /// its own connection.
+    pub(crate) async fn notify(
+        &self,
+        request: &ApprovalRequest,
+        row_headers: Option<&HeaderMap>,
+    ) -> Result<(), ApprovalError> {
         let Some(poll) = &self.poll else {
             return Err(ApprovalError::Misconfigured(
                 "notify is the poll-delivery ack leg, but this client has no poll settings"
                     .to_string(),
             ));
         };
-        let post = self.build_approval_post(request, poll.request_timeout)?;
+        let post = self.build_approval_post(request, poll.request_timeout, row_headers)?;
         match post.send().await {
             Err(e) => Err(e.into()),
             Ok(resp) => {
@@ -1252,6 +1404,46 @@ mod tests {
         );
     }
 
+    /// The park switch, built the production way (`HitlRuntime::from_config`
+    /// over the `[hitl]` config): conversational and webhook-poll park, and
+    /// webhook-sync keeps the live decision path.
+    #[test]
+    fn park_registry_follows_delivery() {
+        fn webhook_route(delivery: aura_config::WebhookDelivery) -> DecisionRoute {
+            let config = aura_config::HitlConfig {
+                require_approval: vec![],
+                park: aura_config::ParkConfig::default(),
+                route: aura_config::DecisionRouteConfig::Webhook {
+                    url: aura_config::WebhookUrl::new("https://approvals.example.com/").unwrap(),
+                    timeout_secs: 60,
+                    headers: std::collections::HashMap::new(),
+                    headers_from_request: std::collections::HashMap::new(),
+                    tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
+                    delivery,
+                    poll_url: None,
+                    poll_interval_secs: 10,
+                    poll_request_timeout_secs: 30,
+                },
+            };
+            let runtime =
+                super::HitlRuntime::from_config(&config, &PendingApprovals::new(), None, None);
+            std::sync::Arc::try_unwrap(runtime.route)
+                .ok()
+                .expect("test-owned route")
+        }
+
+        let (_, conv) = conv_route(Duration::from_secs(60));
+        let (_, got) = conv.park_registry().expect("conversational parks");
+        assert_eq!(got, Duration::from_secs(60));
+
+        let sync = webhook_route(aura_config::WebhookDelivery::Sync);
+        assert!(sync.park_registry().is_none(), "webhook sync does not park");
+
+        let poll = webhook_route(aura_config::WebhookDelivery::Poll);
+        let (_, got) = poll.park_registry().expect("webhook poll parks");
+        assert_eq!(got, Duration::from_secs(60));
+    }
+
     #[tokio::test(start_paused = true)]
     async fn conversational_decide_approved() {
         let (registry, route) = conv_route(Duration::from_secs(60));
@@ -1274,7 +1466,7 @@ mod tests {
         loop {
             tokio::task::yield_now().await;
             if registry
-                .resolve(&decision_id, ApprovalDecision::Approved)
+                .resolve(&decision_id, ApprovalDecision::Approved.into())
                 .await
                 .is_ok()
             {
@@ -1315,7 +1507,8 @@ mod tests {
                     &decision_id,
                     ApprovalDecision::Denied {
                         reason: Some("too risky".into()),
-                    },
+                    }
+                    .into(),
                 )
                 .await
                 .is_ok()
@@ -1359,7 +1552,7 @@ mod tests {
         }
         assert_eq!(
             registry
-                .resolve(&decision_id, ApprovalDecision::Approved)
+                .resolve(&decision_id, ApprovalDecision::Approved.into())
                 .await,
             Err(ResolveError::NotFound),
             "late decisions for timed-out approvals must be rejected as expired",
@@ -1421,7 +1614,7 @@ mod tests {
         loop {
             tokio::task::yield_now().await;
             if registry
-                .resolve(&decision_id, ApprovalDecision::Approved)
+                .resolve(&decision_id, ApprovalDecision::Approved.into())
                 .await
                 .is_ok()
             {
@@ -1494,7 +1687,7 @@ mod tests {
         // An approver reacting to `Requested` immediately must find the
         // record already parked — resolving here may not race registration.
         registry
-            .resolve(&decision_id, ApprovalDecision::Approved)
+            .resolve(&decision_id, ApprovalDecision::Approved.into())
             .await
             .expect("record must be resolvable once Requested is observable");
 
@@ -1519,14 +1712,16 @@ mod tests {
         use super::super::super::decision::{
             AgentScope, ApprovalDecision, ApprovalOrigin, CancelReason, DecisionId,
         };
-        use super::super::super::protocol::{ApprovalRequest, PROTOCOL_VERSION};
+        use super::super::super::protocol::{
+            ApprovalRequest, PROTOCOL_VERSION, PollDecisionWire, PollStatusWire,
+        };
         use super::super::super::signing::{
             PrimarySecret, SIGNATURE_HEADER, SigningContext, TIMESTAMP_HEADER, Tolerance,
             WebhookHmac, authorize_ingress,
         };
         use super::super::{
-            ApprovalError, ApprovalOutcome, EgressSigning, GateDecision, PollOutcome, PollSettings,
-            WebhookClient, build_webhook_client,
+            ApprovalError, ApprovalOutcome, EgressSigning, GateDecision, PendingApprovals,
+            PollOutcome, PollSettings, WebhookClient, build_webhook_client,
         };
         use crate::approver_headers::CaptureError;
 
@@ -2494,7 +2689,9 @@ mod tests {
                 let (url, accepted) = stalled_receiver().await;
                 let route = super::super::DecisionRoute::Webhook {
                     client: loopback_client(&url, EgressSigning::Disabled, user_mapping()),
+                    registry: PendingApprovals::new(),
                     timeout: Duration::from_secs(300),
+                    egress_capture: Ok(()),
                 };
                 let cancel = crate::request_cancellation::RequestCancelToken::unbound();
                 let request = test_request(DecisionId::generate());
@@ -2537,7 +2734,9 @@ mod tests {
             .await;
             let route = super::super::DecisionRoute::Webhook {
                 client: loopback_client(&url, EgressSigning::Disabled, user_mapping()),
+                registry: PendingApprovals::new(),
                 timeout: Duration::from_secs(300),
+                egress_capture: Ok(()),
             };
 
             let decision = route
@@ -2599,7 +2798,7 @@ mod tests {
             let client =
                 loopback_poll_client(&url, EgressSigning::Disabled, &url, Duration::from_secs(5));
             client
-                .notify(&test_request(decision_id))
+                .notify(&test_request(decision_id), None)
                 .await
                 .expect("a 2xx ack must resolve Ok");
 
@@ -2624,7 +2823,7 @@ mod tests {
             let client =
                 loopback_poll_client(&url, EgressSigning::Disabled, &url, Duration::from_secs(5));
             let err = client
-                .notify(&test_request(DecisionId::generate()))
+                .notify(&test_request(DecisionId::generate()), None)
                 .await
                 .expect_err("a 503 ack must fault");
             assert!(
@@ -2644,7 +2843,7 @@ mod tests {
             let client =
                 loopback_poll_client(&url, EgressSigning::Disabled, &url, Duration::from_secs(5));
             client
-                .notify(&test_request(DecisionId::generate()))
+                .notify(&test_request(DecisionId::generate()), None)
                 .await
                 .expect("a 409 ack must resolve Ok: the receiver holding the row is the ack");
         }
@@ -2663,7 +2862,7 @@ mod tests {
                 Duration::from_millis(200),
             );
             let err = client
-                .notify(&test_request(DecisionId::generate()))
+                .notify(&test_request(DecisionId::generate()), None)
                 .await
                 .expect_err("a stalled ack must fault");
             assert!(
@@ -2680,7 +2879,7 @@ mod tests {
             let client =
                 loopback_poll_client(url, EgressSigning::Disabled, url, Duration::from_secs(1));
             let err = client
-                .notify(&test_request(DecisionId::generate()))
+                .notify(&test_request(DecisionId::generate()), None)
                 .await
                 .expect_err("a refused connection must fault");
             let rendered = err.to_string();
@@ -2704,7 +2903,7 @@ mod tests {
                 Duration::from_secs(5),
             );
             client
-                .notify(&test_request(decision_id))
+                .notify(&test_request(decision_id), None)
                 .await
                 .expect("a signed ack must resolve Ok");
 
@@ -2745,7 +2944,7 @@ mod tests {
                     });
                 assert!(
                     matches!(outcome, PollOutcome::NotYet),
-                    "{status}: expected NotYet, got {outcome:?}"
+                    "expected NotYet, got {outcome:?}"
                 );
             }
         }
@@ -2840,10 +3039,162 @@ mod tests {
             let outcome = client
                 .poll_decision(decision_id)
                 .await
-                .expect("a pending-shaped body must not fault");
+                .expect("an out-of-envelope body must not fault");
             assert!(
                 matches!(outcome, PollOutcome::NotYet),
                 "expected NotYet, got {outcome:?}"
+            );
+        }
+
+        /// The receiver's undecided answer: a 200 carrying the status
+        /// envelope with `pending`.
+        #[tokio::test]
+        async fn poll_decision_envelope_pending_is_not_yet() {
+            let (url, _received) =
+                one_shot_receiver(vec![], r#"{"status":"pending"}"#.to_string()).await;
+
+            let client =
+                loopback_poll_client(&url, EgressSigning::Disabled, &url, Duration::from_secs(5));
+            let outcome = client
+                .poll_decision(DecisionId::generate())
+                .await
+                .expect("a pending envelope must not fault");
+            assert!(
+                matches!(outcome, PollOutcome::NotYet),
+                "expected NotYet, got {outcome:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn poll_decision_envelope_approved_resolves() {
+            let (url, _received) =
+                one_shot_receiver(vec![], r#"{"status":"approved"}"#.to_string()).await;
+
+            let client =
+                loopback_poll_client(&url, EgressSigning::Disabled, &url, Duration::from_secs(5));
+            let outcome = client
+                .poll_decision(DecisionId::generate())
+                .await
+                .expect("an approved envelope must resolve");
+            assert!(
+                matches!(
+                    outcome,
+                    PollOutcome::Decided {
+                        decision: ApprovalDecision::Approved,
+                        ..
+                    }
+                ),
+                "expected Decided(Approved), got {outcome:?}"
+            );
+        }
+
+        /// A denial's reason rides the envelope into the decision.
+        #[tokio::test]
+        async fn poll_decision_envelope_denied_carries_reason() {
+            let (url, _received) = one_shot_receiver(
+                vec![],
+                r#"{"status":"denied","reason":"quota exceeded"}"#.to_string(),
+            )
+            .await;
+
+            let client =
+                loopback_poll_client(&url, EgressSigning::Disabled, &url, Duration::from_secs(5));
+            let outcome = client
+                .poll_decision(DecisionId::generate())
+                .await
+                .expect("a denied envelope must resolve");
+            match outcome {
+                PollOutcome::Decided {
+                    decision: ApprovalDecision::Denied { reason },
+                    ..
+                } => assert_eq!(reason.as_deref(), Some("quota exceeded")),
+                other => panic!("expected Decided(Denied), got {other:?}"),
+            }
+        }
+
+        /// The envelope is additive-field tolerant: a receiver decorating a
+        /// decided body must not silently expire the approval.
+        #[tokio::test]
+        async fn poll_decision_envelope_tolerates_unknown_fields_on_decided() {
+            let (url, _received) = one_shot_receiver(
+                vec![],
+                r#"{"status":"approved","reason":null,"decided_by":"policy-x"}"#.to_string(),
+            )
+            .await;
+
+            let client =
+                loopback_poll_client(&url, EgressSigning::Disabled, &url, Duration::from_secs(5));
+            let outcome = client
+                .poll_decision(DecisionId::generate())
+                .await
+                .expect("an approved envelope with extra fields must resolve");
+            assert!(
+                matches!(
+                    outcome,
+                    PollOutcome::Decided {
+                        decision: ApprovalDecision::Approved,
+                        ..
+                    }
+                ),
+                "expected Decided(Approved), got {outcome:?}"
+            );
+        }
+
+        /// The serde matrix for the status envelope: every status parses
+        /// with the reason present, absent, and null; an unknown status
+        /// value fails the parse (which the poll leg treats as not-yet).
+        #[test]
+        fn poll_wire_parses_the_status_envelope_matrix() {
+            for status in ["pending", "approved", "denied"] {
+                for reason in [None, Some("null"), Some("\"policy: auto-approve\"")] {
+                    let body = match reason {
+                        None => format!(r#"{{"status":"{status}"}}"#),
+                        Some("null") => format!(r#"{{"status":"{status}","reason":null}}"#),
+                        Some(value) => format!(r#"{{"status":"{status}","reason":{value}}}"#),
+                    };
+                    let wire: PollDecisionWire = serde_json::from_str(&body)
+                        .unwrap_or_else(|e| panic!("{body} must parse: {e}"));
+                    let expected = match status {
+                        "pending" => PollStatusWire::Pending,
+                        "approved" => PollStatusWire::Approved,
+                        _ => PollStatusWire::Denied,
+                    };
+                    assert_eq!(wire.status, expected, "body: {body}");
+                    assert_eq!(
+                        wire.reason.as_deref(),
+                        reason
+                            .filter(|r| *r != "null")
+                            .map(|_| "policy: auto-approve"),
+                        "body: {body}"
+                    );
+                }
+            }
+            assert!(
+                serde_json::from_str::<PollDecisionWire>(r#"{"status":"revoked"}"#).is_err(),
+                "an unknown status value must fail the parse"
+            );
+        }
+
+        /// The poll outcome's Debug renders response-header names only.
+        #[test]
+        fn poll_outcome_debug_prints_names_not_values() {
+            let mut response_headers = reqwest::header::HeaderMap::new();
+            response_headers.insert(
+                reqwest::header::HeaderName::from_static("x-approver-id"),
+                reqwest::header::HeaderValue::from_str("approver-dave-sentinel").unwrap(),
+            );
+            let outcome = PollOutcome::Decided {
+                decision: ApprovalDecision::Approved,
+                response_headers,
+            };
+            let rendered = format!("{outcome:?}");
+            assert!(
+                rendered.contains("x-approver-id"),
+                "names render: {rendered}"
+            );
+            assert!(
+                !rendered.contains("approver-dave-sentinel"),
+                "identity values must never render: {rendered}"
             );
         }
 
@@ -2921,7 +3272,9 @@ mod tests {
                     &url,
                     Duration::from_secs(5),
                 ),
+                registry: PendingApprovals::new(),
                 timeout: Duration::from_secs(300),
+                egress_capture: Ok(()),
             };
             let cancel = crate::request_cancellation::RequestCancelToken::unbound();
 
@@ -3021,7 +3374,9 @@ mod tests {
                 super::build_webhook_client(),
                 aura_config::WebhookUrl::new("http://127.0.0.1:9").unwrap(),
             ),
+            registry: PendingApprovals::new(),
             timeout: std::time::Duration::from_secs(1),
+            egress_capture: Ok(()),
         };
         let request = ApprovalRequest {
             version: PROTOCOL_VERSION,
@@ -3367,7 +3722,9 @@ mod tests {
 
         let route = super::DecisionRoute::Webhook {
             client,
+            registry: PendingApprovals::new(),
             timeout: std::time::Duration::from_secs(5),
+            egress_capture: Ok(()),
         };
         let cancel = crate::request_cancellation::RequestCancelToken::unbound();
         let result = route.decide(make_approval_request(), &cancel).await;
@@ -3393,7 +3750,9 @@ mod tests {
 
         let route = super::DecisionRoute::Webhook {
             client,
+            registry: PendingApprovals::new(),
             timeout: std::time::Duration::from_secs(5),
+            egress_capture: Ok(()),
         };
         let cancel = crate::request_cancellation::RequestCancelToken::unbound();
         let result = route.decide(make_approval_request(), &cancel).await;
@@ -3432,7 +3791,9 @@ mod tests {
         // Capture 1: the bare constructor (no headers configured).
         let bare = super::DecisionRoute::Webhook {
             client: super::WebhookClient::new(super::build_webhook_client(), url.clone()),
+            registry: PendingApprovals::new(),
             timeout: std::time::Duration::from_secs(5),
+            egress_capture: Ok(()),
         };
         let result = bare.decide(request.clone(), &cancel).await;
         assert!(result.is_ok(), "bare client should get a decision");
@@ -3446,7 +3807,9 @@ mod tests {
                 url,
                 reqwest::header::HeaderMap::new(),
             ),
+            registry: PendingApprovals::new(),
             timeout: std::time::Duration::from_secs(5),
+            egress_capture: Ok(()),
         };
         let result = with_empty.decide(request, &cancel).await;
         assert!(result.is_ok(), "empty-headers client should get a decision");

--- a/crates/aura/src/hitl/tool.rs
+++ b/crates/aura/src/hitl/tool.rs
@@ -345,7 +345,7 @@ mod tests {
 
         // Approve so the spawned tool call completes.
         registry
-            .resolve(&decision_id, ApprovalDecision::Approved)
+            .resolve(&decision_id, ApprovalDecision::Approved.into())
             .await
             .expect("resolve");
 
@@ -502,7 +502,7 @@ mod tests {
                         other => panic!("expected Requested event, got {:?}", other),
                     };
                     registry
-                        .resolve(&id, ApprovalDecision::Approved)
+                        .resolve(&id, ApprovalDecision::Approved.into())
                         .await
                         .expect("parked approval resolves");
                     id

--- a/crates/aura/src/orchestration/mod.rs
+++ b/crates/aura/src/orchestration/mod.rs
@@ -83,6 +83,13 @@ pub use tools::wait_for::{StopReason, WaitForError, WaitForOutput, WaitForTool};
 pub use tools::{SubmitResultDecision, SubmitResultOutput, SubmitResultTool};
 
 pub(crate) use park::{CallKey, ParkGuard, RecordedDecisions, run_owner_id};
+// The sentinel leak guard drives the commit and the resuming document
+// from the reconciler side of the crate.
+#[cfg(test)]
+pub(crate) use park::{
+    ParkCommitInputs, ParkedTaskRecord, ResumingDocumentHandle, RunStateForPark,
+    commit_from_run_state,
+};
 // The worker-model injection seam: `provider_agent.rs`'s cfg(test) variant
 // wraps the rig's scripted agent type.
 pub use prompt_constants::{context, fields, sections};

--- a/crates/aura/src/orchestration/orchestrator.rs
+++ b/crates/aura/src/orchestration/orchestrator.rs
@@ -574,15 +574,13 @@ impl Orchestrator {
             .hitl
             .as_ref()
             .filter(|hitl| hitl.park_enabled)
-            .and_then(|hitl| match &*hitl.route {
-                crate::hitl::DecisionRoute::Conversational { registry, .. } => {
-                    Some(ParkGuard::new(
-                        registry.clone(),
-                        run_id_str.clone(),
-                        agent_config.request_id.clone().unwrap_or_default(),
-                    ))
-                }
-                crate::hitl::DecisionRoute::Webhook { .. } => None,
+            .and_then(|hitl| {
+                let (registry, _) = hitl.route.park_registry()?;
+                Some(ParkGuard::new(
+                    registry.clone(),
+                    run_id_str.clone(),
+                    agent_config.request_id.clone().unwrap_or_default(),
+                ))
             });
         let default_turn_depth = agent_config
             .agent
@@ -878,14 +876,12 @@ impl Orchestrator {
                 worker_config.agent.name.clone(),
                 worker_config.instance_id.clone(),
             );
-            // The park arm needs the store-bearing route; webhook deployments
-            // keep the live decision path.
-            if let (
-                Some(cell),
-                Some(guard),
-                crate::hitl::DecisionRoute::Conversational { registry, .. },
-            ) = (park_cell, self.park_guard.as_ref(), &*hitl.route)
-            {
+            // The park arm needs the park-capable route's registry.
+            if let (Some(cell), Some(guard), Some((registry, _))) = (
+                park_cell,
+                self.park_guard.as_ref(),
+                hitl.route.park_registry(),
+            ) {
                 gate = gate.with_park(registry.clone(), cell.clone(), Arc::clone(guard));
             }
             if let Some(recorded) = recorded {
@@ -1061,15 +1057,13 @@ impl Orchestrator {
         })
     }
 
-    /// `[hitl.park].enabled` on the conversational route.
+    /// `[hitl.park].enabled` on a park-capable route: conversational, or
+    /// webhook with poll delivery.
     fn park_enabled(&self) -> bool {
-        self.agent_config.hitl.as_ref().is_some_and(|hitl| {
-            hitl.park_enabled
-                && matches!(
-                    &*hitl.route,
-                    crate::hitl::DecisionRoute::Conversational { .. }
-                )
-        })
+        self.agent_config
+            .hitl
+            .as_ref()
+            .is_some_and(|hitl| hitl.park_enabled && hitl.route.park_registry().is_some())
     }
 
     /// The worker approval scope stamped on a task's approvals — the same
@@ -1107,7 +1101,7 @@ impl Orchestrator {
         let Some(hitl) = self.agent_config.hitl.clone() else {
             return;
         };
-        let crate::hitl::DecisionRoute::Conversational { registry, .. } = &*hitl.route else {
+        let Some((registry, _)) = hitl.route.park_registry() else {
             return;
         };
         let scope = self.worker_scope(task_id, worker_name).await;
@@ -4079,7 +4073,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
 
         // Step 5: the consumed decisions leave the store with the task.
         if let Some(hitl) = self.agent_config.hitl.clone()
-            && let crate::hitl::DecisionRoute::Conversational { registry, .. } = &*hitl.route
+            && let Some((registry, _)) = hitl.route.park_registry()
         {
             for call in &continuation.pending {
                 registry.remove(&call.decision_id).await;
@@ -5178,8 +5172,8 @@ Assign tasks to the worker whose tools best match the required operations."#,
         let Some(hitl) = self.agent_config.hitl.clone() else {
             return Err("run parked without the HITL runtime configured".into());
         };
-        let crate::hitl::DecisionRoute::Conversational { registry, timeout } = &*hitl.route else {
-            return Err("run parked without the conversational route".into());
+        let Some((registry, timeout)) = hitl.route.park_registry() else {
+            return Err("run parked without a park-capable route".into());
         };
         let (run_id, session_id) = {
             let p = self.persistence.lock().await;
@@ -5218,7 +5212,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
             registry,
             memory_dir: &memory_dir,
             config: &self.agent_config,
-            decision_window: *timeout,
+            decision_window: timeout,
         };
 
         match super::park::commit_from_run_state(&inputs).await {
@@ -5274,7 +5268,7 @@ Assign tasks to the worker whose tools best match the required operations."#,
         let Some(hitl) = self.agent_config.hitl.clone() else {
             return;
         };
-        let crate::hitl::DecisionRoute::Conversational { registry, .. } = &*hitl.route else {
+        let Some((registry, _)) = hitl.route.park_registry() else {
             return;
         };
         let request_id = self.agent_config.request_id.clone().unwrap_or_default();
@@ -7362,34 +7356,51 @@ mod tests {
         );
     }
 
-    /// `park_enabled` requires the flag AND the conversational route — the
-    /// webhook arm of park mode is out of V1 scope.
+    /// A `[hitl.route]` webhook arm with the given delivery, for the
+    /// park-activation tests.
+    fn webhook_route_config(
+        delivery: aura_config::WebhookDelivery,
+    ) -> aura_config::DecisionRouteConfig {
+        aura_config::DecisionRouteConfig::Webhook {
+            url: aura_config::WebhookUrl::new("https://approvals.example.com/").unwrap(),
+            timeout_secs: 5,
+            headers: std::collections::HashMap::new(),
+            headers_from_request: std::collections::HashMap::new(),
+            tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
+            delivery,
+            poll_url: None,
+            poll_interval_secs: 10,
+            poll_request_timeout_secs: 30,
+        }
+    }
+
+    /// `park_enabled` requires the flag AND a park-capable route: the
+    /// conversational route and the webhook route under poll delivery park;
+    /// the webhook route under sync delivery keeps the live decision path.
     #[tokio::test]
-    async fn park_enabled_requires_flag_and_conversational_route() {
+    async fn park_enabled_requires_flag_and_park_capable_route() {
         use aura_config::GlobPattern;
 
-        fn config(park_enabled: bool, conversational: bool) -> AgentRuntimeConfig {
-            let mut config = AgentRuntimeConfig::default();
-            let route = if conversational {
-                crate::hitl::DecisionRoute::Conversational {
-                    registry: crate::hitl::PendingApprovals::new(),
-                    timeout: Duration::from_secs(60),
-                }
-            } else {
-                crate::hitl::DecisionRoute::Webhook {
-                    client: crate::hitl::WebhookClient::new(
-                        reqwest::Client::new(),
-                        aura_config::WebhookUrl::new("https://approvals.example.com/").unwrap(),
-                    ),
-                    timeout: Duration::from_secs(5),
-                }
+        fn config(
+            park_enabled: bool,
+            route: aura_config::DecisionRouteConfig,
+        ) -> AgentRuntimeConfig {
+            let hitl = aura_config::HitlConfig {
+                require_approval: vec![GlobPattern::new("kubectl_*").unwrap()],
+                park: aura_config::ParkConfig {
+                    enabled: park_enabled,
+                },
+                route,
             };
-            config.hitl = Some(crate::hitl::HitlRuntime {
-                patterns: Arc::from([GlobPattern::new("kubectl_*").unwrap()]),
-                route: Arc::new(route),
-                park_enabled,
-            });
-            config
+            AgentRuntimeConfig {
+                hitl: Some(crate::hitl::HitlRuntime::from_config(
+                    &hitl,
+                    &crate::hitl::PendingApprovals::new(),
+                    None,
+                    None,
+                )),
+                ..AgentRuntimeConfig::default()
+            }
         }
 
         let no_hitl = Orchestrator::new(AgentRuntimeConfig::default())
@@ -7397,14 +7408,112 @@ mod tests {
             .unwrap();
         assert!(!no_hitl.park_enabled(), "no [hitl] table: park off");
 
-        let off = Orchestrator::new(config(false, true)).await.unwrap();
+        let off = Orchestrator::new(config(
+            false,
+            aura_config::DecisionRouteConfig::Conversational { timeout_secs: 60 },
+        ))
+        .await
+        .unwrap();
         assert!(!off.park_enabled(), "flag off: park off");
 
-        let on = Orchestrator::new(config(true, true)).await.unwrap();
+        let on = Orchestrator::new(config(
+            true,
+            aura_config::DecisionRouteConfig::Conversational { timeout_secs: 60 },
+        ))
+        .await
+        .unwrap();
         assert!(on.park_enabled(), "flag on + conversational: park on");
 
-        let webhook = Orchestrator::new(config(true, false)).await.unwrap();
-        assert!(!webhook.park_enabled(), "webhook route: park off");
+        let sync = Orchestrator::new(config(
+            true,
+            webhook_route_config(aura_config::WebhookDelivery::Sync),
+        ))
+        .await
+        .unwrap();
+        assert!(!sync.park_enabled(), "webhook sync route: park off");
+
+        let poll = Orchestrator::new(config(
+            true,
+            webhook_route_config(aura_config::WebhookDelivery::Poll),
+        ))
+        .await
+        .unwrap();
+        assert!(poll.park_enabled(), "webhook poll route: park on");
+    }
+
+    /// Run-level activation: a webhook route with poll delivery
+    /// arms the park guard, enables park, and the commit path publishes the
+    /// checkpoint. The reconciler flow itself is the poller's.
+    #[tokio::test]
+    async fn webhook_poll_route_parks_and_commits_the_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let hitl = aura_config::HitlConfig {
+            require_approval: vec![aura_config::GlobPattern::new("kubectl_*").unwrap()],
+            park: aura_config::ParkConfig { enabled: true },
+            route: webhook_route_config(aura_config::WebhookDelivery::Poll),
+        };
+        let store = Arc::new(crate::session_store::InMemoryApprovalStore::new());
+        let registry = crate::hitl::PendingApprovals::with_backend(
+            store,
+            Arc::new(crate::session_store::InMemoryEventBus::new()),
+        );
+        let config = AgentRuntimeConfig {
+            hitl: Some(crate::hitl::HitlRuntime::from_config(
+                &hitl, &registry, None, None,
+            )),
+            memory_dir: Some(dir.path().to_string_lossy().into_owned()),
+            session_id: Some("poll-sess".to_string()),
+            request_id: Some(format!("req_poll_{}", uuid::Uuid::new_v4().simple())),
+            ..AgentRuntimeConfig::default()
+        };
+        let orchestrator = Orchestrator::new(config).await.unwrap();
+
+        assert!(orchestrator.park_enabled(), "poll delivery parks");
+        assert!(orchestrator.park_guard.is_some(), "the park guard arms");
+
+        let run_id = orchestrator.persistence.lock().await.run_id().to_string();
+        let (plan, records, pending) = awaiting_plan_with_parked_calls(&registry, &run_id).await;
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(32);
+
+        let chat_history = vec![rig::completion::Message::user("deploy the service")];
+        orchestrator
+            .park_run(
+                "deploy the service",
+                &chat_history,
+                &[],
+                None,
+                1,
+                2_500,
+                &[],
+                &plan,
+                &records,
+                &event_tx,
+            )
+            .await
+            .expect("the park commit succeeds under poll delivery");
+
+        let document_path = dir
+            .path()
+            .join("poll-sess")
+            .join("parked")
+            .join(format!("{run_id}.json"));
+        assert!(
+            document_path.try_exists().unwrap(),
+            "the checkpoint publishes under poll delivery"
+        );
+        let document = crate::orchestration::park::load_parked_run(&document_path)
+            .await
+            .unwrap();
+        let expected_ids: Vec<String> = pending.iter().map(|c| c.decision_id.to_string()).collect();
+        assert_eq!(document.awaiting_decision_ids(), expected_ids);
+        match tokio::time::timeout(std::time::Duration::from_millis(50), event_rx.recv()).await {
+            Ok(Some(Ok(StreamItem::OrchestratorEvent(
+                crate::orchestration::OrchestratorEvent::RunParked { decision_ids, .. },
+            )))) => {
+                assert_eq!(decision_ids, expected_ids, "both calls are outstanding");
+            }
+            other => panic!("expected the RunParked event, got {other:?}"),
+        }
     }
 
     /// The orphan cleanup: every pending decision id is removed from the
@@ -7460,6 +7569,7 @@ mod tests {
                     },
                     registered_at: now,
                     expires_at: now + chrono::Duration::seconds(60),
+                    egress_headers: None,
                 })
                 .await
                 .expect("durable register succeeds");
@@ -7592,6 +7702,7 @@ mod tests {
                     },
                     registered_at: now,
                     expires_at: now + chrono::Duration::hours(1),
+                    egress_headers: None,
                 })
                 .await
                 .unwrap();
@@ -7725,7 +7836,10 @@ mod tests {
         let (plan, records, pending) = awaiting_plan_with_parked_calls(&registry, &run_id).await;
         for call in &pending {
             registry
-                .resolve(&call.decision_id, crate::hitl::ApprovalDecision::Approved)
+                .resolve(
+                    &call.decision_id,
+                    crate::hitl::ApprovalDecision::Approved.into(),
+                )
                 .await
                 .unwrap();
         }
@@ -7886,7 +8000,7 @@ mod tests {
         let decided = pending[0].decision_id;
         let sibling = pending[1].decision_id;
         registry
-            .resolve(&decided, crate::hitl::ApprovalDecision::Approved)
+            .resolve(&decided, crate::hitl::ApprovalDecision::Approved.into())
             .await
             .unwrap();
 
@@ -8361,11 +8475,39 @@ mod tests {
             .join("\n")
     }
 
+    fn conversational_route(registry: &PendingApprovals) -> Arc<crate::hitl::DecisionRoute> {
+        Arc::new(crate::hitl::DecisionRoute::Conversational {
+            registry: registry.clone(),
+            timeout: Duration::from_secs(3600),
+        })
+    }
+
+    /// A webhook route under poll delivery, built the production way; the
+    /// resume path never reaches its unroutable url.
+    fn poll_webhook_route(registry: &PendingApprovals) -> Arc<crate::hitl::DecisionRoute> {
+        let config = aura_config::HitlConfig {
+            require_approval: vec![],
+            park: aura_config::ParkConfig { enabled: true },
+            route: aura_config::DecisionRouteConfig::Webhook {
+                url: aura_config::WebhookUrl::new("http://127.0.0.1:9").unwrap(),
+                timeout_secs: 3600,
+                headers: std::collections::HashMap::new(),
+                headers_from_request: std::collections::HashMap::new(),
+                tool_headers_from_response: aura_config::ToolHeaderMappings::default(),
+                delivery: aura_config::WebhookDelivery::Poll,
+                poll_url: None,
+                poll_interval_secs: 10,
+                poll_request_timeout_secs: 30,
+            },
+        };
+        crate::hitl::HitlRuntime::from_config(&config, registry, None, None).route
+    }
+
     /// A park-mode orchestrator over a file-backed approval store (the park
     /// contract's backend: `get` returns the approval before and after the
-    /// decision), sharing the given registry.
+    /// decision), gating `echo_tool` on `route`.
     async fn file_backed_park_orchestrator(
-        registry: &PendingApprovals,
+        route: Arc<crate::hitl::DecisionRoute>,
         memory_dir: &std::path::Path,
         session_id: &str,
     ) -> (Orchestrator, String) {
@@ -8385,10 +8527,7 @@ mod tests {
         let config = AgentRuntimeConfig {
             hitl: Some(crate::hitl::HitlRuntime {
                 patterns: Arc::from([aura_config::GlobPattern::new("echo_tool").unwrap()]),
-                route: Arc::new(crate::hitl::DecisionRoute::Conversational {
-                    registry: registry.clone(),
-                    timeout: Duration::from_secs(3600),
-                }),
+                route,
                 park_enabled: true,
             }),
             memory_dir: Some(memory_dir.to_string_lossy().into_owned()),
@@ -8447,6 +8586,7 @@ mod tests {
     /// disk, and drive the continuation with `resume_turns`. Returns the
     /// task outcome plus the handles the proofs assert through.
     async fn park_then_resume(
+        route_for: fn(&PendingApprovals) -> Arc<crate::hitl::DecisionRoute>,
         decision: ApprovalDecision,
         resume_turns: Vec<ScriptedTurn>,
     ) -> (
@@ -8462,7 +8602,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (registry, store) = file_store_registry(&dir.path().join("approvals"));
         let (orchestrator, run_id) =
-            file_backed_park_orchestrator(&registry, dir.path(), "loop-sess").await;
+            file_backed_park_orchestrator(route_for(&registry), dir.path(), "loop-sess").await;
         let (event_tx, _event_rx) = tokio::sync::mpsc::channel(64);
 
         let (park_model, park_invocations) =
@@ -8501,7 +8641,10 @@ mod tests {
             .expect("the park commit succeeds");
         drop(orchestrator);
 
-        registry.resolve(&decision_id, decision).await.unwrap();
+        registry
+            .resolve(&decision_id, decision.into())
+            .await
+            .unwrap();
 
         let document_path = dir
             .path()
@@ -8554,7 +8697,7 @@ mod tests {
         };
 
         let (orchestrator2, _run_id2) =
-            file_backed_park_orchestrator(&registry, dir.path(), "loop-sess").await;
+            file_backed_park_orchestrator(route_for(&registry), dir.path(), "loop-sess").await;
         let (resume_model, resume_invocations) = gated_worker_override(resume_turns);
         let params = TaskExecutionParams {
             task_description: "apply the manifest",
@@ -8584,6 +8727,37 @@ mod tests {
         )
     }
 
+    /// The same loop on a webhook route under poll delivery: the resume
+    /// consumes the recorded decision and removes the row, as the
+    /// conversational route does.
+    #[tokio::test]
+    async fn full_loop_on_a_poll_route_removes_the_consumed_row() {
+        let _serial = WORKER_OVERRIDE_LOCK.lock().await;
+
+        let (outcome, _model, _resumed, _parked, _document, store, decision_id, _dir) =
+            park_then_resume(
+                poll_webhook_route,
+                ApprovalDecision::Approved,
+                vec![ScriptedTurn::tool_calls(vec![ScriptedToolCall::new(
+                    "call_final",
+                    "submit_result",
+                    serde_json::json!({
+                        "summary": "applied the manifest",
+                        "result": "applied successfully to prod",
+                        "confidence": "high",
+                    }),
+                )])],
+            )
+            .await;
+
+        let outcome = outcome.expect("the resumed task completes");
+        assert!(matches!(outcome, TaskOutcome::Completed(_)));
+        assert!(
+            store.get(&decision_id).await.unwrap().is_none(),
+            "the consumed decision is removed on the poll route"
+        );
+    }
+
     /// FULL LOOP, zero human input: the scripted worker parks, the document
     /// publishes, in-memory state drops, the store holds the approval, and
     /// the rehydrated continuation completes the task — the tool running
@@ -8604,6 +8778,7 @@ mod tests {
             decision_id,
             _dir,
         ) = park_then_resume(
+            conversational_route,
             ApprovalDecision::Approved,
             vec![ScriptedTurn::tool_calls(vec![ScriptedToolCall::new(
                 "call_final",
@@ -8693,13 +8868,14 @@ mod tests {
         let args = serde_json::json!({ "namespace": "prod" });
         recorded.push(
             CallKey::new(1, "kubectl_apply", &args),
-            ApprovalDecision::Approved,
+            ApprovalDecision::Approved.into(),
         );
         recorded.push(
             CallKey::new(1, "kubectl_apply", &args),
             ApprovalDecision::Denied {
                 reason: Some("no".to_string()),
-            },
+            }
+            .into(),
         );
 
         let taken = Arc::new(std::sync::Mutex::new(Vec::new()));
@@ -8725,12 +8901,12 @@ mod tests {
             "two decisions consumed exactly once each: {taken:?}"
         );
         assert!(
-            matches!(taken[0].1, ApprovalDecision::Approved),
+            matches!(taken[0].1, crate::hitl::ResolvedDecision::Approved { .. }),
             "recorded order holds across consumers: the approval is consumed first"
         );
         assert!(matches!(
             &taken[1].1,
-            ApprovalDecision::Denied {
+            crate::hitl::ResolvedDecision::Denied {
                 reason: Some(reason),
             } if reason == "no"
         ));
@@ -8826,6 +9002,7 @@ mod tests {
             _decision_id,
             _dir,
         ) = park_then_resume(
+            conversational_route,
             ApprovalDecision::Denied {
                 reason: Some("too risky".to_string()),
             },

--- a/crates/aura/src/orchestration/park/commit.rs
+++ b/crates/aura/src/orchestration/park/commit.rs
@@ -30,8 +30,9 @@ pub(crate) struct ParkCommitInputs<'a> {
     pub decision_window: std::time::Duration,
 }
 
-/// The refreshed awaiting set: per-task pending calls still awaiting a
-/// decision, and the earliest expiry among them.
+/// The refreshed awaiting set: per-task pending calls still parked —
+/// including calls decided since the gate hit, retained for the resume
+/// consult — and the earliest expiry among the undecided tickets.
 pub(crate) struct RefreshedAwaiting {
     pub pending_by_task: HashMap<usize, Vec<PendingCall>>,
     pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
@@ -53,10 +54,13 @@ pub(crate) fn run_owner_id(run_id: &str) -> String {
     format!("run:{run_id}")
 }
 
-/// Narrow the plan's awaiting tasks to the calls still parked and undecided,
-/// with the earliest surviving ticket expiry. A store fault fails the
-/// refresh, and with it the commit, rather than dropping a still-decidable
-/// approval from the checkpoint.
+/// Narrow the plan's awaiting tasks to the calls still parked, with the
+/// earliest surviving ticket expiry. A call decided between gate-hit and
+/// commit stays in the checkpoint — the resume consult consumes its
+/// recorded decision — but its settled ticket contributes neither expiry
+/// nor an outstanding id. A store fault fails the refresh, and with it the
+/// commit, rather than dropping a still-decidable approval from the
+/// checkpoint.
 pub(crate) async fn refresh_awaiting(
     plan: &Plan,
     registry: &PendingApprovals,
@@ -91,8 +95,9 @@ pub(crate) async fn refresh_awaiting(
                 tracing::info!(
                     decision_id = %call.decision_id,
                     task_id = task.id,
-                    "park approval decided before commit; dropping from checkpoint",
+                    "park approval decided before commit; retaining for the resume consult",
                 );
+                surviving.push(call.clone());
                 continue;
             }
             expires_at = Some(match expires_at {
@@ -252,6 +257,13 @@ pub(crate) fn parked_document_dir(memory_dir: &str, session_id: Option<&str>) ->
 /// Fingerprint the configuration a resume must not drift from: the HITL
 /// gating surface (globs, route, park flag), the agent's model and tool
 /// filter, and the per-worker model and tool configuration.
+///
+/// The webhook route's projection carries `"delivery"` derived from the
+/// client's poll marker — the same source `park_registry` reads; no second
+/// delivery flag exists. Poll tuning (poll_url, interval, per-attempt
+/// timeout) is deliberately fingerprint-COMPATIBLE, and no credential value
+/// (headers, secrets) enters the projection; resume-side enforcement is a
+/// one-way bump on change.
 pub(crate) fn config_fingerprint(config: &AgentRuntimeConfig) -> String {
     let hitl = config.hitl.as_ref();
     let route = hitl.map(|h| match &*h.route {
@@ -259,9 +271,12 @@ pub(crate) fn config_fingerprint(config: &AgentRuntimeConfig) -> String {
             "kind": "conversational",
             "timeout_secs": timeout.as_secs(),
         }),
-        crate::hitl::DecisionRoute::Webhook { timeout, .. } => json!({
+        crate::hitl::DecisionRoute::Webhook {
+            client, timeout, ..
+        } => json!({
             "kind": "webhook",
             "timeout_secs": timeout.as_secs(),
+            "delivery": if client.poll_delivery() { "poll" } else { "sync" },
         }),
     });
     let source = json!({
@@ -333,6 +348,7 @@ mod tests {
             },
             registered_at: chrono::Utc::now(),
             expires_at,
+            egress_headers: None,
         }
     }
 
@@ -442,8 +458,11 @@ mod tests {
         assert!(tmp.is_dir(), "the obstruction is left in place");
     }
 
-    /// Refresh drops decided and removed approvals, keeps the undecided
-    /// ones, and reports the earliest surviving expiry.
+    /// Refresh drops approvals the store no longer holds, keeps the
+    /// undecided ones, and reports the earliest surviving expiry. The memory
+    /// backend's resolve moves the row, so a decided call reads as removed
+    /// here; the file-backed retention case is
+    /// [`early_decision_is_retained_and_consumed_at_resume`].
     #[tokio::test]
     async fn refresh_drops_decided_and_takes_earliest_expiry() {
         let (registry, _store) = conv_registry();
@@ -487,7 +506,7 @@ mod tests {
             .await
             .unwrap();
         registry
-            .resolve(&decided, crate::hitl::ApprovalDecision::Approved)
+            .resolve(&decided, crate::hitl::ApprovalDecision::Approved.into())
             .await
             .unwrap();
         registry.remove(&removed).await;
@@ -535,6 +554,132 @@ mod tests {
         );
     }
 
+    /// A decision landing between gate-hit and
+    /// park commit is retained by the refresh and consumed by the resume
+    /// consult. Park mode's file backend keeps the approval readable after
+    /// resolve, which is what both sides key on.
+    #[tokio::test]
+    async fn early_decision_is_retained_and_consumed_at_resume() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn ApprovalStore> = Arc::new(
+            crate::session_store::FileApprovalStore::open(dir.path().join("approvals")).unwrap(),
+        );
+        let registry = PendingApprovals::with_backend(store, Arc::new(InMemoryEventBus::new()));
+
+        let run_id = "0191e8c0-cccc-7000-8000-000000000009";
+        let owner = run_owner_id(run_id);
+        let decided = DecisionId::generate();
+        let args = serde_json::json!({ "namespace": "prod" });
+        let now = chrono::Utc::now();
+        registry
+            .register_durable(ParkedApproval {
+                request: ApprovalRequest {
+                    version: PROTOCOL_VERSION,
+                    instance_id: "test-instance".to_string(),
+                    decision_id: decided,
+                    request_id: owner,
+                    scope: AgentScope::Worker {
+                        run_id: run_id.parse().unwrap(),
+                        task: crate::orchestration::TaskIdentity::new(3, None),
+                        session_id: None,
+                    },
+                    origin: ApprovalOrigin::ConfigGate {
+                        matched_pattern: "kubectl_*".to_string(),
+                        agent_name: "test-agent".to_string(),
+                    },
+                    items: vec![ApprovalItem {
+                        tool_name: "kubectl_apply".to_string(),
+                        arguments: args.clone(),
+                        tool_call_intent: None,
+                    }],
+                },
+                registered_at: now,
+                expires_at: now + chrono::Duration::hours(1),
+                egress_headers: None,
+            })
+            .await
+            .unwrap();
+        // The decision wins the race against the park commit.
+        registry
+            .resolve(&decided, crate::hitl::ApprovalDecision::Approved.into())
+            .await
+            .unwrap();
+
+        let mut plan = Plan::new("Deploy");
+        plan.add_task(Task::new(3, "Gated apply", "r"));
+        plan.tasks[0].state = TaskState::AwaitingApproval {
+            pending: vec![PendingCall {
+                decision_id: decided,
+                tool_name: "kubectl_apply".to_string(),
+                arguments: args.clone(),
+                call_id: "c1".to_string(),
+            }],
+        };
+
+        let refreshed = refresh_awaiting(&plan, &registry).await.unwrap();
+        assert_eq!(
+            refreshed.pending_by_task[&3].len(),
+            1,
+            "the decided call stays in the checkpoint"
+        );
+        assert!(
+            refreshed.decision_ids.is_empty(),
+            "a decided call is no longer outstanding"
+        );
+        assert!(
+            refreshed.expires_at.is_none(),
+            "a settled ticket bounds nothing"
+        );
+
+        // The resume consult consumes the retained call's recorded decision.
+        let mut records = ParkedTaskRecords::new();
+        records.insert(
+            3,
+            crate::orchestration::park::ParkedTaskRecord {
+                attempt: 1,
+                snapshot: crate::orchestration::ParkSnapshot {
+                    history: vec![rig::completion::Message::user("apply it")],
+                    current_prompt: rig::completion::Message::user("tool results"),
+                },
+            },
+        );
+        let document = build_document(
+            &RunStateForPark {
+                run_id,
+                session_id: None,
+                query: "Deploy",
+                chat_history: &[],
+                coordinator_conversation: &[],
+                routing_decision: None,
+                iteration: 1,
+                planning_ms: 0,
+                failure_history: &[],
+            },
+            &plan,
+            &records,
+            &refreshed.pending_by_task,
+            (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339(),
+            config_fingerprint(&AgentRuntimeConfig::default()),
+        )
+        .unwrap();
+        let (recorded, ids) =
+            crate::orchestration::park::load_recorded_decisions(&registry, &document)
+                .await
+                .unwrap();
+        assert_eq!(ids, vec![decided]);
+        assert_eq!(
+            recorded.take(&crate::orchestration::CallKey::new(
+                3,
+                "kubectl_apply",
+                &args
+            )),
+            Some(crate::hitl::ResolvedDecision::from(
+                crate::hitl::ApprovalDecision::Approved
+            )),
+            "the early decision is consumed at resume",
+        );
+    }
+
     /// The sweep cancels exactly what the store still holds: the undecided
     /// sibling clears with one event, while the decided sibling — whose
     /// ticket resolve already removed — is absent from the cleared set and
@@ -567,7 +712,7 @@ mod tests {
             .await
             .unwrap();
         registry
-            .resolve(&decided, crate::hitl::ApprovalDecision::Approved)
+            .resolve(&decided, crate::hitl::ApprovalDecision::Approved.into())
             .await
             .unwrap();
 
@@ -581,8 +726,9 @@ mod tests {
         );
         assert_eq!(
             registry.recorded_decision(&decided).await,
-            Some(crate::hitl::ApprovalDecision::Approved),
-            "the recorded decision survives the sweep"
+            Some(crate::hitl::ResolvedDecision::from(
+                crate::hitl::ApprovalDecision::Approved
+            )),
         );
 
         match tokio::time::timeout(Duration::from_secs(1), events.recv()).await {
@@ -687,7 +833,7 @@ mod tests {
 
         assert_eq!(
             registry
-                .resolve(&ticket, crate::hitl::ApprovalDecision::Approved)
+                .resolve(&ticket, crate::hitl::ApprovalDecision::Approved.into())
                 .await,
             Err(ResolveError::NotFound),
         );
@@ -722,6 +868,125 @@ mod tests {
             config_fingerprint(&config("kubectl_*")),
             config_fingerprint(&config("helm_*")),
             "a changed gate surface changes the hash"
+        );
+    }
+
+    /// Webhook routes: the fingerprint carries `"delivery"` from the client's
+    /// poll marker, so poll and sync differ, an unchanged webhook config is
+    /// stable, and poll TUNING (poll_url, interval, per-attempt timeout)
+    /// stays compatible. Credentials (static headers, mapped-header values)
+    /// never enter the projection.
+    #[test]
+    fn config_fingerprint_carries_delivery_and_stays_tuning_compatible() {
+        use aura_config::{
+            DecisionRouteConfig, GlobPattern, ToolHeaderMappings, WebhookDelivery, WebhookUrl,
+        };
+        use std::collections::HashMap;
+
+        fn config_with_route(
+            route: DecisionRouteConfig,
+            patterns: &str,
+        ) -> crate::config::AgentRuntimeConfig {
+            crate::config::AgentRuntimeConfig {
+                hitl: Some(crate::hitl::HitlRuntime {
+                    patterns: Arc::from([GlobPattern::new(patterns).unwrap()]),
+                    route: Arc::new(match &route {
+                        DecisionRouteConfig::Conversational { .. } => {
+                            crate::hitl::DecisionRoute::Conversational {
+                                registry: PendingApprovals::new(),
+                                timeout: Duration::from_secs(120),
+                            }
+                        }
+                        DecisionRouteConfig::Webhook { .. } => {
+                            let client =
+                                crate::hitl::webhook_client_from_config(&route, None, None)
+                                    .expect("a webhook route config builds a client");
+                            crate::hitl::DecisionRoute::Webhook {
+                                client,
+                                registry: PendingApprovals::new(),
+                                timeout: Duration::from_secs(300),
+                                egress_capture: Ok(()),
+                            }
+                        }
+                    }),
+                    park_enabled: true,
+                }),
+                ..crate::config::AgentRuntimeConfig::default()
+            }
+        }
+
+        fn webhook_route(
+            delivery: WebhookDelivery,
+            poll_url: Option<&str>,
+            poll_interval_secs: u64,
+            poll_request_timeout_secs: u64,
+            headers: HashMap<String, String>,
+        ) -> DecisionRouteConfig {
+            DecisionRouteConfig::Webhook {
+                url: WebhookUrl::new("https://approvals.example.com/hook").unwrap(),
+                timeout_secs: 300,
+                headers,
+                headers_from_request: HashMap::new(),
+                tool_headers_from_response: ToolHeaderMappings::default(),
+                delivery,
+                poll_url: poll_url.map(|u| WebhookUrl::new(u).unwrap()),
+                poll_interval_secs,
+                poll_request_timeout_secs,
+            }
+        }
+
+        let sync = webhook_route(WebhookDelivery::Sync, None, 10, 30, HashMap::new());
+        let poll = webhook_route(WebhookDelivery::Poll, None, 10, 30, HashMap::new());
+
+        assert_eq!(
+            config_fingerprint(&config_with_route(poll.clone(), "kubectl_*")),
+            config_fingerprint(&config_with_route(poll.clone(), "kubectl_*")),
+            "an unchanged webhook config is a stable hash"
+        );
+        assert_ne!(
+            config_fingerprint(&config_with_route(sync.clone(), "kubectl_*")),
+            config_fingerprint(&config_with_route(poll.clone(), "kubectl_*")),
+            "poll and sync deliveries must fingerprint differently"
+        );
+
+        // Poll tuning is fingerprint-compatible: a redeploy that only moves
+        // the status endpoint or retunes cadence/timeouts resumes.
+        let retuned = webhook_route(
+            WebhookDelivery::Poll,
+            Some("https://status.example.com/x"),
+            45,
+            7,
+            HashMap::new(),
+        );
+        assert_eq!(
+            config_fingerprint(&config_with_route(poll.clone(), "kubectl_*")),
+            config_fingerprint(&config_with_route(retuned, "kubectl_*")),
+            "poll tuning must not change the fingerprint"
+        );
+
+        // The gate surface still moves the hash on a webhook route.
+        assert_ne!(
+            config_fingerprint(&config_with_route(poll.clone(), "kubectl_*")),
+            config_fingerprint(&config_with_route(poll, "helm_*")),
+            "a changed gate surface changes the hash"
+        );
+
+        // Credential values are excluded: a route whose static headers carry
+        // a secret fingerprints the same as one with none.
+        let with_secret = webhook_route(
+            WebhookDelivery::Sync,
+            None,
+            10,
+            30,
+            HashMap::from([(
+                "authorization".to_string(),
+                "Bearer credential-value".to_string(),
+            )]),
+        );
+        assert_eq!(
+            config_fingerprint(&config_with_route(sync, "kubectl_*")),
+            config_fingerprint(&config_with_route(with_secret, "kubectl_*")),
+            "credential values must not enter the fingerprint"
         );
     }
 }

--- a/crates/aura/src/orchestration/park/continuation.rs
+++ b/crates/aura/src/orchestration/park/continuation.rs
@@ -279,7 +279,7 @@ pub(crate) async fn load_recorded_decisions(
                     call.tool_name, call.decision_id
                 )));
             }
-            let Some(decision) = store.recorded_decision(&call.decision_id).await else {
+            let Some(resolved) = store.recorded_decision(&call.decision_id).await else {
                 // No decision yet: expired past the window (the 2.6 expired
                 // row outranks parked), still parked otherwise — collected
                 // so the 409 body can carry every outstanding id.
@@ -290,10 +290,11 @@ pub(crate) async fn load_recorded_decisions(
                 continue;
             };
             // The key's task id comes from the awaiting node, the tool name
-            // and arguments from the store's approval record.
+            // and arguments from the store's approval record. The carrier
+            // keeps the recorded identity with the decision it rode in with.
             recorded.push(
                 CallKey::new(node.task_id, &item.tool_name, &item.arguments),
-                decision,
+                resolved,
             );
             decision_ids.push(call.decision_id);
         }
@@ -352,7 +353,7 @@ mod tests {
     use super::*;
     use crate::hitl::{
         AgentScope, ApprovalDecision, ApprovalItem, ApprovalOrigin, ApprovalRequest,
-        PROTOCOL_VERSION, ParkedApproval,
+        PROTOCOL_VERSION, ParkedApproval, ResolvedDecision,
     };
     use crate::orchestration::park::document::{ParkedPlan, ParkedTaskNode, SCHEMA_VERSION};
     use crate::orchestration::types::TaskStatus;
@@ -428,6 +429,7 @@ mod tests {
             },
             registered_at: chrono::Utc::now(),
             expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+            egress_headers: None,
         }
     }
 
@@ -457,7 +459,7 @@ mod tests {
             .await
             .unwrap();
         registry
-            .resolve(&decision_id, ApprovalDecision::Approved)
+            .resolve(&decision_id, ApprovalDecision::Approved.into())
             .await
             .unwrap();
 
@@ -482,7 +484,7 @@ mod tests {
         assert_eq!(ids, vec![decision_id]);
         assert_eq!(
             recorded.take(&CallKey::new(3, "kubectl_apply", &args)),
-            Some(ApprovalDecision::Approved),
+            Some(ResolvedDecision::from(ApprovalDecision::Approved)),
             "the recorded decision is consumable at the resume gate"
         );
         assert!(
@@ -615,7 +617,7 @@ mod tests {
             .unwrap();
         // The decision lands after the document was committed.
         registry
-            .resolve(&decision_id, ApprovalDecision::Approved)
+            .resolve(&decision_id, ApprovalDecision::Approved.into())
             .await
             .unwrap();
 
@@ -624,7 +626,7 @@ mod tests {
         assert_eq!(ids, vec![decision_id]);
         assert_eq!(
             recorded.take(&CallKey::new(3, "kubectl_apply", &args)),
-            Some(ApprovalDecision::Approved)
+            Some(ResolvedDecision::from(ApprovalDecision::Approved))
         );
     }
 

--- a/crates/aura/src/orchestration/park/guard.rs
+++ b/crates/aura/src/orchestration/park/guard.rs
@@ -125,6 +125,7 @@ mod tests {
             },
             registered_at: chrono::Utc::now(),
             expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+            egress_headers: None,
         }
     }
 

--- a/crates/aura/src/orchestration/park/recorded_decisions.rs
+++ b/crates/aura/src/orchestration/park/recorded_decisions.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-use crate::hitl::ApprovalDecision;
+use crate::hitl::ResolvedDecision;
 
 /// Decisions already recorded for this run's parked calls, consumed at most
 /// once each. `strict_tasks` holds the task ids whose continuation is
@@ -24,16 +24,17 @@ use crate::hitl::ApprovalDecision;
 /// mismatch) clears the task's entry.
 #[derive(Debug, Default)]
 pub(crate) struct RecordedDecisions {
-    entries: Mutex<HashMap<CallKey, VecDeque<ApprovalDecision>>>,
+    entries: Mutex<HashMap<CallKey, VecDeque<ResolvedDecision>>>,
     strict_tasks: Mutex<HashSet<usize>>,
 }
 
 impl RecordedDecisions {
-    /// Record a decision for a key, appending to that key's recorded-order
-    /// queue so two same-turn calls with identical arguments keep their own
-    /// decisions. Wired by the orchestrator continuation (P44 commit 3).
+    /// Record a resolved decision — decision and captured identity together —
+    /// for a key, appending to that key's recorded-order queue so two
+    /// same-turn calls with identical arguments keep their own decisions.
+    /// Wired by the orchestrator continuation.
     #[allow(dead_code)]
-    pub(crate) fn push(&self, key: CallKey, decision: ApprovalDecision) {
+    pub(crate) fn push(&self, key: CallKey, decision: ResolvedDecision) {
         self.entries
             .lock()
             .expect("recorded-decisions lock")
@@ -63,9 +64,9 @@ impl RecordedDecisions {
             .contains(&task_id)
     }
 
-    /// Consume one decision for a key in recorded order; the next call returns
-    /// the following decision, and an empty queue returns `None`.
-    pub(crate) fn take(&self, key: &CallKey) -> Option<ApprovalDecision> {
+    /// Consume one resolved decision for a key in recorded order; the next
+    /// call returns the following decision, and an empty queue returns `None`.
+    pub(crate) fn take(&self, key: &CallKey) -> Option<ResolvedDecision> {
         self.entries
             .lock()
             .expect("recorded-decisions lock")
@@ -139,6 +140,7 @@ mod tests {
     use std::panic::{AssertUnwindSafe, catch_unwind};
 
     use super::*;
+    use crate::hitl::ApprovalDecision;
 
     fn key(task_id: usize, tool_name: &str, args: &Value) -> CallKey {
         CallKey::new(task_id, tool_name, args)
@@ -151,24 +153,28 @@ mod tests {
         let recorded = RecordedDecisions::default();
         let args = serde_json::json!({"namespace": "prod"});
 
-        recorded.push(key(1, "kubectl_apply", &args), ApprovalDecision::Approved);
+        recorded.push(
+            key(1, "kubectl_apply", &args),
+            ApprovalDecision::Approved.into(),
+        );
         recorded.push(
             key(1, "kubectl_apply", &args),
             ApprovalDecision::Denied {
                 reason: Some("too risky".to_string()),
-            },
+            }
+            .into(),
         );
 
         let probe = key(1, "kubectl_apply", &args);
         assert_eq!(
             recorded.take(&probe),
-            Some(ApprovalDecision::Approved),
+            Some(ResolvedDecision::from(ApprovalDecision::Approved)),
             "first take returns the first recorded decision",
         );
         assert_eq!(
             recorded
                 .take(&probe)
-                .map(|d| matches!(d, ApprovalDecision::Denied { .. })),
+                .map(|d| matches!(d, ResolvedDecision::Denied { .. })),
             Some(true),
             "second take returns the second recorded decision, in order",
         );

--- a/crates/aura/src/orchestration/persistence_wrapper.rs
+++ b/crates/aura/src/orchestration/persistence_wrapper.rs
@@ -1508,7 +1508,7 @@ mod tests {
         let item = parked.request.items.into_iter().next().expect("one item");
 
         registry_for_resolve
-            .resolve(&decision_id, ApprovalDecision::Approved)
+            .resolve(&decision_id, ApprovalDecision::Approved.into())
             .await
             .expect("resolve");
 

--- a/crates/aura/src/session_store/fault_store.rs
+++ b/crates/aura/src/session_store/fault_store.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use async_trait::async_trait;
 
 use super::{ApprovalStore, InMemoryApprovalStore, SessionStoreError};
-use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
+use crate::hitl::{DecisionId, ParkedApproval, ResolveError, ResolvedDecision};
 
 /// Delegates to an in-memory store; each `fail_*` flag makes that operation
 /// answer `SessionStoreError::Request` (the `*_once` flag fires one time).
@@ -55,7 +55,7 @@ impl ApprovalStore for FaultInjectingStore {
     async fn resolve(
         &self,
         id: &DecisionId,
-        decision: ApprovalDecision,
+        decision: ResolvedDecision,
     ) -> Result<(), ResolveError> {
         self.inner.resolve(id, decision).await
     }
@@ -63,7 +63,7 @@ impl ApprovalStore for FaultInjectingStore {
     async fn decision(
         &self,
         id: &DecisionId,
-    ) -> Result<Option<ApprovalDecision>, SessionStoreError> {
+    ) -> Result<Option<ResolvedDecision>, SessionStoreError> {
         self.inner.decision(id).await
     }
 

--- a/crates/aura/src/session_store/file.rs
+++ b/crates/aura/src/session_store/file.rs
@@ -13,7 +13,8 @@
 //! - `resolve` refuses past the approval's `expires_at`, uniformly with an
 //!   unknown id.
 //! - `resolve` *moves* the approval into the decision file rather than deleting
-//!   it: `get` returns the approval before and after the decision, `decision`
+//!   it, minus its egress headers (a decided id is never notified again):
+//!   `get` returns the approval before and after the decision, `decision`
 //!   returns the recorded decision, and both are retained until `remove`.
 //! - At-most-once `resolve` is the `File::create_new` claim on the decision
 //!   file: `AlreadyExists` reads as `NotFound`.
@@ -52,7 +53,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tokio::task::{JoinError, spawn_blocking};
 
-use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
+use crate::hitl::{DecisionId, ParkedApproval, ResolveError, ResolvedDecision};
 
 use super::{ApprovalStore, DecisionRecord, ParkedApprovalRecord, SessionStoreError};
 
@@ -171,13 +172,13 @@ impl Inner {
     fn resolve_sync(
         &self,
         id: &DecisionId,
-        decision: ApprovalDecision,
+        decision: ResolvedDecision,
     ) -> Result<(), ResolveError> {
         let _guard = self.lock();
         let id = canonical_id(id).map_err(ResolveError::Store)?;
 
         // Reading the approval before claiming avoids claiming unknown ids.
-        let record = match fs::read(self.approval_path(&id)) {
+        let mut record = match fs::read(self.approval_path(&id)) {
             Ok(bytes) => serde_json::from_slice::<ParkedApprovalRecord>(&bytes)
                 .map_err(|e| ResolveError::Store(decode_err(e)))?,
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
@@ -189,6 +190,7 @@ impl Inner {
         if chrono::Utc::now() > record.expires_at {
             return Err(ResolveError::NotFound);
         }
+        record.egress_headers = None;
         let payload = serde_json::to_vec(&ResolvedEntry {
             approval: record,
             decision: DecisionRecord::from(&decision),
@@ -231,13 +233,15 @@ impl Inner {
     fn decision_sync(
         &self,
         id: &DecisionId,
-    ) -> Result<Option<ApprovalDecision>, SessionStoreError> {
+    ) -> Result<Option<ResolvedDecision>, SessionStoreError> {
         let _guard = self.lock();
         let id = canonical_id(id)?;
         match fs::read(self.decision_path(&id)) {
             Ok(bytes) => {
                 let entry: ResolvedEntry = serde_json::from_slice(&bytes).map_err(decode_err)?;
-                Ok(Some(ApprovalDecision::from(entry.decision)))
+                ResolvedDecision::try_from(entry.decision)
+                    .map(Some)
+                    .map_err(decode_err)
             }
             Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
             Err(err) => Err(request_err(err)),
@@ -431,7 +435,7 @@ impl ApprovalStore for FileApprovalStore {
     async fn resolve(
         &self,
         id: &DecisionId,
-        decision: ApprovalDecision,
+        decision: ResolvedDecision,
     ) -> Result<(), ResolveError> {
         let inner = Arc::clone(&self.inner);
         let id = *id;
@@ -443,7 +447,7 @@ impl ApprovalStore for FileApprovalStore {
     async fn decision(
         &self,
         id: &DecisionId,
-    ) -> Result<Option<ApprovalDecision>, SessionStoreError> {
+    ) -> Result<Option<ResolvedDecision>, SessionStoreError> {
         let inner = Arc::clone(&self.inner);
         let id = *id;
         spawn_blocking(move || inner.decision_sync(&id))

--- a/crates/aura/src/session_store/memory.rs
+++ b/crates/aura/src/session_store/memory.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use tokio::sync::broadcast;
 
-use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError, Timestamp};
+use crate::hitl::{DecisionId, ParkedApproval, ResolveError, ResolvedDecision, Timestamp};
 
 use super::{ApprovalStore, EventBus, SessionStoreError, Subscription};
 
@@ -18,9 +18,10 @@ const TOPIC_CAPACITY: usize = 64;
 /// Decision retention margin.
 const DECISION_RETENTION_MARGIN_SECS: i64 = 60;
 
-/// A recorded decision and its retention deadline.
+/// A recorded resolved decision (decision plus captured identity) and its
+/// retention deadline.
 struct DecidedEntry {
-    decision: ApprovalDecision,
+    decision: ResolvedDecision,
     keep_until: Timestamp,
 }
 
@@ -65,7 +66,7 @@ impl ApprovalStore for InMemoryApprovalStore {
     async fn resolve(
         &self,
         id: &DecisionId,
-        decision: ApprovalDecision,
+        decision: ResolvedDecision,
     ) -> Result<(), ResolveError> {
         // Lock removal provides at-most-once.
         let parked = {
@@ -93,7 +94,7 @@ impl ApprovalStore for InMemoryApprovalStore {
     async fn decision(
         &self,
         id: &DecisionId,
-    ) -> Result<Option<ApprovalDecision>, SessionStoreError> {
+    ) -> Result<Option<ResolvedDecision>, SessionStoreError> {
         Ok(self.lock_decided().get(id).map(|e| e.decision.clone()))
     }
 
@@ -212,7 +213,8 @@ mod tests {
 
     use super::*;
     use crate::hitl::{
-        AgentScope, ApprovalItem, ApprovalOrigin, ApprovalRequest, PROTOCOL_VERSION,
+        AgentScope, ApprovalDecision, ApprovalItem, ApprovalOrigin, ApprovalRequest,
+        PROTOCOL_VERSION,
     };
 
     fn parked(request_id: &str) -> ParkedApproval {
@@ -236,49 +238,8 @@ mod tests {
             },
             registered_at: now,
             expires_at: now + chrono::Duration::seconds(60),
+            egress_headers: None,
         }
-    }
-
-    #[tokio::test]
-    async fn approval_store_register_get_resolve() {
-        let store = InMemoryApprovalStore::new();
-        let entry = parked("req-1");
-        let id = entry.request.decision_id;
-
-        store.register(entry).await.unwrap();
-        assert!(store.get(&id).await.unwrap().is_some());
-
-        store
-            .resolve(&id, ApprovalDecision::Approved)
-            .await
-            .unwrap();
-        assert!(store.get(&id).await.unwrap().is_none());
-        assert_eq!(
-            store.resolve(&id, ApprovalDecision::Approved).await,
-            Err(ResolveError::NotFound),
-        );
-    }
-
-    #[tokio::test]
-    async fn approval_store_resolve_records_readable_decision() {
-        let store = InMemoryApprovalStore::new();
-        let entry = parked("req-durable");
-        let id = entry.request.decision_id;
-        store.register(entry).await.unwrap();
-
-        let denied = ApprovalDecision::Denied {
-            reason: Some("not safe".into()),
-        };
-        store.resolve(&id, denied.clone()).await.unwrap();
-
-        assert_eq!(store.decision(&id).await.unwrap(), Some(denied.clone()));
-        // Recorded decision survives rejected second resolve.
-        assert_eq!(
-            store.resolve(&id, ApprovalDecision::Approved).await,
-            Err(ResolveError::NotFound)
-        );
-        assert_eq!(store.decision(&id).await.unwrap(), Some(denied));
-        assert_eq!(store.decision(&DecisionId::generate()).await.unwrap(), None);
     }
 
     /// Retention pruning drops entries past window.
@@ -289,7 +250,7 @@ mod tests {
         store.lock_decided().insert(
             id,
             DecidedEntry {
-                decision: ApprovalDecision::Approved,
+                decision: ResolvedDecision::from(ApprovalDecision::Approved),
                 keep_until: chrono::Utc::now() - chrono::Duration::seconds(1),
             },
         );
@@ -307,7 +268,7 @@ mod tests {
         store.register(entry).await.unwrap();
 
         assert_eq!(
-            store.resolve(&id, ApprovalDecision::Approved).await,
+            store.resolve(&id, ApprovalDecision::Approved.into()).await,
             Err(ResolveError::NotFound)
         );
         assert_eq!(store.decision(&id).await.unwrap(), None);

--- a/crates/aura/src/session_store/mod.rs
+++ b/crates/aura/src/session_store/mod.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::Stream;
 
-use crate::hitl::{ApprovalDecision, DecisionId, ParkedApproval, ResolveError};
+use crate::hitl::{DecisionId, ParkedApproval, ResolveError, ResolvedDecision};
 
 #[cfg(test)]
 pub(crate) use fault_store::FaultInjectingStore;
@@ -67,20 +67,22 @@ pub trait ApprovalStore: Send + Sync {
     /// Look up a parked approval.
     async fn get(&self, id: &DecisionId) -> Result<Option<ParkedApproval>, SessionStoreError>;
 
-    /// Record a terminal decision at most once per id; later attempts read
-    /// as `NotFound`. The file backend moves the ticket into its decision
+    /// Record a terminal decision — and the approver identity captured
+    /// alongside it, as one carrier — at most once per id; later attempts
+    /// read as `NotFound`. The file backend moves the ticket into its decision
     /// record, other backends drop it.
     async fn resolve(
         &self,
         id: &DecisionId,
-        decision: ApprovalDecision,
+        decision: ResolvedDecision,
     ) -> Result<(), ResolveError>;
 
-    /// Look up the decision recorded for an already-resolved approval.
+    /// Look up the decision recorded for an already-resolved approval,
+    /// carrying any captured identity with it.
     async fn decision(
         &self,
         id: &DecisionId,
-    ) -> Result<Option<ApprovalDecision>, SessionStoreError>;
+    ) -> Result<Option<ResolvedDecision>, SessionStoreError>;
 
     /// Remove a parked entry.
     async fn remove(&self, id: &DecisionId) -> Result<(), SessionStoreError>;

--- a/crates/aura/src/session_store/record.rs
+++ b/crates/aura/src/session_store/record.rs
@@ -11,19 +11,24 @@
 //!
 //! [`ApprovalStore`]: super::ApprovalStore
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::config::SessionId;
 use crate::hitl::{
-    AgentScope, ApprovalDecision, ApprovalItem, ApprovalOrigin, ApprovalRequest, DecisionId,
-    ParkedApproval, Timestamp,
+    AgentScope, ApprovalItem, ApprovalOrigin, ApprovalRequest, DecisionId, ParkedApproval,
+    ResolvedDecision, Timestamp,
 };
 use crate::orchestration::{RunId, TaskIdentity};
 
 /// Round-trippable storage form of a [`ParkedApproval`]. Field and tag names
 /// are a persisted contract shared by every instance reading the store — rename
 /// only with a migration.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Manual `Debug`: `egress_headers` values are credentials, so the rendered
+/// form carries names only.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ParkedApprovalRecord {
     pub version: u32,
     #[serde(default)]
@@ -35,6 +40,33 @@ pub struct ParkedApprovalRecord {
     pub items: Vec<ApprovalItem>,
     pub registered_at: Timestamp,
     pub expires_at: Timestamp,
+    /// Resolved egress headers the parked row's notify POST authenticates
+    /// with (lowercased name → value). Additive: absent on rows stored before
+    /// poll-delivery egress capture existed, decoding to `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub egress_headers: Option<BTreeMap<String, String>>,
+}
+
+/// The names of an optional pair map, for names-only Debug rendering.
+fn pair_names(pairs: &Option<BTreeMap<String, String>>) -> Option<Vec<&String>> {
+    pairs.as_ref().map(BTreeMap::keys).map(Iterator::collect)
+}
+
+impl std::fmt::Debug for ParkedApprovalRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ParkedApprovalRecord")
+            .field("version", &self.version)
+            .field("instance_id", &self.instance_id)
+            .field("decision_id", &self.decision_id)
+            .field("request_id", &self.request_id)
+            .field("scope", &self.scope)
+            .field("origin", &self.origin)
+            .field("items", &self.items)
+            .field("registered_at", &self.registered_at)
+            .field("expires_at", &self.expires_at)
+            .field("egress_header_names", &pair_names(&self.egress_headers))
+            .finish()
+    }
 }
 
 /// Storage form of [`AgentScope`].
@@ -71,37 +103,79 @@ pub enum OriginRecord {
     },
 }
 
-/// Storage form of a recorded [`ApprovalDecision`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Storage form of a recorded [`ResolvedDecision`]: the decision fields plus
+/// the approver identity captured at resolve time.
+///
+/// Manual `Debug`: identity values are credentials, so the rendered form
+/// carries names only.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DecisionRecord {
     pub approved: bool,
     pub reason: Option<String>,
     pub decided_at: Timestamp,
+    /// Approver identity captured off the poll-200 (lowercased outbound
+    /// header name → value), persisted in the same record as the decision.
+    /// Additive: absent on records stored before identity docking existed,
+    /// decoding to `None` (uncaptured).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<BTreeMap<String, String>>,
+}
+
+impl std::fmt::Debug for DecisionRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DecisionRecord")
+            .field("approved", &self.approved)
+            .field("reason", &self.reason)
+            .field("decided_at", &self.decided_at)
+            .field("identity_names", &pair_names(&self.identity))
+            .finish()
+    }
 }
 
 /// Stamps `decided_at` with the resolve time.
-impl From<&ApprovalDecision> for DecisionRecord {
-    fn from(decision: &ApprovalDecision) -> Self {
-        let (approved, reason) = match decision {
-            ApprovalDecision::Approved => (true, None),
-            ApprovalDecision::Denied { reason } => (false, reason.clone()),
+impl From<&ResolvedDecision> for DecisionRecord {
+    fn from(resolved: &ResolvedDecision) -> Self {
+        let (approved, reason, identity) = match resolved {
+            ResolvedDecision::Approved { identity } => (
+                true,
+                None,
+                identity
+                    .as_ref()
+                    .map(crate::approver_headers::ApproverHeaders::to_pair_map),
+            ),
+            ResolvedDecision::Denied { reason } => (false, reason.clone(), None),
         };
         Self {
             approved,
             reason,
+            identity,
             decided_at: chrono::Utc::now(),
         }
     }
 }
 
-impl From<DecisionRecord> for ApprovalDecision {
-    fn from(record: DecisionRecord) -> Self {
+impl TryFrom<DecisionRecord> for ResolvedDecision {
+    type Error = InvalidRecord;
+
+    fn try_from(record: DecisionRecord) -> Result<Self, Self::Error> {
         if record.approved {
-            ApprovalDecision::Approved
+            let identity = match record.identity {
+                Some(pairs) => Some(
+                    crate::approver_headers::ApproverHeaders::from_pairs(pairs).map_err(
+                        |reason| InvalidRecord {
+                            reason: format!("stored approver identity: {reason}"),
+                        },
+                    )?,
+                ),
+                None => None,
+            };
+            Ok(ResolvedDecision::approved(identity))
         } else {
-            ApprovalDecision::Denied {
+            // A denial never captures identity; a stored one would be a
+            // record no production path wrote.
+            Ok(ResolvedDecision::Denied {
                 reason: record.reason,
-            }
+            })
         }
     }
 }
@@ -126,6 +200,10 @@ impl From<&ParkedApproval> for ParkedApprovalRecord {
             items: request.items.clone(),
             registered_at: parked.registered_at,
             expires_at: parked.expires_at,
+            egress_headers: parked
+                .egress_headers
+                .as_ref()
+                .map(crate::webhook_utils::header_map_to_pairs),
         }
     }
 }
@@ -134,6 +212,14 @@ impl TryFrom<ParkedApprovalRecord> for ParkedApproval {
     type Error = InvalidRecord;
 
     fn try_from(record: ParkedApprovalRecord) -> Result<Self, Self::Error> {
+        let egress_headers = match record.egress_headers {
+            Some(pairs) => Some(crate::webhook_utils::pairs_to_header_map(pairs).map_err(
+                |reason| InvalidRecord {
+                    reason: format!("stored egress headers: {reason}"),
+                },
+            )?),
+            None => None,
+        };
         Ok(Self {
             request: ApprovalRequest {
                 version: record.version,
@@ -146,6 +232,7 @@ impl TryFrom<ParkedApprovalRecord> for ParkedApproval {
             },
             registered_at: record.registered_at,
             expires_at: record.expires_at,
+            egress_headers,
         })
     }
 }
@@ -262,6 +349,7 @@ mod tests {
             },
             registered_at: now,
             expires_at: now + chrono::Duration::seconds(60),
+            egress_headers: None,
         }
     }
 
@@ -338,5 +426,220 @@ mod tests {
         };
         let err = AgentScope::try_from(scope).unwrap_err();
         assert!(err.reason.contains("not-a-uuid"));
+    }
+
+    fn pairs(values: &[(&str, &str)]) -> BTreeMap<String, String> {
+        values
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    /// Egress headers ride the parked record: new JSON decodes to the map,
+    /// restores to the domain, and round-trips.
+    #[test]
+    fn egress_headers_round_trip() {
+        let mut parked = parked(
+            AgentScope::Single { session_id: None },
+            ApprovalOrigin::ConfigGate {
+                matched_pattern: "kubectl_*".to_string(),
+                agent_name: "test-agent".to_string(),
+            },
+        );
+        parked.egress_headers = Some(
+            crate::webhook_utils::pairs_to_header_map(pairs(&[(
+                "authorization",
+                "Bearer from-request",
+            )]))
+            .unwrap(),
+        );
+
+        let record = ParkedApprovalRecord::from(&parked);
+        assert_eq!(
+            record.egress_headers.as_ref().unwrap(),
+            &pairs(&[("authorization", "Bearer from-request")]),
+        );
+
+        let json = serde_json::to_string(&record).unwrap();
+        let decoded: ParkedApprovalRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, record);
+        let restored = ParkedApproval::try_from(decoded).unwrap();
+        assert_eq!(
+            ParkedApprovalRecord::from(&restored),
+            ParkedApprovalRecord::from(&parked),
+        );
+    }
+
+    /// A row stored before egress capture existed (no `egress_headers` key)
+    /// decodes with `None`: absence means no captured values, never a decode
+    /// failure.
+    #[test]
+    fn legacy_row_without_egress_headers_is_readable() {
+        let legacy_json = r#"{
+            "version": 1,
+            "instance_id": "test-instance",
+            "decision_id": "0191e8c0-1111-7000-8000-000000000001",
+            "request_id": "req-legacy",
+            "scope": { "kind": "single", "session_id": null },
+            "origin": { "kind": "config_gate", "matched_pattern": "kubectl_*", "agent_name": "t" },
+            "items": [],
+            "registered_at": "2026-08-01T00:00:00Z",
+            "expires_at": "2026-08-01T01:00:00Z"
+        }"#;
+
+        let record: ParkedApprovalRecord = serde_json::from_str(legacy_json).unwrap();
+        assert!(record.egress_headers.is_none());
+        let restored = ParkedApproval::try_from(record).unwrap();
+        assert!(restored.egress_headers.is_none());
+        // The old shape is also exactly what a legacy domain row serializes
+        // to (absent, not null).
+        let legacy_domain = ParkedApprovalRecord::from(&parked(
+            AgentScope::Single { session_id: None },
+            ApprovalOrigin::ConfigGate {
+                matched_pattern: "kubectl_*".to_string(),
+                agent_name: "t".to_string(),
+            },
+        ));
+        assert!(
+            !serde_json::to_value(&legacy_domain)
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .contains_key("egress_headers"),
+            "a row with no egress headers must serialize without the key"
+        );
+    }
+
+    /// The record's Debug is a names-only surface: egress values are
+    /// credentials and never render.
+    #[test]
+    fn parked_record_debug_prints_names_not_values() {
+        let mut parked = parked(
+            AgentScope::Single { session_id: None },
+            ApprovalOrigin::ConfigGate {
+                matched_pattern: "kubectl_*".to_string(),
+                agent_name: "test-agent".to_string(),
+            },
+        );
+        parked.egress_headers = Some(
+            crate::webhook_utils::pairs_to_header_map(pairs(&[(
+                "authorization",
+                "Bearer sentinel-egress",
+            )]))
+            .unwrap(),
+        );
+        let rendered = format!("{:?}", ParkedApprovalRecord::from(&parked));
+        assert!(
+            rendered.contains("authorization"),
+            "names render for audit: {rendered}"
+        );
+        assert!(
+            !rendered.contains("sentinel-egress"),
+            "values must never render: {rendered}"
+        );
+    }
+
+    /// The decision record carries identity in the SAME record; the identity
+    /// round-trips through JSON into the carrier.
+    #[test]
+    fn decision_record_round_trips_identity() {
+        let identity = crate::approver_headers::ApproverHeaders::from_pairs(pairs(&[(
+            "x-forwarded-user",
+            "approver-alice",
+        )]))
+        .unwrap();
+        let resolved = ResolvedDecision::approved(Some(identity));
+
+        let record = DecisionRecord::from(&resolved);
+        assert_eq!(
+            record.identity.as_ref().unwrap(),
+            &pairs(&[("x-forwarded-user", "approver-alice")]),
+        );
+        let json = serde_json::to_string(&record).unwrap();
+        let decoded: DecisionRecord = serde_json::from_str(&json).unwrap();
+        let restored = ResolvedDecision::try_from(decoded).unwrap();
+        assert_eq!(restored, resolved, "identity and decision survive storage");
+    }
+
+    /// A decision record stored before identity docking existed (no
+    /// `identity` key) decodes as an uncaptured approval, and a denial never
+    /// carries identity in either direction.
+    #[test]
+    fn legacy_decision_record_and_denials_are_uncaptured() {
+        let legacy_json =
+            r#"{"approved": true, "reason": null, "decided_at": "2026-08-01T00:00:00Z"}"#;
+        let record: DecisionRecord = serde_json::from_str(legacy_json).unwrap();
+        let restored = ResolvedDecision::try_from(record).unwrap();
+        assert_eq!(
+            restored,
+            ResolvedDecision::approved(None),
+            "absence means uncaptured"
+        );
+
+        let denied = ResolvedDecision::Denied {
+            reason: Some("no".to_string()),
+        };
+        let record = DecisionRecord::from(&denied);
+        assert!(
+            record.identity.is_none(),
+            "a denial never captures identity"
+        );
+        assert_eq!(
+            ResolvedDecision::try_from(record).unwrap(),
+            denied,
+            "a denial round-trips without an identity half",
+        );
+    }
+
+    /// The decision record's Debug is a names-only surface.
+    #[test]
+    fn decision_record_debug_prints_names_not_values() {
+        let identity = crate::approver_headers::ApproverHeaders::from_pairs(pairs(&[(
+            "x-forwarded-user",
+            "approver-alice",
+        )]))
+        .unwrap();
+        let record = DecisionRecord::from(&ResolvedDecision::approved(Some(identity)));
+        let rendered = format!("{record:?}");
+        assert!(
+            rendered.contains("x-forwarded-user"),
+            "names render: {rendered}"
+        );
+        assert!(
+            !rendered.contains("approver-alice"),
+            "identity values must never render: {rendered}"
+        );
+    }
+
+    /// The carrier's Debug is a names-only surface.
+    #[test]
+    fn resolved_decision_debug_prints_names_not_values() {
+        let identity = crate::approver_headers::ApproverHeaders::from_pairs(pairs(&[(
+            "x-forwarded-user",
+            "approver-carol",
+        )]))
+        .unwrap();
+        let rendered = format!("{:?}", ResolvedDecision::approved(Some(identity)));
+        assert!(
+            rendered.contains("x-forwarded-user"),
+            "names render: {rendered}"
+        );
+        assert!(
+            !rendered.contains("approver-carol"),
+            "identity values must never render: {rendered}"
+        );
+    }
+
+    /// A stored pair whose value fails `HeaderValue` validation decodes
+    /// fail-loud rather than as a partial map.
+    #[test]
+    fn corrupt_pair_is_rejected_fail_loud() {
+        let err =
+            crate::webhook_utils::pairs_to_header_map(pairs(&[("authorization", "sentinel\nbad")]))
+                .expect_err("a control character in a header value is corrupt");
+        assert!(
+            err.to_string().contains("is not a valid header value"),
+            "error names the corrupt value: {err}"
+        );
     }
 }

--- a/crates/aura/src/webhook_utils.rs
+++ b/crates/aura/src/webhook_utils.rs
@@ -55,7 +55,10 @@ pub fn resolve_headers(
             HeaderName::from_bytes(key.as_bytes()),
             HeaderValue::from_str(value),
         ) {
-            (Ok(name), Ok(val)) => {
+            // `HeaderValue::from_str` admits bytes above 0x7F, but the
+            // resolved map is also persisted as text, so a value outside
+            // visible ASCII is skipped like any other invalid header.
+            (Ok(name), Ok(val)) if val.to_str().is_ok() => {
                 header_map.insert(name, val);
             }
             _ => {
@@ -64,6 +67,55 @@ pub fn resolve_headers(
         }
     }
     header_map
+}
+
+/// Capture failure for poll-delivery egress at rest: a `headers_from_request`
+/// destination with no usable resolved value — its request header was absent
+/// and its static fallback is absent or invalid.
+///
+/// The `names` payload is the audit signal: the mapped destination NAMES,
+/// sorted, never a value.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("webhook egress capture failed: no usable value for mapped headers {names:?}")]
+pub struct EgressCaptureError {
+    names: Vec<String>,
+}
+
+impl EgressCaptureError {
+    pub(crate) fn new(mut names: Vec<String>) -> Self {
+        // Sorted so one failing resolution always renders the same audit string.
+        names.sort_unstable();
+        Self { names }
+    }
+
+    /// The mapped destination names with no usable resolved value, sorted.
+    #[must_use]
+    pub fn missing_names(&self) -> &[String] {
+        &self.names
+    }
+}
+
+/// The strict egress check behind the park arm's registration-closed rule:
+/// every `headers_from_request` destination must appear in `resolved` with a
+/// valid header value. `resolve_headers` skips invalid entries with a warning,
+/// so presence in the resolved map is exactly "a usable resolved value" —
+/// from the request itself or from a valid static fallback (whose existing
+/// resolution semantics this check preserves). A map with no `headers_from_request`
+/// destinations always passes.
+pub fn check_egress_capture(
+    resolved: &HeaderMap,
+    headers_from_request: &HashMap<String, String>,
+) -> Result<(), EgressCaptureError> {
+    let missing: Vec<String> = headers_from_request
+        .keys()
+        .map(|destination| destination.to_lowercase())
+        .filter(|destination| !resolved.contains_key(destination))
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(EgressCaptureError::new(missing))
+    }
 }
 
 /// Build a [`WebhookHmac`] from an operator-configured secret string.
@@ -79,4 +131,160 @@ pub fn build_hmac_from_secret(secret: Option<&str>) -> Result<Option<WebhookHmac
     let primary = PrimarySecret::new(secret.as_bytes());
     let hmac = WebhookHmac::new(primary, None, Tolerance::default())?;
     Ok(Some(hmac))
+}
+
+/// Header pairs as a storage projection: (lowercased name, value) strings.
+/// Every producer of a persisted map keeps values to visible ASCII
+/// (`resolve_headers` skips anything else, `ApproverHeaders::from_captured`
+/// and `pairs_to_header_map` reject it), so `to_str` cannot fail here.
+pub(crate) fn header_map_to_pairs(
+    headers: &reqwest::header::HeaderMap,
+) -> std::collections::BTreeMap<String, String> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.as_str().to_owned(),
+                value
+                    .to_str()
+                    .expect("header values are visible ASCII")
+                    .to_owned(),
+            )
+        })
+        .collect()
+}
+
+/// Restore a header map from its storage pairs: every pair must be a valid
+/// header, so a corrupted record fails the decode instead of dropping the
+/// credential.
+pub(crate) fn pairs_to_header_map(
+    pairs: impl IntoIterator<Item = (String, String)>,
+) -> Result<reqwest::header::HeaderMap, String> {
+    use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+    let mut map = HeaderMap::new();
+    for (name, value) in pairs {
+        let name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|e| format!("invalid header name '{name}': {e}"))?;
+        let value = HeaderValue::from_str(&value)
+            .ok()
+            .filter(|value| value.to_str().is_ok())
+            .ok_or_else(|| {
+                format!("header value for '{name}' is not a valid header value (visible ASCII)")
+            })?;
+        map.insert(name, value);
+    }
+    Ok(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn missing_mapped_destination_fails_capture_with_names_only() {
+        let static_headers = HashMap::new();
+        let mapped = headers(&[
+            ("authorization", "x-incoming-auth"),
+            ("x-tenant", "x-tenant-id"),
+        ]);
+        // Only one of the two mapped sources arrives.
+        let req = headers(&[("x-tenant-id", "acme")]);
+
+        let err = check_egress_capture(
+            &resolve_headers(&static_headers, &mapped, Some(&req)),
+            &mapped,
+        )
+        .expect_err("a mapped destination with no usable value must fail capture");
+
+        assert_eq!(
+            err.missing_names(),
+            ["authorization".to_string()],
+            "the failing destination is named, sorted",
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("authorization"),
+            "the audit message must name the destination: {message}"
+        );
+        // No value anywhere in the message — names are the audit surface.
+        assert!(!message.contains("acme"), "message was: {message}");
+    }
+
+    /// An explicit static fallback keeps the existing resolution semantics:
+    /// an absent request header resolves to the static value, and capture
+    /// passes.
+    #[test]
+    fn static_fallback_satisfies_the_capture() {
+        let static_headers = headers(&[("authorization", "static-token")]);
+        let mapped = headers(&[("authorization", "x-incoming-auth")]);
+        let req = HashMap::new();
+
+        let resolved = resolve_headers(&static_headers, &mapped, Some(&req));
+        check_egress_capture(&resolved, &mapped)
+            .expect("a valid static fallback keeps resolution semantics");
+        assert_eq!(resolved.get("authorization").unwrap(), "static-token");
+    }
+
+    #[test]
+    fn present_request_header_satisfies_the_capture() {
+        let static_headers = HashMap::new();
+        let mapped = headers(&[("authorization", "x-incoming-auth")]);
+        let req = headers(&[("x-incoming-auth", "Bearer dynamic")]);
+
+        let resolved = resolve_headers(&static_headers, &mapped, Some(&req));
+        check_egress_capture(&resolved, &mapped).expect("a present mapped request header captures");
+        assert_eq!(resolved.get("authorization").unwrap(), "Bearer dynamic");
+    }
+
+    /// An invalid static fallback value is not usable: the mapped
+    /// destination ends up missing from the resolved map and capture fails.
+    #[test]
+    fn invalid_static_fallback_fails_capture() {
+        let static_headers = headers(&[("x-bad", "bad\r\nvalue")]);
+        let mapped = headers(&[("x-bad", "x-source")]);
+
+        let err = check_egress_capture(&resolve_headers(&static_headers, &mapped, None), &mapped)
+            .expect_err("an invalid fallback value is not a usable resolved value");
+        assert_eq!(err.missing_names(), ["x-bad".to_string()]);
+    }
+
+    #[test]
+    fn no_mapped_headers_never_fails() {
+        let resolved = resolve_headers(&headers(&[("x-static", "v")]), &HashMap::new(), None);
+        check_egress_capture(&resolved, &HashMap::new())
+            .expect("with nothing mapped there is nothing to fail");
+    }
+
+    /// A request header value outside visible ASCII is admitted by
+    /// `HeaderValue::from_str` but cannot be persisted as text, so
+    /// resolution skips it like any other invalid header.
+    #[test]
+    fn resolve_headers_skips_a_non_ascii_value() {
+        let resolved = resolve_headers(
+            &headers(&[("x-static", "caf\u{e9}"), ("x-ok", "plain")]),
+            &HashMap::new(),
+            None,
+        );
+        assert!(
+            resolved.get("x-static").is_none(),
+            "non-ASCII value skipped"
+        );
+        assert_eq!(resolved.get("x-ok").unwrap(), "plain");
+    }
+
+    /// Restoring a stored pair whose value is outside visible ASCII fails
+    /// the decode instead of producing a map the projection cannot render.
+    #[test]
+    fn pairs_to_header_map_rejects_a_non_ascii_value() {
+        let err = pairs_to_header_map([("x-tenant".to_string(), "caf\u{e9}".to_string())])
+            .expect_err("a non-ASCII value must fail the restore");
+        assert!(err.contains("x-tenant") && !err.contains("caf"), "{err}");
+    }
 }

--- a/docs/adr/2026-08-13-approver-identity-forwarding.md
+++ b/docs/adr/2026-08-13-approver-identity-forwarding.md
@@ -124,6 +124,64 @@ approver header forwarding section.
   never forwards identity either, so the two approval surfaces are not
   symmetric.
 
+## Amendment (2026-09-08): the at-rest posture for poll delivery
+
+The async-webhook poll-delivery route changed the persistence picture this ADR's
+original decision assumed. The sync route captured identity in-process and
+consumed it on the very next tool call - nothing outlived the request. Under
+poll delivery the approval parks durably, a background reconciler POSTs the
+notification, and the decision may return minutes later on a polled status
+read, across a restart. Two new surfaces carry credentials at rest, and both
+follow the same posture as the original decision: values live only in the
+session store and on the wire of the one request they authenticate; events,
+logs, errors, and Debug carry names only; the parked checkpoint document
+carries neither.
+
+Addendum (2026-09-10). Each value's lifetime is bounded by its last use:
+egress headers leave the record at `resolve` (a decided id is never notified
+again), expired undecided rows are unlinked by the poll scan, and a resume
+removes the decision envelopes it consumed on every park-capable route. The
+file backend creates store files and parked documents owner-only, and a
+transport error renders without the webhook URL, which may embed a token.
+
+**Egress values ride the parked approval record.** The webhook route's
+`headers_from_request` mappings resolve at request-scoped runtime
+construction (where the route is built per request - the park arm never
+sees the client request), and the resolved values are copied onto the
+parked approval row before `register_durable`. The reconciler applies the
+row's own headers to each notify POST as a per-row override, never as
+client state: two approvals parked under two different requests keep
+authenticating with their own credentials on every retry, including
+after a store reopen.
+
+**Capture failure closes the registration.** A mapped destination with no
+usable resolved value - its request header absent and no explicit valid
+static fallback - produces no approval row, no pending event, no
+blocked-cell entry, and no notify POST. This is deliberately stricter than
+the identity half of this ADR: notify is egress *auth* with no later reify
+checkpoint to fail at, so an undeliverable registration must not exist. The
+static-fallback exception preserves the pre-existing resolution semantics:
+an explicitly configured static value keeps the registration open and
+parks with it.
+
+**Identity rides the decision record, record-then-block.** The poll-200's
+response headers dock onto the DECISION record through an
+identity-preserving carrier (`ResolvedDecision`): decision and optional
+identity persist in the same resolve - the redis backend's atomic Lua
+script writes both in one record, so concurrent resolvers can never
+separate them. The decision bus publishes only the credential-free
+decision; the wake and the lifecycle events see no identity. Capture
+failure at the poll-200 records the decision WITHOUT identity; re-execution
+applies the recorded identity at the same apply point as the sync gate
+(the `Proceed.overrides` seam), and blocks the approved call closed when
+the route's mapping demands identity and the recorded approval carries
+none. Redacted `Debug` carriers are mandatory on every new carrier (the
+`ApproverHeaders` precedent): `PollOutcome`'s response headers and both
+storage records print names only.
+
+Mechanism detail: [docs/design/hitl.md](../design/hitl.md), the storage
+records section.
+
 ## Links
 
 - Design and implementation note: [docs/design/hitl.md](../design/hitl.md)

--- a/docs/design/hitl.md
+++ b/docs/design/hitl.md
@@ -220,12 +220,28 @@ pub struct ParkedApproval {
                                              //   origin, items -- the full payload
     pub registered_at: Timestamp,
     pub expires_at: Timestamp,
+    pub egress_headers: Option<HeaderMap>,   // poll delivery: resolved webhook headers
+                                             //   captured at request-scoped route
+                                             //   construction; the reconciler's notify
+                                             //   authenticates with the row's own values
 }
 
 impl PendingApprovals {
-    pub fn register(&self, request: ApprovalRequest, timeout: Duration) -> AwaitingDecision;
-    pub fn resolve(&self, id: &DecisionId, d: ApprovalDecision) -> Result<(), ResolveError>;
-    pub fn cancel_request(&self, request_id: &RequestId);
+    pub async fn register(&self, request: ApprovalRequest, timeout: Duration) -> AwaitingDecision;
+    pub async fn register_durable(&self, parked: ParkedApproval) -> Result<(), SessionStoreError>;
+    pub async fn resolve(&self, id: &DecisionId, d: ResolvedDecision) -> Result<(), ResolveError>;
+    pub async fn recorded_decision(&self, id: &DecisionId) -> Option<ResolvedDecision>;
+    pub async fn cancel_request(&self, request_id: &str) -> Vec<ParkedApproval>;
+}
+
+// decision.rs -- the identity-preserving resolve carrier: decision and
+// captured approver identity move as one unit through resolve, the store
+// read-back, and RecordedDecisions. Identity exists only on an approval, so
+// the pairing is the enum, not two parallel Options. The decision bus
+// publishes only `carrier.decision()` -- never identity.
+pub enum ResolvedDecision {
+    Approved { identity: Option<ApproverHeaders> },
+    Denied { reason: Option<String> },
 }
 
 // route.rs -- closed two-variant enum. The spike's ApprovalDispatch trait is
@@ -246,6 +262,70 @@ durable version slots in behind the same type.
 `ApprovalRequest.request_id` is the global request id (the one used for SSE
 routing and MCP cancellation). The spike's two per-call `Uuid::new_v4()` sites
 (`crates/aura/src/hitl.rs:402`, `:534` on `52f37e6`) are deleted.
+
+## Storage records: egress at rest and identity docking
+
+Poll delivery parks approvals durably, so two credential surfaces outlive the
+request that captured them. Both records are additive-serde: a row or decision
+stored before the field existed decodes with `None` - absence means
+uncaptured, never fabricated - and both records implement **manual `Debug`
+that prints header NAMES only**, never values (the `ApproverHeaders`
+precedent; `PollOutcome`'s raw response headers carry the same redaction).
+
+### Parked approval record: egress headers at rest
+
+`ParkedApprovalRecord.egress_headers: Option<BTreeMap<String, String>>`
+(lowercased outbound name → value). The resolved `headers_from_request`
+overlay is captured at **request-scoped runtime construction** - where the
+route is built per request (`webhook_utils::resolve_headers`; the park arm
+never sees the client request) - and copied onto the row **before
+`register_durable`**. The reconciler applies the row's own headers to each
+notify POST as a per-name overlay on the shared client's operator headers:
+per-row override, not client state, so two rows authenticate with their own
+credentials on every retry and after a store reopen.
+
+At rest, the file backend creates rows, decision envelopes, and parked
+documents owner-only (0600 files in 0700 directories). `resolve` writes the
+decision envelope without the row's egress headers, `list_pending` unlinks
+expired undecided rows, and a resume removes the envelopes it consumed. Redis
+rows carry a TTL of the remaining decision window instead.
+
+Registration-closed semantics: a mapped destination with no usable resolved
+value (request header absent, no explicit valid static fallback) fails the
+capture at route construction, and the park arm fails the gated call closed —
+no approval row, no pending event, no blocked-cell entry, no notify POST.
+Notify is egress auth with no later reify checkpoint, so an undeliverable
+registration must not exist. The exception: an explicitly configured **valid
+static fallback** keeps the existing resolution semantics and parks with the
+static value. This is `webhook_utils::check_egress_capture`'s verdict, stored
+on the route at construction and consulted by the park arm.
+
+### Decision record: identity in the same resolve
+
+`DecisionRecord.identity: Option<BTreeMap<String, String>>`, present only on
+approvals. Identity is captured off the poll-200's `tool_headers_from_response`
+mappings by the same `ApproverHeaders::from_captured` the sync gate uses, and
+persists **in the SAME resolve** as the decision: the record is one JSON
+document, and the redis backend's atomic Lua script writes it in one SET, so
+concurrent resolvers can never split the pair. The decision bus publishes only
+the credential-free `ApprovalDecision`; the wake, the events, and every log
+line see no identity.
+
+Capture failure at the poll-200 is NOT a channel error: the decision records
+without identity (a warn names the missing headers). At re-execution the
+resume gate maps the recorded carrier onto the same apply point as the sync
+gate - `PreCallOutcome::Proceed { overrides }` - and **blocks the approved
+call closed** when the route's mapping demands identity and the recorded
+approval carries none. That asymmetry is deliberate: a decision is human
+intent worth keeping; an unauthenticated egress registration is not.
+
+### Carrier
+
+`ResolvedDecision` (`hitl::decision`) is the storage/domain carrier every
+decision-bearing API moves as a unit: `ApprovalStore::resolve`/`decision`,
+`PendingApprovals::resolve`/`recorded_decision`, and `RecordedDecisions`.
+`ApprovalDecision` alone survives only where identity has no meaning: the bus
+payload, the conversational wake, and the projected outcomes.
 
 ## Where cross-request state lives
 

--- a/docs/design/session-storage.md
+++ b/docs/design/session-storage.md
@@ -24,7 +24,13 @@ feature, and `RedisSessionStore`/`RedisTaskStore`
 event bus) is implemented:** `RedisApprovalStore` persists approvals as
 `ParkedApprovalRecord` (`aura::session_store::record`, the round-trippable storage
 projection — the domain types stay deliberately unserializable), and
-`RedisEventBus` carries decision wakes over pub/sub (§6.1). **Phase 4 (A2A
+`RedisEventBus` carries decision wakes over pub/sub (§6.1). Both storage
+records carry optional at-rest fields: resolved egress
+header values on `ParkedApprovalRecord` (poll delivery) and approver
+identity on `DecisionRecord` - additive serde (absence = uncaptured), with
+names-only `Debug` on both so no header value reaches logs (ADR
+`2026-08-13-approver-identity-forwarding.md`, `design/hitl.md` "Storage
+records"). **Phase 4 (A2A
 streaming/cancel over the bus) is implemented:** `BusBridgedExecutor` and the
 `subscribe_to_task` bus relay (`crates/aura-web-server/src/a2a/bus_bridge.rs`,
 §6.2) fan execution events out over `a2a:task:{id}` and route cancels over


### PR DESCRIPTION
Third of four. Routes webhook-poll approvals through the park path and persists what the reconciler needs after a restart; the mode is still off.

What changes:

- `DecisionRoute` gains a `park_registry()` accessor, present for the conversational and webhook-poll routes and absent for webhook-sync. The park guard, `park_enabled`, the park route gate, and the pre-call gate use it instead of matching on the conversational route. Two fixes fall out: decided approvals are removed after resume on any park route, and a worker that dies before its snapshot cancels its parked approvals on any park route rather than only the conversational one.
- The parked approval record carries the resolved `headers_from_request` values captured when the request came in, so the reconciler sends each notify with the row's own headers. A mapped header with no usable value and no static fallback fails the registration closed, and a value outside visible ASCII counts as unusable, since the values are persisted as text.
- The decision record carries optional approver identity. It travels on a new `ResolvedDecision` carrier through `ApprovalStore::resolve` and `ApprovalStore::decision`, the registry, and the recorded decisions; the decision bus still publishes only the credential-free decision. Both new record fields have serde defaults, and records written by current builds still decode.
- Where credentials live at rest. The egress headers sit on the undecided approval row and are cleared from the decision envelope at resolve, because a decided id is never notified again. Approver identity sits on the decision record from resolve onward. On disk both are 0600 files in 0700 directories (from the first PR); expired file rows are unlinked by the pending scan, while Redis rows expire through a TTL equal to the remaining decision window. `Debug` on both records prints header names only.
- There is one change to the conversational park path too. A call decided between the gate hit and the checkpoint commit is kept in the checkpoint and consumed at resume, where it used to be dropped. It costs one recorded-decision read per pending call on the commit path.
- The webhook config fingerprint gains `delivery`.
- `docs/design/hitl.md`, `docs/design/session-storage.md`, and `docs/adr/2026-08-13-approver-identity-forwarding.md` record the same lifetime.

Everything except the switch that turns the mode on is now in place.

Tested with file and Redis store contract tests for both new fields and the cleared envelope, legacy-record decode tests, the status-envelope matrix (all three statuses with absent, null, and string reasons, plus unknown-status rejection), registry and route unit tests, and tests for the two park-route fixes. Redis tests ran against a local Valkey; the header-forwarding integration suite ran against mock-mcp.

Stack: based on `mshearer/271-poll-protocol`. Next: `feature/aura-next-271-poll-delivery`.
