### PR TITLE
fix(ci): keep channel branches from releasing off a stale baseline

### DIFF
--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -9,6 +9,13 @@ on:
     # GitHub runs schedule and workflow_dispatch only from the default
     # branch, so this file has no effect until it is on main.
     - cron: "41 */6 * * *"
+  # semantic-release pushes the version commit and tag before it publishes the
+  # release, so main is complete by the time this fires. The schedule alone
+  # would leave the channels numbering themselves below the new stable version
+  # for up to six hours. `released` skips beta's prereleases, which do not
+  # move main.
+  release:
+    types: [released]
   workflow_dispatch:
     inputs:
       target:
@@ -47,7 +54,9 @@ jobs:
           # so neither the CLA check nor pr-target-branch runs on it. Jenkins
           # runs off webhooks and is unaffected.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
+          # `gh pr` resolves the repository from the local git remote, and this
+          # job has no checkout. It also supplies {owner}/{repo} to `gh api`.
+          GH_REPO: ${{ github.repository }}
           TARGET: ${{ matrix.target }}
           REQUESTED: ${{ github.event.inputs.target || 'all' }}
           DESIGN_DOC: "https://github.com/mezmo/aura/blob/main/docs/design/release-channels.md"
@@ -63,14 +72,14 @@ jobs:
           # inline would read a network or auth error as a missing branch and
           # report a green no-op. Exact name match, because a ref pattern also
           # matches refs/heads/hotfix/$TARGET.
-          branches="$(gh api "repos/${REPO}/branches?per_page=100" --paginate --jq '.[].name')"
+          branches="$(gh api "repos/{owner}/{repo}/branches?per_page=100" --paginate --jq '.[].name')"
           if ! printf '%s\n' "$branches" | grep -Fxq "$TARGET"; then
             echo "No $TARGET branch on the remote; nothing to sync."
             exit 0
           fi
 
           # compare/{base}...{head} reports head's position relative to base.
-          compare() { gh api "repos/${REPO}/compare/${1}...${2}" --jq .status; }
+          compare() { gh api "repos/{owner}/{repo}/compare/${1}...${2}" --jq .status; }
 
           position="$(compare "$TARGET" main)"
           if [ "$position" = "identical" ] || [ "$position" = "behind" ]; then
@@ -90,43 +99,81 @@ jobs:
           fi
 
           sync_branch="sync/main-to-${TARGET}"
-          MAIN_SHA="$(gh api "repos/${REPO}/commits/main" --jq .sha)"
+
+          # The branch should be nothing but a pointer at main, so its position
+          # relative to main decides everything below. Commits main does not
+          # have are someone's reconciliation work — conflict resolutions
+          # pushed onto an open pull request, most likely — and outrank any
+          # conclusion drawn from pull request state.
+          #
+          # Assigned first so a failed compare fails the job. As a `case` word
+          # the same substitution would fall through to the default arm and
+          # force-push over that work.
+          if printf '%s\n' "$branches" | grep -Fxq "$sync_branch"; then
+            position="$(compare main "$sync_branch")"
+            case "$position" in
+              ahead|diverged)
+                echo "${sync_branch} carries commits main does not; leaving it alone."
+                exit 0 ;;
+              identical) action=current ;;
+              behind)    action=move ;;
+              *)
+                echo "unexpected compare status for ${sync_branch}: ${position}" >&2
+                exit 1 ;;
+            esac
+          else
+            action=create
+          fi
+
+          MAIN_SHA="$(gh api "repos/{owner}/{repo}/commits/main" --jq .sha)"
           export MAIN_SHA
 
-          # An open pull request may carry conflict resolutions pushed by a
-          # maintainer, so the branch is left exactly as it is.
           open_pr="$(gh pr list --head "$sync_branch" --base "$TARGET" \
             --state open --json number --jq '.[0].number // empty')"
-          if [ -n "$open_pr" ]; then
-            echo "Pull request #${open_pr} is open; leaving ${sync_branch} untouched."
-            exit 0
-          fi
 
           # A closed pull request at this exact tip was already answered,
           # whether declined or squash-merged. Reopening it every six hours
-          # would argue with the person who closed it.
-          settled="$(gh pr list --head "$sync_branch" --base "$TARGET" --state all \
-            --json number,headRefOid \
-            --jq '[.[] | select(.headRefOid == env.MAIN_SHA)] | .[0].number // empty')"
-          if [ -n "$settled" ]; then
-            echo "Pull request #${settled} already covered main at ${MAIN_SHA}; not reopening."
-            exit 0
-          fi
-
-          # The branch should be nothing but a pointer at main. Commits main
-          # does not have are someone's reconciliation work, which outranks
-          # any conclusion drawn from pull request state above.
-          if printf '%s\n' "$branches" | grep -Fxq "$sync_branch"; then
-            drift="$(compare main "$sync_branch")"
-            if [ "$drift" = "ahead" ] || [ "$drift" = "diverged" ]; then
-              echo "${sync_branch} carries commits main does not; leaving it alone."
+          # would argue with the person who closed it. An open one is moved
+          # forward instead, so it always proposes the whole of main.
+          if [ -z "$open_pr" ]; then
+            settled="$(gh pr list --head "$sync_branch" --base "$TARGET" --state all \
+              --json number,headRefOid \
+              --jq '[.[] | select(.headRefOid == env.MAIN_SHA)] | .[0].number // empty')"
+            if [ -n "$settled" ]; then
+              echo "Pull request #${settled} already covered main at ${MAIN_SHA}; not reopening."
               exit 0
             fi
-            gh api -X PATCH "repos/${REPO}/git/refs/heads/${sync_branch}" \
-              -f "sha=${MAIN_SHA}" -F force=true --silent
-          else
-            gh api -X POST "repos/${REPO}/git/refs" \
-              -f "ref=refs/heads/${sync_branch}" -f "sha=${MAIN_SHA}" --silent
+          fi
+
+          # `current` needs no call — the branch already points at main.
+          case "$action" in
+            create)
+              gh api -X POST "repos/{owner}/{repo}/git/refs" \
+                -f "ref=refs/heads/${sync_branch}" -f "sha=${MAIN_SHA}" --silent ;;
+            move)
+              # Unforced, so the update is a fast-forward or nothing. Moving a
+              # branch that is behind main is a fast-forward; a commit pushed
+              # since the compare above is not, and fails here instead of being
+              # discarded. That closes the window between the two.
+              if ! gh api -X PATCH "repos/{owner}/{repo}/git/refs/heads/${sync_branch}" \
+                  -f "sha=${MAIN_SHA}" --silent; then
+                recheck="$(compare main "$sync_branch")"
+                if [ "$recheck" != "behind" ]; then
+                  echo "${sync_branch} moved while this ran; leaving it alone."
+                  exit 0
+                fi
+                echo "could not move ${sync_branch} to ${MAIN_SHA}" >&2
+                exit 1
+              fi ;;
+          esac
+
+          if [ -n "$open_pr" ]; then
+            if [ "$action" = current ]; then
+              echo "Pull request #${open_pr} already covers main at ${MAIN_SHA}."
+            else
+              echo "Moved ${sync_branch} to ${MAIN_SHA}; pull request #${open_pr} covers it."
+            fi
+            exit 0
           fi
 
           # shellcheck disable=SC2016  # backticks are markdown, not expansions
@@ -144,8 +191,10 @@ jobs:
             'Merging into `beta` changes the release candidate, so a new beta has to be' \
             'validated before promotion.' \
             '' \
-            'Opened by a workflow, so GitHub Actions checks do not start on it. Closing' \
-            'this pull request is respected — it is not reopened unless `main` advances.' \
+            'Opened by a workflow, so GitHub Actions checks do not start on it. While' \
+            'this pull request stays open it is moved forward as `main` advances, unless' \
+            'it carries commits `main` does not. Closing it is respected — it is not' \
+            'reopened unless `main` advances.' \
             '' \
             "See [docs/design/release-channels.md](${DESIGN_DOC})." \
             > "${RUNNER_TEMP}/sync-body.md"

--- a/.makefiles/scripts.mk
+++ b/.makefiles/scripts.mk
@@ -1,0 +1,5 @@
+test:: test-scripts
+
+.PHONY: test-scripts
+test-scripts: ## Run the shell script test suites in scripts/tests
+	@for t in scripts/tests/*.test.sh; do "$$t" || exit 1; done

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -492,6 +492,23 @@ pipeline {
                   returnStdout: true
                 ).trim()
               }
+
+              // Clearing the version skips every stage below. Exit 10 is the
+              // stale verdict; anything else non-zero means the check could
+              // not run and must not read as a release-worthy branch.
+              if (env.NEXT_RELEASE_VERSION && env.BRANCH_NAME != 'main') {
+                def baseline = sh(
+                  script: './scripts/check-release-baseline.sh',
+                  returnStatus: true
+                )
+                if (baseline == 10) {
+                  env.NEXT_RELEASE_VERSION = ''
+                  unstable("${env.BRANCH_NAME} is behind main's release tag; merge the sync pull request before releasing")
+                } else if (baseline != 0) {
+                  error("check-release-baseline.sh could not evaluate ${env.BRANCH_NAME} (exit ${baseline})")
+                }
+              }
+
               echo env.NEXT_RELEASE_VERSION ? "Release version: ${env.NEXT_RELEASE_VERSION}" : 'No release version determined; skipping build'
             }
           }

--- a/docs/design/release-channels.md
+++ b/docs/design/release-channels.md
@@ -14,7 +14,9 @@ administrative and remain outstanding.
 
 - Three `semantic-release` branches: permanent `main` (release → `X.Y.Z`) and
   `nightly` (prerelease `nightly`), plus a per-cycle `beta` (prerelease `beta`).
-  `nightly` and `beta` derive their base version from the last release on `main`.
+  `nightly` and `beta` derive their base version from the highest tag **reachable
+  from their own history**, so the `main →` back-merge is what advances them past
+  a stable release.
 - One `release.config.js` selects **plugins, exec commands, and Docker tags by
   channel**, derived from `BRANCH_NAME`. `semantic-release` computes the version and
   publishes; no versioning logic is hand-rolled.
@@ -185,10 +187,28 @@ The Cut commit must descend from the latest `main` tag; do not re-merge
 `nightly → beta` during a cycle (it would pull in features landed after the cut).
 
 `.github/workflows/sync-main.yml` proposes the `main →` back-merges as pull
-requests. It leaves an open one alone, respects a closed one, never overwrites
-a sync branch carrying commits `main` lacks, and skips `beta` once that branch
-is contained in `main`. Deleting `beta` and the Stabilize `beta → nightly`
-back-merge stay manual.
+requests, on a schedule and whenever a release is published. It moves an open
+one forward as `main` advances, respects a closed one, never overwrites a sync
+branch carrying commits `main` lacks, and skips `beta` once that branch is
+contained in `main`.
+Deleting `beta` and the Stabilize `beta → nightly` back-merge stay manual.
+
+**Sync is a release-correctness requirement.**
+`semantic-release` reads each branch's tags with `git tag --merged`, and
+`normalize.prerelease` takes the base version from that list alone — it never
+consults the release branch. A channel missing `main`'s release commit therefore
+keeps numbering from the tag before it: after `main` releases `0.2.17`, an
+unsynced `nightly` builds `0.2.17-nightly.1`, a prerelease of a shipped version,
+and the moving `nightly` tag lands on an image that sorts below `latest`. The
+tag rides the `[skip ci]` version commit, so a sync opened between the promotion
+merge and that commit carries `main`'s source without its tag and does not
+resolve this.
+
+`scripts/check-release-baseline.sh` is the backstop. The `Compute Release
+Version` stage runs it on `nightly` and `beta` and refuses to release a branch
+that cannot reach `main`'s latest release tag. Reachability rather than a
+version comparison, because a channel that takes a `feat` while behind
+computes a version above the stable release and would otherwise pass.
 
 `.github/workflows/pr-target-branch.yml` fails a pull request into `main` whose
 head is not `nightly`, `beta`, or `hotfix/*`. Both files have to exist on
@@ -289,6 +309,8 @@ Recovery rules:
   against the full channel branch list so a prerelease computes a prerelease version.
 - `scripts/bump-homebrew-tap.sh` — exits for prerelease versions as its first action,
   before any credential/network use (§3).
+- `scripts/check-release-baseline.sh` — skips a channel release whose base version
+  `main` has already shipped (§5).
 - `scripts/set-version.sh`, `.makefiles/rust.mk` (`build-binaries-*`,
   `release-artifacts`) — unchanged, reused per channel.
 - `.makefiles/commitlint.mk` — lints a branch against its base (`nightly` by default,
@@ -299,7 +321,7 @@ Recovery rules:
 - `.github/workflows/pr-target-branch.yml` — fails pull requests into `main`
   from outside the promotion and hotfix branches (§5).
 - `.github/workflows/sync-main.yml` — proposes the `main →` channel back-merges
-  as pull requests (§5).
+  as pull requests, on a schedule and on `release: published` (§5).
 
 ## 11. Related docs
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,11 +10,13 @@ Release and install helpers.
 | [`bump-homebrew-tap.sh`](bump-homebrew-tap.sh) | Bump `mezmo/homebrew-tap` formulae to a released version |
 | [`set-version.sh`](set-version.sh) | Set the workspace and crate versions in `Cargo.toml` |
 | [`next-version.mjs`](next-version.mjs) | Print the version semantic-release would release next |
+| [`check-release-baseline.sh`](check-release-baseline.sh) | Reject a channel prerelease of a version `main` already released |
 | [`sync-release-downloads.sh`](sync-release-downloads.sh) | Snapshot cumulative release-asset download totals into PostHog |
 | [`sync-cloudsmith-downloads.sh`](sync-cloudsmith-downloads.sh) | Snapshot cumulative Cloudsmith package download totals into PostHog |
 | [`sync-docker-downloads.sh`](sync-docker-downloads.sh) | Snapshot cumulative Docker Hub pull totals into PostHog |
 | [`sync-docker-dvp-reports.sh`](sync-docker-dvp-reports.sh) | Snapshot Docker Verified Publisher pulls per tag into PostHog |
 | [`lib/posthog-snapshot.sh`](lib/posthog-snapshot.sh) | Shared machinery the snapshot scripts source |
+| [`tests/`](tests) | Shell test suites, run by `make test-scripts` |
 
 `BRANCH_NAME` selects the release channel; see
 [the release channels design note](../docs/design/release-channels.md).
@@ -380,9 +382,39 @@ command runs; semantic-release's logging goes to stderr, leaving stdout as the
 version alone.
 
 `BRANCH_NAME` selects the branch to analyse. A channel branch is analysed
-against the whole channel branch list, so a prerelease derives its version from
-the last release on `main` (`0.2.0-nightly.1`); any other branch on its own,
-which is what makes a feature branch under test releasable.
+against the whole channel branch list so it resolves as a prerelease
+(`0.2.0-nightly.1`); any other branch on its own, which is what makes a feature
+branch under test releasable.
+
+A prerelease's base version comes from the tags reachable from its own branch,
+not from `main`; see
+[the release channels design note](../docs/design/release-channels.md) for what
+follows from that.
+
+## `check-release-baseline.sh`
+
+```
+check-release-baseline.sh [main-ref]
+```
+
+Reports whether `HEAD` can reach the latest release tag on `main-ref`
+(default `main`).
+
+| Exit | Meaning |
+| --- | --- |
+| 0 | `HEAD` reaches it, or `main-ref` carries no stable tag |
+| 10 | `HEAD` is behind that tag — merge the sync pull request |
+| other | the check could not run; not a verdict |
+
+The `Compute Release Version` stage runs it on `nightly` and `beta`. Exit 10
+clears `NEXT_RELEASE_VERSION` and marks the build unstable; any other non-zero
+fails the stage, so a broken check never reads as a releasable branch.
+
+## Tests
+
+`scripts/tests/*.test.sh` hold the shell suites, run by `make test-scripts` and
+by the `make test` hook. Each builds throwaway git repositories under `mktemp`,
+so they need no network and no fixtures.
 
 ## `set-version.sh`
 

--- a/scripts/check-release-baseline.sh
+++ b/scripts/check-release-baseline.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Exit 10 when HEAD is missing the latest release tag on main. Channel
+# branches derive their version from the tags they can reach, so one that has
+# not taken the main → channel back-merge releases from an older baseline.
+# See docs/design/release-channels.md.
+#
+# Any other non-zero exit is a failure to evaluate, not a verdict.
+#
+# Usage: check-release-baseline.sh [main-ref]
+
+set -euo pipefail
+
+STALE=10
+main_ref="${1:-main}"
+
+if ! main_sha="$(git rev-parse --verify --quiet "${main_ref}^{commit}")"; then
+  echo "error: ${main_ref} does not resolve to a commit" >&2
+  exit 1
+fi
+
+# Prerelease tags are excluded so this is the last stable release alone.
+latest_stable="$(git tag --merged "$main_sha" --list 'v*' |
+  sed -n 's/^v\([0-9][0-9.]*\)$/\1/p' | sort -V | tail -n 1)"
+
+if [ -z "$latest_stable" ]; then
+  echo "no stable tag reachable from ${main_ref}; nothing to be behind" >&2
+  exit 0
+fi
+
+if git merge-base --is-ancestor "v${latest_stable}" HEAD; then
+  exit 0
+fi
+
+echo "HEAD is missing v${latest_stable}, the latest release on ${main_ref}." >&2
+echo "Merge the sync pull request, or delete beta once it is promoted." >&2
+exit "$STALE"

--- a/scripts/next-version.mjs
+++ b/scripts/next-version.mjs
@@ -21,9 +21,10 @@ const configured = branches.map((branch) => {
   return typeof branch === 'string' ? branch : branch.name
 })
 
-// A channel branch is analysed against the whole list so a prerelease derives
-// from the last release on main; any other branch on its own, which is what
-// makes a feature branch under test releasable.
+// A channel branch is analysed against the whole list so it resolves as a
+// prerelease; any other branch on its own, which is what makes a feature
+// branch under test releasable. A prerelease's base version comes from the
+// tags reachable from the branch itself — see docs/design/release-channels.md.
 const options = {
   dryRun: true,
   ci: false,

--- a/scripts/tests/check-release-baseline.test.sh
+++ b/scripts/tests/check-release-baseline.test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Tests for check-release-baseline.sh, run against throwaway git repositories.
+#
+# Usage: check-release-baseline.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/check-release-baseline.sh"
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+passed=0
+failed=0
+
+# A repository with main, one channel branch, and whatever tags a case needs.
+# Commits are empty, so only the shape of the history matters.
+new_repo() {
+  local dir="${workdir}/$1"
+  git init --quiet --initial-branch=main "${dir}"
+  git -C "${dir}" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "root"
+  printf '%s' "${dir}"
+}
+
+commit() { git -C "$1" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "$2"; }
+
+expect() {
+  local name="$1" dir="$2" want="$3"; shift 3
+  local out; out="$(cd "${dir}" && "${SCRIPT}" "$@" 2>&1)"
+  local got=$?
+  if [ "${got}" = "${want}" ]; then
+    printf '  ok    %s\n' "${name}"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL  %s (want exit %s, got %s)\n        %s\n' "${name}" "${want}" "${got}" "${out}"
+    failed=$((failed + 1))
+  fi
+}
+
+echo "check-release-baseline.sh"
+
+# main releases v0.2.17; the channel branched before that tag.
+r="$(new_repo stale)"
+git -C "$r" branch nightly
+commit "$r" "version bump"
+git -C "$r" tag v0.2.17
+git -C "$r" checkout --quiet nightly
+commit "$r" "channel work"
+expect "channel missing main's release tag" "$r" 10
+
+# The same repository once the back-merge has landed.
+git -C "$r" -c user.email=t@t -c user.name=t merge --quiet --no-ff --no-edit main
+expect "channel that took the back-merge" "$r" 0
+
+# A prerelease tag newer than the stable one must not become the baseline.
+r="$(new_repo prerelease)"
+git -C "$r" tag v0.2.17
+git -C "$r" branch nightly
+commit "$r" "next cycle"
+git -C "$r" tag v0.3.0-beta.1
+git -C "$r" checkout --quiet nightly
+expect "prerelease tags are not the baseline" "$r" 0
+
+# sort -V, not lexical: v0.2.10 is newer than v0.2.9.
+r="$(new_repo numeric)"
+git -C "$r" tag v0.2.9
+commit "$r" "ten"
+git -C "$r" tag v0.2.10
+git -C "$r" branch -f nightly HEAD~1
+git -C "$r" checkout --quiet nightly
+expect "versions compare numerically" "$r" 10
+
+# Tags that are not vX.Y.Z are ignored entirely.
+r="$(new_repo othertags)"
+git -C "$r" tag v0.2.17
+git -C "$r" branch nightly
+commit "$r" "later"
+git -C "$r" tag nightly-build
+git -C "$r" tag v0.4.0-rc.1
+git -C "$r" checkout --quiet nightly
+expect "non-release tags are ignored" "$r" 0
+
+# Nothing to be behind.
+r="$(new_repo untagged)"
+git -C "$r" branch nightly
+git -C "$r" checkout --quiet nightly
+expect "no stable tag on main" "$r" 0
+
+# Refs other than a local branch resolve rather than silently passing.
+r="$(new_repo refs)"
+git -C "$r" branch nightly
+commit "$r" "version bump"
+git -C "$r" tag v0.2.17
+git -C "$r" update-ref refs/remotes/origin/main HEAD
+sha="$(git -C "$r" rev-parse HEAD)"
+git -C "$r" checkout --quiet nightly
+expect "a remote-tracking ref" "$r" 10 origin/main
+expect "a raw commit sha"      "$r" 10 "${sha}"
+
+# A ref that does not resolve is an error, never a pass.
+expect "unresolvable ref is not a pass" "$r" 1 refs/heads/nope
+
+printf '\n%d passed, %d failed\n' "${passed}" "${failed}"
+[ "${failed}" -eq 0 ]


### PR DESCRIPTION
Stable releases run on main, where semantic-release lands a version commit and hangs the release tag on it. nightly and beta never produce that commit, so the main → channel back-merge is how they receive the tag. A channel's version comes from the tags it can reach, so one still waiting on that back-merge keeps numbering from the tag before it. After main shipped 0.2.17, nightly would build 0.2.17-nightly.1, and the moving `nightly` image tag would sort below `latest`.

sync-main.yml proposes those back-merges and has never opened one. The job runs without a checkout, so `gh pr list` and `gh pr create` die with "fatal: not a git repository" resolving the repository from a git
remote.

- GH_REPO hands gh the repository instead.
- A `release: released` trigger stops sync waiting up to six hours for the schedule, and skips beta's prereleases, which do not move main.
- An open sync pull request moves forward with main rather than going stale, unless its branch carries commits main does not.
- check-release-baseline.sh backstops all of it, refusing to release a channel that cannot reach main's latest release tag. Exit 10 is the stale verdict; any other non-zero fails the stage rather than reading as a releasable branch.

See docs/design/release-channels.md.